### PR TITLE
Attempt to fix infinite recursion in authorization code.

### DIFF
--- a/src/afw/tests/authorization/application/recurse/afw.conf
+++ b/src/afw/tests/authorization/application/recurse/afw.conf
@@ -1,0 +1,11 @@
+[
+    {
+        type                            : "application",
+        applicationId                   : "test-app-auth",
+        description                     : "testing application authorization that recurses",
+        defaultFlags                    : [ "trace:authorization" ],
+        authorizationControl            : {
+            initialAuthorizationCheck   : "get_object(\"afw\",\"_AdaptiveObjectType_\",\"_AdaptiveObjectType_\");\n\nlet  decisionPermit = {\n    \"decisionId\": \"permit\"\n};\n\nlet  decisionDeny = {\n    \"decisionId\": \"deny\"\n};\n\nreturn decisionPermit;"
+        }
+    }
+]

--- a/src/afw/tests/authorization/application/recurse/recurse.as
+++ b/src/afw/tests/authorization/application/recurse/recurse.as
@@ -1,0 +1,15 @@
+#!/usr/bin/env -S afw --syntax test_script --conf ./afw.conf
+//?
+//? testScript: recurse.as
+//? customPurpose: Part of authorization tests
+//? description: Test authorization script that may cause recursive authorization calls.
+//? sourceType: script
+//?
+//? test: get_object
+//? description: Test get_object succeeds
+//? expect: 0
+//? source: ...
+
+const o: object = get_object("afw", "_AdaptiveAdaptor_", "afw");
+
+return 0;

--- a/src/afw/tests/authorization/script/recurse/afw.conf
+++ b/src/afw/tests/authorization/script/recurse/afw.conf
@@ -1,0 +1,11 @@
+[
+    {
+        type                        : "authorizationHandler",
+        authorizationHandlerType    : "script",
+        authorizationHandlerId      : "auth-script",
+        allowDenyOverride           : false,    
+        description                 : "Test authorization handler that uses calls that may invoke recursive authorization",
+        qualifiedVariables          : {},
+        authorizationCheck          : "get_object(\"afw\", \"_AdaptiveObjectType_\", \"_AdaptiveObjectType_\");\n\nreturn {decisionId:\"permit\"};"
+    }
+]

--- a/src/afw/tests/authorization/script/recurse/recurse.as
+++ b/src/afw/tests/authorization/script/recurse/recurse.as
@@ -1,0 +1,15 @@
+#!/usr/bin/env -S afw --syntax test_script --conf ./afw.conf
+//?
+//? testScript: recurse.as
+//? customPurpose: Part of authorization tests
+//? description: Test authorization script that may cause recursive authorization calls.
+//? sourceType: script
+//?
+//? test: get_object
+//? description: Test get_object succeeds
+//? expect: 0
+//? source: ...
+
+const o: object = get_object("afw", "_AdaptiveAdaptor_", "afw");
+
+return 0;

--- a/src/afw/xctx/afw_xctx.h
+++ b/src/afw/xctx/afw_xctx.h
@@ -205,7 +205,7 @@ do { \
  * AFW_XCTX_AUTHORIZATION_MODE_END;
  */
 #define AFW_XCTX_AUTHORIZATION_MODE_BEGIN(modeId) \
-const afw_value_t *this_PREVIOUS_MODE = \
+    const afw_value_t *this_PREVIOUS_MODE = xctx->mode; \
     xctx->mode = afw_authorization_mode_id_ ## modeId ## _value; \
 AFW_TRY
 


### PR DESCRIPTION
When an authorization script is executed out of an application's initialAuthorizationCheck or AuthorizationHandler, the script may make function calls in order to gather more information about a particular subject or resource. These calls also require authorization, creating an infinite recursion scenario.