### PR TITLE
Updated docker legacy labeling

### DIFF
--- a/docker/images/afw-admin/Dockerfile
+++ b/docker/images/afw-admin/Dockerfile
@@ -9,7 +9,7 @@ RUN chmod +x /builder.sh && BUILD_TARGET=js /builder.sh
 
 FROM nginx:latest
 
-LABEL org.opencontainers.image.source https://github.com/afw-org/afw
+LABEL org.opencontainers.image.source=https://github.com/afw-org/afw
 
 # builder images must already be created to grab artifacts
 COPY --from=build-stage /afw-apps-*.tar /usr/share/nginx/html

--- a/docker/images/afw-base/Dockerfile.alpine
+++ b/docker/images/afw-base/Dockerfile.alpine
@@ -1,6 +1,6 @@
 FROM alpine:3.16.8
 
-LABEL org.opencontainers.image.source https://github.com/afw-org/afw
+LABEL org.opencontainers.image.source=https://github.com/afw-org/afw
 
 RUN apk add --no-cache apr apr-util apr-util-ldap \
     apr-util-dbd_mysql apr-util-dbd_pgsql icu-libs fcgi \

--- a/docker/images/afw-dev-base/Dockerfile.alpine
+++ b/docker/images/afw-dev-base/Dockerfile.alpine
@@ -1,6 +1,6 @@
 FROM alpine:3.16.8
 
-LABEL org.opencontainers.image.source https://github.com/afw-org/afw
+LABEL org.opencontainers.image.source=https://github.com/afw-org/afw
 
 RUN apk add --no-cache build-base libtool clang-analyzer py3-clang \
     apr-dev fcgi-dev libxml2-dev libxslt-dev apache2-dev cmake nginx \

--- a/docker/images/afw-dev-base/Dockerfile.opensuse
+++ b/docker/images/afw-dev-base/Dockerfile.opensuse
@@ -1,6 +1,6 @@
 FROM opensuse/leap:15.5
 
-LABEL org.opencontainers.image.source https://github.com/afw-org/afw
+LABEL org.opencontainers.image.source=https://github.com/afw-org/afw
 
 # Install packages
 RUN zypper ref -s && \

--- a/docker/images/afw-dev-base/Dockerfile.rockylinux
+++ b/docker/images/afw-dev-base/Dockerfile.rockylinux
@@ -1,6 +1,6 @@
 FROM rockylinux:8.9.20231119
 
-LABEL org.opencontainers.image.source https://github.com/afw-org/afw
+LABEL org.opencontainers.image.source=https://github.com/afw-org/afw
 
 # Install packages
 RUN dnf install -y epel-release && \

--- a/docker/images/afw-dev-base/Dockerfile.ubuntu
+++ b/docker/images/afw-dev-base/Dockerfile.ubuntu
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-LABEL org.opencontainers.image.source https://github.com/afw-org/afw
+LABEL org.opencontainers.image.source=https://github.com/afw-org/afw
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/docker/images/afw-dev/Dockerfile.alpine
+++ b/docker/images/afw-dev/Dockerfile.alpine
@@ -27,7 +27,7 @@ COPY --from=build-stage-js /*.tar /
 # create a final output image
 FROM ghcr.io/afw-org/afw-dev-base:alpine
 
-LABEL org.opencontainers.image.source https://github.com/afw-org/afw
+LABEL org.opencontainers.image.source=https://github.com/afw-org/afw
 
 # obtain the artifacts from build-stage
 COPY --from=build-stage /afw-*alpine*.tar.gz /

--- a/docker/images/afw-dev/Dockerfile.opensuse
+++ b/docker/images/afw-dev/Dockerfile.opensuse
@@ -27,7 +27,7 @@ COPY --from=build-stage-js /*.tar /
 # create a final output image
 FROM ghcr.io/afw-org/afw-dev-base:opensuse
 
-LABEL org.opencontainers.image.source https://github.com/afw-org/afw
+LABEL org.opencontainers.image.source=https://github.com/afw-org/afw
 
 # obtain the artifacts from build-stage
 COPY --from=build-stage /afw-*.rpm /

--- a/docker/images/afw-dev/Dockerfile.rockylinux
+++ b/docker/images/afw-dev/Dockerfile.rockylinux
@@ -27,7 +27,7 @@ COPY --from=build-stage-js /*.tar /
 # create a final output image
 FROM ghcr.io/afw-org/afw-dev-base:rockylinux
 
-LABEL org.opencontainers.image.source https://github.com/afw-org/afw
+LABEL org.opencontainers.image.source=https://github.com/afw-org/afw
 
 # obtain the artifacts from build-stage
 COPY --from=build-stage /afw-*.rpm /

--- a/docker/images/afw-dev/Dockerfile.ubuntu
+++ b/docker/images/afw-dev/Dockerfile.ubuntu
@@ -27,7 +27,7 @@ COPY --from=build-stage-js /*.tar /
 # create a final output image
 FROM ghcr.io/afw-org/afw-dev-base:ubuntu
 
-LABEL org.opencontainers.image.source https://github.com/afw-org/afw
+LABEL org.opencontainers.image.source=https://github.com/afw-org/afw
 
 # obtain the artifacts from build-stage
 COPY --from=build-stage /afw-*.deb /

--- a/docker/images/afw/Dockerfile.alpine
+++ b/docker/images/afw/Dockerfile.alpine
@@ -27,7 +27,7 @@ COPY --from=build-stage-js /*.tar /
 # create a final output image
 FROM ghcr.io/afw-org/afw-base:alpine
 
-LABEL org.opencontainers.image.source https://github.com/afw-org/afw
+LABEL org.opencontainers.image.source=https://github.com/afw-org/afw
 
 # add supervisor package for managing startup services
 RUN apk add --no-cache nginx supervisor

--- a/docker/images/afwfcgi/Dockerfile.alpine
+++ b/docker/images/afwfcgi/Dockerfile.alpine
@@ -8,7 +8,7 @@ RUN chmod +x /builder.sh && /builder.sh
 
 FROM ghcr.io/afw-org/afw-base:alpine
 
-LABEL org.opencontainers.image.source https://github.com/afw-org/afw
+LABEL org.opencontainers.image.source=https://github.com/afw-org/afw
 
 # builder images must already be created to grab artifacts
 COPY --from=build-stage-c /afw-*alpine*.tar /


### PR DESCRIPTION
Building the AFW docker images produces:

```
 1 warning found (use --debug to expand):
 - LegacyKeyValueFormat: "LABEL key=value" should be used instead of legacy "LABEL key value" format (line 3)
```

Added equals signs to fix the warning.

Test: 
```
docker build -f docker/images/afw-base/Dockerfile.alpine \
    -t ghcr.io/afw-org/afw-base:alpine3.16.6 \
    -t ghcr.io/afw-org/afw-base:alpine \
    docker/images/afw-base
```