### PR TITLE
Fix JSON Schema generation mixed $ref and improve adaptive OT projection (#3)

### DIFF
--- a/.cursor/rules/afw-afwdev-generate.mdc
+++ b/.cursor/rules/afw-afwdev-generate.mdc
@@ -11,8 +11,13 @@ This rule is for **`src/afw_dev/_afwdev/generate/`** — the Python that turns p
 ## Roles
 - Orchestration: `generate.py` — per-srcdir `generate()` then package `root_generate()`.
 - Per-srcdir: wipe `generated/`; optional overlay of `generate/external/` into `generate/temp_generate/`; run modules that match existing `generate/` subdirs (objects, interfaces, polymorphic functions, bindings, strings, cmake fragments, …).
-- Package-level: `root_generate()` writes package `generated/` (cmake fragments, JSON schemas, …).
-- Sibling modules (`function_bindings.py`, `interfaces.py`, `cmake.py`, …) are the generators; extend those rather than patching outputs.
+- Package-level: `root_generate()` writes package `generated/` (cmake fragments, **JSON schemas**, …).
+- Sibling modules (`function_bindings.py`, `interfaces.py`, `cmake.py`, `json_schema.py`, …) are the generators; extend those rather than patching outputs.
+
+## JSON Schema (`json_schema.py`)
+- Emits package-root `generated/schemas/afw/` from adaptive `_AdaptiveObjectType_` JSON.
+- **Primary consumer: editors** (VS Code), not a compact JS client. Never hand-edit schema output.
+- Full rules (issue #3 `$ref` form, inheritance merge/override, tests): `.cursor/rules/afw-json-schema.mdc`.
 
 ## Hard rules
 - Write only under `generated/` (or documented generator outputs). Never hand-edit `src/*/generated/**`.

--- a/.cursor/rules/afw-generate-metadata.mdc
+++ b/.cursor/rules/afw-generate-metadata.mdc
@@ -15,7 +15,7 @@ alwaysApply: false
 - `_AdaptiveFunctionGenerate_/` — Adaptive functions (`functionId`, `functionLabel`, `category`, `parameters`, `returns`). Example: `src/afw/generate/objects/_AdaptiveFunctionGenerate_/and.json`.
 - `_AdaptiveDataTypeGenerate_/` — data types (not `_AdaptiveDataType_`).
 - `_AdaptivePolymorphicFunction_/` — polymorphic / shared execute dispatch.
-- `_AdaptiveObjectType_/` and related — object type metadata.
+- `_AdaptiveObjectType_/` and related — object type metadata. Inheritance uses `propertyTypes._meta_.parentPaths` (not flattened on generate→generated copy). Package-root JSON Schema for editors is projected from these OTs — see `afw-json-schema`.
 - Interfaces: `generate/interfaces/*.xml` (core: `src/afw/generate/interfaces/afw_interface.xml`).
 - EBNF: `generate/ebnf/*.txt` lists which compile sources to scan; grammar text lives in `/*ebnf>>>` comments in those `.c` files → `generated/ebnf/`. See `.cursor/rules/afw-compiler-ebnf.mdc`.
 

--- a/.cursor/rules/afw-json-schema.mdc
+++ b/.cursor/rules/afw-json-schema.mdc
@@ -1,0 +1,54 @@
+---
+description: Package JSON Schema projection (json_schema.py, generated/schemas, editor use, tests)
+globs: "**/json_schema.py,**/generated/schemas/**/*,src/afw_dev/tests/json_schema/**/*"
+alwaysApply: false
+---
+
+# Adaptive object types → JSON Schema
+
+## Role
+- **Source of truth**: adaptive object types under `src/**/generate/objects/_AdaptiveObjectType_/` (and post-generate `src/**/generated/objects/_AdaptiveObjectType_/`).
+- **Projection**: package-root `generated/schemas/afw/*.json`, produced by `src/afw_dev/_afwdev/generate/json_schema.py` during package **`root_generate()`** (after per-srcdir generate).
+- **Primary use**: **editors** (VS Code `json.schemas` fileMatch → completion, hovers, light validation) when editing adaptive object JSON under `generate/objects/` (and similar paths).
+- **Secondary**: `afwdev validate`, generator regression tests. Not a full adaptive meta model; not optimized as a minimal JS-client payload.
+- **Never hand-edit** `generated/schemas/**` — change the generator or adaptive OT metadata, then regenerate.
+
+## Adaptive model reminders
+- Almost everything is an adaptive object typed by an `_AdaptiveObjectType_` instance.
+- Inheritance is **not** flattened in generate→generated OT JSON: keep `propertyTypes._meta_.parentPaths` links (e.g. `/afw/_AdaptiveObjectType_/<Parent>/propertyTypes` or layout `/*/*/<Parent>/propertyTypes`).
+- Child property definitions **override** same-named parent properties (e.g. ModelObjectType.`propertyTypes` → ModelPropertyTypes, not ObjectType’s PropertyTypes).
+
+## Generator rules (do not regress)
+- **Issue #3**: never emit `$ref` as a sibling of other keywords. Use pure `{ "$ref" }` or annotations + `"type": "object"` + `"allOf": [ { "$ref" } ]`.
+- **Entity documents**: put entity `type` / `properties` / `required` / `additionalProperties` at the **document root** (editor applies the file directly); keep nested types in `$defs`.
+- **Inheritance**: merge property maps with **child override** for the entity. Do **not** stack parent `.propertyTypes` as constraining `allOf` (breaks overrides and confuses editors). Record chain in `x-afw-inheritedObjectTypes` if useful for tests/tooling.
+- **required**: leaf object type only (not on shared `.propertyTypes` maps that would force ancestor-only fields on children).
+- Prefer **`additionalProperties: false`** (closed) over `unevaluatedProperties` for editor support.
+- Map `defaultValue` → `default`, `allowedValues`/`possibleValues` → `enum`; optional instance `_meta_` bag on closed composites.
+- Verbose schemas are fine (generated, read-only). Optimize for VS Code-style consumers, not size.
+
+## Wire-up
+- VS Code: generator may update `.vscode/settings.json` `json.schemas` entries for `/src/*/generate*/objects/<ObjectType>/*.json`.
+- Validate: `afwdev validate` uses `generated/schemas/afw/` by object-type directory name (or `$schema` URI).
+
+## Tests
+- Location: `src/afw_dev/tests/json_schema/` (Python mode; files starting with `_` are helpers, not tests).
+- Assume **`generated/schemas/afw/` already exists** (run generate/build first). Resolve package root via `afw-package.json`, not `cwd` (test runner uses a temp work dir).
+- Run:
+```bash
+afwdev test -p afw_dev --tags json_schema --show-all
+```
+- Suites: structural (#3), adaptive OT compare, instances, complex inheritance, gnarly models (`_AdaptiveModel_`, TestModel1, TIER).
+
+## After changes
+```bash
+# Refresh schemas (part of package generate / full generate path)
+./afwdev build --cdev -j   # or generate that runs root_generate
+afwdev test -p afw_dev --tags json_schema --show-all
+```
+
+## Related
+- Generators orchestration: `afw-afwdev-generate`
+- Metadata inputs: `afw-generate-metadata`
+- afwdev Python layout: `afw-afwdev-python`
+- Tests layout: `afw-tests`

--- a/.cursor/rules/afw-project.mdc
+++ b/.cursor/rules/afw-project.mdc
@@ -52,5 +52,5 @@ Use **`./afwdev`** when the build may refresh the installed `afwdev` itself; oth
 - When in `src/afw_server_fcgi/`: `afw-server-fcgi`
 - When in `src/afw_{curl,ldap,lmdb,ubjson,vfs,yaml}/`: `afw-extensions`
 - Long-form map: `@AGENTS.md`
-- File-scoped rules: C, generate, afwdev Python, tests
+- File-scoped rules: C, generate, afwdev Python, JSON Schema projection, tests
 - Workflows: skills `add-adaptive-function`, `afw-generate-build-test`

--- a/.cursor/rules/afw-tests.mdc
+++ b/.cursor/rules/afw-tests.mdc
@@ -1,6 +1,6 @@
 ---
-description: Adaptive Script (.as) tests and afwdev test / config.py environments
-globs: "**/tests/**/*.as","**/tests/**/config.py"
+description: Adaptive Script (.as) and Python afwdev tests, config.py, environments
+globs: "**/tests/**/*.as","**/tests/**/*.py","**/tests/**/config.py"
 alwaysApply: false
 ---
 
@@ -8,34 +8,47 @@ alwaysApply: false
 
 ## Layout
 - Per srcdir: `src/<srcdir>/tests/` — groups are subdirs with optional `config.py`.
-- Primary tests: `.as` files. Files starting with `_` and `config.py` are not tests.
+- Test files: `.as`, `.py`, `.sh`, or `commands_*.txt`. Files starting with `_` and `config.py` are not tests.
 - Environments: `tests/environments/<name>/` (`afw.conf`, seed objects); set `Environment = "<name>"` in `config.py`.
 - Hooks in `config.py`: `before_all`, `before_each`, `after_each`, `after_all` when needed.
+- Optional `Tags = ["..."]` in `config.py` for `afwdev test --tags`.
 
 ## `.as` test_script
 - Shebang: `#!/usr/bin/env -S afw --syntax test_script`
 - Metadata and cases via `//?` comments (multiple `//? test:` blocks per file).
 - Example pattern: `src/afw/tests/rql/eq.as`.
 
+## Python tests (afwdev python mode)
+- `.py` files always run in **python** mode (not the default `afw` env-mode runner).
+- Prefer `def run():` returning `{ "description", "tests": [ { "test", "description", "passed", ... } ] }`.
+- The runner may chdir to a temp work dir: resolve the package root (e.g. walk to `afw-package.json` from `__file__`), do not assume `cwd` is the monorepo root.
+- Put sibling helpers in `_name.py` so they are not discovered as tests.
+
+### JSON Schema projection tests
+- `src/afw_dev/tests/json_schema/` — tags `json_schema`, `generate`.
+- Uses pre-built package-root `generated/schemas/afw/` (run generate/build first).
+- Run: `afwdev test -p afw_dev --tags json_schema --show-all`
+- Rules: `.cursor/rules/afw-json-schema.mdc`
+
 ## Commands
 ```bash
 # After C/Python changes, build/install first:
 ./afwdev build --cdev -j
 
-# Usual full script-test run (judge success from output)
+# Usual full script-test run (judge success from command output)
 afwdev test -j
 
-# Occasional: same tests under valgrind (much slower). Use when working on
-# memory management or before a major PR — not for every edit cycle.
+# Occasional memory check (much slower): before major PRs or memory work
 afwdev test --env-mode valgrind -j
 
-afwdev test --srcdir-pattern afw --pattern 'rql/.*'
+afwdev test --srcdir-pattern afw --test-pattern 'rql/.*'
 afwdev test --srcdir-pattern afw --tags rql
 afwdev test --srcdir-pattern afw --list
 afwdev test --srcdir-pattern afw --bail 1
+afwdev test -p afw_dev --tags json_schema --show-all
 ```
 
-Default `--env-mode` is `afw` (runs via the **`afw` CLI** from `src/afw_command` — see `afw-command`). Use `afwdev` from PATH after `--cdev` has installed it.
+Default `--env-mode` is `afw` (runs via the **`afw` CLI** from `src/afw_command` — see `afw-command`). Use `afwdev` from PATH after `--cdev` has installed it. `.py` tests still use python mode.
 
 ## Other test styles
 - `src/afw_command/tests/` — Python-mode fixtures for `afw --local` (`local_test.py`), not `.as` test_script.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,10 @@
         "textbox"
     ],
     "cmake.configureOnOpen": false,
+    "cursorpyright.analysis.extraPaths": [
+        "./src/afw/generated",
+        "./src/afw_client/python"
+    ],
     "json.schemas": [
         {
             "fileMatch": [
@@ -409,6 +413,72 @@
                 "/src/*/generate*/objects/_AdaptiveCurlHttpResponse_/*.json"
             ],
             "url": "./generated/schemas/afw/_AdaptiveCurlHttpResponse_.json"
+        },
+        {
+            "fileMatch": [
+                "/src/*/generate*/objects/_AdaptiveModelCurrentOnModifyObject_/*.json"
+            ],
+            "url": "./generated/schemas/afw/_AdaptiveModelCurrentOnModifyObject_.json"
+        },
+        {
+            "fileMatch": [
+                "/src/*/generate*/objects/_AdaptiveModelCurrentOnGetProperty_/*.json"
+            ],
+            "url": "./generated/schemas/afw/_AdaptiveModelCurrentOnGetProperty_.json"
+        },
+        {
+            "fileMatch": [
+                "/src/*/generate*/objects/_AdaptiveModelCurrentOnGetInitialObjectId_/*.json"
+            ],
+            "url": "./generated/schemas/afw/_AdaptiveModelCurrentOnGetInitialObjectId_.json"
+        },
+        {
+            "fileMatch": [
+                "/src/*/generate*/objects/_AdaptiveModelCurrentOnAddObject_/*.json"
+            ],
+            "url": "./generated/schemas/afw/_AdaptiveModelCurrentOnAddObject_.json"
+        },
+        {
+            "fileMatch": [
+                "/src/*/generate*/objects/_AdaptiveModelPropertyType_/*.json"
+            ],
+            "url": "./generated/schemas/afw/_AdaptiveModelPropertyType_.json"
+        },
+        {
+            "fileMatch": [
+                "/src/*/generate*/objects/_AdaptiveModelCurrentOnRetrieveObjects_/*.json"
+            ],
+            "url": "./generated/schemas/afw/_AdaptiveModelCurrentOnRetrieveObjects_.json"
+        },
+        {
+            "fileMatch": [
+                "/src/*/generate*/objects/_AdaptiveModelCurrentOnReplaceObject_/*.json"
+            ],
+            "url": "./generated/schemas/afw/_AdaptiveModelCurrentOnReplaceObject_.json"
+        },
+        {
+            "fileMatch": [
+                "/src/*/generate*/objects/_AdaptiveModelCurrentOnDeleteObject_/*.json"
+            ],
+            "url": "./generated/schemas/afw/_AdaptiveModelCurrentOnDeleteObject_.json"
+        },
+        {
+            "fileMatch": [
+                "/src/*/generate*/objects/_AdaptiveModelCurrentOnSetProperty_/*.json"
+            ],
+            "url": "./generated/schemas/afw/_AdaptiveModelCurrentOnSetProperty_.json"
+        },
+        {
+            "fileMatch": [
+                "/src/*/generate*/objects/_AdaptiveModelCurrentOnGetInitialValue_/*.json"
+            ],
+            "url": "./generated/schemas/afw/_AdaptiveModelCurrentOnGetInitialValue_.json"
+        },
+        {
+            "fileMatch": [
+                "/src/*/generate*/objects/_AdaptiveModelCurrentOnGetObject_/*.json"
+            ],
+            "url": "./generated/schemas/afw/_AdaptiveModelCurrentOnGetObject_.json"
         }
     ],
     "python.analysis.extraPaths": [
@@ -427,9 +497,5 @@
     "spellright.language": [
         "en"
     ],
-    "terminal.integrated.scrollback": 2000,
-    "cursorpyright.analysis.extraPaths": [
-        "./src/afw/generated",
-        "./src/afw_client/python"
-    ]
+    "terminal.integrated.scrollback": 2000
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,9 @@ afwdev generate --srcdir-pattern '*'
 | `.cursor/rules/afw-function.mdc` | Built-in execute_*, polymorphic, compiler_* |
 | `.cursor/rules/afw-generate-metadata.mdc` | When editing `generate/` |
 | `.cursor/rules/afw-afwdev-python.mdc` | When editing `src/afw_dev` |
-| `.cursor/rules/afw-tests.mdc` | When editing `.as` / test `config.py` |
+| `.cursor/rules/afw-afwdev-generate.mdc` | When editing `_afwdev/generate/` generators |
+| `.cursor/rules/afw-json-schema.mdc` | JSON Schema projection / `generated/schemas` / schema tests |
+| `.cursor/rules/afw-tests.mdc` | When editing tests (`.as`, Python, `config.py`) |
 | `.cursor/skills/add-adaptive-function/` | Add/change Adaptive functions or data types |
 | `.cursor/skills/afw-generate-build-test/` | Regenerate, build, validate, test |
 | `.cursorignore` | Skips `node_modules/`, `build/`, `generated/`, binaries |

--- a/generated/schemas/afw/_AdaptiveAdapterType_.json
+++ b/generated/schemas/afw/_AdaptiveAdapterType_.json
@@ -1,25 +1,47 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveAdapterType_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveAdapterType_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveAdapterType_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "A registry type adapter_factory entry.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveAdapterType_.propertyTypes": {
+            "markdownDescription": "A registry type adapter_factory entry.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "adapterType": {
                     "description": "This is the type for this adapter. It will create a registered adapter_type string, from which adapter instances will created from.",
+                    "markdownDescription": "**Adapter Type**\n\nThis is the type for this adapter. It will create a registered adapter_type string, from which adapter instances will created from.",
                     "title": "Adapter Type",
                     "type": "string"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "This is the description for this adapter type.",
+                    "markdownDescription": "**Description**\n\nThis is the description for this adapter type.",
+                    "title": "Description",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveAdapterType_",
+            "type": "object"
+        },
+        "_AdaptiveAdapterType_.propertyTypes": {
+            "properties": {
+                "adapterType": {
+                    "description": "This is the type for this adapter. It will create a registered adapter_type string, from which adapter instances will created from.",
+                    "markdownDescription": "**Adapter Type**\n\nThis is the type for this adapter. It will create a registered adapter_type string, from which adapter instances will created from.",
+                    "title": "Adapter Type",
+                    "type": "string"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "This is the description for this adapter type.",
+                    "markdownDescription": "**Description**\n\nThis is the description for this adapter type.",
                     "title": "Description",
                     "type": "string"
                 }
@@ -28,9 +50,31 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveAdapterType_"
+    "additionalProperties": false,
+    "description": "A registry type adapter_factory entry.",
+    "markdownDescription": "A registry type adapter_factory entry.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "adapterType": {
+            "description": "This is the type for this adapter. It will create a registered adapter_type string, from which adapter instances will created from.",
+            "markdownDescription": "**Adapter Type**\n\nThis is the type for this adapter. It will create a registered adapter_type string, from which adapter instances will created from.",
+            "title": "Adapter Type",
+            "type": "string"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "This is the description for this adapter type.",
+            "markdownDescription": "**Description**\n\nThis is the description for this adapter type.",
+            "title": "Description",
+            "type": "string"
         }
-    ]
+    },
+    "title": "_AdaptiveAdapterType_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveAdapterType_.json
+++ b/generated/schemas/afw/_AdaptiveAdapterType_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveAdapterType_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveAdapterType_.propertyTypes"
                 }
@@ -28,7 +28,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveAdapterType_"
         }

--- a/generated/schemas/afw/_AdaptiveAdapter_.json
+++ b/generated/schemas/afw/_AdaptiveAdapter_.json
@@ -1,12 +1,22 @@
 {
     "$defs": {
         "_AdaptiveAdapterMetrics_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveAdapterMetrics_.propertyTypes"
                 }
             ],
             "description": "An adapter may provide metrics to describe the current state of this adapter instance.",
+            "required": [
+                "addObjectCount",
+                "additional",
+                "deleteObjectCount",
+                "getObjectCount",
+                "modifyObjectCount",
+                "replaceObjectCount",
+                "retrieveObjectsCount",
+                "updateObjectCount"
+            ],
             "title": "Metrics",
             "type": "object",
             "unevaluatedProperties": false
@@ -54,20 +64,10 @@
                     "type": "integer"
                 }
             },
-            "required": [
-                "addObjectCount",
-                "additional",
-                "deleteObjectCount",
-                "getObjectCount",
-                "modifyObjectCount",
-                "replaceObjectCount",
-                "retrieveObjectsCount",
-                "updateObjectCount"
-            ],
             "type": "object"
         },
         "_AdaptiveAdapter_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveAdapter_.propertyTypes"
                 }
@@ -84,10 +84,13 @@
                     "type": "string"
                 },
                 "metrics": {
-                    "$ref": "#/$defs/_AdaptiveAdapterMetrics_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveAdapterMetrics_"
+                        }
+                    ],
                     "description": "An adapter may provide metrics to describe the current state of this adapter instance.",
-                    "title": "Metrics",
-                    "type": "object"
+                    "title": "Metrics"
                 },
                 "properties": {
                     "description": "This object contains some of properties from the associated conf object plus other runtime properties.",
@@ -119,7 +122,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveAdapter_"
         }

--- a/generated/schemas/afw/_AdaptiveAdapter_.json
+++ b/generated/schemas/afw/_AdaptiveAdapter_.json
@@ -1,12 +1,67 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveAdapter_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveAdapterMetrics_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveAdapterMetrics_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "An adapter may provide metrics to describe the current state of this adapter instance.",
+            "markdownDescription": "An adapter may provide metrics to describe the current state of this adapter instance.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "addObjectCount": {
+                    "description": "Method add_object() count.",
+                    "markdownDescription": "Method add_object() count.",
+                    "title": "Add Object Count",
+                    "type": "integer"
+                },
+                "additional": {
+                    "description": "Additional adapter specific metrics.",
+                    "markdownDescription": "Additional adapter specific metrics.",
+                    "title": "Additional",
+                    "type": "object"
+                },
+                "deleteObjectCount": {
+                    "description": "Method delete_object() count.",
+                    "markdownDescription": "Method delete_object() count.",
+                    "title": "Delete Object Count",
+                    "type": "integer"
+                },
+                "getObjectCount": {
+                    "description": "Method get_object() count.",
+                    "markdownDescription": "Method get_object() count.",
+                    "title": "Get Object Count",
+                    "type": "integer"
+                },
+                "modifyObjectCount": {
+                    "description": "Method modify_object() count.",
+                    "markdownDescription": "Method modify_object() count.",
+                    "title": "Modify Object Count",
+                    "type": "integer"
+                },
+                "replaceObjectCount": {
+                    "description": "Method replace_object() count.",
+                    "markdownDescription": "Method replace_object() count.",
+                    "title": "Replace Object Count",
+                    "type": "integer"
+                },
+                "retrieveObjectsCount": {
+                    "description": "Method retrieve_objects() count.",
+                    "markdownDescription": "Method retrieve_objects() count.",
+                    "title": "Retrieve Objects Count",
+                    "type": "integer"
+                },
+                "updateObjectCount": {
+                    "description": "Method update_object() count.",
+                    "markdownDescription": "Method update_object() count.",
+                    "title": "Update Object Count",
+                    "type": "integer"
+                }
+            },
             "required": [
                 "addObjectCount",
                 "additional",
@@ -18,48 +73,55 @@
                 "updateObjectCount"
             ],
             "title": "Metrics",
-            "type": "object",
-            "unevaluatedProperties": false
+            "type": "object"
         },
         "_AdaptiveAdapterMetrics_.propertyTypes": {
             "properties": {
                 "addObjectCount": {
                     "description": "Method add_object() count.",
+                    "markdownDescription": "Method add_object() count.",
                     "title": "Add Object Count",
                     "type": "integer"
                 },
                 "additional": {
                     "description": "Additional adapter specific metrics.",
+                    "markdownDescription": "Additional adapter specific metrics.",
                     "title": "Additional",
                     "type": "object"
                 },
                 "deleteObjectCount": {
                     "description": "Method delete_object() count.",
+                    "markdownDescription": "Method delete_object() count.",
                     "title": "Delete Object Count",
                     "type": "integer"
                 },
                 "getObjectCount": {
                     "description": "Method get_object() count.",
+                    "markdownDescription": "Method get_object() count.",
                     "title": "Get Object Count",
                     "type": "integer"
                 },
                 "modifyObjectCount": {
                     "description": "Method modify_object() count.",
+                    "markdownDescription": "Method modify_object() count.",
                     "title": "Modify Object Count",
                     "type": "integer"
                 },
                 "replaceObjectCount": {
                     "description": "Method replace_object() count.",
+                    "markdownDescription": "Method replace_object() count.",
                     "title": "Replace Object Count",
                     "type": "integer"
                 },
                 "retrieveObjectsCount": {
                     "description": "Method retrieve_objects() count.",
+                    "markdownDescription": "Method retrieve_objects() count.",
                     "title": "Retrieve Objects Count",
                     "type": "integer"
                 },
                 "updateObjectCount": {
                     "description": "Method update_object() count.",
+                    "markdownDescription": "Method update_object() count.",
                     "title": "Update Object Count",
                     "type": "integer"
                 }
@@ -67,19 +129,20 @@
             "type": "object"
         },
         "_AdaptiveAdapter_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveAdapter_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Runtime adapter information.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveAdapter_.propertyTypes": {
+            "markdownDescription": "Runtime adapter information.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "adapterId": {
                     "description": "The adapter id uniquely identifies an adapter instance.",
+                    "markdownDescription": "**Adapter Id**\n\nThe adapter id uniquely identifies an adapter instance.",
                     "title": "Adapter Id",
                     "type": "string"
                 },
@@ -90,20 +153,25 @@
                         }
                     ],
                     "description": "An adapter may provide metrics to describe the current state of this adapter instance.",
-                    "title": "Metrics"
+                    "markdownDescription": "**Metrics**\n\nAn adapter may provide metrics to describe the current state of this adapter instance.",
+                    "title": "Metrics",
+                    "type": "object"
                 },
                 "properties": {
                     "description": "This object contains some of properties from the associated conf object plus other runtime properties.",
+                    "markdownDescription": "**Properties**\n\nThis object contains some of properties from the associated conf object plus other runtime properties.",
                     "title": "Properties",
                     "type": "object"
                 },
                 "referenceCount": {
                     "description": "The reference count is the total number of references that are currently being used for this adapter.",
+                    "markdownDescription": "**Reference Count**\n\nThe reference count is the total number of references that are currently being used for this adapter.",
                     "title": "Reference Count",
                     "type": "integer"
                 },
                 "serviceId": {
                     "description": "The id of the associated service. The URI of the service is '/afw/_AdaptiveService_/' followed by this id.",
+                    "markdownDescription": "**Service Id**\n\nThe id of the associated service. The URI of the service is '/afw/_AdaptiveService_/' followed by this id.",
                     "title": "Service Id",
                     "type": "string"
                 },
@@ -111,9 +179,64 @@
                     "description": "Reference counts of stopping instances.",
                     "items": {
                         "description": "Reference counts of stopping instances.",
+                        "markdownDescription": "Reference counts of stopping instances.",
                         "title": "Reference counts of stopping instances",
                         "type": "integer"
                     },
+                    "markdownDescription": "**Stopping Instances**\n\nReference counts of stopping instances.",
+                    "title": "Stopping Instances",
+                    "type": "array"
+                }
+            },
+            "title": "_AdaptiveAdapter_",
+            "type": "object"
+        },
+        "_AdaptiveAdapter_.propertyTypes": {
+            "properties": {
+                "adapterId": {
+                    "description": "The adapter id uniquely identifies an adapter instance.",
+                    "markdownDescription": "**Adapter Id**\n\nThe adapter id uniquely identifies an adapter instance.",
+                    "title": "Adapter Id",
+                    "type": "string"
+                },
+                "metrics": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveAdapterMetrics_"
+                        }
+                    ],
+                    "description": "An adapter may provide metrics to describe the current state of this adapter instance.",
+                    "markdownDescription": "**Metrics**\n\nAn adapter may provide metrics to describe the current state of this adapter instance.",
+                    "title": "Metrics",
+                    "type": "object"
+                },
+                "properties": {
+                    "description": "This object contains some of properties from the associated conf object plus other runtime properties.",
+                    "markdownDescription": "**Properties**\n\nThis object contains some of properties from the associated conf object plus other runtime properties.",
+                    "title": "Properties",
+                    "type": "object"
+                },
+                "referenceCount": {
+                    "description": "The reference count is the total number of references that are currently being used for this adapter.",
+                    "markdownDescription": "**Reference Count**\n\nThe reference count is the total number of references that are currently being used for this adapter.",
+                    "title": "Reference Count",
+                    "type": "integer"
+                },
+                "serviceId": {
+                    "description": "The id of the associated service. The URI of the service is '/afw/_AdaptiveService_/' followed by this id.",
+                    "markdownDescription": "**Service Id**\n\nThe id of the associated service. The URI of the service is '/afw/_AdaptiveService_/' followed by this id.",
+                    "title": "Service Id",
+                    "type": "string"
+                },
+                "stopping": {
+                    "description": "Reference counts of stopping instances.",
+                    "items": {
+                        "description": "Reference counts of stopping instances.",
+                        "markdownDescription": "Reference counts of stopping instances.",
+                        "title": "Reference counts of stopping instances",
+                        "type": "integer"
+                    },
+                    "markdownDescription": "**Stopping Instances**\n\nReference counts of stopping instances.",
                     "title": "Stopping Instances",
                     "type": "array"
                 }
@@ -122,9 +245,65 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveAdapter_"
+    "additionalProperties": false,
+    "description": "Runtime adapter information.",
+    "markdownDescription": "Runtime adapter information.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "adapterId": {
+            "description": "The adapter id uniquely identifies an adapter instance.",
+            "markdownDescription": "**Adapter Id**\n\nThe adapter id uniquely identifies an adapter instance.",
+            "title": "Adapter Id",
+            "type": "string"
+        },
+        "metrics": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveAdapterMetrics_"
+                }
+            ],
+            "description": "An adapter may provide metrics to describe the current state of this adapter instance.",
+            "markdownDescription": "**Metrics**\n\nAn adapter may provide metrics to describe the current state of this adapter instance.",
+            "title": "Metrics",
+            "type": "object"
+        },
+        "properties": {
+            "description": "This object contains some of properties from the associated conf object plus other runtime properties.",
+            "markdownDescription": "**Properties**\n\nThis object contains some of properties from the associated conf object plus other runtime properties.",
+            "title": "Properties",
+            "type": "object"
+        },
+        "referenceCount": {
+            "description": "The reference count is the total number of references that are currently being used for this adapter.",
+            "markdownDescription": "**Reference Count**\n\nThe reference count is the total number of references that are currently being used for this adapter.",
+            "title": "Reference Count",
+            "type": "integer"
+        },
+        "serviceId": {
+            "description": "The id of the associated service. The URI of the service is '/afw/_AdaptiveService_/' followed by this id.",
+            "markdownDescription": "**Service Id**\n\nThe id of the associated service. The URI of the service is '/afw/_AdaptiveService_/' followed by this id.",
+            "title": "Service Id",
+            "type": "string"
+        },
+        "stopping": {
+            "description": "Reference counts of stopping instances.",
+            "items": {
+                "description": "Reference counts of stopping instances.",
+                "markdownDescription": "Reference counts of stopping instances.",
+                "title": "Reference counts of stopping instances",
+                "type": "integer"
+            },
+            "markdownDescription": "**Stopping Instances**\n\nReference counts of stopping instances.",
+            "title": "Stopping Instances",
+            "type": "array"
         }
-    ]
+    },
+    "title": "_AdaptiveAdapter_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveApplication_.json
+++ b/generated/schemas/afw/_AdaptiveApplication_.json
@@ -1,93 +1,21 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveApplication_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveApplication_": {
             "additionalProperties": true,
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveApplication_.propertyTypes"
-                },
-                {
-                    "$ref": "#/$defs/_AdaptiveConf_application.propertyTypes"
-                },
-                {
-                    "$ref": "#/$defs/_AdaptiveConf_.propertyTypes"
-                }
-            ],
             "description": "Adaptive Application.",
-            "type": "object"
-        },
-        "_AdaptiveApplication_.propertyTypes": {
-            "properties": {},
-            "type": "object"
-        },
-        "_AdaptiveAuthorizationControl_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveAuthorizationControl_.propertyTypes"
-                }
-            ],
-            "description": "This defines how authorization checking occurs in this application.",
-            "title": "Authorization",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveAuthorizationControl_.propertyTypes": {
+            "markdownDescription": "Adaptive Application.",
             "properties": {
-                "checkIntermediateMode": {
-                    "default": false,
-                    "description": "Do authorization check when running in mode intermediate. If false, the checks will be bypassed.",
-                    "title": "Check Intermediate",
-                    "type": "boolean"
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
                 },
-                "coreAuthorizationCheck": {
-                    "description": "This is evaluated for authorization checks when running in core mode. If not specified, access is permitted. Be very careful when specifying this parameter because an error can cause the application to fail.",
-                    "title": "Core Check",
-                    "type": "string"
-                },
-                "denyIfNotApplicable": {
-                    "default": false,
-                    "description": "Specify true to deny access to resources when notApplicable is the final result of other checks.",
-                    "title": "Deny If Not Applicable",
-                    "type": "boolean"
-                },
-                "initialAuthorizationCheck": {
-                    "description": "This is evaluated before authorization handlers are called to determine whether to allow the requested access to the specified resourceId and/or object. A result of permit or deny is the final decision. If this parameter is not specified or the result is notApplicable, active authorization handlers will be processed. Parameter permitIfNotApplicable is used to determine the result when all checks return notApplicable.",
-                    "title": "Initial Check",
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "_AdaptiveConf_.propertyTypes": {
-            "properties": {
-                "description": {
-                    "contentMediaType": "text/plain",
-                    "description": "The description of this configuration component.",
-                    "title": "Description",
-                    "type": "string"
-                },
-                "sourceLocation": {
-                    "description": "This is a contextual string added when this configuration object is processed.",
-                    "title": "Source Location",
-                    "type": "string"
-                },
-                "title": {
-                    "description": "The title for this configuration component.",
-                    "title": "Title",
-                    "type": "string"
-                },
-                "type": {
-                    "description": "Configuration type.",
-                    "title": "Type",
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "_AdaptiveConf_application.propertyTypes": {
-            "properties": {
                 "applicationId": {
                     "description": "This is id of the application. The default applicationId is 'application'. This property can only be specified in the type=application entry of the conf file.",
+                    "markdownDescription": "**Application Id**\n\nThis is id of the application. The default applicationId is 'application'. This property can only be specified in the type=application entry of the conf file.",
                     "readOnly": true,
                     "title": "Application Id",
                     "type": "string"
@@ -99,16 +27,20 @@
                         }
                     ],
                     "description": "This defines how authorization checking occurs in this application.",
-                    "title": "Authorization"
+                    "markdownDescription": "**Authorization**\n\nThis defines how authorization checking occurs in this application.",
+                    "title": "Authorization",
+                    "type": "object"
                 },
                 "confAdapterId": {
                     "description": "This is the optional adapterId of the running adapter that contains configuration related objects. This property can only be specified in the type=application entry of the conf file.\n\nThe runtime /afw/_AdaptiveApplication_/current object will consist of properties from the type=application entry of the conf file plus unique properties from the optional /<confAdapterId>/_AdaptiveConf_application/<applicationId> object.\n\nAll services defined by _AdaptiveServiceConf_ objects in <confAdapterId> with startup 'permanent' or 'immediate' will be started when the type=application conf entry is processed.",
+                    "markdownDescription": "**Conf Adapter**\n\nThis is the optional adapterId of the running adapter that contains configuration related objects. This property can only be specified in the type=application entry of the conf file.\n\nThe runtime /afw/_AdaptiveApplication_/current object will consist of properties from the type=application entry of the conf file plus unique properties from the optional /<confAdapterId>/_AdaptiveConf_application/<applicationId> object.\n\nAll services defined by _AdaptiveServiceConf_ objects in <confAdapterId> with startup 'permanent' or 'immediate' will be started when the type=application conf entry is processed.",
                     "readOnly": true,
                     "title": "Conf Adapter",
                     "type": "string"
                 },
                 "defaultAdapterId": {
                     "description": "This is the adapterId chosen by default for user interface select components.",
+                    "markdownDescription": "**Default Adapter**\n\nThis is the adapterId chosen by default for user interface select components.",
                     "title": "Default Adapter",
                     "type": "string"
                 },
@@ -116,20 +48,24 @@
                     "description": "This is an array of the flagId of default flags that will be set when an execution context (xctx) is created. Flags in this array that are not yet registered will be set as a default when/if they are registered. Each registered flagId is the objectId of an object in /afw/_AdaptiveFlag_/.",
                     "items": {
                         "description": "This is an array of the flagId of default flags that will be set when an execution context (xctx) is created. Flags in this array that are not yet registered will be set as a default when/if they are registered. Each registered flagId is the objectId of an object in /afw/_AdaptiveFlag_/.",
+                        "markdownDescription": "This is an array of the flagId of default flags that will be set when an execution context (xctx) is created. Flags in this array that are not yet registered will be set as a default when/if they are registered. Each registered flagId is the objectId of an object in /afw/_AdaptiveFlag_/.",
                         "title": "List of default flags to be set when an execution context (xctx) is created.",
                         "type": "string"
                     },
+                    "markdownDescription": "**Default Flags**\n\nThis is an array of the flagId of default flags that will be set when an execution context (xctx) is created. Flags in this array that are not yet registered will be set as a default when/if they are registered. Each registered flagId is the objectId of an object in /afw/_AdaptiveFlag_/.",
                     "title": "Default Flags",
                     "type": "array"
                 },
                 "defaultModelAdapterId": {
                     "description": "When presented with multiple model adapters, this is the default adapterId to use. This will be the default selected adapter chosen by user interface components.",
+                    "markdownDescription": "**Default Model Adapter**\n\nWhen presented with multiple model adapters, this is the default adapterId to use. This will be the default selected adapter chosen by user interface components.",
                     "title": "Default Model Adapter",
                     "type": "string"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "The description of the application.",
+                    "markdownDescription": "**Description**\n\nThe description of the application.",
                     "title": "Description",
                     "type": "string"
                 },
@@ -137,9 +73,11 @@
                     "description": "This is an array of modulePaths of extensions to load at startup. If there is already an extension manifest that has the extensionId, use the extensions property instead. This property is most useful for loading the extension manifest of an AFW package.",
                     "items": {
                         "description": "This is an array of modulePaths of extensions to load at startup. If there is already an extension manifest that has the extensionId, use the extensions property instead. This property is most useful for loading the extension manifest of an AFW package.",
+                        "markdownDescription": "This is an array of modulePaths of extensions to load at startup. If there is already an extension manifest that has the extensionId, use the extensions property instead. This property is most useful for loading the extension manifest of an AFW package.",
                         "title": "List of modulePaths of extensions to load at startup",
                         "type": "string"
                     },
+                    "markdownDescription": "**Extension Module Paths**\n\nThis is an array of modulePaths of extensions to load at startup. If there is already an extension manifest that has the extensionId, use the extensions property instead. This property is most useful for loading the extension manifest of an AFW package.",
                     "title": "Extension Module Paths",
                     "type": "array"
                 },
@@ -147,19 +85,23 @@
                     "description": "This is an array of extensionId of extensions to load at startup. Each extensionId must be the objectId of an object in /afw/_AdaptiveManifest_/.",
                     "items": {
                         "description": "This is an array of extensionId of extensions to load at startup. Each extensionId must be the objectId of an object in /afw/_AdaptiveManifest_/.",
+                        "markdownDescription": "This is an array of extensionId of extensions to load at startup. Each extensionId must be the objectId of an object in /afw/_AdaptiveManifest_/.",
                         "title": "List of extensionIds to load at startup",
                         "type": "string"
                     },
+                    "markdownDescription": "**Extensions**\n\nThis is an array of extensionId of extensions to load at startup. Each extensionId must be the objectId of an object in /afw/_AdaptiveManifest_/.",
                     "title": "Extensions",
                     "type": "array"
                 },
                 "layoutsAdapterId": {
                     "description": "This is the adapterId that locates Adaptive Layout Component objects.",
+                    "markdownDescription": "**Layouts Adapter**\n\nThis is the adapterId that locates Adaptive Layout Component objects.",
                     "title": "Layouts Adapter",
                     "type": "string"
                 },
                 "onApplicationStartupComplete": {
                     "description": "This is an optional script to run after this application has completed startup but before starting to process requests. The script can perform additional startup functions or request that the application terminate. All permanent and immediate services will have been started before the script is called. If the script fails or explicitly returns a value other than 0, the application will terminate.",
+                    "markdownDescription": "**Application Startup Complete**\n\nThis is an optional script to run after this application has completed startup but before starting to process requests. The script can perform additional startup functions or request that the application terminate. All permanent and immediate services will have been started before the script is called. If the script fails or explicitly returns a value other than 0, the application will terminate.",
                     "title": "Application Startup Complete",
                     "type": "string"
                 },
@@ -170,7 +112,9 @@
                         }
                     ],
                     "description": "The name of each property in this object corresponds to a qualifier that is available in processing associated with this application. The qualifier can not be an empty string. The properties of these 'qualifier objects' are template values that are accessible as qualified variables. These variables are evaluated once per execution context (xctx) as they are accessed.\n\nSome qualifiers are restricted.",
-                    "title": "Qualified Variables"
+                    "markdownDescription": "**Qualified Variables**\n\nThe name of each property in this object corresponds to a qualifier that is available in processing associated with this application. The qualifier can not be an empty string. The properties of these 'qualifier objects' are template values that are accessible as qualified variables. These variables are evaluated once per execution context (xctx) as they are accessed.\n\nSome qualifiers are restricted.",
+                    "title": "Qualified Variables",
+                    "type": "object"
                 },
                 "rootFilePaths": {
                     "allOf": [
@@ -179,10 +123,262 @@
                         }
                     ],
                     "description": "The properties of this object are the root file paths used by open_file().",
-                    "title": "Root File Paths"
+                    "markdownDescription": "**Root File Paths**\n\nThe properties of this object are the root file paths used by open_file().",
+                    "title": "Root File Paths",
+                    "type": "object"
+                },
+                "sourceLocation": {
+                    "description": "This is a contextual string added when this configuration object is processed.",
+                    "markdownDescription": "**Source Location**\n\nThis is a contextual string added when this configuration object is processed.",
+                    "title": "Source Location",
+                    "type": "string"
                 },
                 "title": {
                     "description": "The title of the application. This is used as the title of the Adaptive Framework Web App and is available for use in other places as appropriate.",
+                    "markdownDescription": "**Title**\n\nThe title of the application. This is used as the title of the Adaptive Framework Web App and is available for use in other places as appropriate.",
+                    "title": "Title",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Configuration type.",
+                    "markdownDescription": "**Type**\n\nConfiguration type.",
+                    "title": "Type",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveApplication_",
+            "type": "object",
+            "x-afw-inheritedObjectTypes": [
+                "_AdaptiveConf_application",
+                "_AdaptiveConf_"
+            ]
+        },
+        "_AdaptiveApplication_.propertyTypes": {
+            "properties": {},
+            "type": "object"
+        },
+        "_AdaptiveAuthorizationControl_": {
+            "additionalProperties": false,
+            "description": "This defines how authorization checking occurs in this application.",
+            "markdownDescription": "This defines how authorization checking occurs in this application.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "checkIntermediateMode": {
+                    "default": false,
+                    "description": "Do authorization check when running in mode intermediate. If false, the checks will be bypassed.",
+                    "markdownDescription": "**Check Intermediate**\n\nDo authorization check when running in mode intermediate. If false, the checks will be bypassed.",
+                    "title": "Check Intermediate",
+                    "type": "boolean"
+                },
+                "coreAuthorizationCheck": {
+                    "description": "This is evaluated for authorization checks when running in core mode. If not specified, access is permitted. Be very careful when specifying this parameter because an error can cause the application to fail.",
+                    "markdownDescription": "**Core Check**\n\nThis is evaluated for authorization checks when running in core mode. If not specified, access is permitted. Be very careful when specifying this parameter because an error can cause the application to fail.",
+                    "title": "Core Check",
+                    "type": "string"
+                },
+                "denyIfNotApplicable": {
+                    "default": false,
+                    "description": "Specify true to deny access to resources when notApplicable is the final result of other checks.",
+                    "markdownDescription": "**Deny If Not Applicable**\n\nSpecify true to deny access to resources when notApplicable is the final result of other checks.",
+                    "title": "Deny If Not Applicable",
+                    "type": "boolean"
+                },
+                "initialAuthorizationCheck": {
+                    "description": "This is evaluated before authorization handlers are called to determine whether to allow the requested access to the specified resourceId and/or object. A result of permit or deny is the final decision. If this parameter is not specified or the result is notApplicable, active authorization handlers will be processed. Parameter permitIfNotApplicable is used to determine the result when all checks return notApplicable.",
+                    "markdownDescription": "**Initial Check**\n\nThis is evaluated before authorization handlers are called to determine whether to allow the requested access to the specified resourceId and/or object. A result of permit or deny is the final decision. If this parameter is not specified or the result is notApplicable, active authorization handlers will be processed. Parameter permitIfNotApplicable is used to determine the result when all checks return notApplicable.",
+                    "title": "Initial Check",
+                    "type": "string"
+                }
+            },
+            "title": "Authorization",
+            "type": "object"
+        },
+        "_AdaptiveAuthorizationControl_.propertyTypes": {
+            "properties": {
+                "checkIntermediateMode": {
+                    "default": false,
+                    "description": "Do authorization check when running in mode intermediate. If false, the checks will be bypassed.",
+                    "markdownDescription": "**Check Intermediate**\n\nDo authorization check when running in mode intermediate. If false, the checks will be bypassed.",
+                    "title": "Check Intermediate",
+                    "type": "boolean"
+                },
+                "coreAuthorizationCheck": {
+                    "description": "This is evaluated for authorization checks when running in core mode. If not specified, access is permitted. Be very careful when specifying this parameter because an error can cause the application to fail.",
+                    "markdownDescription": "**Core Check**\n\nThis is evaluated for authorization checks when running in core mode. If not specified, access is permitted. Be very careful when specifying this parameter because an error can cause the application to fail.",
+                    "title": "Core Check",
+                    "type": "string"
+                },
+                "denyIfNotApplicable": {
+                    "default": false,
+                    "description": "Specify true to deny access to resources when notApplicable is the final result of other checks.",
+                    "markdownDescription": "**Deny If Not Applicable**\n\nSpecify true to deny access to resources when notApplicable is the final result of other checks.",
+                    "title": "Deny If Not Applicable",
+                    "type": "boolean"
+                },
+                "initialAuthorizationCheck": {
+                    "description": "This is evaluated before authorization handlers are called to determine whether to allow the requested access to the specified resourceId and/or object. A result of permit or deny is the final decision. If this parameter is not specified or the result is notApplicable, active authorization handlers will be processed. Parameter permitIfNotApplicable is used to determine the result when all checks return notApplicable.",
+                    "markdownDescription": "**Initial Check**\n\nThis is evaluated before authorization handlers are called to determine whether to allow the requested access to the specified resourceId and/or object. A result of permit or deny is the final decision. If this parameter is not specified or the result is notApplicable, active authorization handlers will be processed. Parameter permitIfNotApplicable is used to determine the result when all checks return notApplicable.",
+                    "title": "Initial Check",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "_AdaptiveConf_.propertyTypes": {
+            "properties": {
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "The description of this configuration component.",
+                    "markdownDescription": "**Description**\n\nThe description of this configuration component.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "sourceLocation": {
+                    "description": "This is a contextual string added when this configuration object is processed.",
+                    "markdownDescription": "**Source Location**\n\nThis is a contextual string added when this configuration object is processed.",
+                    "title": "Source Location",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "The title for this configuration component.",
+                    "markdownDescription": "**Title**\n\nThe title for this configuration component.",
+                    "title": "Title",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Configuration type.",
+                    "markdownDescription": "**Type**\n\nConfiguration type.",
+                    "title": "Type",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "_AdaptiveConf_application.propertyTypes": {
+            "properties": {
+                "applicationId": {
+                    "description": "This is id of the application. The default applicationId is 'application'. This property can only be specified in the type=application entry of the conf file.",
+                    "markdownDescription": "**Application Id**\n\nThis is id of the application. The default applicationId is 'application'. This property can only be specified in the type=application entry of the conf file.",
+                    "readOnly": true,
+                    "title": "Application Id",
+                    "type": "string"
+                },
+                "authorizationControl": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveAuthorizationControl_"
+                        }
+                    ],
+                    "description": "This defines how authorization checking occurs in this application.",
+                    "markdownDescription": "**Authorization**\n\nThis defines how authorization checking occurs in this application.",
+                    "title": "Authorization",
+                    "type": "object"
+                },
+                "confAdapterId": {
+                    "description": "This is the optional adapterId of the running adapter that contains configuration related objects. This property can only be specified in the type=application entry of the conf file.\n\nThe runtime /afw/_AdaptiveApplication_/current object will consist of properties from the type=application entry of the conf file plus unique properties from the optional /<confAdapterId>/_AdaptiveConf_application/<applicationId> object.\n\nAll services defined by _AdaptiveServiceConf_ objects in <confAdapterId> with startup 'permanent' or 'immediate' will be started when the type=application conf entry is processed.",
+                    "markdownDescription": "**Conf Adapter**\n\nThis is the optional adapterId of the running adapter that contains configuration related objects. This property can only be specified in the type=application entry of the conf file.\n\nThe runtime /afw/_AdaptiveApplication_/current object will consist of properties from the type=application entry of the conf file plus unique properties from the optional /<confAdapterId>/_AdaptiveConf_application/<applicationId> object.\n\nAll services defined by _AdaptiveServiceConf_ objects in <confAdapterId> with startup 'permanent' or 'immediate' will be started when the type=application conf entry is processed.",
+                    "readOnly": true,
+                    "title": "Conf Adapter",
+                    "type": "string"
+                },
+                "defaultAdapterId": {
+                    "description": "This is the adapterId chosen by default for user interface select components.",
+                    "markdownDescription": "**Default Adapter**\n\nThis is the adapterId chosen by default for user interface select components.",
+                    "title": "Default Adapter",
+                    "type": "string"
+                },
+                "defaultFlags": {
+                    "description": "This is an array of the flagId of default flags that will be set when an execution context (xctx) is created. Flags in this array that are not yet registered will be set as a default when/if they are registered. Each registered flagId is the objectId of an object in /afw/_AdaptiveFlag_/.",
+                    "items": {
+                        "description": "This is an array of the flagId of default flags that will be set when an execution context (xctx) is created. Flags in this array that are not yet registered will be set as a default when/if they are registered. Each registered flagId is the objectId of an object in /afw/_AdaptiveFlag_/.",
+                        "markdownDescription": "This is an array of the flagId of default flags that will be set when an execution context (xctx) is created. Flags in this array that are not yet registered will be set as a default when/if they are registered. Each registered flagId is the objectId of an object in /afw/_AdaptiveFlag_/.",
+                        "title": "List of default flags to be set when an execution context (xctx) is created.",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Default Flags**\n\nThis is an array of the flagId of default flags that will be set when an execution context (xctx) is created. Flags in this array that are not yet registered will be set as a default when/if they are registered. Each registered flagId is the objectId of an object in /afw/_AdaptiveFlag_/.",
+                    "title": "Default Flags",
+                    "type": "array"
+                },
+                "defaultModelAdapterId": {
+                    "description": "When presented with multiple model adapters, this is the default adapterId to use. This will be the default selected adapter chosen by user interface components.",
+                    "markdownDescription": "**Default Model Adapter**\n\nWhen presented with multiple model adapters, this is the default adapterId to use. This will be the default selected adapter chosen by user interface components.",
+                    "title": "Default Model Adapter",
+                    "type": "string"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "The description of the application.",
+                    "markdownDescription": "**Description**\n\nThe description of the application.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "extensionModulePaths": {
+                    "description": "This is an array of modulePaths of extensions to load at startup. If there is already an extension manifest that has the extensionId, use the extensions property instead. This property is most useful for loading the extension manifest of an AFW package.",
+                    "items": {
+                        "description": "This is an array of modulePaths of extensions to load at startup. If there is already an extension manifest that has the extensionId, use the extensions property instead. This property is most useful for loading the extension manifest of an AFW package.",
+                        "markdownDescription": "This is an array of modulePaths of extensions to load at startup. If there is already an extension manifest that has the extensionId, use the extensions property instead. This property is most useful for loading the extension manifest of an AFW package.",
+                        "title": "List of modulePaths of extensions to load at startup",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Extension Module Paths**\n\nThis is an array of modulePaths of extensions to load at startup. If there is already an extension manifest that has the extensionId, use the extensions property instead. This property is most useful for loading the extension manifest of an AFW package.",
+                    "title": "Extension Module Paths",
+                    "type": "array"
+                },
+                "extensions": {
+                    "description": "This is an array of extensionId of extensions to load at startup. Each extensionId must be the objectId of an object in /afw/_AdaptiveManifest_/.",
+                    "items": {
+                        "description": "This is an array of extensionId of extensions to load at startup. Each extensionId must be the objectId of an object in /afw/_AdaptiveManifest_/.",
+                        "markdownDescription": "This is an array of extensionId of extensions to load at startup. Each extensionId must be the objectId of an object in /afw/_AdaptiveManifest_/.",
+                        "title": "List of extensionIds to load at startup",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Extensions**\n\nThis is an array of extensionId of extensions to load at startup. Each extensionId must be the objectId of an object in /afw/_AdaptiveManifest_/.",
+                    "title": "Extensions",
+                    "type": "array"
+                },
+                "layoutsAdapterId": {
+                    "description": "This is the adapterId that locates Adaptive Layout Component objects.",
+                    "markdownDescription": "**Layouts Adapter**\n\nThis is the adapterId that locates Adaptive Layout Component objects.",
+                    "title": "Layouts Adapter",
+                    "type": "string"
+                },
+                "onApplicationStartupComplete": {
+                    "description": "This is an optional script to run after this application has completed startup but before starting to process requests. The script can perform additional startup functions or request that the application terminate. All permanent and immediate services will have been started before the script is called. If the script fails or explicitly returns a value other than 0, the application will terminate.",
+                    "markdownDescription": "**Application Startup Complete**\n\nThis is an optional script to run after this application has completed startup but before starting to process requests. The script can perform additional startup functions or request that the application terminate. All permanent and immediate services will have been started before the script is called. If the script fails or explicitly returns a value other than 0, the application will terminate.",
+                    "title": "Application Startup Complete",
+                    "type": "string"
+                },
+                "qualifiedVariables": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveTemplatePropertiesObjects_"
+                        }
+                    ],
+                    "description": "The name of each property in this object corresponds to a qualifier that is available in processing associated with this application. The qualifier can not be an empty string. The properties of these 'qualifier objects' are template values that are accessible as qualified variables. These variables are evaluated once per execution context (xctx) as they are accessed.\n\nSome qualifiers are restricted.",
+                    "markdownDescription": "**Qualified Variables**\n\nThe name of each property in this object corresponds to a qualifier that is available in processing associated with this application. The qualifier can not be an empty string. The properties of these 'qualifier objects' are template values that are accessible as qualified variables. These variables are evaluated once per execution context (xctx) as they are accessed.\n\nSome qualifiers are restricted.",
+                    "title": "Qualified Variables",
+                    "type": "object"
+                },
+                "rootFilePaths": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveRootFilePaths_"
+                        }
+                    ],
+                    "description": "The properties of this object are the root file paths used by open_file().",
+                    "markdownDescription": "**Root File Paths**\n\nThe properties of this object are the root file paths used by open_file().",
+                    "title": "Root File Paths",
+                    "type": "object"
+                },
+                "title": {
+                    "description": "The title of the application. This is used as the title of the Adaptive Framework Web App and is available for use in other places as appropriate.",
+                    "markdownDescription": "**Title**\n\nThe title of the application. This is used as the title of the Adaptive Framework Web App and is available for use in other places as appropriate.",
                     "title": "Title",
                     "type": "string"
                 }
@@ -192,14 +388,20 @@
         "_AdaptiveRootFilePaths_": {
             "additionalProperties": {
                 "description": "A function open_file path that begins with a slash followed by this property name will access a file in the directory path specified as a value to this property. For example, if this property is 'my': '/temp/my', file_open('mine', '/my/xyz', 'w') will open '/temp/my/xyz' for write in the host file system.",
+                "markdownDescription": "A function open_file path that begins with a slash followed by this property name will access a file in the directory path specified as a value to this property. For example, if this property is 'my': '/temp/my', file_open('mine', '/my/xyz', 'w') will open '/temp/my/xyz' for write in the host file system.",
                 "type": "string"
             },
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveRootFilePaths_.propertyTypes"
-                }
-            ],
             "description": "The properties of this object are the root file paths used by open_file().",
+            "markdownDescription": "The properties of this object are the root file paths used by open_file().",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                }
+            },
             "title": "Root File Paths",
             "type": "object"
         },
@@ -214,14 +416,21 @@
                         "$ref": "#/$defs/_AdaptiveTemplateProperties_"
                     }
                 ],
-                "description": "Each property is a _AdaptiveTemplateProperties_ object."
+                "description": "Each property is a _AdaptiveTemplateProperties_ object.",
+                "markdownDescription": "Each property is a _AdaptiveTemplateProperties_ object.",
+                "type": "object"
             },
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveTemplatePropertiesObjects_.propertyTypes"
-                }
-            ],
             "description": "The name of each property in this object corresponds to a qualifier that is available in processing associated with this application. The qualifier can not be an empty string. The properties of these 'qualifier objects' are template values that are accessible as qualified variables. These variables are evaluated once per execution context (xctx) as they are accessed.\n\nSome qualifiers are restricted.",
+            "markdownDescription": "The name of each property in this object corresponds to a qualifier that is available in processing associated with this application. The qualifier can not be an empty string. The properties of these 'qualifier objects' are template values that are accessible as qualified variables. These variables are evaluated once per execution context (xctx) as they are accessed.\n\nSome qualifiers are restricted.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                }
+            },
             "title": "Qualified Variables",
             "type": "object"
         },
@@ -232,14 +441,21 @@
         "_AdaptiveTemplateProperties_": {
             "additionalProperties": {
                 "description": "Each property is a template value.",
+                "markdownDescription": "Each property is a template value.",
                 "type": "string"
             },
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveTemplateProperties_.propertyTypes"
-                }
-            ],
             "description": "Each property is a template value.",
+            "markdownDescription": "Each property is a template value.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                }
+            },
+            "title": "_AdaptiveTemplateProperties_",
             "type": "object"
         },
         "_AdaptiveTemplateProperties_.propertyTypes": {
@@ -248,9 +464,154 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveApplication_"
+    "additionalProperties": true,
+    "description": "Adaptive Application.",
+    "markdownDescription": "Adaptive Application.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "applicationId": {
+            "description": "This is id of the application. The default applicationId is 'application'. This property can only be specified in the type=application entry of the conf file.",
+            "markdownDescription": "**Application Id**\n\nThis is id of the application. The default applicationId is 'application'. This property can only be specified in the type=application entry of the conf file.",
+            "readOnly": true,
+            "title": "Application Id",
+            "type": "string"
+        },
+        "authorizationControl": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveAuthorizationControl_"
+                }
+            ],
+            "description": "This defines how authorization checking occurs in this application.",
+            "markdownDescription": "**Authorization**\n\nThis defines how authorization checking occurs in this application.",
+            "title": "Authorization",
+            "type": "object"
+        },
+        "confAdapterId": {
+            "description": "This is the optional adapterId of the running adapter that contains configuration related objects. This property can only be specified in the type=application entry of the conf file.\n\nThe runtime /afw/_AdaptiveApplication_/current object will consist of properties from the type=application entry of the conf file plus unique properties from the optional /<confAdapterId>/_AdaptiveConf_application/<applicationId> object.\n\nAll services defined by _AdaptiveServiceConf_ objects in <confAdapterId> with startup 'permanent' or 'immediate' will be started when the type=application conf entry is processed.",
+            "markdownDescription": "**Conf Adapter**\n\nThis is the optional adapterId of the running adapter that contains configuration related objects. This property can only be specified in the type=application entry of the conf file.\n\nThe runtime /afw/_AdaptiveApplication_/current object will consist of properties from the type=application entry of the conf file plus unique properties from the optional /<confAdapterId>/_AdaptiveConf_application/<applicationId> object.\n\nAll services defined by _AdaptiveServiceConf_ objects in <confAdapterId> with startup 'permanent' or 'immediate' will be started when the type=application conf entry is processed.",
+            "readOnly": true,
+            "title": "Conf Adapter",
+            "type": "string"
+        },
+        "defaultAdapterId": {
+            "description": "This is the adapterId chosen by default for user interface select components.",
+            "markdownDescription": "**Default Adapter**\n\nThis is the adapterId chosen by default for user interface select components.",
+            "title": "Default Adapter",
+            "type": "string"
+        },
+        "defaultFlags": {
+            "description": "This is an array of the flagId of default flags that will be set when an execution context (xctx) is created. Flags in this array that are not yet registered will be set as a default when/if they are registered. Each registered flagId is the objectId of an object in /afw/_AdaptiveFlag_/.",
+            "items": {
+                "description": "This is an array of the flagId of default flags that will be set when an execution context (xctx) is created. Flags in this array that are not yet registered will be set as a default when/if they are registered. Each registered flagId is the objectId of an object in /afw/_AdaptiveFlag_/.",
+                "markdownDescription": "This is an array of the flagId of default flags that will be set when an execution context (xctx) is created. Flags in this array that are not yet registered will be set as a default when/if they are registered. Each registered flagId is the objectId of an object in /afw/_AdaptiveFlag_/.",
+                "title": "List of default flags to be set when an execution context (xctx) is created.",
+                "type": "string"
+            },
+            "markdownDescription": "**Default Flags**\n\nThis is an array of the flagId of default flags that will be set when an execution context (xctx) is created. Flags in this array that are not yet registered will be set as a default when/if they are registered. Each registered flagId is the objectId of an object in /afw/_AdaptiveFlag_/.",
+            "title": "Default Flags",
+            "type": "array"
+        },
+        "defaultModelAdapterId": {
+            "description": "When presented with multiple model adapters, this is the default adapterId to use. This will be the default selected adapter chosen by user interface components.",
+            "markdownDescription": "**Default Model Adapter**\n\nWhen presented with multiple model adapters, this is the default adapterId to use. This will be the default selected adapter chosen by user interface components.",
+            "title": "Default Model Adapter",
+            "type": "string"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "The description of the application.",
+            "markdownDescription": "**Description**\n\nThe description of the application.",
+            "title": "Description",
+            "type": "string"
+        },
+        "extensionModulePaths": {
+            "description": "This is an array of modulePaths of extensions to load at startup. If there is already an extension manifest that has the extensionId, use the extensions property instead. This property is most useful for loading the extension manifest of an AFW package.",
+            "items": {
+                "description": "This is an array of modulePaths of extensions to load at startup. If there is already an extension manifest that has the extensionId, use the extensions property instead. This property is most useful for loading the extension manifest of an AFW package.",
+                "markdownDescription": "This is an array of modulePaths of extensions to load at startup. If there is already an extension manifest that has the extensionId, use the extensions property instead. This property is most useful for loading the extension manifest of an AFW package.",
+                "title": "List of modulePaths of extensions to load at startup",
+                "type": "string"
+            },
+            "markdownDescription": "**Extension Module Paths**\n\nThis is an array of modulePaths of extensions to load at startup. If there is already an extension manifest that has the extensionId, use the extensions property instead. This property is most useful for loading the extension manifest of an AFW package.",
+            "title": "Extension Module Paths",
+            "type": "array"
+        },
+        "extensions": {
+            "description": "This is an array of extensionId of extensions to load at startup. Each extensionId must be the objectId of an object in /afw/_AdaptiveManifest_/.",
+            "items": {
+                "description": "This is an array of extensionId of extensions to load at startup. Each extensionId must be the objectId of an object in /afw/_AdaptiveManifest_/.",
+                "markdownDescription": "This is an array of extensionId of extensions to load at startup. Each extensionId must be the objectId of an object in /afw/_AdaptiveManifest_/.",
+                "title": "List of extensionIds to load at startup",
+                "type": "string"
+            },
+            "markdownDescription": "**Extensions**\n\nThis is an array of extensionId of extensions to load at startup. Each extensionId must be the objectId of an object in /afw/_AdaptiveManifest_/.",
+            "title": "Extensions",
+            "type": "array"
+        },
+        "layoutsAdapterId": {
+            "description": "This is the adapterId that locates Adaptive Layout Component objects.",
+            "markdownDescription": "**Layouts Adapter**\n\nThis is the adapterId that locates Adaptive Layout Component objects.",
+            "title": "Layouts Adapter",
+            "type": "string"
+        },
+        "onApplicationStartupComplete": {
+            "description": "This is an optional script to run after this application has completed startup but before starting to process requests. The script can perform additional startup functions or request that the application terminate. All permanent and immediate services will have been started before the script is called. If the script fails or explicitly returns a value other than 0, the application will terminate.",
+            "markdownDescription": "**Application Startup Complete**\n\nThis is an optional script to run after this application has completed startup but before starting to process requests. The script can perform additional startup functions or request that the application terminate. All permanent and immediate services will have been started before the script is called. If the script fails or explicitly returns a value other than 0, the application will terminate.",
+            "title": "Application Startup Complete",
+            "type": "string"
+        },
+        "qualifiedVariables": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveTemplatePropertiesObjects_"
+                }
+            ],
+            "description": "The name of each property in this object corresponds to a qualifier that is available in processing associated with this application. The qualifier can not be an empty string. The properties of these 'qualifier objects' are template values that are accessible as qualified variables. These variables are evaluated once per execution context (xctx) as they are accessed.\n\nSome qualifiers are restricted.",
+            "markdownDescription": "**Qualified Variables**\n\nThe name of each property in this object corresponds to a qualifier that is available in processing associated with this application. The qualifier can not be an empty string. The properties of these 'qualifier objects' are template values that are accessible as qualified variables. These variables are evaluated once per execution context (xctx) as they are accessed.\n\nSome qualifiers are restricted.",
+            "title": "Qualified Variables",
+            "type": "object"
+        },
+        "rootFilePaths": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveRootFilePaths_"
+                }
+            ],
+            "description": "The properties of this object are the root file paths used by open_file().",
+            "markdownDescription": "**Root File Paths**\n\nThe properties of this object are the root file paths used by open_file().",
+            "title": "Root File Paths",
+            "type": "object"
+        },
+        "sourceLocation": {
+            "description": "This is a contextual string added when this configuration object is processed.",
+            "markdownDescription": "**Source Location**\n\nThis is a contextual string added when this configuration object is processed.",
+            "title": "Source Location",
+            "type": "string"
+        },
+        "title": {
+            "description": "The title of the application. This is used as the title of the Adaptive Framework Web App and is available for use in other places as appropriate.",
+            "markdownDescription": "**Title**\n\nThe title of the application. This is used as the title of the Adaptive Framework Web App and is available for use in other places as appropriate.",
+            "title": "Title",
+            "type": "string"
+        },
+        "type": {
+            "description": "Configuration type.",
+            "markdownDescription": "**Type**\n\nConfiguration type.",
+            "title": "Type",
+            "type": "string"
         }
+    },
+    "title": "_AdaptiveApplication_",
+    "type": "object",
+    "x-afw-inheritedObjectTypes": [
+        "_AdaptiveConf_application",
+        "_AdaptiveConf_"
     ]
 }

--- a/generated/schemas/afw/_AdaptiveApplication_.json
+++ b/generated/schemas/afw/_AdaptiveApplication_.json
@@ -1,30 +1,27 @@
 {
     "$defs": {
         "_AdaptiveApplication_": {
-            "additionalProperties": {
-                "description": "Adaptive Application."
-            },
-            "anyOf": [
+            "additionalProperties": true,
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveApplication_.propertyTypes"
                 },
                 {
                     "$ref": "#/$defs/_AdaptiveConf_application.propertyTypes"
+                },
+                {
+                    "$ref": "#/$defs/_AdaptiveConf_.propertyTypes"
                 }
             ],
             "description": "Adaptive Application.",
             "type": "object"
         },
         "_AdaptiveApplication_.propertyTypes": {
-            "properties": {
-                "_meta_": {
-                    "title": " Meta "
-                }
-            },
+            "properties": {},
             "type": "object"
         },
         "_AdaptiveAuthorizationControl_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveAuthorizationControl_.propertyTypes"
                 }
@@ -37,6 +34,7 @@
         "_AdaptiveAuthorizationControl_.propertyTypes": {
             "properties": {
                 "checkIntermediateMode": {
+                    "default": false,
                     "description": "Do authorization check when running in mode intermediate. If false, the checks will be bypassed.",
                     "title": "Check Intermediate",
                     "type": "boolean"
@@ -47,6 +45,7 @@
                     "type": "string"
                 },
                 "denyIfNotApplicable": {
+                    "default": false,
                     "description": "Specify true to deny access to resources when notApplicable is the final result of other checks.",
                     "title": "Deny If Not Applicable",
                     "type": "boolean"
@@ -59,9 +58,34 @@
             },
             "type": "object"
         },
+        "_AdaptiveConf_.propertyTypes": {
+            "properties": {
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "The description of this configuration component.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "sourceLocation": {
+                    "description": "This is a contextual string added when this configuration object is processed.",
+                    "title": "Source Location",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "The title for this configuration component.",
+                    "title": "Title",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Configuration type.",
+                    "title": "Type",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "_AdaptiveConf_application.propertyTypes": {
             "properties": {
-                "_meta_": {},
                 "applicationId": {
                     "description": "This is id of the application. The default applicationId is 'application'. This property can only be specified in the type=application entry of the conf file.",
                     "readOnly": true,
@@ -69,10 +93,13 @@
                     "type": "string"
                 },
                 "authorizationControl": {
-                    "$ref": "#/$defs/_AdaptiveAuthorizationControl_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveAuthorizationControl_"
+                        }
+                    ],
                     "description": "This defines how authorization checking occurs in this application.",
-                    "title": "Authorization",
-                    "type": "object"
+                    "title": "Authorization"
                 },
                 "confAdapterId": {
                     "description": "This is the optional adapterId of the running adapter that contains configuration related objects. This property can only be specified in the type=application entry of the conf file.\n\nThe runtime /afw/_AdaptiveApplication_/current object will consist of properties from the type=application entry of the conf file plus unique properties from the optional /<confAdapterId>/_AdaptiveConf_application/<applicationId> object.\n\nAll services defined by _AdaptiveServiceConf_ objects in <confAdapterId> with startup 'permanent' or 'immediate' will be started when the type=application conf entry is processed.",
@@ -137,16 +164,22 @@
                     "type": "string"
                 },
                 "qualifiedVariables": {
-                    "$ref": "#/$defs/_AdaptiveTemplatePropertiesObjects_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveTemplatePropertiesObjects_"
+                        }
+                    ],
                     "description": "The name of each property in this object corresponds to a qualifier that is available in processing associated with this application. The qualifier can not be an empty string. The properties of these 'qualifier objects' are template values that are accessible as qualified variables. These variables are evaluated once per execution context (xctx) as they are accessed.\n\nSome qualifiers are restricted.",
-                    "title": "Qualified Variables",
-                    "type": "object"
+                    "title": "Qualified Variables"
                 },
                 "rootFilePaths": {
-                    "$ref": "#/$defs/_AdaptiveRootFilePaths_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveRootFilePaths_"
+                        }
+                    ],
                     "description": "The properties of this object are the root file paths used by open_file().",
-                    "title": "Root File Paths",
-                    "type": "object"
+                    "title": "Root File Paths"
                 },
                 "title": {
                     "description": "The title of the application. This is used as the title of the Adaptive Framework Web App and is available for use in other places as appropriate.",
@@ -161,7 +194,7 @@
                 "description": "A function open_file path that begins with a slash followed by this property name will access a file in the directory path specified as a value to this property. For example, if this property is 'my': '/temp/my', file_open('mine', '/my/xyz', 'w') will open '/temp/my/xyz' for write in the host file system.",
                 "type": "string"
             },
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveRootFilePaths_.propertyTypes"
                 }
@@ -176,11 +209,14 @@
         },
         "_AdaptiveTemplatePropertiesObjects_": {
             "additionalProperties": {
-                "$ref": "#/$defs/_AdaptiveTemplateProperties_",
-                "description": "Each property is a _AdaptiveTemplateProperties_ object.",
-                "type": "object"
+                "allOf": [
+                    {
+                        "$ref": "#/$defs/_AdaptiveTemplateProperties_"
+                    }
+                ],
+                "description": "Each property is a _AdaptiveTemplateProperties_ object."
             },
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveTemplatePropertiesObjects_.propertyTypes"
                 }
@@ -198,7 +234,7 @@
                 "description": "Each property is a template value.",
                 "type": "string"
             },
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveTemplateProperties_.propertyTypes"
                 }
@@ -212,7 +248,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveApplication_"
         }

--- a/generated/schemas/afw/_AdaptiveAuthorizationDecision_.json
+++ b/generated/schemas/afw/_AdaptiveAuthorizationDecision_.json
@@ -1,36 +1,73 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveAuthorizationDecision_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveAuthorizationDecision_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveAuthorizationDecision_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "This is meta for a decisionId property value of _AdaptiveAuthorizationResult_.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveAuthorizationDecision_.propertyTypes": {
+            "markdownDescription": "This is meta for a decisionId property value of _AdaptiveAuthorizationResult_.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "brief": {
                     "description": "This is a predicate for this decisionId value with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for this decisionId value with the first letter capitalized and without a trailing period.",
                     "title": "Brief",
                     "type": "string"
                 },
                 "decisionId": {
                     "description": "This is used to uniquely identify this particular decision.",
+                    "markdownDescription": "**Decision Id**\n\nThis is used to uniquely identify this particular decision.",
                     "title": "Decision Id",
                     "type": "string"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "This is the description of this decisionId value.",
+                    "markdownDescription": "**Description**\n\nThis is the description of this decisionId value.",
                     "title": "Description",
                     "type": "string"
                 },
                 "intermediateOnly": {
                     "default": false,
                     "description": "Intermediate decision only.",
+                    "markdownDescription": "**Intermediate Only**\n\nIntermediate decision only.",
+                    "title": "Intermediate Only",
+                    "type": "boolean"
+                }
+            },
+            "title": "_AdaptiveAuthorizationDecision_",
+            "type": "object"
+        },
+        "_AdaptiveAuthorizationDecision_.propertyTypes": {
+            "properties": {
+                "brief": {
+                    "description": "This is a predicate for this decisionId value with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for this decisionId value with the first letter capitalized and without a trailing period.",
+                    "title": "Brief",
+                    "type": "string"
+                },
+                "decisionId": {
+                    "description": "This is used to uniquely identify this particular decision.",
+                    "markdownDescription": "**Decision Id**\n\nThis is used to uniquely identify this particular decision.",
+                    "title": "Decision Id",
+                    "type": "string"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "This is the description of this decisionId value.",
+                    "markdownDescription": "**Description**\n\nThis is the description of this decisionId value.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "intermediateOnly": {
+                    "default": false,
+                    "description": "Intermediate decision only.",
+                    "markdownDescription": "**Intermediate Only**\n\nIntermediate decision only.",
                     "title": "Intermediate Only",
                     "type": "boolean"
                 }
@@ -39,9 +76,44 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveAuthorizationDecision_"
+    "additionalProperties": false,
+    "description": "This is meta for a decisionId property value of _AdaptiveAuthorizationResult_.",
+    "markdownDescription": "This is meta for a decisionId property value of _AdaptiveAuthorizationResult_.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "brief": {
+            "description": "This is a predicate for this decisionId value with the first letter capitalized and without a trailing period.",
+            "markdownDescription": "**Brief**\n\nThis is a predicate for this decisionId value with the first letter capitalized and without a trailing period.",
+            "title": "Brief",
+            "type": "string"
+        },
+        "decisionId": {
+            "description": "This is used to uniquely identify this particular decision.",
+            "markdownDescription": "**Decision Id**\n\nThis is used to uniquely identify this particular decision.",
+            "title": "Decision Id",
+            "type": "string"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "This is the description of this decisionId value.",
+            "markdownDescription": "**Description**\n\nThis is the description of this decisionId value.",
+            "title": "Description",
+            "type": "string"
+        },
+        "intermediateOnly": {
+            "default": false,
+            "description": "Intermediate decision only.",
+            "markdownDescription": "**Intermediate Only**\n\nIntermediate decision only.",
+            "title": "Intermediate Only",
+            "type": "boolean"
         }
-    ]
+    },
+    "title": "_AdaptiveAuthorizationDecision_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveAuthorizationDecision_.json
+++ b/generated/schemas/afw/_AdaptiveAuthorizationDecision_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveAuthorizationDecision_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveAuthorizationDecision_.propertyTypes"
                 }
@@ -29,6 +29,7 @@
                     "type": "string"
                 },
                 "intermediateOnly": {
+                    "default": false,
                     "description": "Intermediate decision only.",
                     "title": "Intermediate Only",
                     "type": "boolean"
@@ -38,7 +39,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveAuthorizationDecision_"
         }

--- a/generated/schemas/afw/_AdaptiveAuthorizationHandlerType_.json
+++ b/generated/schemas/afw/_AdaptiveAuthorizationHandlerType_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveAuthorizationHandlerType_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveAuthorizationHandlerType_.propertyTypes"
                 }
@@ -28,7 +28,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveAuthorizationHandlerType_"
         }

--- a/generated/schemas/afw/_AdaptiveAuthorizationHandlerType_.json
+++ b/generated/schemas/afw/_AdaptiveAuthorizationHandlerType_.json
@@ -1,25 +1,47 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveAuthorizationHandlerType_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveAuthorizationHandlerType_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveAuthorizationHandlerType_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "A registry type authorization_handler_factory entry.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveAuthorizationHandlerType_.propertyTypes": {
+            "markdownDescription": "A registry type authorization_handler_factory entry.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "authorizationHandlerType": {
                     "description": "Type of authorization handler.",
+                    "markdownDescription": "**Authorization Handler Type**\n\nType of authorization handler.",
                     "title": "Authorization Handler Type",
                     "type": "string"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "Description of authorization handler type.",
+                    "markdownDescription": "**Description**\n\nDescription of authorization handler type.",
+                    "title": "Description",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveAuthorizationHandlerType_",
+            "type": "object"
+        },
+        "_AdaptiveAuthorizationHandlerType_.propertyTypes": {
+            "properties": {
+                "authorizationHandlerType": {
+                    "description": "Type of authorization handler.",
+                    "markdownDescription": "**Authorization Handler Type**\n\nType of authorization handler.",
+                    "title": "Authorization Handler Type",
+                    "type": "string"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "Description of authorization handler type.",
+                    "markdownDescription": "**Description**\n\nDescription of authorization handler type.",
                     "title": "Description",
                     "type": "string"
                 }
@@ -28,9 +50,31 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveAuthorizationHandlerType_"
+    "additionalProperties": false,
+    "description": "A registry type authorization_handler_factory entry.",
+    "markdownDescription": "A registry type authorization_handler_factory entry.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "authorizationHandlerType": {
+            "description": "Type of authorization handler.",
+            "markdownDescription": "**Authorization Handler Type**\n\nType of authorization handler.",
+            "title": "Authorization Handler Type",
+            "type": "string"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "Description of authorization handler type.",
+            "markdownDescription": "**Description**\n\nDescription of authorization handler type.",
+            "title": "Description",
+            "type": "string"
         }
-    ]
+    },
+    "title": "_AdaptiveAuthorizationHandlerType_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveAuthorizationHandler_.json
+++ b/generated/schemas/afw/_AdaptiveAuthorizationHandler_.json
@@ -1,39 +1,45 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveAuthorizationHandler_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveAuthorizationHandler_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveAuthorizationHandler_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Runtime authorization handler information.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveAuthorizationHandler_.propertyTypes": {
+            "markdownDescription": "Runtime authorization handler information.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "authorizationHandlerId": {
                     "description": "Authorization handler id.",
+                    "markdownDescription": "**Authorization Handler Id**\n\nAuthorization handler id.",
                     "title": "Authorization Handler Id",
                     "type": "string"
                 },
                 "processingOrder": {
                     "description": "This is the order this authorization handler will be processed. If 0, this handler is not active.",
+                    "markdownDescription": "**Processing Order**\n\nThis is the order this authorization handler will be processed. If 0, this handler is not active.",
                     "title": "Processing Order",
                     "type": "integer"
                 },
                 "properties": {
                     "description": "This object contains some of properties from the associated conf object plus other runtime properties.",
+                    "markdownDescription": "**Properties**\n\nThis object contains some of properties from the associated conf object plus other runtime properties.",
                     "title": "Properties",
                     "type": "object"
                 },
                 "referenceCount": {
                     "description": "Authorization handler's reference count.",
+                    "markdownDescription": "**Reference Count**\n\nAuthorization handler's reference count.",
                     "title": "Reference Count",
                     "type": "integer"
                 },
                 "serviceId": {
                     "description": "The id of the associated service. The URI of the service is '/afw/_AdaptiveService_/' followed by this id.",
+                    "markdownDescription": "**Service Id**\n\nThe id of the associated service. The URI of the service is '/afw/_AdaptiveService_/' followed by this id.",
                     "title": "Service Id",
                     "type": "string"
                 },
@@ -41,9 +47,59 @@
                     "description": "Reference count of stopping instances.",
                     "items": {
                         "description": "Reference count of stopping instances.",
+                        "markdownDescription": "Reference count of stopping instances.",
                         "title": "Reference count of stopping instances",
                         "type": "integer"
                     },
+                    "markdownDescription": "**Stopping Instances**\n\nReference count of stopping instances.",
+                    "title": "Stopping Instances",
+                    "type": "array"
+                }
+            },
+            "title": "_AdaptiveAuthorizationHandler_",
+            "type": "object"
+        },
+        "_AdaptiveAuthorizationHandler_.propertyTypes": {
+            "properties": {
+                "authorizationHandlerId": {
+                    "description": "Authorization handler id.",
+                    "markdownDescription": "**Authorization Handler Id**\n\nAuthorization handler id.",
+                    "title": "Authorization Handler Id",
+                    "type": "string"
+                },
+                "processingOrder": {
+                    "description": "This is the order this authorization handler will be processed. If 0, this handler is not active.",
+                    "markdownDescription": "**Processing Order**\n\nThis is the order this authorization handler will be processed. If 0, this handler is not active.",
+                    "title": "Processing Order",
+                    "type": "integer"
+                },
+                "properties": {
+                    "description": "This object contains some of properties from the associated conf object plus other runtime properties.",
+                    "markdownDescription": "**Properties**\n\nThis object contains some of properties from the associated conf object plus other runtime properties.",
+                    "title": "Properties",
+                    "type": "object"
+                },
+                "referenceCount": {
+                    "description": "Authorization handler's reference count.",
+                    "markdownDescription": "**Reference Count**\n\nAuthorization handler's reference count.",
+                    "title": "Reference Count",
+                    "type": "integer"
+                },
+                "serviceId": {
+                    "description": "The id of the associated service. The URI of the service is '/afw/_AdaptiveService_/' followed by this id.",
+                    "markdownDescription": "**Service Id**\n\nThe id of the associated service. The URI of the service is '/afw/_AdaptiveService_/' followed by this id.",
+                    "title": "Service Id",
+                    "type": "string"
+                },
+                "stopping": {
+                    "description": "Reference count of stopping instances.",
+                    "items": {
+                        "description": "Reference count of stopping instances.",
+                        "markdownDescription": "Reference count of stopping instances.",
+                        "title": "Reference count of stopping instances",
+                        "type": "integer"
+                    },
+                    "markdownDescription": "**Stopping Instances**\n\nReference count of stopping instances.",
                     "title": "Stopping Instances",
                     "type": "array"
                 }
@@ -52,9 +108,60 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveAuthorizationHandler_"
+    "additionalProperties": false,
+    "description": "Runtime authorization handler information.",
+    "markdownDescription": "Runtime authorization handler information.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "authorizationHandlerId": {
+            "description": "Authorization handler id.",
+            "markdownDescription": "**Authorization Handler Id**\n\nAuthorization handler id.",
+            "title": "Authorization Handler Id",
+            "type": "string"
+        },
+        "processingOrder": {
+            "description": "This is the order this authorization handler will be processed. If 0, this handler is not active.",
+            "markdownDescription": "**Processing Order**\n\nThis is the order this authorization handler will be processed. If 0, this handler is not active.",
+            "title": "Processing Order",
+            "type": "integer"
+        },
+        "properties": {
+            "description": "This object contains some of properties from the associated conf object plus other runtime properties.",
+            "markdownDescription": "**Properties**\n\nThis object contains some of properties from the associated conf object plus other runtime properties.",
+            "title": "Properties",
+            "type": "object"
+        },
+        "referenceCount": {
+            "description": "Authorization handler's reference count.",
+            "markdownDescription": "**Reference Count**\n\nAuthorization handler's reference count.",
+            "title": "Reference Count",
+            "type": "integer"
+        },
+        "serviceId": {
+            "description": "The id of the associated service. The URI of the service is '/afw/_AdaptiveService_/' followed by this id.",
+            "markdownDescription": "**Service Id**\n\nThe id of the associated service. The URI of the service is '/afw/_AdaptiveService_/' followed by this id.",
+            "title": "Service Id",
+            "type": "string"
+        },
+        "stopping": {
+            "description": "Reference count of stopping instances.",
+            "items": {
+                "description": "Reference count of stopping instances.",
+                "markdownDescription": "Reference count of stopping instances.",
+                "title": "Reference count of stopping instances",
+                "type": "integer"
+            },
+            "markdownDescription": "**Stopping Instances**\n\nReference count of stopping instances.",
+            "title": "Stopping Instances",
+            "type": "array"
         }
-    ]
+    },
+    "title": "_AdaptiveAuthorizationHandler_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveAuthorizationHandler_.json
+++ b/generated/schemas/afw/_AdaptiveAuthorizationHandler_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveAuthorizationHandler_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveAuthorizationHandler_.propertyTypes"
                 }
@@ -52,7 +52,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveAuthorizationHandler_"
         }

--- a/generated/schemas/afw/_AdaptiveAuthorizationMode_.json
+++ b/generated/schemas/afw/_AdaptiveAuthorizationMode_.json
@@ -1,30 +1,59 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveAuthorizationMode_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveAuthorizationMode_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveAuthorizationMode_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "This is meta for current::modeId qualified variable value.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveAuthorizationMode_.propertyTypes": {
+            "markdownDescription": "This is meta for current::modeId qualified variable value.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "brief": {
                     "description": "This is a predicate for this modeId value with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for this modeId value with the first letter capitalized and without a trailing period.",
                     "title": "Brief",
                     "type": "string"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "This is the description of this modeId value.",
+                    "markdownDescription": "**Description**\n\nThis is the description of this modeId value.",
                     "title": "Description",
                     "type": "string"
                 },
                 "modeId": {
                     "description": "This is used to uniquely identify this particular authorization mode.",
+                    "markdownDescription": "**Mode Id**\n\nThis is used to uniquely identify this particular authorization mode.",
+                    "title": "Mode Id",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveAuthorizationMode_",
+            "type": "object"
+        },
+        "_AdaptiveAuthorizationMode_.propertyTypes": {
+            "properties": {
+                "brief": {
+                    "description": "This is a predicate for this modeId value with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for this modeId value with the first letter capitalized and without a trailing period.",
+                    "title": "Brief",
+                    "type": "string"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "This is the description of this modeId value.",
+                    "markdownDescription": "**Description**\n\nThis is the description of this modeId value.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "modeId": {
+                    "description": "This is used to uniquely identify this particular authorization mode.",
+                    "markdownDescription": "**Mode Id**\n\nThis is used to uniquely identify this particular authorization mode.",
                     "title": "Mode Id",
                     "type": "string"
                 }
@@ -33,9 +62,37 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveAuthorizationMode_"
+    "additionalProperties": false,
+    "description": "This is meta for current::modeId qualified variable value.",
+    "markdownDescription": "This is meta for current::modeId qualified variable value.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "brief": {
+            "description": "This is a predicate for this modeId value with the first letter capitalized and without a trailing period.",
+            "markdownDescription": "**Brief**\n\nThis is a predicate for this modeId value with the first letter capitalized and without a trailing period.",
+            "title": "Brief",
+            "type": "string"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "This is the description of this modeId value.",
+            "markdownDescription": "**Description**\n\nThis is the description of this modeId value.",
+            "title": "Description",
+            "type": "string"
+        },
+        "modeId": {
+            "description": "This is used to uniquely identify this particular authorization mode.",
+            "markdownDescription": "**Mode Id**\n\nThis is used to uniquely identify this particular authorization mode.",
+            "title": "Mode Id",
+            "type": "string"
         }
-    ]
+    },
+    "title": "_AdaptiveAuthorizationMode_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveAuthorizationMode_.json
+++ b/generated/schemas/afw/_AdaptiveAuthorizationMode_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveAuthorizationMode_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveAuthorizationMode_.propertyTypes"
                 }
@@ -33,7 +33,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveAuthorizationMode_"
         }

--- a/generated/schemas/afw/_AdaptiveCollection_.json
+++ b/generated/schemas/afw/_AdaptiveCollection_.json
@@ -1,12 +1,15 @@
 {
     "$defs": {
         "_AdaptiveCollection_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveCollection_.propertyTypes"
                 }
             ],
             "description": "Describes a collection.",
+            "required": [
+                "objectId"
+            ],
             "type": "object",
             "unevaluatedProperties": false
         },
@@ -35,14 +38,11 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "objectId"
-            ],
             "type": "object"
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveCollection_"
         }

--- a/generated/schemas/afw/_AdaptiveCollection_.json
+++ b/generated/schemas/afw/_AdaptiveCollection_.json
@@ -1,39 +1,76 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveCollection_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveCollection_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveCollection_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Describes a collection.",
-            "required": [
-                "objectId"
-            ],
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveCollection_.propertyTypes": {
+            "markdownDescription": "Describes a collection.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "brief": {
                     "description": "Brief description of the collection",
+                    "markdownDescription": "Brief description of the collection",
                     "title": "Brief",
                     "type": "string"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "Description of the collection.",
+                    "markdownDescription": "Description of the collection.",
                     "title": "Description",
                     "type": "string"
                 },
                 "objectId": {
                     "description": "Id of the collection.",
+                    "markdownDescription": "Id of the collection.",
                     "title": "Object",
                     "type": "string"
                 },
                 "originURI": {
                     "description": "The origin URI of this collection. This may be different from the URI within this instance of Adaptive Framework.",
                     "format": "uri-reference",
+                    "markdownDescription": "The origin URI of this collection. This may be different from the URI within this instance of Adaptive Framework.",
+                    "title": "Origin URI",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "objectId"
+            ],
+            "title": "_AdaptiveCollection_",
+            "type": "object"
+        },
+        "_AdaptiveCollection_.propertyTypes": {
+            "properties": {
+                "brief": {
+                    "description": "Brief description of the collection",
+                    "markdownDescription": "Brief description of the collection",
+                    "title": "Brief",
+                    "type": "string"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "Description of the collection.",
+                    "markdownDescription": "Description of the collection.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "objectId": {
+                    "description": "Id of the collection.",
+                    "markdownDescription": "Id of the collection.",
+                    "title": "Object",
+                    "type": "string"
+                },
+                "originURI": {
+                    "description": "The origin URI of this collection. This may be different from the URI within this instance of Adaptive Framework.",
+                    "format": "uri-reference",
+                    "markdownDescription": "The origin URI of this collection. This may be different from the URI within this instance of Adaptive Framework.",
                     "title": "Origin URI",
                     "type": "string"
                 }
@@ -42,9 +79,47 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveCollection_"
+    "additionalProperties": false,
+    "description": "Describes a collection.",
+    "markdownDescription": "Describes a collection.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "brief": {
+            "description": "Brief description of the collection",
+            "markdownDescription": "Brief description of the collection",
+            "title": "Brief",
+            "type": "string"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "Description of the collection.",
+            "markdownDescription": "Description of the collection.",
+            "title": "Description",
+            "type": "string"
+        },
+        "objectId": {
+            "description": "Id of the collection.",
+            "markdownDescription": "Id of the collection.",
+            "title": "Object",
+            "type": "string"
+        },
+        "originURI": {
+            "description": "The origin URI of this collection. This may be different from the URI within this instance of Adaptive Framework.",
+            "format": "uri-reference",
+            "markdownDescription": "The origin URI of this collection. This may be different from the URI within this instance of Adaptive Framework.",
+            "title": "Origin URI",
+            "type": "string"
         }
-    ]
+    },
+    "required": [
+        "objectId"
+    ],
+    "title": "_AdaptiveCollection_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveConfType_.json
+++ b/generated/schemas/afw/_AdaptiveConfType_.json
@@ -1,65 +1,143 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveConfType_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveConfType_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveConfType_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "An adaptive configuration (conf) type.",
-            "type": "object",
-            "unevaluatedProperties": false
+            "markdownDescription": "An adaptive configuration (conf) type.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "Description of this configuration type.",
+                    "markdownDescription": "**Description**\n\nDescription of this configuration type.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "idPropertyName": {
+                    "description": "This is the id property name for instances of this conf type. For adapter, this is 'adapterId'.",
+                    "markdownDescription": "**Id Property Name**\n\nThis is the id property name for instances of this conf type. For adapter, this is 'adapterId'.",
+                    "title": "Id Property Name",
+                    "type": "string"
+                },
+                "idRegistryType": {
+                    "description": "This is the registry type for instances of this conf type. For adapter, this is 'adapter_id'.",
+                    "markdownDescription": "**Id Registry Type**\n\nThis is the registry type for instances of this conf type. For adapter, this is 'adapter_id'.",
+                    "title": "Id Registry Type",
+                    "type": "string"
+                },
+                "idRuntimeObjectType": {
+                    "description": "This is the runtime object type for instances of this conf type. For adapter, this is '_AdaptiveAdapter_'.",
+                    "markdownDescription": "**Id Runtime Object Type**\n\nThis is the runtime object type for instances of this conf type. For adapter, this is '_AdaptiveAdapter_'.",
+                    "title": "Id Runtime Object Type",
+                    "type": "string"
+                },
+                "isUnique": {
+                    "description": "This configuration type can only be specified once.",
+                    "markdownDescription": "**Is Unique**\n\nThis configuration type can only be specified once.",
+                    "title": "Is Unique",
+                    "type": "boolean"
+                },
+                "subtypePropertyName": {
+                    "description": "This is the subtype property name for instances of this conf type.  For adapter, this is 'adapterType'.",
+                    "markdownDescription": "**Subtype Property Name**\n\nThis is the subtype property name for instances of this conf type.  For adapter, this is 'adapterType'.",
+                    "title": "Subtype Property Name",
+                    "type": "string"
+                },
+                "subtypeRegistryType": {
+                    "description": "This is the subtype registry type for instances of this conf type. For adapter, this is 'adapter_type'.",
+                    "markdownDescription": "**Subtype Registry Type**\n\nThis is the subtype registry type for instances of this conf type. For adapter, this is 'adapter_type'.",
+                    "title": "Subtype Registry Type",
+                    "type": "string"
+                },
+                "subtypeRuntimeObjectType": {
+                    "description": "This is the subtype runtime object type for instances of this conf type. For adapter, this is '_AdaptiveAdapterType_'.",
+                    "markdownDescription": "**Subtype Runtime Object Type**\n\nThis is the subtype runtime object type for instances of this conf type. For adapter, this is '_AdaptiveAdapterType_'.",
+                    "title": "Subtype Runtime Object Type",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Title for this configuration type.",
+                    "markdownDescription": "**Title**\n\nTitle for this configuration type.",
+                    "title": "Title",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Configuration type id.",
+                    "markdownDescription": "**Type**\n\nConfiguration type id.",
+                    "title": "Type",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveConfType_",
+            "type": "object"
         },
         "_AdaptiveConfType_.propertyTypes": {
             "properties": {
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "Description of this configuration type.",
+                    "markdownDescription": "**Description**\n\nDescription of this configuration type.",
                     "title": "Description",
                     "type": "string"
                 },
                 "idPropertyName": {
                     "description": "This is the id property name for instances of this conf type. For adapter, this is 'adapterId'.",
+                    "markdownDescription": "**Id Property Name**\n\nThis is the id property name for instances of this conf type. For adapter, this is 'adapterId'.",
                     "title": "Id Property Name",
                     "type": "string"
                 },
                 "idRegistryType": {
                     "description": "This is the registry type for instances of this conf type. For adapter, this is 'adapter_id'.",
+                    "markdownDescription": "**Id Registry Type**\n\nThis is the registry type for instances of this conf type. For adapter, this is 'adapter_id'.",
                     "title": "Id Registry Type",
                     "type": "string"
                 },
                 "idRuntimeObjectType": {
                     "description": "This is the runtime object type for instances of this conf type. For adapter, this is '_AdaptiveAdapter_'.",
+                    "markdownDescription": "**Id Runtime Object Type**\n\nThis is the runtime object type for instances of this conf type. For adapter, this is '_AdaptiveAdapter_'.",
                     "title": "Id Runtime Object Type",
                     "type": "string"
                 },
                 "isUnique": {
                     "description": "This configuration type can only be specified once.",
+                    "markdownDescription": "**Is Unique**\n\nThis configuration type can only be specified once.",
                     "title": "Is Unique",
                     "type": "boolean"
                 },
                 "subtypePropertyName": {
                     "description": "This is the subtype property name for instances of this conf type.  For adapter, this is 'adapterType'.",
+                    "markdownDescription": "**Subtype Property Name**\n\nThis is the subtype property name for instances of this conf type.  For adapter, this is 'adapterType'.",
                     "title": "Subtype Property Name",
                     "type": "string"
                 },
                 "subtypeRegistryType": {
                     "description": "This is the subtype registry type for instances of this conf type. For adapter, this is 'adapter_type'.",
+                    "markdownDescription": "**Subtype Registry Type**\n\nThis is the subtype registry type for instances of this conf type. For adapter, this is 'adapter_type'.",
                     "title": "Subtype Registry Type",
                     "type": "string"
                 },
                 "subtypeRuntimeObjectType": {
                     "description": "This is the subtype runtime object type for instances of this conf type. For adapter, this is '_AdaptiveAdapterType_'.",
+                    "markdownDescription": "**Subtype Runtime Object Type**\n\nThis is the subtype runtime object type for instances of this conf type. For adapter, this is '_AdaptiveAdapterType_'.",
                     "title": "Subtype Runtime Object Type",
                     "type": "string"
                 },
                 "title": {
                     "description": "Title for this configuration type.",
+                    "markdownDescription": "**Title**\n\nTitle for this configuration type.",
                     "title": "Title",
                     "type": "string"
                 },
                 "type": {
                     "description": "Configuration type id.",
+                    "markdownDescription": "**Type**\n\nConfiguration type id.",
                     "title": "Type",
                     "type": "string"
                 }
@@ -68,9 +146,79 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveConfType_"
+    "additionalProperties": false,
+    "description": "An adaptive configuration (conf) type.",
+    "markdownDescription": "An adaptive configuration (conf) type.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "Description of this configuration type.",
+            "markdownDescription": "**Description**\n\nDescription of this configuration type.",
+            "title": "Description",
+            "type": "string"
+        },
+        "idPropertyName": {
+            "description": "This is the id property name for instances of this conf type. For adapter, this is 'adapterId'.",
+            "markdownDescription": "**Id Property Name**\n\nThis is the id property name for instances of this conf type. For adapter, this is 'adapterId'.",
+            "title": "Id Property Name",
+            "type": "string"
+        },
+        "idRegistryType": {
+            "description": "This is the registry type for instances of this conf type. For adapter, this is 'adapter_id'.",
+            "markdownDescription": "**Id Registry Type**\n\nThis is the registry type for instances of this conf type. For adapter, this is 'adapter_id'.",
+            "title": "Id Registry Type",
+            "type": "string"
+        },
+        "idRuntimeObjectType": {
+            "description": "This is the runtime object type for instances of this conf type. For adapter, this is '_AdaptiveAdapter_'.",
+            "markdownDescription": "**Id Runtime Object Type**\n\nThis is the runtime object type for instances of this conf type. For adapter, this is '_AdaptiveAdapter_'.",
+            "title": "Id Runtime Object Type",
+            "type": "string"
+        },
+        "isUnique": {
+            "description": "This configuration type can only be specified once.",
+            "markdownDescription": "**Is Unique**\n\nThis configuration type can only be specified once.",
+            "title": "Is Unique",
+            "type": "boolean"
+        },
+        "subtypePropertyName": {
+            "description": "This is the subtype property name for instances of this conf type.  For adapter, this is 'adapterType'.",
+            "markdownDescription": "**Subtype Property Name**\n\nThis is the subtype property name for instances of this conf type.  For adapter, this is 'adapterType'.",
+            "title": "Subtype Property Name",
+            "type": "string"
+        },
+        "subtypeRegistryType": {
+            "description": "This is the subtype registry type for instances of this conf type. For adapter, this is 'adapter_type'.",
+            "markdownDescription": "**Subtype Registry Type**\n\nThis is the subtype registry type for instances of this conf type. For adapter, this is 'adapter_type'.",
+            "title": "Subtype Registry Type",
+            "type": "string"
+        },
+        "subtypeRuntimeObjectType": {
+            "description": "This is the subtype runtime object type for instances of this conf type. For adapter, this is '_AdaptiveAdapterType_'.",
+            "markdownDescription": "**Subtype Runtime Object Type**\n\nThis is the subtype runtime object type for instances of this conf type. For adapter, this is '_AdaptiveAdapterType_'.",
+            "title": "Subtype Runtime Object Type",
+            "type": "string"
+        },
+        "title": {
+            "description": "Title for this configuration type.",
+            "markdownDescription": "**Title**\n\nTitle for this configuration type.",
+            "title": "Title",
+            "type": "string"
+        },
+        "type": {
+            "description": "Configuration type id.",
+            "markdownDescription": "**Type**\n\nConfiguration type id.",
+            "title": "Type",
+            "type": "string"
         }
-    ]
+    },
+    "title": "_AdaptiveConfType_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveConfType_.json
+++ b/generated/schemas/afw/_AdaptiveConfType_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveConfType_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveConfType_.propertyTypes"
                 }
@@ -68,7 +68,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveConfType_"
         }

--- a/generated/schemas/afw/_AdaptiveConf_application.json
+++ b/generated/schemas/afw/_AdaptiveConf_application.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveAuthorizationControl_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveAuthorizationControl_.propertyTypes"
                 }
@@ -14,6 +14,7 @@
         "_AdaptiveAuthorizationControl_.propertyTypes": {
             "properties": {
                 "checkIntermediateMode": {
+                    "default": false,
                     "description": "Do authorization check when running in mode intermediate. If false, the checks will be bypassed.",
                     "title": "Check Intermediate",
                     "type": "boolean"
@@ -24,6 +25,7 @@
                     "type": "string"
                 },
                 "denyIfNotApplicable": {
+                    "default": false,
                     "description": "Specify true to deny access to resources when notApplicable is the final result of other checks.",
                     "title": "Deny If Not Applicable",
                     "type": "boolean"
@@ -60,13 +62,10 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "type"
-            ],
             "type": "object"
         },
         "_AdaptiveConf_application": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveConf_application.propertyTypes"
                 },
@@ -80,7 +79,6 @@
         },
         "_AdaptiveConf_application.propertyTypes": {
             "properties": {
-                "_meta_": {},
                 "applicationId": {
                     "description": "This is id of the application. The default applicationId is 'application'. This property can only be specified in the type=application entry of the conf file.",
                     "readOnly": true,
@@ -88,10 +86,13 @@
                     "type": "string"
                 },
                 "authorizationControl": {
-                    "$ref": "#/$defs/_AdaptiveAuthorizationControl_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveAuthorizationControl_"
+                        }
+                    ],
                     "description": "This defines how authorization checking occurs in this application.",
-                    "title": "Authorization",
-                    "type": "object"
+                    "title": "Authorization"
                 },
                 "confAdapterId": {
                     "description": "This is the optional adapterId of the running adapter that contains configuration related objects. This property can only be specified in the type=application entry of the conf file.\n\nThe runtime /afw/_AdaptiveApplication_/current object will consist of properties from the type=application entry of the conf file plus unique properties from the optional /<confAdapterId>/_AdaptiveConf_application/<applicationId> object.\n\nAll services defined by _AdaptiveServiceConf_ objects in <confAdapterId> with startup 'permanent' or 'immediate' will be started when the type=application conf entry is processed.",
@@ -156,16 +157,22 @@
                     "type": "string"
                 },
                 "qualifiedVariables": {
-                    "$ref": "#/$defs/_AdaptiveTemplatePropertiesObjects_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveTemplatePropertiesObjects_"
+                        }
+                    ],
                     "description": "The name of each property in this object corresponds to a qualifier that is available in processing associated with this application. The qualifier can not be an empty string. The properties of these 'qualifier objects' are template values that are accessible as qualified variables. These variables are evaluated once per execution context (xctx) as they are accessed.\n\nSome qualifiers are restricted.",
-                    "title": "Qualified Variables",
-                    "type": "object"
+                    "title": "Qualified Variables"
                 },
                 "rootFilePaths": {
-                    "$ref": "#/$defs/_AdaptiveRootFilePaths_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveRootFilePaths_"
+                        }
+                    ],
                     "description": "The properties of this object are the root file paths used by open_file().",
-                    "title": "Root File Paths",
-                    "type": "object"
+                    "title": "Root File Paths"
                 },
                 "title": {
                     "description": "The title of the application. This is used as the title of the Adaptive Framework Web App and is available for use in other places as appropriate.",
@@ -180,7 +187,7 @@
                 "description": "A function open_file path that begins with a slash followed by this property name will access a file in the directory path specified as a value to this property. For example, if this property is 'my': '/temp/my', file_open('mine', '/my/xyz', 'w') will open '/temp/my/xyz' for write in the host file system.",
                 "type": "string"
             },
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveRootFilePaths_.propertyTypes"
                 }
@@ -195,11 +202,14 @@
         },
         "_AdaptiveTemplatePropertiesObjects_": {
             "additionalProperties": {
-                "$ref": "#/$defs/_AdaptiveTemplateProperties_",
-                "description": "Each property is a _AdaptiveTemplateProperties_ object.",
-                "type": "object"
+                "allOf": [
+                    {
+                        "$ref": "#/$defs/_AdaptiveTemplateProperties_"
+                    }
+                ],
+                "description": "Each property is a _AdaptiveTemplateProperties_ object."
             },
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveTemplatePropertiesObjects_.propertyTypes"
                 }
@@ -217,7 +227,7 @@
                 "description": "Each property is a template value.",
                 "type": "string"
             },
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveTemplateProperties_.propertyTypes"
                 }
@@ -231,7 +241,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveConf_application"
         }

--- a/generated/schemas/afw/_AdaptiveConf_application.json
+++ b/generated/schemas/afw/_AdaptiveConf_application.json
@@ -1,37 +1,73 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveConf_application. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveAuthorizationControl_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveAuthorizationControl_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "This defines how authorization checking occurs in this application.",
-            "title": "Authorization",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveAuthorizationControl_.propertyTypes": {
+            "markdownDescription": "This defines how authorization checking occurs in this application.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "checkIntermediateMode": {
                     "default": false,
                     "description": "Do authorization check when running in mode intermediate. If false, the checks will be bypassed.",
+                    "markdownDescription": "**Check Intermediate**\n\nDo authorization check when running in mode intermediate. If false, the checks will be bypassed.",
                     "title": "Check Intermediate",
                     "type": "boolean"
                 },
                 "coreAuthorizationCheck": {
                     "description": "This is evaluated for authorization checks when running in core mode. If not specified, access is permitted. Be very careful when specifying this parameter because an error can cause the application to fail.",
+                    "markdownDescription": "**Core Check**\n\nThis is evaluated for authorization checks when running in core mode. If not specified, access is permitted. Be very careful when specifying this parameter because an error can cause the application to fail.",
                     "title": "Core Check",
                     "type": "string"
                 },
                 "denyIfNotApplicable": {
                     "default": false,
                     "description": "Specify true to deny access to resources when notApplicable is the final result of other checks.",
+                    "markdownDescription": "**Deny If Not Applicable**\n\nSpecify true to deny access to resources when notApplicable is the final result of other checks.",
                     "title": "Deny If Not Applicable",
                     "type": "boolean"
                 },
                 "initialAuthorizationCheck": {
                     "description": "This is evaluated before authorization handlers are called to determine whether to allow the requested access to the specified resourceId and/or object. A result of permit or deny is the final decision. If this parameter is not specified or the result is notApplicable, active authorization handlers will be processed. Parameter permitIfNotApplicable is used to determine the result when all checks return notApplicable.",
+                    "markdownDescription": "**Initial Check**\n\nThis is evaluated before authorization handlers are called to determine whether to allow the requested access to the specified resourceId and/or object. A result of permit or deny is the final decision. If this parameter is not specified or the result is notApplicable, active authorization handlers will be processed. Parameter permitIfNotApplicable is used to determine the result when all checks return notApplicable.",
+                    "title": "Initial Check",
+                    "type": "string"
+                }
+            },
+            "title": "Authorization",
+            "type": "object"
+        },
+        "_AdaptiveAuthorizationControl_.propertyTypes": {
+            "properties": {
+                "checkIntermediateMode": {
+                    "default": false,
+                    "description": "Do authorization check when running in mode intermediate. If false, the checks will be bypassed.",
+                    "markdownDescription": "**Check Intermediate**\n\nDo authorization check when running in mode intermediate. If false, the checks will be bypassed.",
+                    "title": "Check Intermediate",
+                    "type": "boolean"
+                },
+                "coreAuthorizationCheck": {
+                    "description": "This is evaluated for authorization checks when running in core mode. If not specified, access is permitted. Be very careful when specifying this parameter because an error can cause the application to fail.",
+                    "markdownDescription": "**Core Check**\n\nThis is evaluated for authorization checks when running in core mode. If not specified, access is permitted. Be very careful when specifying this parameter because an error can cause the application to fail.",
+                    "title": "Core Check",
+                    "type": "string"
+                },
+                "denyIfNotApplicable": {
+                    "default": false,
+                    "description": "Specify true to deny access to resources when notApplicable is the final result of other checks.",
+                    "markdownDescription": "**Deny If Not Applicable**\n\nSpecify true to deny access to resources when notApplicable is the final result of other checks.",
+                    "title": "Deny If Not Applicable",
+                    "type": "boolean"
+                },
+                "initialAuthorizationCheck": {
+                    "description": "This is evaluated before authorization handlers are called to determine whether to allow the requested access to the specified resourceId and/or object. A result of permit or deny is the final decision. If this parameter is not specified or the result is notApplicable, active authorization handlers will be processed. Parameter permitIfNotApplicable is used to determine the result when all checks return notApplicable.",
+                    "markdownDescription": "**Initial Check**\n\nThis is evaluated before authorization handlers are called to determine whether to allow the requested access to the specified resourceId and/or object. A result of permit or deny is the final decision. If this parameter is not specified or the result is notApplicable, active authorization handlers will be processed. Parameter permitIfNotApplicable is used to determine the result when all checks return notApplicable.",
                     "title": "Initial Check",
                     "type": "string"
                 }
@@ -43,21 +79,25 @@
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "The description of this configuration component.",
+                    "markdownDescription": "**Description**\n\nThe description of this configuration component.",
                     "title": "Description",
                     "type": "string"
                 },
                 "sourceLocation": {
                     "description": "This is a contextual string added when this configuration object is processed.",
+                    "markdownDescription": "**Source Location**\n\nThis is a contextual string added when this configuration object is processed.",
                     "title": "Source Location",
                     "type": "string"
                 },
                 "title": {
                     "description": "The title for this configuration component.",
+                    "markdownDescription": "**Title**\n\nThe title for this configuration component.",
                     "title": "Title",
                     "type": "string"
                 },
                 "type": {
                     "description": "Configuration type.",
+                    "markdownDescription": "**Type**\n\nConfiguration type.",
                     "title": "Type",
                     "type": "string"
                 }
@@ -65,22 +105,20 @@
             "type": "object"
         },
         "_AdaptiveConf_application": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveConf_application.propertyTypes"
-                },
-                {
-                    "$ref": "#/$defs/_AdaptiveConf_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Adaptive Framework configuration component for type=application. There is only one application conf entry per Adaptive Framework instance.\n\nUse path /afw/_AdaptiveConf_application/current to access this entry at run time.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveConf_application.propertyTypes": {
+            "markdownDescription": "Adaptive Framework configuration component for type=application. There is only one application conf entry per Adaptive Framework instance.\n\nUse path /afw/_AdaptiveConf_application/current to access this entry at run time.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "applicationId": {
                     "description": "This is id of the application. The default applicationId is 'application'. This property can only be specified in the type=application entry of the conf file.",
+                    "markdownDescription": "**Application Id**\n\nThis is id of the application. The default applicationId is 'application'. This property can only be specified in the type=application entry of the conf file.",
                     "readOnly": true,
                     "title": "Application Id",
                     "type": "string"
@@ -92,16 +130,20 @@
                         }
                     ],
                     "description": "This defines how authorization checking occurs in this application.",
-                    "title": "Authorization"
+                    "markdownDescription": "**Authorization**\n\nThis defines how authorization checking occurs in this application.",
+                    "title": "Authorization",
+                    "type": "object"
                 },
                 "confAdapterId": {
                     "description": "This is the optional adapterId of the running adapter that contains configuration related objects. This property can only be specified in the type=application entry of the conf file.\n\nThe runtime /afw/_AdaptiveApplication_/current object will consist of properties from the type=application entry of the conf file plus unique properties from the optional /<confAdapterId>/_AdaptiveConf_application/<applicationId> object.\n\nAll services defined by _AdaptiveServiceConf_ objects in <confAdapterId> with startup 'permanent' or 'immediate' will be started when the type=application conf entry is processed.",
+                    "markdownDescription": "**Conf Adapter**\n\nThis is the optional adapterId of the running adapter that contains configuration related objects. This property can only be specified in the type=application entry of the conf file.\n\nThe runtime /afw/_AdaptiveApplication_/current object will consist of properties from the type=application entry of the conf file plus unique properties from the optional /<confAdapterId>/_AdaptiveConf_application/<applicationId> object.\n\nAll services defined by _AdaptiveServiceConf_ objects in <confAdapterId> with startup 'permanent' or 'immediate' will be started when the type=application conf entry is processed.",
                     "readOnly": true,
                     "title": "Conf Adapter",
                     "type": "string"
                 },
                 "defaultAdapterId": {
                     "description": "This is the adapterId chosen by default for user interface select components.",
+                    "markdownDescription": "**Default Adapter**\n\nThis is the adapterId chosen by default for user interface select components.",
                     "title": "Default Adapter",
                     "type": "string"
                 },
@@ -109,20 +151,24 @@
                     "description": "This is an array of the flagId of default flags that will be set when an execution context (xctx) is created. Flags in this array that are not yet registered will be set as a default when/if they are registered. Each registered flagId is the objectId of an object in /afw/_AdaptiveFlag_/.",
                     "items": {
                         "description": "This is an array of the flagId of default flags that will be set when an execution context (xctx) is created. Flags in this array that are not yet registered will be set as a default when/if they are registered. Each registered flagId is the objectId of an object in /afw/_AdaptiveFlag_/.",
+                        "markdownDescription": "This is an array of the flagId of default flags that will be set when an execution context (xctx) is created. Flags in this array that are not yet registered will be set as a default when/if they are registered. Each registered flagId is the objectId of an object in /afw/_AdaptiveFlag_/.",
                         "title": "List of default flags to be set when an execution context (xctx) is created.",
                         "type": "string"
                     },
+                    "markdownDescription": "**Default Flags**\n\nThis is an array of the flagId of default flags that will be set when an execution context (xctx) is created. Flags in this array that are not yet registered will be set as a default when/if they are registered. Each registered flagId is the objectId of an object in /afw/_AdaptiveFlag_/.",
                     "title": "Default Flags",
                     "type": "array"
                 },
                 "defaultModelAdapterId": {
                     "description": "When presented with multiple model adapters, this is the default adapterId to use. This will be the default selected adapter chosen by user interface components.",
+                    "markdownDescription": "**Default Model Adapter**\n\nWhen presented with multiple model adapters, this is the default adapterId to use. This will be the default selected adapter chosen by user interface components.",
                     "title": "Default Model Adapter",
                     "type": "string"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "The description of the application.",
+                    "markdownDescription": "**Description**\n\nThe description of the application.",
                     "title": "Description",
                     "type": "string"
                 },
@@ -130,9 +176,11 @@
                     "description": "This is an array of modulePaths of extensions to load at startup. If there is already an extension manifest that has the extensionId, use the extensions property instead. This property is most useful for loading the extension manifest of an AFW package.",
                     "items": {
                         "description": "This is an array of modulePaths of extensions to load at startup. If there is already an extension manifest that has the extensionId, use the extensions property instead. This property is most useful for loading the extension manifest of an AFW package.",
+                        "markdownDescription": "This is an array of modulePaths of extensions to load at startup. If there is already an extension manifest that has the extensionId, use the extensions property instead. This property is most useful for loading the extension manifest of an AFW package.",
                         "title": "List of modulePaths of extensions to load at startup",
                         "type": "string"
                     },
+                    "markdownDescription": "**Extension Module Paths**\n\nThis is an array of modulePaths of extensions to load at startup. If there is already an extension manifest that has the extensionId, use the extensions property instead. This property is most useful for loading the extension manifest of an AFW package.",
                     "title": "Extension Module Paths",
                     "type": "array"
                 },
@@ -140,19 +188,23 @@
                     "description": "This is an array of extensionId of extensions to load at startup. Each extensionId must be the objectId of an object in /afw/_AdaptiveManifest_/.",
                     "items": {
                         "description": "This is an array of extensionId of extensions to load at startup. Each extensionId must be the objectId of an object in /afw/_AdaptiveManifest_/.",
+                        "markdownDescription": "This is an array of extensionId of extensions to load at startup. Each extensionId must be the objectId of an object in /afw/_AdaptiveManifest_/.",
                         "title": "List of extensionIds to load at startup",
                         "type": "string"
                     },
+                    "markdownDescription": "**Extensions**\n\nThis is an array of extensionId of extensions to load at startup. Each extensionId must be the objectId of an object in /afw/_AdaptiveManifest_/.",
                     "title": "Extensions",
                     "type": "array"
                 },
                 "layoutsAdapterId": {
                     "description": "This is the adapterId that locates Adaptive Layout Component objects.",
+                    "markdownDescription": "**Layouts Adapter**\n\nThis is the adapterId that locates Adaptive Layout Component objects.",
                     "title": "Layouts Adapter",
                     "type": "string"
                 },
                 "onApplicationStartupComplete": {
                     "description": "This is an optional script to run after this application has completed startup but before starting to process requests. The script can perform additional startup functions or request that the application terminate. All permanent and immediate services will have been started before the script is called. If the script fails or explicitly returns a value other than 0, the application will terminate.",
+                    "markdownDescription": "**Application Startup Complete**\n\nThis is an optional script to run after this application has completed startup but before starting to process requests. The script can perform additional startup functions or request that the application terminate. All permanent and immediate services will have been started before the script is called. If the script fails or explicitly returns a value other than 0, the application will terminate.",
                     "title": "Application Startup Complete",
                     "type": "string"
                 },
@@ -163,7 +215,9 @@
                         }
                     ],
                     "description": "The name of each property in this object corresponds to a qualifier that is available in processing associated with this application. The qualifier can not be an empty string. The properties of these 'qualifier objects' are template values that are accessible as qualified variables. These variables are evaluated once per execution context (xctx) as they are accessed.\n\nSome qualifiers are restricted.",
-                    "title": "Qualified Variables"
+                    "markdownDescription": "**Qualified Variables**\n\nThe name of each property in this object corresponds to a qualifier that is available in processing associated with this application. The qualifier can not be an empty string. The properties of these 'qualifier objects' are template values that are accessible as qualified variables. These variables are evaluated once per execution context (xctx) as they are accessed.\n\nSome qualifiers are restricted.",
+                    "title": "Qualified Variables",
+                    "type": "object"
                 },
                 "rootFilePaths": {
                     "allOf": [
@@ -172,10 +226,154 @@
                         }
                     ],
                     "description": "The properties of this object are the root file paths used by open_file().",
-                    "title": "Root File Paths"
+                    "markdownDescription": "**Root File Paths**\n\nThe properties of this object are the root file paths used by open_file().",
+                    "title": "Root File Paths",
+                    "type": "object"
+                },
+                "sourceLocation": {
+                    "description": "This is a contextual string added when this configuration object is processed.",
+                    "markdownDescription": "**Source Location**\n\nThis is a contextual string added when this configuration object is processed.",
+                    "title": "Source Location",
+                    "type": "string"
                 },
                 "title": {
                     "description": "The title of the application. This is used as the title of the Adaptive Framework Web App and is available for use in other places as appropriate.",
+                    "markdownDescription": "**Title**\n\nThe title of the application. This is used as the title of the Adaptive Framework Web App and is available for use in other places as appropriate.",
+                    "title": "Title",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Configuration type.",
+                    "markdownDescription": "**Type**\n\nConfiguration type.",
+                    "title": "Type",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveConf_application",
+            "type": "object",
+            "x-afw-inheritedObjectTypes": [
+                "_AdaptiveConf_"
+            ]
+        },
+        "_AdaptiveConf_application.propertyTypes": {
+            "properties": {
+                "applicationId": {
+                    "description": "This is id of the application. The default applicationId is 'application'. This property can only be specified in the type=application entry of the conf file.",
+                    "markdownDescription": "**Application Id**\n\nThis is id of the application. The default applicationId is 'application'. This property can only be specified in the type=application entry of the conf file.",
+                    "readOnly": true,
+                    "title": "Application Id",
+                    "type": "string"
+                },
+                "authorizationControl": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveAuthorizationControl_"
+                        }
+                    ],
+                    "description": "This defines how authorization checking occurs in this application.",
+                    "markdownDescription": "**Authorization**\n\nThis defines how authorization checking occurs in this application.",
+                    "title": "Authorization",
+                    "type": "object"
+                },
+                "confAdapterId": {
+                    "description": "This is the optional adapterId of the running adapter that contains configuration related objects. This property can only be specified in the type=application entry of the conf file.\n\nThe runtime /afw/_AdaptiveApplication_/current object will consist of properties from the type=application entry of the conf file plus unique properties from the optional /<confAdapterId>/_AdaptiveConf_application/<applicationId> object.\n\nAll services defined by _AdaptiveServiceConf_ objects in <confAdapterId> with startup 'permanent' or 'immediate' will be started when the type=application conf entry is processed.",
+                    "markdownDescription": "**Conf Adapter**\n\nThis is the optional adapterId of the running adapter that contains configuration related objects. This property can only be specified in the type=application entry of the conf file.\n\nThe runtime /afw/_AdaptiveApplication_/current object will consist of properties from the type=application entry of the conf file plus unique properties from the optional /<confAdapterId>/_AdaptiveConf_application/<applicationId> object.\n\nAll services defined by _AdaptiveServiceConf_ objects in <confAdapterId> with startup 'permanent' or 'immediate' will be started when the type=application conf entry is processed.",
+                    "readOnly": true,
+                    "title": "Conf Adapter",
+                    "type": "string"
+                },
+                "defaultAdapterId": {
+                    "description": "This is the adapterId chosen by default for user interface select components.",
+                    "markdownDescription": "**Default Adapter**\n\nThis is the adapterId chosen by default for user interface select components.",
+                    "title": "Default Adapter",
+                    "type": "string"
+                },
+                "defaultFlags": {
+                    "description": "This is an array of the flagId of default flags that will be set when an execution context (xctx) is created. Flags in this array that are not yet registered will be set as a default when/if they are registered. Each registered flagId is the objectId of an object in /afw/_AdaptiveFlag_/.",
+                    "items": {
+                        "description": "This is an array of the flagId of default flags that will be set when an execution context (xctx) is created. Flags in this array that are not yet registered will be set as a default when/if they are registered. Each registered flagId is the objectId of an object in /afw/_AdaptiveFlag_/.",
+                        "markdownDescription": "This is an array of the flagId of default flags that will be set when an execution context (xctx) is created. Flags in this array that are not yet registered will be set as a default when/if they are registered. Each registered flagId is the objectId of an object in /afw/_AdaptiveFlag_/.",
+                        "title": "List of default flags to be set when an execution context (xctx) is created.",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Default Flags**\n\nThis is an array of the flagId of default flags that will be set when an execution context (xctx) is created. Flags in this array that are not yet registered will be set as a default when/if they are registered. Each registered flagId is the objectId of an object in /afw/_AdaptiveFlag_/.",
+                    "title": "Default Flags",
+                    "type": "array"
+                },
+                "defaultModelAdapterId": {
+                    "description": "When presented with multiple model adapters, this is the default adapterId to use. This will be the default selected adapter chosen by user interface components.",
+                    "markdownDescription": "**Default Model Adapter**\n\nWhen presented with multiple model adapters, this is the default adapterId to use. This will be the default selected adapter chosen by user interface components.",
+                    "title": "Default Model Adapter",
+                    "type": "string"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "The description of the application.",
+                    "markdownDescription": "**Description**\n\nThe description of the application.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "extensionModulePaths": {
+                    "description": "This is an array of modulePaths of extensions to load at startup. If there is already an extension manifest that has the extensionId, use the extensions property instead. This property is most useful for loading the extension manifest of an AFW package.",
+                    "items": {
+                        "description": "This is an array of modulePaths of extensions to load at startup. If there is already an extension manifest that has the extensionId, use the extensions property instead. This property is most useful for loading the extension manifest of an AFW package.",
+                        "markdownDescription": "This is an array of modulePaths of extensions to load at startup. If there is already an extension manifest that has the extensionId, use the extensions property instead. This property is most useful for loading the extension manifest of an AFW package.",
+                        "title": "List of modulePaths of extensions to load at startup",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Extension Module Paths**\n\nThis is an array of modulePaths of extensions to load at startup. If there is already an extension manifest that has the extensionId, use the extensions property instead. This property is most useful for loading the extension manifest of an AFW package.",
+                    "title": "Extension Module Paths",
+                    "type": "array"
+                },
+                "extensions": {
+                    "description": "This is an array of extensionId of extensions to load at startup. Each extensionId must be the objectId of an object in /afw/_AdaptiveManifest_/.",
+                    "items": {
+                        "description": "This is an array of extensionId of extensions to load at startup. Each extensionId must be the objectId of an object in /afw/_AdaptiveManifest_/.",
+                        "markdownDescription": "This is an array of extensionId of extensions to load at startup. Each extensionId must be the objectId of an object in /afw/_AdaptiveManifest_/.",
+                        "title": "List of extensionIds to load at startup",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Extensions**\n\nThis is an array of extensionId of extensions to load at startup. Each extensionId must be the objectId of an object in /afw/_AdaptiveManifest_/.",
+                    "title": "Extensions",
+                    "type": "array"
+                },
+                "layoutsAdapterId": {
+                    "description": "This is the adapterId that locates Adaptive Layout Component objects.",
+                    "markdownDescription": "**Layouts Adapter**\n\nThis is the adapterId that locates Adaptive Layout Component objects.",
+                    "title": "Layouts Adapter",
+                    "type": "string"
+                },
+                "onApplicationStartupComplete": {
+                    "description": "This is an optional script to run after this application has completed startup but before starting to process requests. The script can perform additional startup functions or request that the application terminate. All permanent and immediate services will have been started before the script is called. If the script fails or explicitly returns a value other than 0, the application will terminate.",
+                    "markdownDescription": "**Application Startup Complete**\n\nThis is an optional script to run after this application has completed startup but before starting to process requests. The script can perform additional startup functions or request that the application terminate. All permanent and immediate services will have been started before the script is called. If the script fails or explicitly returns a value other than 0, the application will terminate.",
+                    "title": "Application Startup Complete",
+                    "type": "string"
+                },
+                "qualifiedVariables": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveTemplatePropertiesObjects_"
+                        }
+                    ],
+                    "description": "The name of each property in this object corresponds to a qualifier that is available in processing associated with this application. The qualifier can not be an empty string. The properties of these 'qualifier objects' are template values that are accessible as qualified variables. These variables are evaluated once per execution context (xctx) as they are accessed.\n\nSome qualifiers are restricted.",
+                    "markdownDescription": "**Qualified Variables**\n\nThe name of each property in this object corresponds to a qualifier that is available in processing associated with this application. The qualifier can not be an empty string. The properties of these 'qualifier objects' are template values that are accessible as qualified variables. These variables are evaluated once per execution context (xctx) as they are accessed.\n\nSome qualifiers are restricted.",
+                    "title": "Qualified Variables",
+                    "type": "object"
+                },
+                "rootFilePaths": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveRootFilePaths_"
+                        }
+                    ],
+                    "description": "The properties of this object are the root file paths used by open_file().",
+                    "markdownDescription": "**Root File Paths**\n\nThe properties of this object are the root file paths used by open_file().",
+                    "title": "Root File Paths",
+                    "type": "object"
+                },
+                "title": {
+                    "description": "The title of the application. This is used as the title of the Adaptive Framework Web App and is available for use in other places as appropriate.",
+                    "markdownDescription": "**Title**\n\nThe title of the application. This is used as the title of the Adaptive Framework Web App and is available for use in other places as appropriate.",
                     "title": "Title",
                     "type": "string"
                 }
@@ -185,14 +383,20 @@
         "_AdaptiveRootFilePaths_": {
             "additionalProperties": {
                 "description": "A function open_file path that begins with a slash followed by this property name will access a file in the directory path specified as a value to this property. For example, if this property is 'my': '/temp/my', file_open('mine', '/my/xyz', 'w') will open '/temp/my/xyz' for write in the host file system.",
+                "markdownDescription": "A function open_file path that begins with a slash followed by this property name will access a file in the directory path specified as a value to this property. For example, if this property is 'my': '/temp/my', file_open('mine', '/my/xyz', 'w') will open '/temp/my/xyz' for write in the host file system.",
                 "type": "string"
             },
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveRootFilePaths_.propertyTypes"
-                }
-            ],
             "description": "The properties of this object are the root file paths used by open_file().",
+            "markdownDescription": "The properties of this object are the root file paths used by open_file().",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                }
+            },
             "title": "Root File Paths",
             "type": "object"
         },
@@ -207,14 +411,21 @@
                         "$ref": "#/$defs/_AdaptiveTemplateProperties_"
                     }
                 ],
-                "description": "Each property is a _AdaptiveTemplateProperties_ object."
+                "description": "Each property is a _AdaptiveTemplateProperties_ object.",
+                "markdownDescription": "Each property is a _AdaptiveTemplateProperties_ object.",
+                "type": "object"
             },
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveTemplatePropertiesObjects_.propertyTypes"
-                }
-            ],
             "description": "The name of each property in this object corresponds to a qualifier that is available in processing associated with this application. The qualifier can not be an empty string. The properties of these 'qualifier objects' are template values that are accessible as qualified variables. These variables are evaluated once per execution context (xctx) as they are accessed.\n\nSome qualifiers are restricted.",
+            "markdownDescription": "The name of each property in this object corresponds to a qualifier that is available in processing associated with this application. The qualifier can not be an empty string. The properties of these 'qualifier objects' are template values that are accessible as qualified variables. These variables are evaluated once per execution context (xctx) as they are accessed.\n\nSome qualifiers are restricted.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                }
+            },
             "title": "Qualified Variables",
             "type": "object"
         },
@@ -225,14 +436,21 @@
         "_AdaptiveTemplateProperties_": {
             "additionalProperties": {
                 "description": "Each property is a template value.",
+                "markdownDescription": "Each property is a template value.",
                 "type": "string"
             },
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveTemplateProperties_.propertyTypes"
-                }
-            ],
             "description": "Each property is a template value.",
+            "markdownDescription": "Each property is a template value.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                }
+            },
+            "title": "_AdaptiveTemplateProperties_",
             "type": "object"
         },
         "_AdaptiveTemplateProperties_.propertyTypes": {
@@ -241,9 +459,153 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveConf_application"
+    "additionalProperties": false,
+    "description": "Adaptive Framework configuration component for type=application. There is only one application conf entry per Adaptive Framework instance.\n\nUse path /afw/_AdaptiveConf_application/current to access this entry at run time.",
+    "markdownDescription": "Adaptive Framework configuration component for type=application. There is only one application conf entry per Adaptive Framework instance.\n\nUse path /afw/_AdaptiveConf_application/current to access this entry at run time.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "applicationId": {
+            "description": "This is id of the application. The default applicationId is 'application'. This property can only be specified in the type=application entry of the conf file.",
+            "markdownDescription": "**Application Id**\n\nThis is id of the application. The default applicationId is 'application'. This property can only be specified in the type=application entry of the conf file.",
+            "readOnly": true,
+            "title": "Application Id",
+            "type": "string"
+        },
+        "authorizationControl": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveAuthorizationControl_"
+                }
+            ],
+            "description": "This defines how authorization checking occurs in this application.",
+            "markdownDescription": "**Authorization**\n\nThis defines how authorization checking occurs in this application.",
+            "title": "Authorization",
+            "type": "object"
+        },
+        "confAdapterId": {
+            "description": "This is the optional adapterId of the running adapter that contains configuration related objects. This property can only be specified in the type=application entry of the conf file.\n\nThe runtime /afw/_AdaptiveApplication_/current object will consist of properties from the type=application entry of the conf file plus unique properties from the optional /<confAdapterId>/_AdaptiveConf_application/<applicationId> object.\n\nAll services defined by _AdaptiveServiceConf_ objects in <confAdapterId> with startup 'permanent' or 'immediate' will be started when the type=application conf entry is processed.",
+            "markdownDescription": "**Conf Adapter**\n\nThis is the optional adapterId of the running adapter that contains configuration related objects. This property can only be specified in the type=application entry of the conf file.\n\nThe runtime /afw/_AdaptiveApplication_/current object will consist of properties from the type=application entry of the conf file plus unique properties from the optional /<confAdapterId>/_AdaptiveConf_application/<applicationId> object.\n\nAll services defined by _AdaptiveServiceConf_ objects in <confAdapterId> with startup 'permanent' or 'immediate' will be started when the type=application conf entry is processed.",
+            "readOnly": true,
+            "title": "Conf Adapter",
+            "type": "string"
+        },
+        "defaultAdapterId": {
+            "description": "This is the adapterId chosen by default for user interface select components.",
+            "markdownDescription": "**Default Adapter**\n\nThis is the adapterId chosen by default for user interface select components.",
+            "title": "Default Adapter",
+            "type": "string"
+        },
+        "defaultFlags": {
+            "description": "This is an array of the flagId of default flags that will be set when an execution context (xctx) is created. Flags in this array that are not yet registered will be set as a default when/if they are registered. Each registered flagId is the objectId of an object in /afw/_AdaptiveFlag_/.",
+            "items": {
+                "description": "This is an array of the flagId of default flags that will be set when an execution context (xctx) is created. Flags in this array that are not yet registered will be set as a default when/if they are registered. Each registered flagId is the objectId of an object in /afw/_AdaptiveFlag_/.",
+                "markdownDescription": "This is an array of the flagId of default flags that will be set when an execution context (xctx) is created. Flags in this array that are not yet registered will be set as a default when/if they are registered. Each registered flagId is the objectId of an object in /afw/_AdaptiveFlag_/.",
+                "title": "List of default flags to be set when an execution context (xctx) is created.",
+                "type": "string"
+            },
+            "markdownDescription": "**Default Flags**\n\nThis is an array of the flagId of default flags that will be set when an execution context (xctx) is created. Flags in this array that are not yet registered will be set as a default when/if they are registered. Each registered flagId is the objectId of an object in /afw/_AdaptiveFlag_/.",
+            "title": "Default Flags",
+            "type": "array"
+        },
+        "defaultModelAdapterId": {
+            "description": "When presented with multiple model adapters, this is the default adapterId to use. This will be the default selected adapter chosen by user interface components.",
+            "markdownDescription": "**Default Model Adapter**\n\nWhen presented with multiple model adapters, this is the default adapterId to use. This will be the default selected adapter chosen by user interface components.",
+            "title": "Default Model Adapter",
+            "type": "string"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "The description of the application.",
+            "markdownDescription": "**Description**\n\nThe description of the application.",
+            "title": "Description",
+            "type": "string"
+        },
+        "extensionModulePaths": {
+            "description": "This is an array of modulePaths of extensions to load at startup. If there is already an extension manifest that has the extensionId, use the extensions property instead. This property is most useful for loading the extension manifest of an AFW package.",
+            "items": {
+                "description": "This is an array of modulePaths of extensions to load at startup. If there is already an extension manifest that has the extensionId, use the extensions property instead. This property is most useful for loading the extension manifest of an AFW package.",
+                "markdownDescription": "This is an array of modulePaths of extensions to load at startup. If there is already an extension manifest that has the extensionId, use the extensions property instead. This property is most useful for loading the extension manifest of an AFW package.",
+                "title": "List of modulePaths of extensions to load at startup",
+                "type": "string"
+            },
+            "markdownDescription": "**Extension Module Paths**\n\nThis is an array of modulePaths of extensions to load at startup. If there is already an extension manifest that has the extensionId, use the extensions property instead. This property is most useful for loading the extension manifest of an AFW package.",
+            "title": "Extension Module Paths",
+            "type": "array"
+        },
+        "extensions": {
+            "description": "This is an array of extensionId of extensions to load at startup. Each extensionId must be the objectId of an object in /afw/_AdaptiveManifest_/.",
+            "items": {
+                "description": "This is an array of extensionId of extensions to load at startup. Each extensionId must be the objectId of an object in /afw/_AdaptiveManifest_/.",
+                "markdownDescription": "This is an array of extensionId of extensions to load at startup. Each extensionId must be the objectId of an object in /afw/_AdaptiveManifest_/.",
+                "title": "List of extensionIds to load at startup",
+                "type": "string"
+            },
+            "markdownDescription": "**Extensions**\n\nThis is an array of extensionId of extensions to load at startup. Each extensionId must be the objectId of an object in /afw/_AdaptiveManifest_/.",
+            "title": "Extensions",
+            "type": "array"
+        },
+        "layoutsAdapterId": {
+            "description": "This is the adapterId that locates Adaptive Layout Component objects.",
+            "markdownDescription": "**Layouts Adapter**\n\nThis is the adapterId that locates Adaptive Layout Component objects.",
+            "title": "Layouts Adapter",
+            "type": "string"
+        },
+        "onApplicationStartupComplete": {
+            "description": "This is an optional script to run after this application has completed startup but before starting to process requests. The script can perform additional startup functions or request that the application terminate. All permanent and immediate services will have been started before the script is called. If the script fails or explicitly returns a value other than 0, the application will terminate.",
+            "markdownDescription": "**Application Startup Complete**\n\nThis is an optional script to run after this application has completed startup but before starting to process requests. The script can perform additional startup functions or request that the application terminate. All permanent and immediate services will have been started before the script is called. If the script fails or explicitly returns a value other than 0, the application will terminate.",
+            "title": "Application Startup Complete",
+            "type": "string"
+        },
+        "qualifiedVariables": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveTemplatePropertiesObjects_"
+                }
+            ],
+            "description": "The name of each property in this object corresponds to a qualifier that is available in processing associated with this application. The qualifier can not be an empty string. The properties of these 'qualifier objects' are template values that are accessible as qualified variables. These variables are evaluated once per execution context (xctx) as they are accessed.\n\nSome qualifiers are restricted.",
+            "markdownDescription": "**Qualified Variables**\n\nThe name of each property in this object corresponds to a qualifier that is available in processing associated with this application. The qualifier can not be an empty string. The properties of these 'qualifier objects' are template values that are accessible as qualified variables. These variables are evaluated once per execution context (xctx) as they are accessed.\n\nSome qualifiers are restricted.",
+            "title": "Qualified Variables",
+            "type": "object"
+        },
+        "rootFilePaths": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveRootFilePaths_"
+                }
+            ],
+            "description": "The properties of this object are the root file paths used by open_file().",
+            "markdownDescription": "**Root File Paths**\n\nThe properties of this object are the root file paths used by open_file().",
+            "title": "Root File Paths",
+            "type": "object"
+        },
+        "sourceLocation": {
+            "description": "This is a contextual string added when this configuration object is processed.",
+            "markdownDescription": "**Source Location**\n\nThis is a contextual string added when this configuration object is processed.",
+            "title": "Source Location",
+            "type": "string"
+        },
+        "title": {
+            "description": "The title of the application. This is used as the title of the Adaptive Framework Web App and is available for use in other places as appropriate.",
+            "markdownDescription": "**Title**\n\nThe title of the application. This is used as the title of the Adaptive Framework Web App and is available for use in other places as appropriate.",
+            "title": "Title",
+            "type": "string"
+        },
+        "type": {
+            "description": "Configuration type.",
+            "markdownDescription": "**Type**\n\nConfiguration type.",
+            "title": "Type",
+            "type": "string"
         }
+    },
+    "title": "_AdaptiveConf_application",
+    "type": "object",
+    "x-afw-inheritedObjectTypes": [
+        "_AdaptiveConf_"
     ]
 }

--- a/generated/schemas/afw/_AdaptiveContentType_.json
+++ b/generated/schemas/afw/_AdaptiveContentType_.json
@@ -1,19 +1,33 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveContentType_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveContentType_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveContentType_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "There is one of these for each media type registered for a content type implementation.",
-            "type": "object",
-            "unevaluatedProperties": false
+            "markdownDescription": "There is one of these for each media type registered for a content type implementation.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "mediaType": {
+                    "description": "Key of entry.",
+                    "markdownDescription": "**Media Type**\n\nKey of entry.",
+                    "title": "Media Type",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveContentType_",
+            "type": "object"
         },
         "_AdaptiveContentType_.propertyTypes": {
             "properties": {
                 "mediaType": {
                     "description": "Key of entry.",
+                    "markdownDescription": "**Media Type**\n\nKey of entry.",
                     "title": "Media Type",
                     "type": "string"
                 }
@@ -22,9 +36,24 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveContentType_"
+    "additionalProperties": false,
+    "description": "There is one of these for each media type registered for a content type implementation.",
+    "markdownDescription": "There is one of these for each media type registered for a content type implementation.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "mediaType": {
+            "description": "Key of entry.",
+            "markdownDescription": "**Media Type**\n\nKey of entry.",
+            "title": "Media Type",
+            "type": "string"
         }
-    ]
+    },
+    "title": "_AdaptiveContentType_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveContentType_.json
+++ b/generated/schemas/afw/_AdaptiveContentType_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveContentType_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveContentType_.propertyTypes"
                 }
@@ -22,7 +22,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveContentType_"
         }

--- a/generated/schemas/afw/_AdaptiveContextType_.json
+++ b/generated/schemas/afw/_AdaptiveContextType_.json
@@ -1,25 +1,28 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveContextType_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveContextType_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveContextType_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Context information.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveContextType_.propertyTypes": {
+            "markdownDescription": "Context information.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "contextTypeId": {
                     "description": "This is the context type id. For context types related to conf objects, the id should be the type followed by an optional dash and subtype. For example, the id for conf type log logType standard must be log-standard.",
+                    "markdownDescription": "**Context Type Id**\n\nThis is the context type id. For context types related to conf objects, the id should be the type followed by an optional dash and subtype. For example, the id for conf type log logType standard must be log-standard.",
                     "title": "Context Type Id",
                     "type": "string"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "Description of this context type.",
+                    "markdownDescription": "**Description**\n\nDescription of this context type.",
                     "title": "Description",
                     "type": "string"
                 },
@@ -30,10 +33,49 @@
                         }
                     ],
                     "description": "Qualifiers that can be used in log related expressions. An empty string qualifier is used for unqualified variable references.",
-                    "title": "Qualifiers"
+                    "markdownDescription": "**Qualifiers**\n\nQualifiers that can be used in log related expressions. An empty string qualifier is used for unqualified variable references.",
+                    "title": "Qualifiers",
+                    "type": "object"
                 },
                 "title": {
                     "description": "Title of this context type.",
+                    "markdownDescription": "**Title**\n\nTitle of this context type.",
+                    "title": "Title",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveContextType_",
+            "type": "object"
+        },
+        "_AdaptiveContextType_.propertyTypes": {
+            "properties": {
+                "contextTypeId": {
+                    "description": "This is the context type id. For context types related to conf objects, the id should be the type followed by an optional dash and subtype. For example, the id for conf type log logType standard must be log-standard.",
+                    "markdownDescription": "**Context Type Id**\n\nThis is the context type id. For context types related to conf objects, the id should be the type followed by an optional dash and subtype. For example, the id for conf type log logType standard must be log-standard.",
+                    "title": "Context Type Id",
+                    "type": "string"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "Description of this context type.",
+                    "markdownDescription": "**Description**\n\nDescription of this context type.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "qualifierDefinitions": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveQualifierDefinitions_"
+                        }
+                    ],
+                    "description": "Qualifiers that can be used in log related expressions. An empty string qualifier is used for unqualified variable references.",
+                    "markdownDescription": "**Qualifiers**\n\nQualifiers that can be used in log related expressions. An empty string qualifier is used for unqualified variable references.",
+                    "title": "Qualifiers",
+                    "type": "object"
+                },
+                "title": {
+                    "description": "Title of this context type.",
+                    "markdownDescription": "**Title**\n\nTitle of this context type.",
                     "title": "Title",
                     "type": "string"
                 }
@@ -42,12 +84,17 @@
         },
         "_AdaptiveObject_": {
             "additionalProperties": true,
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveObject_.propertyTypes"
-                }
-            ],
             "description": "Hints that can optionally be used by UI to render this value.",
+            "markdownDescription": "Hints that can optionally be used by UI to render this value.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                }
+            },
             "title": "Hints",
             "type": "object"
         },
@@ -62,9 +109,12 @@
                         "$ref": "#/$defs/_AdaptiveValueMeta_"
                     }
                 ],
-                "description": "Object type of the propertyTypes property of an object type."
+                "description": "Object type of the propertyTypes property of an object type.",
+                "markdownDescription": "Object type of the propertyTypes property of an object type.",
+                "type": "object"
             },
             "description": "Object type of the propertyTypes property of an object type.",
+            "markdownDescription": "Object type of the propertyTypes property of an object type.",
             "properties": {
                 "_meta_": {
                     "description": "This is the special Meta object that has deltas between this instance and its Adaptive Object Type.",
@@ -83,6 +133,7 @@
                     "title": "Meta"
                 }
             },
+            "title": "_AdaptivePropertyTypes_",
             "type": "object"
         },
         "_AdaptiveQualifierDefinitions_": {
@@ -92,14 +143,21 @@
                         "$ref": "#/$defs/_AdaptivePropertyTypes_"
                     }
                 ],
-                "description": "This object type used for qualifier definitions where each property is a _AdaptivePropertyTypes_ object with a qualifier id as a property name."
+                "description": "This object type used for qualifier definitions where each property is a _AdaptivePropertyTypes_ object with a qualifier id as a property name.",
+                "markdownDescription": "This object type used for qualifier definitions where each property is a _AdaptivePropertyTypes_ object with a qualifier id as a property name.",
+                "type": "object"
             },
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveQualifierDefinitions_.propertyTypes"
-                }
-            ],
             "description": "Qualifiers that can be used in log related expressions. An empty string qualifier is used for unqualified variable references.",
+            "markdownDescription": "Qualifiers that can be used in log related expressions. An empty string qualifier is used for unqualified variable references.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                }
+            },
             "title": "Qualifiers",
             "type": "object"
         },
@@ -108,35 +166,68 @@
             "type": "object"
         },
         "_AdaptiveRuntimeProperty_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveRuntimeProperty_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
-            "title": "Runtime",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveRuntimeProperty_.propertyTypes": {
+            "markdownDescription": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "memberName": {
                     "description": "The member name of this property in the runtime struct if other than the property name.",
+                    "markdownDescription": "**Member Name**\n\nThe member name of this property in the runtime struct if other than the property name.",
                     "title": "Member Name",
                     "type": "string"
                 },
                 "onGetValueCFunctionName": {
                     "description": "This is the name of the c callback function called to get the value of this property at runtime. If this property is specified, valueAccessor is ignored.",
+                    "markdownDescription": "**onGetValueCFunctionName**\n\nThis is the name of the c callback function called to get the value of this property at runtime. If this property is specified, valueAccessor is ignored.",
                     "title": "onGetValueCFunctionName",
                     "type": "string"
                 },
                 "valueAccessor": {
                     "description": "The name of the registered value accessor used to access this property. The default is default. See afw_runtime_value_accessor.h for the built in accessors.",
+                    "markdownDescription": "**Value Accessor**\n\nThe name of the registered value accessor used to access this property. The default is default. See afw_runtime_value_accessor.h for the built in accessors.",
                     "title": "Value Accessor",
                     "type": "string"
                 },
                 "zeroOffset": {
                     "description": "Indicates that the value accessor is called with a pointer to the struct and a 0 offset.",
+                    "markdownDescription": "**Zero Offset**\n\nIndicates that the value accessor is called with a pointer to the struct and a 0 offset.",
+                    "title": "Zero Offset",
+                    "type": "boolean"
+                }
+            },
+            "title": "Runtime",
+            "type": "object"
+        },
+        "_AdaptiveRuntimeProperty_.propertyTypes": {
+            "properties": {
+                "memberName": {
+                    "description": "The member name of this property in the runtime struct if other than the property name.",
+                    "markdownDescription": "**Member Name**\n\nThe member name of this property in the runtime struct if other than the property name.",
+                    "title": "Member Name",
+                    "type": "string"
+                },
+                "onGetValueCFunctionName": {
+                    "description": "This is the name of the c callback function called to get the value of this property at runtime. If this property is specified, valueAccessor is ignored.",
+                    "markdownDescription": "**onGetValueCFunctionName**\n\nThis is the name of the c callback function called to get the value of this property at runtime. If this property is specified, valueAccessor is ignored.",
+                    "title": "onGetValueCFunctionName",
+                    "type": "string"
+                },
+                "valueAccessor": {
+                    "description": "The name of the registered value accessor used to access this property. The default is default. See afw_runtime_value_accessor.h for the built in accessors.",
+                    "markdownDescription": "**Value Accessor**\n\nThe name of the registered value accessor used to access this property. The default is default. See afw_runtime_value_accessor.h for the built in accessors.",
+                    "title": "Value Accessor",
+                    "type": "string"
+                },
+                "zeroOffset": {
+                    "description": "Indicates that the value accessor is called with a pointer to the struct and a 0 offset.",
+                    "markdownDescription": "**Zero Offset**\n\nIndicates that the value accessor is called with a pointer to the struct and a 0 offset.",
                     "title": "Zero Offset",
                     "type": "boolean"
                 }
@@ -144,39 +235,44 @@
             "type": "object"
         },
         "_AdaptiveValueMeta_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveValueMeta_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "The object type for an adaptive value's meta.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveValueMeta_.propertyTypes": {
+            "markdownDescription": "The object type for an adaptive value's meta.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "additionalConstraints": {
                     "description": "Additional constraint for the value.",
+                    "markdownDescription": "**Additional Constraints**\n\nAdditional constraint for the value.",
                     "title": "Additional Constraints",
                     "type": "string"
                 },
                 "allowQuery": {
                     "description": "If false, this value can NEVER be queried. If true, this value can be queried if allowed by authorization policy.",
+                    "markdownDescription": "**Allow Query**\n\nIf false, this value can NEVER be queried. If true, this value can be queried if allowed by authorization policy.",
                     "title": "Allow Query",
                     "type": "boolean"
                 },
                 "allowWrite": {
                     "description": "If true, the value can be written if allowed by authorization policy as long as allowChange for the instance is also true. If false, the value can only be written if required is true when adding a new object.",
+                    "markdownDescription": "**Allow Write**\n\nIf true, the value can be written if allowed by authorization policy as long as allowChange for the instance is also true. If false, the value can only be written if required is true when adding a new object.",
                     "title": "Allow Write",
                     "type": "boolean"
                 },
                 "allowedValues": {
                     "description": "This is an array of the allowed values for this adaptive value. The dataType and dataTypeParameter of these values is the same as for the adaptive value itself.",
+                    "markdownDescription": "**Allowed Values**\n\nThis is an array of the allowed values for this adaptive value. The dataType and dataTypeParameter of these values is the same as for the adaptive value itself.",
                     "title": "Allowed Values",
                     "type": "array"
                 },
                 "brief": {
                     "description": "This is a predicate for this value, with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for this value, with the first letter capitalized and without a trailing period.",
                     "title": "Brief",
                     "type": "string"
                 },
@@ -185,39 +281,47 @@
                     "items": {
                         "description": "This is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
                         "format": "uri-reference",
+                        "markdownDescription": "This is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
                         "title": "The URIs of the collection that this value is a part of",
                         "type": "string"
                     },
+                    "markdownDescription": "**Collection URIs**\n\nThis is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
                     "title": "Collection URIs",
                     "type": "array"
                 },
                 "contextType": {
                     "description": "For data types that are evaluated (evaluate property true), this is the context type used for the evaluation.",
+                    "markdownDescription": "**Context Type**\n\nFor data types that are evaluated (evaluate property true), this is the context type used for the evaluation.",
                     "title": "Context Type",
                     "type": "string"
                 },
                 "dataType": {
                     "description": "Data type of this value.",
+                    "markdownDescription": "**Data Type**\n\nData type of this value.",
                     "title": "Data Type",
                     "type": "string"
                 },
                 "dataTypeParameter": {
                     "description": "See the data type's dataTypeParameterType property to determine how to interpret this.",
+                    "markdownDescription": "**Data Type Parameter**\n\nSee the data type's dataTypeParameterType property to determine how to interpret this.",
                     "title": "Data Type Parameter",
                     "type": "string"
                 },
                 "dataTypeParameterFormatted": {
                     "description": "This is the same as dataTypeParameter with possible comments and whitespace. This is especially useful for data type function to document its signature. If this property is not present, dataTypeParameter can be used in its place.",
+                    "markdownDescription": "**Formatted Data Type Parameter**\n\nThis is the same as dataTypeParameter with possible comments and whitespace. This is especially useful for data type function to document its signature. If this property is not present, dataTypeParameter can be used in its place.",
                     "title": "Formatted Data Type Parameter",
                     "type": "string"
                 },
                 "defaultValue": {
                     "description": "This is the default value. The dataType and dataTypeParameter properties apply to this value. If needed, this value will be normalized.",
+                    "markdownDescription": "**Default Value**\n\nThis is the default value. The dataType and dataTypeParameter properties apply to this value. If needed, this value will be normalized.",
                     "title": "Default Value"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "The description of this value.",
+                    "markdownDescription": "**Description**\n\nThe description of this value.",
                     "title": "Description",
                     "type": "string"
                 },
@@ -228,56 +332,68 @@
                         }
                     ],
                     "description": "Hints that can optionally be used by UI to render this value.",
-                    "title": "Hints"
+                    "markdownDescription": "**Hints**\n\nHints that can optionally be used by UI to render this value.",
+                    "title": "Hints",
+                    "type": "object"
                 },
                 "label": {
                     "description": "Label used to identify this value.",
+                    "markdownDescription": "**Label**\n\nLabel used to identify this value.",
                     "title": "Label",
                     "type": "string"
                 },
                 "maxLength": {
                     "description": "This is maximum length of the to_string() for this value. If not specified, there is no maximum length.",
+                    "markdownDescription": "**Maximum Length**\n\nThis is maximum length of the to_string() for this value. If not specified, there is no maximum length.",
                     "title": "Maximum Length",
                     "type": "integer"
                 },
                 "maxNormalLength": {
                     "description": "This is maximum normal length of the to_string() for this value.  If not specified, maxLength is used.",
+                    "markdownDescription": "**Normal Maximum Length**\n\nThis is maximum normal length of the to_string() for this value.  If not specified, maxLength is used.",
                     "title": "Normal Maximum Length",
                     "type": "integer"
                 },
                 "maxValue": {
                     "description": "This is the maximum for this value. If not specified, there is no maximum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "markdownDescription": "**Maximum Value**\n\nThis is the maximum for this value. If not specified, there is no maximum value. The dataType and dataTypeParameter of this value is the same as for the value.",
                     "title": "Maximum Value"
                 },
                 "minLength": {
                     "description": "This is minimum length of the to_string() for this value. If not specified, there is no minimum length.",
+                    "markdownDescription": "**Minimum Length**\n\nThis is minimum length of the to_string() for this value. If not specified, there is no minimum length.",
                     "title": "Minimum Length",
                     "type": "integer"
                 },
                 "minValue": {
                     "description": "This is the minimum for this. If not specified, there is no minimum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "markdownDescription": "**Minimum Value**\n\nThis is the minimum for this. If not specified, there is no minimum value. The dataType and dataTypeParameter of this value is the same as for the value.",
                     "title": "Minimum Value"
                 },
                 "originURI": {
                     "description": "The origin URI of this value meta. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
                     "format": "uri-reference",
+                    "markdownDescription": "**Origin URI**\n\nThe origin URI of this value meta. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
                     "title": "Origin URI",
                     "type": "string"
                 },
                 "possibleValues": {
                     "description": "Possible values of this value. This can be the typed value or the string value.",
+                    "markdownDescription": "**Possible Values**\n\nPossible values of this value. This can be the typed value or the string value.",
                     "title": "Possible Values",
                     "type": "array"
                 },
                 "referenceURI": {
                     "description": "URI of more reference information about this value meta.",
                     "format": "uri-reference",
+                    "markdownDescription": "**Reference URI**\n\nURI of more reference information about this value meta.",
                     "title": "Reference URI",
                     "type": "string"
                 },
                 "required": {
                     "default": false,
                     "description": "Indicates that value is required.",
+                    "markdownDescription": "**Required**\n\nIndicates that value is required.",
                     "title": "Required",
                     "type": "boolean"
                 },
@@ -288,34 +404,246 @@
                         }
                     ],
                     "description": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
-                    "title": "Runtime"
+                    "markdownDescription": "**Runtime**\n\nThis is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
+                    "title": "Runtime",
+                    "type": "object"
                 },
                 "skeleton": {
                     "description": "This is a skeleton example that can optionally be used by an application as an initial value. For example, if this is a new data type 'template' value, this can be the text used to prime the edit window with sample Adaptive Script code including comments.",
+                    "markdownDescription": "**Skeleton**\n\nThis is a skeleton example that can optionally be used by an application as an initial value. For example, if this is a new data type 'template' value, this can be the text used to prime the edit window with sample Adaptive Script code including comments.",
                     "title": "Skeleton"
                 },
                 "tags": {
                     "description": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
                     "items": {
                         "description": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                        "markdownDescription": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
                         "title": "List of keywords and terms associated with values with this meta",
                         "type": "string"
                     },
+                    "markdownDescription": "**Tags**\n\nThis is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
                     "title": "Tags",
                     "type": "array"
                 },
                 "testDataParameter": {
                     "description": "This contains additional information about values with this meta that is used to produce test data.",
+                    "markdownDescription": "**Test Data Parameter**\n\nThis contains additional information about values with this meta that is used to produce test data.",
                     "title": "Test Data Parameter",
                     "type": "string"
                 },
                 "unique": {
                     "description": "Value of property must be unique within object type.",
+                    "markdownDescription": "**Unique**\n\nValue of property must be unique within object type.",
                     "title": "Unique",
                     "type": "boolean"
                 },
                 "valueInfId": {
                     "description": "This is a runtime property that is the implementation id of the value interface.",
+                    "markdownDescription": "**valueInf**\n\nThis is a runtime property that is the implementation id of the value interface.",
+                    "readOnly": true,
+                    "title": "valueInf",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveValueMeta_",
+            "type": "object"
+        },
+        "_AdaptiveValueMeta_.propertyTypes": {
+            "properties": {
+                "additionalConstraints": {
+                    "description": "Additional constraint for the value.",
+                    "markdownDescription": "**Additional Constraints**\n\nAdditional constraint for the value.",
+                    "title": "Additional Constraints",
+                    "type": "string"
+                },
+                "allowQuery": {
+                    "description": "If false, this value can NEVER be queried. If true, this value can be queried if allowed by authorization policy.",
+                    "markdownDescription": "**Allow Query**\n\nIf false, this value can NEVER be queried. If true, this value can be queried if allowed by authorization policy.",
+                    "title": "Allow Query",
+                    "type": "boolean"
+                },
+                "allowWrite": {
+                    "description": "If true, the value can be written if allowed by authorization policy as long as allowChange for the instance is also true. If false, the value can only be written if required is true when adding a new object.",
+                    "markdownDescription": "**Allow Write**\n\nIf true, the value can be written if allowed by authorization policy as long as allowChange for the instance is also true. If false, the value can only be written if required is true when adding a new object.",
+                    "title": "Allow Write",
+                    "type": "boolean"
+                },
+                "allowedValues": {
+                    "description": "This is an array of the allowed values for this adaptive value. The dataType and dataTypeParameter of these values is the same as for the adaptive value itself.",
+                    "markdownDescription": "**Allowed Values**\n\nThis is an array of the allowed values for this adaptive value. The dataType and dataTypeParameter of these values is the same as for the adaptive value itself.",
+                    "title": "Allowed Values",
+                    "type": "array"
+                },
+                "brief": {
+                    "description": "This is a predicate for this value, with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for this value, with the first letter capitalized and without a trailing period.",
+                    "title": "Brief",
+                    "type": "string"
+                },
+                "collectionURIs": {
+                    "description": "This is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                    "items": {
+                        "description": "This is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                        "format": "uri-reference",
+                        "markdownDescription": "This is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                        "title": "The URIs of the collection that this value is a part of",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Collection URIs**\n\nThis is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                    "title": "Collection URIs",
+                    "type": "array"
+                },
+                "contextType": {
+                    "description": "For data types that are evaluated (evaluate property true), this is the context type used for the evaluation.",
+                    "markdownDescription": "**Context Type**\n\nFor data types that are evaluated (evaluate property true), this is the context type used for the evaluation.",
+                    "title": "Context Type",
+                    "type": "string"
+                },
+                "dataType": {
+                    "description": "Data type of this value.",
+                    "markdownDescription": "**Data Type**\n\nData type of this value.",
+                    "title": "Data Type",
+                    "type": "string"
+                },
+                "dataTypeParameter": {
+                    "description": "See the data type's dataTypeParameterType property to determine how to interpret this.",
+                    "markdownDescription": "**Data Type Parameter**\n\nSee the data type's dataTypeParameterType property to determine how to interpret this.",
+                    "title": "Data Type Parameter",
+                    "type": "string"
+                },
+                "dataTypeParameterFormatted": {
+                    "description": "This is the same as dataTypeParameter with possible comments and whitespace. This is especially useful for data type function to document its signature. If this property is not present, dataTypeParameter can be used in its place.",
+                    "markdownDescription": "**Formatted Data Type Parameter**\n\nThis is the same as dataTypeParameter with possible comments and whitespace. This is especially useful for data type function to document its signature. If this property is not present, dataTypeParameter can be used in its place.",
+                    "title": "Formatted Data Type Parameter",
+                    "type": "string"
+                },
+                "defaultValue": {
+                    "description": "This is the default value. The dataType and dataTypeParameter properties apply to this value. If needed, this value will be normalized.",
+                    "markdownDescription": "**Default Value**\n\nThis is the default value. The dataType and dataTypeParameter properties apply to this value. If needed, this value will be normalized.",
+                    "title": "Default Value"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "The description of this value.",
+                    "markdownDescription": "**Description**\n\nThe description of this value.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "hints": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveObject_"
+                        }
+                    ],
+                    "description": "Hints that can optionally be used by UI to render this value.",
+                    "markdownDescription": "**Hints**\n\nHints that can optionally be used by UI to render this value.",
+                    "title": "Hints",
+                    "type": "object"
+                },
+                "label": {
+                    "description": "Label used to identify this value.",
+                    "markdownDescription": "**Label**\n\nLabel used to identify this value.",
+                    "title": "Label",
+                    "type": "string"
+                },
+                "maxLength": {
+                    "description": "This is maximum length of the to_string() for this value. If not specified, there is no maximum length.",
+                    "markdownDescription": "**Maximum Length**\n\nThis is maximum length of the to_string() for this value. If not specified, there is no maximum length.",
+                    "title": "Maximum Length",
+                    "type": "integer"
+                },
+                "maxNormalLength": {
+                    "description": "This is maximum normal length of the to_string() for this value.  If not specified, maxLength is used.",
+                    "markdownDescription": "**Normal Maximum Length**\n\nThis is maximum normal length of the to_string() for this value.  If not specified, maxLength is used.",
+                    "title": "Normal Maximum Length",
+                    "type": "integer"
+                },
+                "maxValue": {
+                    "description": "This is the maximum for this value. If not specified, there is no maximum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "markdownDescription": "**Maximum Value**\n\nThis is the maximum for this value. If not specified, there is no maximum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "title": "Maximum Value"
+                },
+                "minLength": {
+                    "description": "This is minimum length of the to_string() for this value. If not specified, there is no minimum length.",
+                    "markdownDescription": "**Minimum Length**\n\nThis is minimum length of the to_string() for this value. If not specified, there is no minimum length.",
+                    "title": "Minimum Length",
+                    "type": "integer"
+                },
+                "minValue": {
+                    "description": "This is the minimum for this. If not specified, there is no minimum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "markdownDescription": "**Minimum Value**\n\nThis is the minimum for this. If not specified, there is no minimum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "title": "Minimum Value"
+                },
+                "originURI": {
+                    "description": "The origin URI of this value meta. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
+                    "format": "uri-reference",
+                    "markdownDescription": "**Origin URI**\n\nThe origin URI of this value meta. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
+                    "title": "Origin URI",
+                    "type": "string"
+                },
+                "possibleValues": {
+                    "description": "Possible values of this value. This can be the typed value or the string value.",
+                    "markdownDescription": "**Possible Values**\n\nPossible values of this value. This can be the typed value or the string value.",
+                    "title": "Possible Values",
+                    "type": "array"
+                },
+                "referenceURI": {
+                    "description": "URI of more reference information about this value meta.",
+                    "format": "uri-reference",
+                    "markdownDescription": "**Reference URI**\n\nURI of more reference information about this value meta.",
+                    "title": "Reference URI",
+                    "type": "string"
+                },
+                "required": {
+                    "default": false,
+                    "description": "Indicates that value is required.",
+                    "markdownDescription": "**Required**\n\nIndicates that value is required.",
+                    "title": "Required",
+                    "type": "boolean"
+                },
+                "runtime": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveRuntimeProperty_"
+                        }
+                    ],
+                    "description": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
+                    "markdownDescription": "**Runtime**\n\nThis is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
+                    "title": "Runtime",
+                    "type": "object"
+                },
+                "skeleton": {
+                    "description": "This is a skeleton example that can optionally be used by an application as an initial value. For example, if this is a new data type 'template' value, this can be the text used to prime the edit window with sample Adaptive Script code including comments.",
+                    "markdownDescription": "**Skeleton**\n\nThis is a skeleton example that can optionally be used by an application as an initial value. For example, if this is a new data type 'template' value, this can be the text used to prime the edit window with sample Adaptive Script code including comments.",
+                    "title": "Skeleton"
+                },
+                "tags": {
+                    "description": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                    "items": {
+                        "description": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                        "markdownDescription": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                        "title": "List of keywords and terms associated with values with this meta",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Tags**\n\nThis is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                    "title": "Tags",
+                    "type": "array"
+                },
+                "testDataParameter": {
+                    "description": "This contains additional information about values with this meta that is used to produce test data.",
+                    "markdownDescription": "**Test Data Parameter**\n\nThis contains additional information about values with this meta that is used to produce test data.",
+                    "title": "Test Data Parameter",
+                    "type": "string"
+                },
+                "unique": {
+                    "description": "Value of property must be unique within object type.",
+                    "markdownDescription": "**Unique**\n\nValue of property must be unique within object type.",
+                    "title": "Unique",
+                    "type": "boolean"
+                },
+                "valueInfId": {
+                    "description": "This is a runtime property that is the implementation id of the value interface.",
+                    "markdownDescription": "**valueInf**\n\nThis is a runtime property that is the implementation id of the value interface.",
                     "readOnly": true,
                     "title": "valueInf",
                     "type": "string"
@@ -325,9 +653,48 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveContextType_"
+    "additionalProperties": false,
+    "description": "Context information.",
+    "markdownDescription": "Context information.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "contextTypeId": {
+            "description": "This is the context type id. For context types related to conf objects, the id should be the type followed by an optional dash and subtype. For example, the id for conf type log logType standard must be log-standard.",
+            "markdownDescription": "**Context Type Id**\n\nThis is the context type id. For context types related to conf objects, the id should be the type followed by an optional dash and subtype. For example, the id for conf type log logType standard must be log-standard.",
+            "title": "Context Type Id",
+            "type": "string"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "Description of this context type.",
+            "markdownDescription": "**Description**\n\nDescription of this context type.",
+            "title": "Description",
+            "type": "string"
+        },
+        "qualifierDefinitions": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveQualifierDefinitions_"
+                }
+            ],
+            "description": "Qualifiers that can be used in log related expressions. An empty string qualifier is used for unqualified variable references.",
+            "markdownDescription": "**Qualifiers**\n\nQualifiers that can be used in log related expressions. An empty string qualifier is used for unqualified variable references.",
+            "title": "Qualifiers",
+            "type": "object"
+        },
+        "title": {
+            "description": "Title of this context type.",
+            "markdownDescription": "**Title**\n\nTitle of this context type.",
+            "title": "Title",
+            "type": "string"
         }
-    ]
+    },
+    "title": "_AdaptiveContextType_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveContextType_.json
+++ b/generated/schemas/afw/_AdaptiveContextType_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveContextType_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveContextType_.propertyTypes"
                 }
@@ -24,10 +24,13 @@
                     "type": "string"
                 },
                 "qualifierDefinitions": {
-                    "$ref": "#/$defs/_AdaptiveQualifierDefinitions_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveQualifierDefinitions_"
+                        }
+                    ],
                     "description": "Qualifiers that can be used in log related expressions. An empty string qualifier is used for unqualified variable references.",
-                    "title": "Qualifiers",
-                    "type": "object"
+                    "title": "Qualifiers"
                 },
                 "title": {
                     "description": "Title of this context type.",
@@ -38,8 +41,8 @@
             "type": "object"
         },
         "_AdaptiveObject_": {
-            "additionalProperties": {},
-            "anyOf": [
+            "additionalProperties": true,
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveObject_.propertyTypes"
                 }
@@ -54,9 +57,12 @@
         },
         "_AdaptivePropertyTypes_": {
             "additionalProperties": {
-                "$ref": "#/$defs/_AdaptiveValueMeta_",
-                "description": "Object type of the propertyTypes property of an object type.",
-                "type": "object"
+                "allOf": [
+                    {
+                        "$ref": "#/$defs/_AdaptiveValueMeta_"
+                    }
+                ],
+                "description": "Object type of the propertyTypes property of an object type."
             },
             "description": "Object type of the propertyTypes property of an object type.",
             "properties": {
@@ -81,11 +87,14 @@
         },
         "_AdaptiveQualifierDefinitions_": {
             "additionalProperties": {
-                "$ref": "#/$defs/_AdaptivePropertyTypes_",
-                "description": "This object type used for qualifier definitions where each property is a _AdaptivePropertyTypes_ object with a qualifier id as a property name.",
-                "type": "object"
+                "allOf": [
+                    {
+                        "$ref": "#/$defs/_AdaptivePropertyTypes_"
+                    }
+                ],
+                "description": "This object type used for qualifier definitions where each property is a _AdaptivePropertyTypes_ object with a qualifier id as a property name."
             },
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveQualifierDefinitions_.propertyTypes"
                 }
@@ -99,7 +108,7 @@
             "type": "object"
         },
         "_AdaptiveRuntimeProperty_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveRuntimeProperty_.propertyTypes"
                 }
@@ -135,7 +144,7 @@
             "type": "object"
         },
         "_AdaptiveValueMeta_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveValueMeta_.propertyTypes"
                 }
@@ -213,10 +222,13 @@
                     "type": "string"
                 },
                 "hints": {
-                    "$ref": "#/$defs/_AdaptiveObject_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveObject_"
+                        }
+                    ],
                     "description": "Hints that can optionally be used by UI to render this value.",
-                    "title": "Hints",
-                    "type": "object"
+                    "title": "Hints"
                 },
                 "label": {
                     "description": "Label used to identify this value.",
@@ -264,15 +276,19 @@
                     "type": "string"
                 },
                 "required": {
+                    "default": false,
                     "description": "Indicates that value is required.",
                     "title": "Required",
                     "type": "boolean"
                 },
                 "runtime": {
-                    "$ref": "#/$defs/_AdaptiveRuntimeProperty_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveRuntimeProperty_"
+                        }
+                    ],
                     "description": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
-                    "title": "Runtime",
-                    "type": "object"
+                    "title": "Runtime"
                 },
                 "skeleton": {
                     "description": "This is a skeleton example that can optionally be used by an application as an initial value. For example, if this is a new data type 'template' value, this can be the text used to prime the edit window with sample Adaptive Script code including comments.",
@@ -309,7 +325,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveContextType_"
         }

--- a/generated/schemas/afw/_AdaptiveCurlHttpResponse_.json
+++ b/generated/schemas/afw/_AdaptiveCurlHttpResponse_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveCurlHttpResponse_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveCurlHttpResponse_.propertyTypes"
                 }
@@ -36,7 +36,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveCurlHttpResponse_"
         }

--- a/generated/schemas/afw/_AdaptiveCurlHttpResponse_.json
+++ b/generated/schemas/afw/_AdaptiveCurlHttpResponse_.json
@@ -1,14 +1,44 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveCurlHttpResponse_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveCurlHttpResponse_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveCurlHttpResponse_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Object type for cURL HTTP Responses.",
-            "type": "object",
-            "unevaluatedProperties": false
+            "markdownDescription": "Object type for cURL HTTP Responses.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "headers": {
+                    "description": "HTTP Headers from the server.",
+                    "items": {
+                        "description": "HTTP Headers from the server.",
+                        "markdownDescription": "HTTP Headers from the server.",
+                        "type": "string"
+                    },
+                    "markdownDescription": "HTTP Headers from the server.",
+                    "title": "Headers",
+                    "type": "array"
+                },
+                "response": {
+                    "description": "HTTP Response Data from the server.",
+                    "markdownDescription": "HTTP Response Data from the server.",
+                    "title": "Response",
+                    "type": "string"
+                },
+                "response_code": {
+                    "description": "HTTP Response Code from the server.",
+                    "markdownDescription": "HTTP Response Code from the server.",
+                    "title": "Response Code",
+                    "type": "integer"
+                }
+            },
+            "title": "_AdaptiveCurlHttpResponse_",
+            "type": "object"
         },
         "_AdaptiveCurlHttpResponse_.propertyTypes": {
             "properties": {
@@ -16,18 +46,22 @@
                     "description": "HTTP Headers from the server.",
                     "items": {
                         "description": "HTTP Headers from the server.",
+                        "markdownDescription": "HTTP Headers from the server.",
                         "type": "string"
                     },
+                    "markdownDescription": "HTTP Headers from the server.",
                     "title": "Headers",
                     "type": "array"
                 },
                 "response": {
                     "description": "HTTP Response Data from the server.",
+                    "markdownDescription": "HTTP Response Data from the server.",
                     "title": "Response",
                     "type": "string"
                 },
                 "response_code": {
                     "description": "HTTP Response Code from the server.",
+                    "markdownDescription": "HTTP Response Code from the server.",
                     "title": "Response Code",
                     "type": "integer"
                 }
@@ -36,9 +70,41 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveCurlHttpResponse_"
+    "additionalProperties": false,
+    "description": "Object type for cURL HTTP Responses.",
+    "markdownDescription": "Object type for cURL HTTP Responses.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "headers": {
+            "description": "HTTP Headers from the server.",
+            "items": {
+                "description": "HTTP Headers from the server.",
+                "markdownDescription": "HTTP Headers from the server.",
+                "type": "string"
+            },
+            "markdownDescription": "HTTP Headers from the server.",
+            "title": "Headers",
+            "type": "array"
+        },
+        "response": {
+            "description": "HTTP Response Data from the server.",
+            "markdownDescription": "HTTP Response Data from the server.",
+            "title": "Response",
+            "type": "string"
+        },
+        "response_code": {
+            "description": "HTTP Response Code from the server.",
+            "markdownDescription": "HTTP Response Code from the server.",
+            "title": "Response Code",
+            "type": "integer"
         }
-    ]
+    },
+    "title": "_AdaptiveCurlHttpResponse_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveCurlOptions_.json
+++ b/generated/schemas/afw/_AdaptiveCurlOptions_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveCurlOptions_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveCurlOptions_.propertyTypes"
                 }
@@ -169,7 +169,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveCurlOptions_"
         }

--- a/generated/schemas/afw/_AdaptiveCurlOptions_.json
+++ b/generated/schemas/afw/_AdaptiveCurlOptions_.json
@@ -1,167 +1,388 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveCurlOptions_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveCurlOptions_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveCurlOptions_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Object type for cURL General Options.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveCurlOptions_.propertyTypes": {
+            "markdownDescription": "Object type for cURL General Options.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "autoReferer": {
                     "description": "When true, libcurl will automatically set the Referer: header field in HTTP requests where it follows a Location: redirect.",
+                    "markdownDescription": "When true, libcurl will automatically set the Referer: header field in HTTP requests where it follows a Location: redirect.",
                     "title": "Auto Referer",
                     "type": "boolean"
                 },
                 "awsSigv4": {
                     "description": "When specified, libcurl will use AWS Signature Version 4 for authentication.",
+                    "markdownDescription": "When specified, libcurl will use AWS Signature Version 4 for authentication.",
                     "title": "V4 Signature",
                     "type": "string"
                 },
                 "caBlob": {
                     "description": "Certificate Authority (CA) bundle in PEM format.",
+                    "markdownDescription": "Certificate Authority (CA) bundle in PEM format.",
                     "title": "CA Blob",
                     "type": "string"
                 },
                 "caInfo": {
                     "description": "Path to Certificate Authority (CA) bundle.",
+                    "markdownDescription": "Path to Certificate Authority (CA) bundle.",
                     "title": "CA Info",
                     "type": "string"
                 },
                 "caPath": {
                     "description": "Directory holding CA certificates",
+                    "markdownDescription": "Directory holding CA certificates",
                     "title": "CA Path",
                     "type": "string"
                 },
                 "certInfo": {
                     "description": "Request SSL certificate information.",
+                    "markdownDescription": "Request SSL certificate information.",
                     "title": "Cert Info",
                     "type": "boolean"
                 },
                 "connectTimeout": {
                     "description": "Timeout (in milliseconds) for the connection phase.",
+                    "markdownDescription": "Timeout (in milliseconds) for the connection phase.",
                     "title": "Connect Timeout",
                     "type": "integer"
                 },
                 "cookies": {
                     "description": "Cookie(s) to send.",
+                    "markdownDescription": "Cookie(s) to send.",
                     "title": "Cookies",
                     "type": "array"
                 },
                 "followLocation": {
                     "description": "Follow HTTP redirects.",
+                    "markdownDescription": "Follow HTTP redirects.",
                     "title": "Follow Location",
                     "type": "boolean"
                 },
                 "freshConnect": {
                     "description": "Sets the next transfer to use a new (fresh) connection instead of trying to re-use an existing one.",
+                    "markdownDescription": "Sets the next transfer to use a new (fresh) connection instead of trying to re-use an existing one.",
                     "title": "Fresh Connect",
                     "type": "boolean"
                 },
                 "headerFunction": {
                     "description": "The optional callback function to read the headers.\nThis callback function gets invoked by libcurl as soon as it has received header data. The header callback is called once for each header and only complete header lines are passed on to the callback.\nYour callback should return the number of bytes actually taken care of. If that amount differs from the amount passed to your callback function, it signals an error condition to the library. This causes the transfer to get aborted.",
+                    "markdownDescription": "The optional callback function to read the headers.\nThis callback function gets invoked by libcurl as soon as it has received header data. The header callback is called once for each header and only complete header lines are passed on to the callback.\nYour callback should return the number of bytes actually taken care of. If that amount differs from the amount passed to your callback function, it signals an error condition to the library. This causes the transfer to get aborted.",
                     "title": "Header Function",
                     "type": "string"
                 },
                 "headerUserData": {
                     "description": "The user data to pass to the header callback function.",
+                    "markdownDescription": "The user data to pass to the header callback function.",
                     "title": "Header User Data"
                 },
                 "httpProxyTunnel": {
                     "description": "Set this parameter to true to make libcurl tunnel all operations through the HTTP proxy.",
+                    "markdownDescription": "Set this parameter to true to make libcurl tunnel all operations through the HTTP proxy.",
                     "title": "HTTP Proxy Tunnel",
                     "type": "boolean"
                 },
                 "http_version": {
                     "description": "HTTP version to use.",
+                    "markdownDescription": "HTTP version to use.",
                     "title": "HTTP Version",
                     "type": "string"
                 },
                 "interface": {
                     "description": "This sets the interface name to use as outgoing network interface.  The name can be an interface name, an IP address, or host name.",
+                    "markdownDescription": "This sets the interface name to use as outgoing network interface.  The name can be an interface name, an IP address, or host name.",
                     "title": "Interface",
                     "type": "string"
                 },
                 "keepAlive": {
                     "description": "If true, TCP keepalive probes will be sent.",
+                    "markdownDescription": "If true, TCP keepalive probes will be sent.",
                     "title": "Keepalive",
                     "type": "boolean"
                 },
                 "proxy": {
                     "description": "Set the proxy to use for the upcoming request.  This parameter should be a string holding the host name or dotted numerical IP address.  A numerical IPv6 address must be written within [brackets].  To specify a port number in this string, append :[port] to the end of the host name.  The proxy string may be prefixed with the [scheme]:// to specify which kind of proxy is used.",
+                    "markdownDescription": "Set the proxy to use for the upcoming request.  This parameter should be a string holding the host name or dotted numerical IP address.  A numerical IPv6 address must be written within [brackets].  To specify a port number in this string, append :[port] to the end of the host name.  The proxy string may be prefixed with the [scheme]:// to specify which kind of proxy is used.",
                     "title": "Proxy",
                     "type": "string"
                 },
                 "proxyServiceName": {
                     "description": "Parameter specifies the name of the service.  The default service name is 'HTTP' for HTTP based proxies and 'rcmd' for SOCKS5.",
+                    "markdownDescription": "Parameter specifies the name of the service.  The default service name is 'HTTP' for HTTP based proxies and 'rcmd' for SOCKS5.",
                     "title": "Proxy Service Name",
                     "type": "string"
                 },
                 "readFunction": {
                     "description": "The optional callback function to read the request body.\nThis callback function gets called by libcurl as soon as it has data to send. The read callback is called repeatedly until it returns 0 or an error occurs. The read callback should return the number of bytes actually taken care of. If that amount differs from the amount passed to your callback function, it signals an error condition to the library. This causes the transfer to get aborted.",
+                    "markdownDescription": "The optional callback function to read the request body.\nThis callback function gets called by libcurl as soon as it has data to send. The read callback is called repeatedly until it returns 0 or an error occurs. The read callback should return the number of bytes actually taken care of. If that amount differs from the amount passed to your callback function, it signals an error condition to the library. This causes the transfer to get aborted.",
                     "title": "Read Function",
                     "type": "string"
                 },
                 "readUserData": {
                     "description": "The user data to pass to the read callback function.",
+                    "markdownDescription": "The user data to pass to the read callback function.",
                     "title": "Read User Data"
                 },
                 "serviceName": {
                     "description": "The name of teh service for DIGEST-MD5, SPNEGO and Kerberos 5 authentication mechanisms.  The default service names are 'ftp', 'HTTP', 'imap', 'pop' and 'smtp'.",
+                    "markdownDescription": "The name of teh service for DIGEST-MD5, SPNEGO and Kerberos 5 authentication mechanisms.  The default service names are 'ftp', 'HTTP', 'imap', 'pop' and 'smtp'.",
                     "title": "Service Name",
                     "type": "string"
                 },
                 "sslVerifyHost": {
                     "description": "Verify the host name in the SSL certificate.",
+                    "markdownDescription": "Verify the host name in the SSL certificate.",
                     "title": "SSL Verify Host",
                     "type": "boolean"
                 },
                 "sslVerifyPeer": {
                     "description": "Verify the SSL certificate.",
+                    "markdownDescription": "Verify the SSL certificate.",
                     "title": "SSL Verify Peer",
                     "type": "boolean"
                 },
                 "sslVerifyStatus": {
                     "description": "Verify the SSL certificate's status.",
+                    "markdownDescription": "Verify the SSL certificate's status.",
                     "title": "SSL Verify Status",
                     "type": "boolean"
                 },
                 "sslVersion": {
                     "description": "SSL Version to use.",
+                    "markdownDescription": "SSL Version to use.",
                     "title": "SSL Version",
                     "type": "string"
                 },
                 "tcpNoDelay": {
                     "description": "Specifies whether the TCP_NODELAY option is to be set or cleared.  Setting this to true will disable TCP's Nagle algorithm on this connection.  The purpose of this algorithm is to try to minimize the number of small packets on the network.",
+                    "markdownDescription": "Specifies whether the TCP_NODELAY option is to be set or cleared.  Setting this to true will disable TCP's Nagle algorithm on this connection.  The purpose of this algorithm is to try to minimize the number of small packets on the network.",
                     "title": "TCP No Delay",
                     "type": "boolean"
                 },
                 "timeout": {
                     "description": "Timeout (in milliseconds) for the entire request.",
+                    "markdownDescription": "Timeout (in milliseconds) for the entire request.",
                     "title": "Timeout",
                     "type": "integer"
                 },
                 "userPassword": {
                     "description": "The user/password combination to use for authentication in the form user:password",
+                    "markdownDescription": "The user/password combination to use for authentication in the form user:password",
                     "title": "User/Password",
                     "type": "string"
                 },
                 "verbose": {
                     "description": "Display verbose information.",
+                    "markdownDescription": "Display verbose information.",
                     "title": "Verbose",
                     "type": "boolean"
                 },
                 "writeFunction": {
                     "description": "The optional callback function to write the response body.\nThis callback function gets called by libcurl as soon as there is data received that needs to be saved. For most transfers, this callback gets called many times and each invoke delivers another chunk of data.",
+                    "markdownDescription": "The optional callback function to write the response body.\nThis callback function gets called by libcurl as soon as there is data received that needs to be saved. For most transfers, this callback gets called many times and each invoke delivers another chunk of data.",
                     "title": "Write Function",
                     "type": "string"
                 },
                 "writeUserData": {
                     "description": "The user data to pass to the write callback function.",
+                    "markdownDescription": "The user data to pass to the write callback function.",
+                    "title": "Write User Data"
+                }
+            },
+            "title": "_AdaptiveCurlOptions_",
+            "type": "object"
+        },
+        "_AdaptiveCurlOptions_.propertyTypes": {
+            "properties": {
+                "autoReferer": {
+                    "description": "When true, libcurl will automatically set the Referer: header field in HTTP requests where it follows a Location: redirect.",
+                    "markdownDescription": "When true, libcurl will automatically set the Referer: header field in HTTP requests where it follows a Location: redirect.",
+                    "title": "Auto Referer",
+                    "type": "boolean"
+                },
+                "awsSigv4": {
+                    "description": "When specified, libcurl will use AWS Signature Version 4 for authentication.",
+                    "markdownDescription": "When specified, libcurl will use AWS Signature Version 4 for authentication.",
+                    "title": "V4 Signature",
+                    "type": "string"
+                },
+                "caBlob": {
+                    "description": "Certificate Authority (CA) bundle in PEM format.",
+                    "markdownDescription": "Certificate Authority (CA) bundle in PEM format.",
+                    "title": "CA Blob",
+                    "type": "string"
+                },
+                "caInfo": {
+                    "description": "Path to Certificate Authority (CA) bundle.",
+                    "markdownDescription": "Path to Certificate Authority (CA) bundle.",
+                    "title": "CA Info",
+                    "type": "string"
+                },
+                "caPath": {
+                    "description": "Directory holding CA certificates",
+                    "markdownDescription": "Directory holding CA certificates",
+                    "title": "CA Path",
+                    "type": "string"
+                },
+                "certInfo": {
+                    "description": "Request SSL certificate information.",
+                    "markdownDescription": "Request SSL certificate information.",
+                    "title": "Cert Info",
+                    "type": "boolean"
+                },
+                "connectTimeout": {
+                    "description": "Timeout (in milliseconds) for the connection phase.",
+                    "markdownDescription": "Timeout (in milliseconds) for the connection phase.",
+                    "title": "Connect Timeout",
+                    "type": "integer"
+                },
+                "cookies": {
+                    "description": "Cookie(s) to send.",
+                    "markdownDescription": "Cookie(s) to send.",
+                    "title": "Cookies",
+                    "type": "array"
+                },
+                "followLocation": {
+                    "description": "Follow HTTP redirects.",
+                    "markdownDescription": "Follow HTTP redirects.",
+                    "title": "Follow Location",
+                    "type": "boolean"
+                },
+                "freshConnect": {
+                    "description": "Sets the next transfer to use a new (fresh) connection instead of trying to re-use an existing one.",
+                    "markdownDescription": "Sets the next transfer to use a new (fresh) connection instead of trying to re-use an existing one.",
+                    "title": "Fresh Connect",
+                    "type": "boolean"
+                },
+                "headerFunction": {
+                    "description": "The optional callback function to read the headers.\nThis callback function gets invoked by libcurl as soon as it has received header data. The header callback is called once for each header and only complete header lines are passed on to the callback.\nYour callback should return the number of bytes actually taken care of. If that amount differs from the amount passed to your callback function, it signals an error condition to the library. This causes the transfer to get aborted.",
+                    "markdownDescription": "The optional callback function to read the headers.\nThis callback function gets invoked by libcurl as soon as it has received header data. The header callback is called once for each header and only complete header lines are passed on to the callback.\nYour callback should return the number of bytes actually taken care of. If that amount differs from the amount passed to your callback function, it signals an error condition to the library. This causes the transfer to get aborted.",
+                    "title": "Header Function",
+                    "type": "string"
+                },
+                "headerUserData": {
+                    "description": "The user data to pass to the header callback function.",
+                    "markdownDescription": "The user data to pass to the header callback function.",
+                    "title": "Header User Data"
+                },
+                "httpProxyTunnel": {
+                    "description": "Set this parameter to true to make libcurl tunnel all operations through the HTTP proxy.",
+                    "markdownDescription": "Set this parameter to true to make libcurl tunnel all operations through the HTTP proxy.",
+                    "title": "HTTP Proxy Tunnel",
+                    "type": "boolean"
+                },
+                "http_version": {
+                    "description": "HTTP version to use.",
+                    "markdownDescription": "HTTP version to use.",
+                    "title": "HTTP Version",
+                    "type": "string"
+                },
+                "interface": {
+                    "description": "This sets the interface name to use as outgoing network interface.  The name can be an interface name, an IP address, or host name.",
+                    "markdownDescription": "This sets the interface name to use as outgoing network interface.  The name can be an interface name, an IP address, or host name.",
+                    "title": "Interface",
+                    "type": "string"
+                },
+                "keepAlive": {
+                    "description": "If true, TCP keepalive probes will be sent.",
+                    "markdownDescription": "If true, TCP keepalive probes will be sent.",
+                    "title": "Keepalive",
+                    "type": "boolean"
+                },
+                "proxy": {
+                    "description": "Set the proxy to use for the upcoming request.  This parameter should be a string holding the host name or dotted numerical IP address.  A numerical IPv6 address must be written within [brackets].  To specify a port number in this string, append :[port] to the end of the host name.  The proxy string may be prefixed with the [scheme]:// to specify which kind of proxy is used.",
+                    "markdownDescription": "Set the proxy to use for the upcoming request.  This parameter should be a string holding the host name or dotted numerical IP address.  A numerical IPv6 address must be written within [brackets].  To specify a port number in this string, append :[port] to the end of the host name.  The proxy string may be prefixed with the [scheme]:// to specify which kind of proxy is used.",
+                    "title": "Proxy",
+                    "type": "string"
+                },
+                "proxyServiceName": {
+                    "description": "Parameter specifies the name of the service.  The default service name is 'HTTP' for HTTP based proxies and 'rcmd' for SOCKS5.",
+                    "markdownDescription": "Parameter specifies the name of the service.  The default service name is 'HTTP' for HTTP based proxies and 'rcmd' for SOCKS5.",
+                    "title": "Proxy Service Name",
+                    "type": "string"
+                },
+                "readFunction": {
+                    "description": "The optional callback function to read the request body.\nThis callback function gets called by libcurl as soon as it has data to send. The read callback is called repeatedly until it returns 0 or an error occurs. The read callback should return the number of bytes actually taken care of. If that amount differs from the amount passed to your callback function, it signals an error condition to the library. This causes the transfer to get aborted.",
+                    "markdownDescription": "The optional callback function to read the request body.\nThis callback function gets called by libcurl as soon as it has data to send. The read callback is called repeatedly until it returns 0 or an error occurs. The read callback should return the number of bytes actually taken care of. If that amount differs from the amount passed to your callback function, it signals an error condition to the library. This causes the transfer to get aborted.",
+                    "title": "Read Function",
+                    "type": "string"
+                },
+                "readUserData": {
+                    "description": "The user data to pass to the read callback function.",
+                    "markdownDescription": "The user data to pass to the read callback function.",
+                    "title": "Read User Data"
+                },
+                "serviceName": {
+                    "description": "The name of teh service for DIGEST-MD5, SPNEGO and Kerberos 5 authentication mechanisms.  The default service names are 'ftp', 'HTTP', 'imap', 'pop' and 'smtp'.",
+                    "markdownDescription": "The name of teh service for DIGEST-MD5, SPNEGO and Kerberos 5 authentication mechanisms.  The default service names are 'ftp', 'HTTP', 'imap', 'pop' and 'smtp'.",
+                    "title": "Service Name",
+                    "type": "string"
+                },
+                "sslVerifyHost": {
+                    "description": "Verify the host name in the SSL certificate.",
+                    "markdownDescription": "Verify the host name in the SSL certificate.",
+                    "title": "SSL Verify Host",
+                    "type": "boolean"
+                },
+                "sslVerifyPeer": {
+                    "description": "Verify the SSL certificate.",
+                    "markdownDescription": "Verify the SSL certificate.",
+                    "title": "SSL Verify Peer",
+                    "type": "boolean"
+                },
+                "sslVerifyStatus": {
+                    "description": "Verify the SSL certificate's status.",
+                    "markdownDescription": "Verify the SSL certificate's status.",
+                    "title": "SSL Verify Status",
+                    "type": "boolean"
+                },
+                "sslVersion": {
+                    "description": "SSL Version to use.",
+                    "markdownDescription": "SSL Version to use.",
+                    "title": "SSL Version",
+                    "type": "string"
+                },
+                "tcpNoDelay": {
+                    "description": "Specifies whether the TCP_NODELAY option is to be set or cleared.  Setting this to true will disable TCP's Nagle algorithm on this connection.  The purpose of this algorithm is to try to minimize the number of small packets on the network.",
+                    "markdownDescription": "Specifies whether the TCP_NODELAY option is to be set or cleared.  Setting this to true will disable TCP's Nagle algorithm on this connection.  The purpose of this algorithm is to try to minimize the number of small packets on the network.",
+                    "title": "TCP No Delay",
+                    "type": "boolean"
+                },
+                "timeout": {
+                    "description": "Timeout (in milliseconds) for the entire request.",
+                    "markdownDescription": "Timeout (in milliseconds) for the entire request.",
+                    "title": "Timeout",
+                    "type": "integer"
+                },
+                "userPassword": {
+                    "description": "The user/password combination to use for authentication in the form user:password",
+                    "markdownDescription": "The user/password combination to use for authentication in the form user:password",
+                    "title": "User/Password",
+                    "type": "string"
+                },
+                "verbose": {
+                    "description": "Display verbose information.",
+                    "markdownDescription": "Display verbose information.",
+                    "title": "Verbose",
+                    "type": "boolean"
+                },
+                "writeFunction": {
+                    "description": "The optional callback function to write the response body.\nThis callback function gets called by libcurl as soon as there is data received that needs to be saved. For most transfers, this callback gets called many times and each invoke delivers another chunk of data.",
+                    "markdownDescription": "The optional callback function to write the response body.\nThis callback function gets called by libcurl as soon as there is data received that needs to be saved. For most transfers, this callback gets called many times and each invoke delivers another chunk of data.",
+                    "title": "Write Function",
+                    "type": "string"
+                },
+                "writeUserData": {
+                    "description": "The user data to pass to the write callback function.",
+                    "markdownDescription": "The user data to pass to the write callback function.",
                     "title": "Write User Data"
                 }
             },
@@ -169,9 +390,201 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveCurlOptions_"
+    "additionalProperties": false,
+    "description": "Object type for cURL General Options.",
+    "markdownDescription": "Object type for cURL General Options.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "autoReferer": {
+            "description": "When true, libcurl will automatically set the Referer: header field in HTTP requests where it follows a Location: redirect.",
+            "markdownDescription": "When true, libcurl will automatically set the Referer: header field in HTTP requests where it follows a Location: redirect.",
+            "title": "Auto Referer",
+            "type": "boolean"
+        },
+        "awsSigv4": {
+            "description": "When specified, libcurl will use AWS Signature Version 4 for authentication.",
+            "markdownDescription": "When specified, libcurl will use AWS Signature Version 4 for authentication.",
+            "title": "V4 Signature",
+            "type": "string"
+        },
+        "caBlob": {
+            "description": "Certificate Authority (CA) bundle in PEM format.",
+            "markdownDescription": "Certificate Authority (CA) bundle in PEM format.",
+            "title": "CA Blob",
+            "type": "string"
+        },
+        "caInfo": {
+            "description": "Path to Certificate Authority (CA) bundle.",
+            "markdownDescription": "Path to Certificate Authority (CA) bundle.",
+            "title": "CA Info",
+            "type": "string"
+        },
+        "caPath": {
+            "description": "Directory holding CA certificates",
+            "markdownDescription": "Directory holding CA certificates",
+            "title": "CA Path",
+            "type": "string"
+        },
+        "certInfo": {
+            "description": "Request SSL certificate information.",
+            "markdownDescription": "Request SSL certificate information.",
+            "title": "Cert Info",
+            "type": "boolean"
+        },
+        "connectTimeout": {
+            "description": "Timeout (in milliseconds) for the connection phase.",
+            "markdownDescription": "Timeout (in milliseconds) for the connection phase.",
+            "title": "Connect Timeout",
+            "type": "integer"
+        },
+        "cookies": {
+            "description": "Cookie(s) to send.",
+            "markdownDescription": "Cookie(s) to send.",
+            "title": "Cookies",
+            "type": "array"
+        },
+        "followLocation": {
+            "description": "Follow HTTP redirects.",
+            "markdownDescription": "Follow HTTP redirects.",
+            "title": "Follow Location",
+            "type": "boolean"
+        },
+        "freshConnect": {
+            "description": "Sets the next transfer to use a new (fresh) connection instead of trying to re-use an existing one.",
+            "markdownDescription": "Sets the next transfer to use a new (fresh) connection instead of trying to re-use an existing one.",
+            "title": "Fresh Connect",
+            "type": "boolean"
+        },
+        "headerFunction": {
+            "description": "The optional callback function to read the headers.\nThis callback function gets invoked by libcurl as soon as it has received header data. The header callback is called once for each header and only complete header lines are passed on to the callback.\nYour callback should return the number of bytes actually taken care of. If that amount differs from the amount passed to your callback function, it signals an error condition to the library. This causes the transfer to get aborted.",
+            "markdownDescription": "The optional callback function to read the headers.\nThis callback function gets invoked by libcurl as soon as it has received header data. The header callback is called once for each header and only complete header lines are passed on to the callback.\nYour callback should return the number of bytes actually taken care of. If that amount differs from the amount passed to your callback function, it signals an error condition to the library. This causes the transfer to get aborted.",
+            "title": "Header Function",
+            "type": "string"
+        },
+        "headerUserData": {
+            "description": "The user data to pass to the header callback function.",
+            "markdownDescription": "The user data to pass to the header callback function.",
+            "title": "Header User Data"
+        },
+        "httpProxyTunnel": {
+            "description": "Set this parameter to true to make libcurl tunnel all operations through the HTTP proxy.",
+            "markdownDescription": "Set this parameter to true to make libcurl tunnel all operations through the HTTP proxy.",
+            "title": "HTTP Proxy Tunnel",
+            "type": "boolean"
+        },
+        "http_version": {
+            "description": "HTTP version to use.",
+            "markdownDescription": "HTTP version to use.",
+            "title": "HTTP Version",
+            "type": "string"
+        },
+        "interface": {
+            "description": "This sets the interface name to use as outgoing network interface.  The name can be an interface name, an IP address, or host name.",
+            "markdownDescription": "This sets the interface name to use as outgoing network interface.  The name can be an interface name, an IP address, or host name.",
+            "title": "Interface",
+            "type": "string"
+        },
+        "keepAlive": {
+            "description": "If true, TCP keepalive probes will be sent.",
+            "markdownDescription": "If true, TCP keepalive probes will be sent.",
+            "title": "Keepalive",
+            "type": "boolean"
+        },
+        "proxy": {
+            "description": "Set the proxy to use for the upcoming request.  This parameter should be a string holding the host name or dotted numerical IP address.  A numerical IPv6 address must be written within [brackets].  To specify a port number in this string, append :[port] to the end of the host name.  The proxy string may be prefixed with the [scheme]:// to specify which kind of proxy is used.",
+            "markdownDescription": "Set the proxy to use for the upcoming request.  This parameter should be a string holding the host name or dotted numerical IP address.  A numerical IPv6 address must be written within [brackets].  To specify a port number in this string, append :[port] to the end of the host name.  The proxy string may be prefixed with the [scheme]:// to specify which kind of proxy is used.",
+            "title": "Proxy",
+            "type": "string"
+        },
+        "proxyServiceName": {
+            "description": "Parameter specifies the name of the service.  The default service name is 'HTTP' for HTTP based proxies and 'rcmd' for SOCKS5.",
+            "markdownDescription": "Parameter specifies the name of the service.  The default service name is 'HTTP' for HTTP based proxies and 'rcmd' for SOCKS5.",
+            "title": "Proxy Service Name",
+            "type": "string"
+        },
+        "readFunction": {
+            "description": "The optional callback function to read the request body.\nThis callback function gets called by libcurl as soon as it has data to send. The read callback is called repeatedly until it returns 0 or an error occurs. The read callback should return the number of bytes actually taken care of. If that amount differs from the amount passed to your callback function, it signals an error condition to the library. This causes the transfer to get aborted.",
+            "markdownDescription": "The optional callback function to read the request body.\nThis callback function gets called by libcurl as soon as it has data to send. The read callback is called repeatedly until it returns 0 or an error occurs. The read callback should return the number of bytes actually taken care of. If that amount differs from the amount passed to your callback function, it signals an error condition to the library. This causes the transfer to get aborted.",
+            "title": "Read Function",
+            "type": "string"
+        },
+        "readUserData": {
+            "description": "The user data to pass to the read callback function.",
+            "markdownDescription": "The user data to pass to the read callback function.",
+            "title": "Read User Data"
+        },
+        "serviceName": {
+            "description": "The name of teh service for DIGEST-MD5, SPNEGO and Kerberos 5 authentication mechanisms.  The default service names are 'ftp', 'HTTP', 'imap', 'pop' and 'smtp'.",
+            "markdownDescription": "The name of teh service for DIGEST-MD5, SPNEGO and Kerberos 5 authentication mechanisms.  The default service names are 'ftp', 'HTTP', 'imap', 'pop' and 'smtp'.",
+            "title": "Service Name",
+            "type": "string"
+        },
+        "sslVerifyHost": {
+            "description": "Verify the host name in the SSL certificate.",
+            "markdownDescription": "Verify the host name in the SSL certificate.",
+            "title": "SSL Verify Host",
+            "type": "boolean"
+        },
+        "sslVerifyPeer": {
+            "description": "Verify the SSL certificate.",
+            "markdownDescription": "Verify the SSL certificate.",
+            "title": "SSL Verify Peer",
+            "type": "boolean"
+        },
+        "sslVerifyStatus": {
+            "description": "Verify the SSL certificate's status.",
+            "markdownDescription": "Verify the SSL certificate's status.",
+            "title": "SSL Verify Status",
+            "type": "boolean"
+        },
+        "sslVersion": {
+            "description": "SSL Version to use.",
+            "markdownDescription": "SSL Version to use.",
+            "title": "SSL Version",
+            "type": "string"
+        },
+        "tcpNoDelay": {
+            "description": "Specifies whether the TCP_NODELAY option is to be set or cleared.  Setting this to true will disable TCP's Nagle algorithm on this connection.  The purpose of this algorithm is to try to minimize the number of small packets on the network.",
+            "markdownDescription": "Specifies whether the TCP_NODELAY option is to be set or cleared.  Setting this to true will disable TCP's Nagle algorithm on this connection.  The purpose of this algorithm is to try to minimize the number of small packets on the network.",
+            "title": "TCP No Delay",
+            "type": "boolean"
+        },
+        "timeout": {
+            "description": "Timeout (in milliseconds) for the entire request.",
+            "markdownDescription": "Timeout (in milliseconds) for the entire request.",
+            "title": "Timeout",
+            "type": "integer"
+        },
+        "userPassword": {
+            "description": "The user/password combination to use for authentication in the form user:password",
+            "markdownDescription": "The user/password combination to use for authentication in the form user:password",
+            "title": "User/Password",
+            "type": "string"
+        },
+        "verbose": {
+            "description": "Display verbose information.",
+            "markdownDescription": "Display verbose information.",
+            "title": "Verbose",
+            "type": "boolean"
+        },
+        "writeFunction": {
+            "description": "The optional callback function to write the response body.\nThis callback function gets called by libcurl as soon as there is data received that needs to be saved. For most transfers, this callback gets called many times and each invoke delivers another chunk of data.",
+            "markdownDescription": "The optional callback function to write the response body.\nThis callback function gets called by libcurl as soon as there is data received that needs to be saved. For most transfers, this callback gets called many times and each invoke delivers another chunk of data.",
+            "title": "Write Function",
+            "type": "string"
+        },
+        "writeUserData": {
+            "description": "The user data to pass to the write callback function.",
+            "markdownDescription": "The user data to pass to the write callback function.",
+            "title": "Write User Data"
         }
-    ]
+    },
+    "title": "_AdaptiveCurlOptions_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveCurlVersionInfo_.json
+++ b/generated/schemas/afw/_AdaptiveCurlVersionInfo_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveCurlVersionInfo_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveCurlVersionInfo_.propertyTypes"
                 }
@@ -67,7 +67,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveCurlVersionInfo_"
         }

--- a/generated/schemas/afw/_AdaptiveCurlVersionInfo_.json
+++ b/generated/schemas/afw/_AdaptiveCurlVersionInfo_.json
@@ -1,14 +1,71 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveCurlVersionInfo_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveCurlVersionInfo_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveCurlVersionInfo_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Object type for cURL extension version info object.",
-            "type": "object",
-            "unevaluatedProperties": false
+            "markdownDescription": "Object type for cURL extension version info object.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "age": {
+                    "title": "Age",
+                    "type": "string"
+                },
+                "brotli_version": {
+                    "title": "Brotli Version",
+                    "type": "string"
+                },
+                "features": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "title": "Features",
+                    "type": "array"
+                },
+                "host": {
+                    "title": "Host",
+                    "type": "string"
+                },
+                "libssh_version": {
+                    "title": "LibSSH Version",
+                    "type": "string"
+                },
+                "libz_version": {
+                    "title": "LibZ Version",
+                    "type": "string"
+                },
+                "protocols": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "title": "Protocols",
+                    "type": "array"
+                },
+                "ssl_version": {
+                    "title": "SSL Version",
+                    "type": "string"
+                },
+                "ssl_version_num": {
+                    "title": "SSL Version Number",
+                    "type": "integer"
+                },
+                "version": {
+                    "title": "Version",
+                    "type": "string"
+                },
+                "version_num": {
+                    "title": "Version Number",
+                    "type": "integer"
+                }
+            },
+            "title": "_AdaptiveCurlVersionInfo_",
+            "type": "object"
         },
         "_AdaptiveCurlVersionInfo_.propertyTypes": {
             "properties": {
@@ -67,9 +124,68 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveCurlVersionInfo_"
+    "additionalProperties": false,
+    "description": "Object type for cURL extension version info object.",
+    "markdownDescription": "Object type for cURL extension version info object.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "age": {
+            "title": "Age",
+            "type": "string"
+        },
+        "brotli_version": {
+            "title": "Brotli Version",
+            "type": "string"
+        },
+        "features": {
+            "items": {
+                "type": "string"
+            },
+            "title": "Features",
+            "type": "array"
+        },
+        "host": {
+            "title": "Host",
+            "type": "string"
+        },
+        "libssh_version": {
+            "title": "LibSSH Version",
+            "type": "string"
+        },
+        "libz_version": {
+            "title": "LibZ Version",
+            "type": "string"
+        },
+        "protocols": {
+            "items": {
+                "type": "string"
+            },
+            "title": "Protocols",
+            "type": "array"
+        },
+        "ssl_version": {
+            "title": "SSL Version",
+            "type": "string"
+        },
+        "ssl_version_num": {
+            "title": "SSL Version Number",
+            "type": "integer"
+        },
+        "version": {
+            "title": "Version",
+            "type": "string"
+        },
+        "version_num": {
+            "title": "Version Number",
+            "type": "integer"
         }
-    ]
+    },
+    "title": "_AdaptiveCurlVersionInfo_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveDataTypeGenerate_.json
+++ b/generated/schemas/afw/_AdaptiveDataTypeGenerate_.json
@@ -1,52 +1,51 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveDataTypeGenerate_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveDataTypeGenerate_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveDataTypeGenerate_.propertyTypes"
-                },
-                {
-                    "$ref": "#/$defs/_AdaptiveDataType_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "This is the object type for objects in the generate/objects/_AdaptiveDataTypeGenerate_/ of command, core, and extension source directories. These objects are used by the 'dev.py generate' script to generate _AdaptiveDataType_ objects.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveDataTypeGenerate_.propertyTypes": {
+            "markdownDescription": "This is the object type for objects in the generate/objects/_AdaptiveDataTypeGenerate_/ of command, core, and extension source directories. These objects are used by the 'dev.py generate' script to generate _AdaptiveDataType_ objects.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "afw_value_get_evaluated_meta": {
                     "description": "This is the label in C source of the afw_value_get_evaluated_meta for this data type.",
+                    "markdownDescription": "**afw_value_get_evaluated_meta**\n\nThis is the label in C source of the afw_value_get_evaluated_meta for this data type.",
                     "title": "afw_value_get_evaluated_meta",
                     "type": "string"
                 },
                 "afw_value_get_evaluated_metas": {
                     "description": "This is the label in C source of the afw_value_get_evaluated_metas for this data type.",
+                    "markdownDescription": "**afw_value_get_evaluated_metas**\n\nThis is the label in C source of the afw_value_get_evaluated_metas for this data type.",
                     "title": "afw_value_get_evaluated_metas",
                     "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "_AdaptiveDataType_.propertyTypes": {
-            "properties": {
+                },
                 "brief": {
                     "description": "This is a predicate for the data type with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for the data type with the first letter capitalized and without a trailing period.",
                     "title": "Brief",
                     "type": "string"
                 },
                 "cType": {
                     "description": "C data type.",
+                    "markdownDescription": "**C Type**\n\nC data type.",
                     "title": "C Type",
                     "type": "string"
                 },
                 "compileType": {
                     "description": "If specified, the internal for this data type can be compiled using the afw_compile_type_<type> where <type> is the value of this property.",
+                    "markdownDescription": "**Compile Type**\n\nIf specified, the internal for this data type can be compiled using the afw_compile_type_<type> where <type> is the value of this property.",
                     "title": "Compile Type",
                     "type": "string"
                 },
                 "dataType": {
                     "description": "Data type id.",
+                    "markdownDescription": "**Data Type**\n\nData type id.",
                     "title": "Data Type",
                     "type": "string"
                 },
@@ -60,58 +59,195 @@
                         "SourceParameter",
                         "Type"
                     ],
+                    "markdownDescription": "**Parameter Type**\n\nThis is the type of parameter that can optionally be specified for this data type. A data type parameter is specified in the 'dataTypeParameter' property of an _AdaptiveValueMeta_ object or in a Type in Adaptive syntax. If the value of the 'dataTypeParameter' property is a single quoted string, the quotes are optional.\n\nAll dataTypeParameterType values correspond to a production by the same name in Adaptive syntax. These are the valid types and their meanings:\n\nFunctionSignature - A return Type and parameter array.\n\nArrayOf - Zero or more 'of array' followed by 'of' and a Type.\n\nMediaType - A quoted string containing a media-type as define in https://tools.ietf.org/html/rfc7763 that is appropriate for the data type..\n\nObjectType - The object type id of the object.\n\nSourceParameter - Either the return Type resulting from the evaluation of the compiled source or 'body' followed by a FunctionSignature if the value is the body of a function with this signature.\n\nType - Any Type in Adaptive syntax that is expected when the value is evaluated.",
                     "title": "Parameter Type",
                     "type": "string"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "Description of this object type.",
+                    "markdownDescription": "**Description**\n\nDescription of this object type.",
                     "title": "Description",
                     "type": "string"
                 },
                 "directReturn": {
                     "description": "Generate afw_value_as_* and afw_object_old_get_property_as_* return value instead of value pointer.",
+                    "markdownDescription": "**Direct Return**\n\nGenerate afw_value_as_* and afw_object_old_get_property_as_* return value instead of value pointer.",
                     "title": "Direct Return",
                     "type": "boolean"
                 },
                 "evaluated": {
                     "description": "This data type is source that can be compiled and evaluated with the compile() adaptive function.",
+                    "markdownDescription": "**Evaluated**\n\nThis data type is source that can be compiled and evaluated with the compile() adaptive function.",
                     "title": "Evaluated",
                     "type": "boolean"
                 },
                 "jsonImpliesDataType": {
                     "default": false,
                     "description": "Indicates that dataType needs to be available to fully interpret json value. If not available, this data type can be implied from the appropriate JSON value.",
+                    "markdownDescription": "**JSON Implies Data Type**\n\nIndicates that dataType needs to be available to fully interpret json value. If not available, this data type can be implied from the appropriate JSON value.",
                     "title": "JSON Implies Data Type",
                     "type": "boolean"
                 },
                 "jsonPrimitive": {
                     "description": "This specifies the JSON primitive type that is used to represent this dataType.",
+                    "markdownDescription": "**JSON Primitive**\n\nThis specifies the JSON primitive type that is used to represent this dataType.",
                     "title": "JSON Primitive",
                     "type": "string"
                 },
                 "jsonSchemaStringFormat": {
                     "description": "This is the format to use in JSON Schema for this data type. This is only applicable to data types with jsonPrimitive of 'string'.",
+                    "markdownDescription": "**JSON String Format**\n\nThis is the format to use in JSON Schema for this data type. This is only applicable to data types with jsonPrimitive of 'string'.",
                     "title": "JSON String Format",
                     "type": "string"
                 },
                 "ldapOid": {
                     "description": "LDAP OID.",
+                    "markdownDescription": "**Ldap Oid**\n\nLDAP OID.",
                     "title": "Ldap Oid",
                     "type": "string"
                 },
                 "relationalCompares": {
                     "description": "If true, this data type supports equality (equal) and relational compares (greater than and less than). If false, only equality compares are allowed.",
+                    "markdownDescription": "**Relational Compares**\n\nIf true, this data type supports equality (equal) and relational compares (greater than and less than). If false, only equality compares are allowed.",
                     "title": "Relational Compares",
                     "type": "boolean"
                 },
                 "scalar": {
                     "description": "Data type represents a scalar value.",
+                    "markdownDescription": "**Scalar**\n\nData type represents a scalar value.",
                     "title": "Scalar",
                     "type": "boolean"
                 },
                 "special": {
                     "description": "Special data types are not associated with a particular instance of a value but can be used to specify what data types a value can be.",
+                    "markdownDescription": "**Special**\n\nSpecial data types are not associated with a particular instance of a value but can be used to specify what data types a value can be.",
+                    "title": "Special",
+                    "type": "boolean"
+                }
+            },
+            "title": "_AdaptiveDataTypeGenerate_",
+            "type": "object",
+            "x-afw-inheritedObjectTypes": [
+                "_AdaptiveDataType_"
+            ]
+        },
+        "_AdaptiveDataTypeGenerate_.propertyTypes": {
+            "properties": {
+                "afw_value_get_evaluated_meta": {
+                    "description": "This is the label in C source of the afw_value_get_evaluated_meta for this data type.",
+                    "markdownDescription": "**afw_value_get_evaluated_meta**\n\nThis is the label in C source of the afw_value_get_evaluated_meta for this data type.",
+                    "title": "afw_value_get_evaluated_meta",
+                    "type": "string"
+                },
+                "afw_value_get_evaluated_metas": {
+                    "description": "This is the label in C source of the afw_value_get_evaluated_metas for this data type.",
+                    "markdownDescription": "**afw_value_get_evaluated_metas**\n\nThis is the label in C source of the afw_value_get_evaluated_metas for this data type.",
+                    "title": "afw_value_get_evaluated_metas",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "_AdaptiveDataType_.propertyTypes": {
+            "properties": {
+                "brief": {
+                    "description": "This is a predicate for the data type with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for the data type with the first letter capitalized and without a trailing period.",
+                    "title": "Brief",
+                    "type": "string"
+                },
+                "cType": {
+                    "description": "C data type.",
+                    "markdownDescription": "**C Type**\n\nC data type.",
+                    "title": "C Type",
+                    "type": "string"
+                },
+                "compileType": {
+                    "description": "If specified, the internal for this data type can be compiled using the afw_compile_type_<type> where <type> is the value of this property.",
+                    "markdownDescription": "**Compile Type**\n\nIf specified, the internal for this data type can be compiled using the afw_compile_type_<type> where <type> is the value of this property.",
+                    "title": "Compile Type",
+                    "type": "string"
+                },
+                "dataType": {
+                    "description": "Data type id.",
+                    "markdownDescription": "**Data Type**\n\nData type id.",
+                    "title": "Data Type",
+                    "type": "string"
+                },
+                "dataTypeParameterType": {
+                    "description": "This is the type of parameter that can optionally be specified for this data type. A data type parameter is specified in the 'dataTypeParameter' property of an _AdaptiveValueMeta_ object or in a Type in Adaptive syntax. If the value of the 'dataTypeParameter' property is a single quoted string, the quotes are optional.\n\nAll dataTypeParameterType values correspond to a production by the same name in Adaptive syntax. These are the valid types and their meanings:\n\nFunctionSignature - A return Type and parameter array.\n\nArrayOf - Zero or more 'of array' followed by 'of' and a Type.\n\nMediaType - A quoted string containing a media-type as define in https://tools.ietf.org/html/rfc7763 that is appropriate for the data type..\n\nObjectType - The object type id of the object.\n\nSourceParameter - Either the return Type resulting from the evaluation of the compiled source or 'body' followed by a FunctionSignature if the value is the body of a function with this signature.\n\nType - Any Type in Adaptive syntax that is expected when the value is evaluated.",
+                    "enum": [
+                        "FunctionSignature",
+                        "ArrayOf",
+                        "MediaType",
+                        "ObjectType",
+                        "SourceParameter",
+                        "Type"
+                    ],
+                    "markdownDescription": "**Parameter Type**\n\nThis is the type of parameter that can optionally be specified for this data type. A data type parameter is specified in the 'dataTypeParameter' property of an _AdaptiveValueMeta_ object or in a Type in Adaptive syntax. If the value of the 'dataTypeParameter' property is a single quoted string, the quotes are optional.\n\nAll dataTypeParameterType values correspond to a production by the same name in Adaptive syntax. These are the valid types and their meanings:\n\nFunctionSignature - A return Type and parameter array.\n\nArrayOf - Zero or more 'of array' followed by 'of' and a Type.\n\nMediaType - A quoted string containing a media-type as define in https://tools.ietf.org/html/rfc7763 that is appropriate for the data type..\n\nObjectType - The object type id of the object.\n\nSourceParameter - Either the return Type resulting from the evaluation of the compiled source or 'body' followed by a FunctionSignature if the value is the body of a function with this signature.\n\nType - Any Type in Adaptive syntax that is expected when the value is evaluated.",
+                    "title": "Parameter Type",
+                    "type": "string"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "Description of this object type.",
+                    "markdownDescription": "**Description**\n\nDescription of this object type.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "directReturn": {
+                    "description": "Generate afw_value_as_* and afw_object_old_get_property_as_* return value instead of value pointer.",
+                    "markdownDescription": "**Direct Return**\n\nGenerate afw_value_as_* and afw_object_old_get_property_as_* return value instead of value pointer.",
+                    "title": "Direct Return",
+                    "type": "boolean"
+                },
+                "evaluated": {
+                    "description": "This data type is source that can be compiled and evaluated with the compile() adaptive function.",
+                    "markdownDescription": "**Evaluated**\n\nThis data type is source that can be compiled and evaluated with the compile() adaptive function.",
+                    "title": "Evaluated",
+                    "type": "boolean"
+                },
+                "jsonImpliesDataType": {
+                    "default": false,
+                    "description": "Indicates that dataType needs to be available to fully interpret json value. If not available, this data type can be implied from the appropriate JSON value.",
+                    "markdownDescription": "**JSON Implies Data Type**\n\nIndicates that dataType needs to be available to fully interpret json value. If not available, this data type can be implied from the appropriate JSON value.",
+                    "title": "JSON Implies Data Type",
+                    "type": "boolean"
+                },
+                "jsonPrimitive": {
+                    "description": "This specifies the JSON primitive type that is used to represent this dataType.",
+                    "markdownDescription": "**JSON Primitive**\n\nThis specifies the JSON primitive type that is used to represent this dataType.",
+                    "title": "JSON Primitive",
+                    "type": "string"
+                },
+                "jsonSchemaStringFormat": {
+                    "description": "This is the format to use in JSON Schema for this data type. This is only applicable to data types with jsonPrimitive of 'string'.",
+                    "markdownDescription": "**JSON String Format**\n\nThis is the format to use in JSON Schema for this data type. This is only applicable to data types with jsonPrimitive of 'string'.",
+                    "title": "JSON String Format",
+                    "type": "string"
+                },
+                "ldapOid": {
+                    "description": "LDAP OID.",
+                    "markdownDescription": "**Ldap Oid**\n\nLDAP OID.",
+                    "title": "Ldap Oid",
+                    "type": "string"
+                },
+                "relationalCompares": {
+                    "description": "If true, this data type supports equality (equal) and relational compares (greater than and less than). If false, only equality compares are allowed.",
+                    "markdownDescription": "**Relational Compares**\n\nIf true, this data type supports equality (equal) and relational compares (greater than and less than). If false, only equality compares are allowed.",
+                    "title": "Relational Compares",
+                    "type": "boolean"
+                },
+                "scalar": {
+                    "description": "Data type represents a scalar value.",
+                    "markdownDescription": "**Scalar**\n\nData type represents a scalar value.",
+                    "title": "Scalar",
+                    "type": "boolean"
+                },
+                "special": {
+                    "description": "Special data types are not associated with a particular instance of a value but can be used to specify what data types a value can be.",
+                    "markdownDescription": "**Special**\n\nSpecial data types are not associated with a particular instance of a value but can be used to specify what data types a value can be.",
                     "title": "Special",
                     "type": "boolean"
                 }
@@ -120,9 +256,133 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveDataTypeGenerate_"
+    "additionalProperties": false,
+    "description": "This is the object type for objects in the generate/objects/_AdaptiveDataTypeGenerate_/ of command, core, and extension source directories. These objects are used by the 'dev.py generate' script to generate _AdaptiveDataType_ objects.",
+    "markdownDescription": "This is the object type for objects in the generate/objects/_AdaptiveDataTypeGenerate_/ of command, core, and extension source directories. These objects are used by the 'dev.py generate' script to generate _AdaptiveDataType_ objects.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "afw_value_get_evaluated_meta": {
+            "description": "This is the label in C source of the afw_value_get_evaluated_meta for this data type.",
+            "markdownDescription": "**afw_value_get_evaluated_meta**\n\nThis is the label in C source of the afw_value_get_evaluated_meta for this data type.",
+            "title": "afw_value_get_evaluated_meta",
+            "type": "string"
+        },
+        "afw_value_get_evaluated_metas": {
+            "description": "This is the label in C source of the afw_value_get_evaluated_metas for this data type.",
+            "markdownDescription": "**afw_value_get_evaluated_metas**\n\nThis is the label in C source of the afw_value_get_evaluated_metas for this data type.",
+            "title": "afw_value_get_evaluated_metas",
+            "type": "string"
+        },
+        "brief": {
+            "description": "This is a predicate for the data type with the first letter capitalized and without a trailing period.",
+            "markdownDescription": "**Brief**\n\nThis is a predicate for the data type with the first letter capitalized and without a trailing period.",
+            "title": "Brief",
+            "type": "string"
+        },
+        "cType": {
+            "description": "C data type.",
+            "markdownDescription": "**C Type**\n\nC data type.",
+            "title": "C Type",
+            "type": "string"
+        },
+        "compileType": {
+            "description": "If specified, the internal for this data type can be compiled using the afw_compile_type_<type> where <type> is the value of this property.",
+            "markdownDescription": "**Compile Type**\n\nIf specified, the internal for this data type can be compiled using the afw_compile_type_<type> where <type> is the value of this property.",
+            "title": "Compile Type",
+            "type": "string"
+        },
+        "dataType": {
+            "description": "Data type id.",
+            "markdownDescription": "**Data Type**\n\nData type id.",
+            "title": "Data Type",
+            "type": "string"
+        },
+        "dataTypeParameterType": {
+            "description": "This is the type of parameter that can optionally be specified for this data type. A data type parameter is specified in the 'dataTypeParameter' property of an _AdaptiveValueMeta_ object or in a Type in Adaptive syntax. If the value of the 'dataTypeParameter' property is a single quoted string, the quotes are optional.\n\nAll dataTypeParameterType values correspond to a production by the same name in Adaptive syntax. These are the valid types and their meanings:\n\nFunctionSignature - A return Type and parameter array.\n\nArrayOf - Zero or more 'of array' followed by 'of' and a Type.\n\nMediaType - A quoted string containing a media-type as define in https://tools.ietf.org/html/rfc7763 that is appropriate for the data type..\n\nObjectType - The object type id of the object.\n\nSourceParameter - Either the return Type resulting from the evaluation of the compiled source or 'body' followed by a FunctionSignature if the value is the body of a function with this signature.\n\nType - Any Type in Adaptive syntax that is expected when the value is evaluated.",
+            "enum": [
+                "FunctionSignature",
+                "ArrayOf",
+                "MediaType",
+                "ObjectType",
+                "SourceParameter",
+                "Type"
+            ],
+            "markdownDescription": "**Parameter Type**\n\nThis is the type of parameter that can optionally be specified for this data type. A data type parameter is specified in the 'dataTypeParameter' property of an _AdaptiveValueMeta_ object or in a Type in Adaptive syntax. If the value of the 'dataTypeParameter' property is a single quoted string, the quotes are optional.\n\nAll dataTypeParameterType values correspond to a production by the same name in Adaptive syntax. These are the valid types and their meanings:\n\nFunctionSignature - A return Type and parameter array.\n\nArrayOf - Zero or more 'of array' followed by 'of' and a Type.\n\nMediaType - A quoted string containing a media-type as define in https://tools.ietf.org/html/rfc7763 that is appropriate for the data type..\n\nObjectType - The object type id of the object.\n\nSourceParameter - Either the return Type resulting from the evaluation of the compiled source or 'body' followed by a FunctionSignature if the value is the body of a function with this signature.\n\nType - Any Type in Adaptive syntax that is expected when the value is evaluated.",
+            "title": "Parameter Type",
+            "type": "string"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "Description of this object type.",
+            "markdownDescription": "**Description**\n\nDescription of this object type.",
+            "title": "Description",
+            "type": "string"
+        },
+        "directReturn": {
+            "description": "Generate afw_value_as_* and afw_object_old_get_property_as_* return value instead of value pointer.",
+            "markdownDescription": "**Direct Return**\n\nGenerate afw_value_as_* and afw_object_old_get_property_as_* return value instead of value pointer.",
+            "title": "Direct Return",
+            "type": "boolean"
+        },
+        "evaluated": {
+            "description": "This data type is source that can be compiled and evaluated with the compile() adaptive function.",
+            "markdownDescription": "**Evaluated**\n\nThis data type is source that can be compiled and evaluated with the compile() adaptive function.",
+            "title": "Evaluated",
+            "type": "boolean"
+        },
+        "jsonImpliesDataType": {
+            "default": false,
+            "description": "Indicates that dataType needs to be available to fully interpret json value. If not available, this data type can be implied from the appropriate JSON value.",
+            "markdownDescription": "**JSON Implies Data Type**\n\nIndicates that dataType needs to be available to fully interpret json value. If not available, this data type can be implied from the appropriate JSON value.",
+            "title": "JSON Implies Data Type",
+            "type": "boolean"
+        },
+        "jsonPrimitive": {
+            "description": "This specifies the JSON primitive type that is used to represent this dataType.",
+            "markdownDescription": "**JSON Primitive**\n\nThis specifies the JSON primitive type that is used to represent this dataType.",
+            "title": "JSON Primitive",
+            "type": "string"
+        },
+        "jsonSchemaStringFormat": {
+            "description": "This is the format to use in JSON Schema for this data type. This is only applicable to data types with jsonPrimitive of 'string'.",
+            "markdownDescription": "**JSON String Format**\n\nThis is the format to use in JSON Schema for this data type. This is only applicable to data types with jsonPrimitive of 'string'.",
+            "title": "JSON String Format",
+            "type": "string"
+        },
+        "ldapOid": {
+            "description": "LDAP OID.",
+            "markdownDescription": "**Ldap Oid**\n\nLDAP OID.",
+            "title": "Ldap Oid",
+            "type": "string"
+        },
+        "relationalCompares": {
+            "description": "If true, this data type supports equality (equal) and relational compares (greater than and less than). If false, only equality compares are allowed.",
+            "markdownDescription": "**Relational Compares**\n\nIf true, this data type supports equality (equal) and relational compares (greater than and less than). If false, only equality compares are allowed.",
+            "title": "Relational Compares",
+            "type": "boolean"
+        },
+        "scalar": {
+            "description": "Data type represents a scalar value.",
+            "markdownDescription": "**Scalar**\n\nData type represents a scalar value.",
+            "title": "Scalar",
+            "type": "boolean"
+        },
+        "special": {
+            "description": "Special data types are not associated with a particular instance of a value but can be used to specify what data types a value can be.",
+            "markdownDescription": "**Special**\n\nSpecial data types are not associated with a particular instance of a value but can be used to specify what data types a value can be.",
+            "title": "Special",
+            "type": "boolean"
         }
+    },
+    "title": "_AdaptiveDataTypeGenerate_",
+    "type": "object",
+    "x-afw-inheritedObjectTypes": [
+        "_AdaptiveDataType_"
     ]
 }

--- a/generated/schemas/afw/_AdaptiveDataTypeGenerate_.json
+++ b/generated/schemas/afw/_AdaptiveDataTypeGenerate_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveDataTypeGenerate_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveDataTypeGenerate_.propertyTypes"
                 },
@@ -15,7 +15,6 @@
         },
         "_AdaptiveDataTypeGenerate_.propertyTypes": {
             "properties": {
-                "_meta_": {},
                 "afw_value_get_evaluated_meta": {
                     "description": "This is the label in C source of the afw_value_get_evaluated_meta for this data type.",
                     "title": "afw_value_get_evaluated_meta",
@@ -53,6 +52,14 @@
                 },
                 "dataTypeParameterType": {
                     "description": "This is the type of parameter that can optionally be specified for this data type. A data type parameter is specified in the 'dataTypeParameter' property of an _AdaptiveValueMeta_ object or in a Type in Adaptive syntax. If the value of the 'dataTypeParameter' property is a single quoted string, the quotes are optional.\n\nAll dataTypeParameterType values correspond to a production by the same name in Adaptive syntax. These are the valid types and their meanings:\n\nFunctionSignature - A return Type and parameter array.\n\nArrayOf - Zero or more 'of array' followed by 'of' and a Type.\n\nMediaType - A quoted string containing a media-type as define in https://tools.ietf.org/html/rfc7763 that is appropriate for the data type..\n\nObjectType - The object type id of the object.\n\nSourceParameter - Either the return Type resulting from the evaluation of the compiled source or 'body' followed by a FunctionSignature if the value is the body of a function with this signature.\n\nType - Any Type in Adaptive syntax that is expected when the value is evaluated.",
+                    "enum": [
+                        "FunctionSignature",
+                        "ArrayOf",
+                        "MediaType",
+                        "ObjectType",
+                        "SourceParameter",
+                        "Type"
+                    ],
                     "title": "Parameter Type",
                     "type": "string"
                 },
@@ -73,6 +80,7 @@
                     "type": "boolean"
                 },
                 "jsonImpliesDataType": {
+                    "default": false,
                     "description": "Indicates that dataType needs to be available to fully interpret json value. If not available, this data type can be implied from the appropriate JSON value.",
                     "title": "JSON Implies Data Type",
                     "type": "boolean"
@@ -108,15 +116,11 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "cType",
-                "dataType"
-            ],
             "type": "object"
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveDataTypeGenerate_"
         }

--- a/generated/schemas/afw/_AdaptiveDataType_.json
+++ b/generated/schemas/afw/_AdaptiveDataType_.json
@@ -1,38 +1,39 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveDataType_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveDataType_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveDataType_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Adaptive data type.",
-            "required": [
-                "cType",
-                "dataType"
-            ],
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveDataType_.propertyTypes": {
+            "markdownDescription": "Adaptive data type.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "brief": {
                     "description": "This is a predicate for the data type with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for the data type with the first letter capitalized and without a trailing period.",
                     "title": "Brief",
                     "type": "string"
                 },
                 "cType": {
                     "description": "C data type.",
+                    "markdownDescription": "**C Type**\n\nC data type.",
                     "title": "C Type",
                     "type": "string"
                 },
                 "compileType": {
                     "description": "If specified, the internal for this data type can be compiled using the afw_compile_type_<type> where <type> is the value of this property.",
+                    "markdownDescription": "**Compile Type**\n\nIf specified, the internal for this data type can be compiled using the afw_compile_type_<type> where <type> is the value of this property.",
                     "title": "Compile Type",
                     "type": "string"
                 },
                 "dataType": {
                     "description": "Data type id.",
+                    "markdownDescription": "**Data Type**\n\nData type id.",
                     "title": "Data Type",
                     "type": "string"
                 },
@@ -46,58 +47,179 @@
                         "SourceParameter",
                         "Type"
                     ],
+                    "markdownDescription": "**Parameter Type**\n\nThis is the type of parameter that can optionally be specified for this data type. A data type parameter is specified in the 'dataTypeParameter' property of an _AdaptiveValueMeta_ object or in a Type in Adaptive syntax. If the value of the 'dataTypeParameter' property is a single quoted string, the quotes are optional.\n\nAll dataTypeParameterType values correspond to a production by the same name in Adaptive syntax. These are the valid types and their meanings:\n\nFunctionSignature - A return Type and parameter array.\n\nArrayOf - Zero or more 'of array' followed by 'of' and a Type.\n\nMediaType - A quoted string containing a media-type as define in https://tools.ietf.org/html/rfc7763 that is appropriate for the data type..\n\nObjectType - The object type id of the object.\n\nSourceParameter - Either the return Type resulting from the evaluation of the compiled source or 'body' followed by a FunctionSignature if the value is the body of a function with this signature.\n\nType - Any Type in Adaptive syntax that is expected when the value is evaluated.",
                     "title": "Parameter Type",
                     "type": "string"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "Description of this object type.",
+                    "markdownDescription": "**Description**\n\nDescription of this object type.",
                     "title": "Description",
                     "type": "string"
                 },
                 "directReturn": {
                     "description": "Generate afw_value_as_* and afw_object_old_get_property_as_* return value instead of value pointer.",
+                    "markdownDescription": "**Direct Return**\n\nGenerate afw_value_as_* and afw_object_old_get_property_as_* return value instead of value pointer.",
                     "title": "Direct Return",
                     "type": "boolean"
                 },
                 "evaluated": {
                     "description": "This data type is source that can be compiled and evaluated with the compile() adaptive function.",
+                    "markdownDescription": "**Evaluated**\n\nThis data type is source that can be compiled and evaluated with the compile() adaptive function.",
                     "title": "Evaluated",
                     "type": "boolean"
                 },
                 "jsonImpliesDataType": {
                     "default": false,
                     "description": "Indicates that dataType needs to be available to fully interpret json value. If not available, this data type can be implied from the appropriate JSON value.",
+                    "markdownDescription": "**JSON Implies Data Type**\n\nIndicates that dataType needs to be available to fully interpret json value. If not available, this data type can be implied from the appropriate JSON value.",
                     "title": "JSON Implies Data Type",
                     "type": "boolean"
                 },
                 "jsonPrimitive": {
                     "description": "This specifies the JSON primitive type that is used to represent this dataType.",
+                    "markdownDescription": "**JSON Primitive**\n\nThis specifies the JSON primitive type that is used to represent this dataType.",
                     "title": "JSON Primitive",
                     "type": "string"
                 },
                 "jsonSchemaStringFormat": {
                     "description": "This is the format to use in JSON Schema for this data type. This is only applicable to data types with jsonPrimitive of 'string'.",
+                    "markdownDescription": "**JSON String Format**\n\nThis is the format to use in JSON Schema for this data type. This is only applicable to data types with jsonPrimitive of 'string'.",
                     "title": "JSON String Format",
                     "type": "string"
                 },
                 "ldapOid": {
                     "description": "LDAP OID.",
+                    "markdownDescription": "**Ldap Oid**\n\nLDAP OID.",
                     "title": "Ldap Oid",
                     "type": "string"
                 },
                 "relationalCompares": {
                     "description": "If true, this data type supports equality (equal) and relational compares (greater than and less than). If false, only equality compares are allowed.",
+                    "markdownDescription": "**Relational Compares**\n\nIf true, this data type supports equality (equal) and relational compares (greater than and less than). If false, only equality compares are allowed.",
                     "title": "Relational Compares",
                     "type": "boolean"
                 },
                 "scalar": {
                     "description": "Data type represents a scalar value.",
+                    "markdownDescription": "**Scalar**\n\nData type represents a scalar value.",
                     "title": "Scalar",
                     "type": "boolean"
                 },
                 "special": {
                     "description": "Special data types are not associated with a particular instance of a value but can be used to specify what data types a value can be.",
+                    "markdownDescription": "**Special**\n\nSpecial data types are not associated with a particular instance of a value but can be used to specify what data types a value can be.",
+                    "title": "Special",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "cType",
+                "dataType"
+            ],
+            "title": "_AdaptiveDataType_",
+            "type": "object"
+        },
+        "_AdaptiveDataType_.propertyTypes": {
+            "properties": {
+                "brief": {
+                    "description": "This is a predicate for the data type with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for the data type with the first letter capitalized and without a trailing period.",
+                    "title": "Brief",
+                    "type": "string"
+                },
+                "cType": {
+                    "description": "C data type.",
+                    "markdownDescription": "**C Type**\n\nC data type.",
+                    "title": "C Type",
+                    "type": "string"
+                },
+                "compileType": {
+                    "description": "If specified, the internal for this data type can be compiled using the afw_compile_type_<type> where <type> is the value of this property.",
+                    "markdownDescription": "**Compile Type**\n\nIf specified, the internal for this data type can be compiled using the afw_compile_type_<type> where <type> is the value of this property.",
+                    "title": "Compile Type",
+                    "type": "string"
+                },
+                "dataType": {
+                    "description": "Data type id.",
+                    "markdownDescription": "**Data Type**\n\nData type id.",
+                    "title": "Data Type",
+                    "type": "string"
+                },
+                "dataTypeParameterType": {
+                    "description": "This is the type of parameter that can optionally be specified for this data type. A data type parameter is specified in the 'dataTypeParameter' property of an _AdaptiveValueMeta_ object or in a Type in Adaptive syntax. If the value of the 'dataTypeParameter' property is a single quoted string, the quotes are optional.\n\nAll dataTypeParameterType values correspond to a production by the same name in Adaptive syntax. These are the valid types and their meanings:\n\nFunctionSignature - A return Type and parameter array.\n\nArrayOf - Zero or more 'of array' followed by 'of' and a Type.\n\nMediaType - A quoted string containing a media-type as define in https://tools.ietf.org/html/rfc7763 that is appropriate for the data type..\n\nObjectType - The object type id of the object.\n\nSourceParameter - Either the return Type resulting from the evaluation of the compiled source or 'body' followed by a FunctionSignature if the value is the body of a function with this signature.\n\nType - Any Type in Adaptive syntax that is expected when the value is evaluated.",
+                    "enum": [
+                        "FunctionSignature",
+                        "ArrayOf",
+                        "MediaType",
+                        "ObjectType",
+                        "SourceParameter",
+                        "Type"
+                    ],
+                    "markdownDescription": "**Parameter Type**\n\nThis is the type of parameter that can optionally be specified for this data type. A data type parameter is specified in the 'dataTypeParameter' property of an _AdaptiveValueMeta_ object or in a Type in Adaptive syntax. If the value of the 'dataTypeParameter' property is a single quoted string, the quotes are optional.\n\nAll dataTypeParameterType values correspond to a production by the same name in Adaptive syntax. These are the valid types and their meanings:\n\nFunctionSignature - A return Type and parameter array.\n\nArrayOf - Zero or more 'of array' followed by 'of' and a Type.\n\nMediaType - A quoted string containing a media-type as define in https://tools.ietf.org/html/rfc7763 that is appropriate for the data type..\n\nObjectType - The object type id of the object.\n\nSourceParameter - Either the return Type resulting from the evaluation of the compiled source or 'body' followed by a FunctionSignature if the value is the body of a function with this signature.\n\nType - Any Type in Adaptive syntax that is expected when the value is evaluated.",
+                    "title": "Parameter Type",
+                    "type": "string"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "Description of this object type.",
+                    "markdownDescription": "**Description**\n\nDescription of this object type.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "directReturn": {
+                    "description": "Generate afw_value_as_* and afw_object_old_get_property_as_* return value instead of value pointer.",
+                    "markdownDescription": "**Direct Return**\n\nGenerate afw_value_as_* and afw_object_old_get_property_as_* return value instead of value pointer.",
+                    "title": "Direct Return",
+                    "type": "boolean"
+                },
+                "evaluated": {
+                    "description": "This data type is source that can be compiled and evaluated with the compile() adaptive function.",
+                    "markdownDescription": "**Evaluated**\n\nThis data type is source that can be compiled and evaluated with the compile() adaptive function.",
+                    "title": "Evaluated",
+                    "type": "boolean"
+                },
+                "jsonImpliesDataType": {
+                    "default": false,
+                    "description": "Indicates that dataType needs to be available to fully interpret json value. If not available, this data type can be implied from the appropriate JSON value.",
+                    "markdownDescription": "**JSON Implies Data Type**\n\nIndicates that dataType needs to be available to fully interpret json value. If not available, this data type can be implied from the appropriate JSON value.",
+                    "title": "JSON Implies Data Type",
+                    "type": "boolean"
+                },
+                "jsonPrimitive": {
+                    "description": "This specifies the JSON primitive type that is used to represent this dataType.",
+                    "markdownDescription": "**JSON Primitive**\n\nThis specifies the JSON primitive type that is used to represent this dataType.",
+                    "title": "JSON Primitive",
+                    "type": "string"
+                },
+                "jsonSchemaStringFormat": {
+                    "description": "This is the format to use in JSON Schema for this data type. This is only applicable to data types with jsonPrimitive of 'string'.",
+                    "markdownDescription": "**JSON String Format**\n\nThis is the format to use in JSON Schema for this data type. This is only applicable to data types with jsonPrimitive of 'string'.",
+                    "title": "JSON String Format",
+                    "type": "string"
+                },
+                "ldapOid": {
+                    "description": "LDAP OID.",
+                    "markdownDescription": "**Ldap Oid**\n\nLDAP OID.",
+                    "title": "Ldap Oid",
+                    "type": "string"
+                },
+                "relationalCompares": {
+                    "description": "If true, this data type supports equality (equal) and relational compares (greater than and less than). If false, only equality compares are allowed.",
+                    "markdownDescription": "**Relational Compares**\n\nIf true, this data type supports equality (equal) and relational compares (greater than and less than). If false, only equality compares are allowed.",
+                    "title": "Relational Compares",
+                    "type": "boolean"
+                },
+                "scalar": {
+                    "description": "Data type represents a scalar value.",
+                    "markdownDescription": "**Scalar**\n\nData type represents a scalar value.",
+                    "title": "Scalar",
+                    "type": "boolean"
+                },
+                "special": {
+                    "description": "Special data types are not associated with a particular instance of a value but can be used to specify what data types a value can be.",
+                    "markdownDescription": "**Special**\n\nSpecial data types are not associated with a particular instance of a value but can be used to specify what data types a value can be.",
                     "title": "Special",
                     "type": "boolean"
                 }
@@ -106,9 +228,122 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveDataType_"
+    "additionalProperties": false,
+    "description": "Adaptive data type.",
+    "markdownDescription": "Adaptive data type.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "brief": {
+            "description": "This is a predicate for the data type with the first letter capitalized and without a trailing period.",
+            "markdownDescription": "**Brief**\n\nThis is a predicate for the data type with the first letter capitalized and without a trailing period.",
+            "title": "Brief",
+            "type": "string"
+        },
+        "cType": {
+            "description": "C data type.",
+            "markdownDescription": "**C Type**\n\nC data type.",
+            "title": "C Type",
+            "type": "string"
+        },
+        "compileType": {
+            "description": "If specified, the internal for this data type can be compiled using the afw_compile_type_<type> where <type> is the value of this property.",
+            "markdownDescription": "**Compile Type**\n\nIf specified, the internal for this data type can be compiled using the afw_compile_type_<type> where <type> is the value of this property.",
+            "title": "Compile Type",
+            "type": "string"
+        },
+        "dataType": {
+            "description": "Data type id.",
+            "markdownDescription": "**Data Type**\n\nData type id.",
+            "title": "Data Type",
+            "type": "string"
+        },
+        "dataTypeParameterType": {
+            "description": "This is the type of parameter that can optionally be specified for this data type. A data type parameter is specified in the 'dataTypeParameter' property of an _AdaptiveValueMeta_ object or in a Type in Adaptive syntax. If the value of the 'dataTypeParameter' property is a single quoted string, the quotes are optional.\n\nAll dataTypeParameterType values correspond to a production by the same name in Adaptive syntax. These are the valid types and their meanings:\n\nFunctionSignature - A return Type and parameter array.\n\nArrayOf - Zero or more 'of array' followed by 'of' and a Type.\n\nMediaType - A quoted string containing a media-type as define in https://tools.ietf.org/html/rfc7763 that is appropriate for the data type..\n\nObjectType - The object type id of the object.\n\nSourceParameter - Either the return Type resulting from the evaluation of the compiled source or 'body' followed by a FunctionSignature if the value is the body of a function with this signature.\n\nType - Any Type in Adaptive syntax that is expected when the value is evaluated.",
+            "enum": [
+                "FunctionSignature",
+                "ArrayOf",
+                "MediaType",
+                "ObjectType",
+                "SourceParameter",
+                "Type"
+            ],
+            "markdownDescription": "**Parameter Type**\n\nThis is the type of parameter that can optionally be specified for this data type. A data type parameter is specified in the 'dataTypeParameter' property of an _AdaptiveValueMeta_ object or in a Type in Adaptive syntax. If the value of the 'dataTypeParameter' property is a single quoted string, the quotes are optional.\n\nAll dataTypeParameterType values correspond to a production by the same name in Adaptive syntax. These are the valid types and their meanings:\n\nFunctionSignature - A return Type and parameter array.\n\nArrayOf - Zero or more 'of array' followed by 'of' and a Type.\n\nMediaType - A quoted string containing a media-type as define in https://tools.ietf.org/html/rfc7763 that is appropriate for the data type..\n\nObjectType - The object type id of the object.\n\nSourceParameter - Either the return Type resulting from the evaluation of the compiled source or 'body' followed by a FunctionSignature if the value is the body of a function with this signature.\n\nType - Any Type in Adaptive syntax that is expected when the value is evaluated.",
+            "title": "Parameter Type",
+            "type": "string"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "Description of this object type.",
+            "markdownDescription": "**Description**\n\nDescription of this object type.",
+            "title": "Description",
+            "type": "string"
+        },
+        "directReturn": {
+            "description": "Generate afw_value_as_* and afw_object_old_get_property_as_* return value instead of value pointer.",
+            "markdownDescription": "**Direct Return**\n\nGenerate afw_value_as_* and afw_object_old_get_property_as_* return value instead of value pointer.",
+            "title": "Direct Return",
+            "type": "boolean"
+        },
+        "evaluated": {
+            "description": "This data type is source that can be compiled and evaluated with the compile() adaptive function.",
+            "markdownDescription": "**Evaluated**\n\nThis data type is source that can be compiled and evaluated with the compile() adaptive function.",
+            "title": "Evaluated",
+            "type": "boolean"
+        },
+        "jsonImpliesDataType": {
+            "default": false,
+            "description": "Indicates that dataType needs to be available to fully interpret json value. If not available, this data type can be implied from the appropriate JSON value.",
+            "markdownDescription": "**JSON Implies Data Type**\n\nIndicates that dataType needs to be available to fully interpret json value. If not available, this data type can be implied from the appropriate JSON value.",
+            "title": "JSON Implies Data Type",
+            "type": "boolean"
+        },
+        "jsonPrimitive": {
+            "description": "This specifies the JSON primitive type that is used to represent this dataType.",
+            "markdownDescription": "**JSON Primitive**\n\nThis specifies the JSON primitive type that is used to represent this dataType.",
+            "title": "JSON Primitive",
+            "type": "string"
+        },
+        "jsonSchemaStringFormat": {
+            "description": "This is the format to use in JSON Schema for this data type. This is only applicable to data types with jsonPrimitive of 'string'.",
+            "markdownDescription": "**JSON String Format**\n\nThis is the format to use in JSON Schema for this data type. This is only applicable to data types with jsonPrimitive of 'string'.",
+            "title": "JSON String Format",
+            "type": "string"
+        },
+        "ldapOid": {
+            "description": "LDAP OID.",
+            "markdownDescription": "**Ldap Oid**\n\nLDAP OID.",
+            "title": "Ldap Oid",
+            "type": "string"
+        },
+        "relationalCompares": {
+            "description": "If true, this data type supports equality (equal) and relational compares (greater than and less than). If false, only equality compares are allowed.",
+            "markdownDescription": "**Relational Compares**\n\nIf true, this data type supports equality (equal) and relational compares (greater than and less than). If false, only equality compares are allowed.",
+            "title": "Relational Compares",
+            "type": "boolean"
+        },
+        "scalar": {
+            "description": "Data type represents a scalar value.",
+            "markdownDescription": "**Scalar**\n\nData type represents a scalar value.",
+            "title": "Scalar",
+            "type": "boolean"
+        },
+        "special": {
+            "description": "Special data types are not associated with a particular instance of a value but can be used to specify what data types a value can be.",
+            "markdownDescription": "**Special**\n\nSpecial data types are not associated with a particular instance of a value but can be used to specify what data types a value can be.",
+            "title": "Special",
+            "type": "boolean"
         }
-    ]
+    },
+    "required": [
+        "cType",
+        "dataType"
+    ],
+    "title": "_AdaptiveDataType_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveDataType_.json
+++ b/generated/schemas/afw/_AdaptiveDataType_.json
@@ -1,12 +1,16 @@
 {
     "$defs": {
         "_AdaptiveDataType_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveDataType_.propertyTypes"
                 }
             ],
             "description": "Adaptive data type.",
+            "required": [
+                "cType",
+                "dataType"
+            ],
             "type": "object",
             "unevaluatedProperties": false
         },
@@ -34,6 +38,14 @@
                 },
                 "dataTypeParameterType": {
                     "description": "This is the type of parameter that can optionally be specified for this data type. A data type parameter is specified in the 'dataTypeParameter' property of an _AdaptiveValueMeta_ object or in a Type in Adaptive syntax. If the value of the 'dataTypeParameter' property is a single quoted string, the quotes are optional.\n\nAll dataTypeParameterType values correspond to a production by the same name in Adaptive syntax. These are the valid types and their meanings:\n\nFunctionSignature - A return Type and parameter array.\n\nArrayOf - Zero or more 'of array' followed by 'of' and a Type.\n\nMediaType - A quoted string containing a media-type as define in https://tools.ietf.org/html/rfc7763 that is appropriate for the data type..\n\nObjectType - The object type id of the object.\n\nSourceParameter - Either the return Type resulting from the evaluation of the compiled source or 'body' followed by a FunctionSignature if the value is the body of a function with this signature.\n\nType - Any Type in Adaptive syntax that is expected when the value is evaluated.",
+                    "enum": [
+                        "FunctionSignature",
+                        "ArrayOf",
+                        "MediaType",
+                        "ObjectType",
+                        "SourceParameter",
+                        "Type"
+                    ],
                     "title": "Parameter Type",
                     "type": "string"
                 },
@@ -54,6 +66,7 @@
                     "type": "boolean"
                 },
                 "jsonImpliesDataType": {
+                    "default": false,
                     "description": "Indicates that dataType needs to be available to fully interpret json value. If not available, this data type can be implied from the appropriate JSON value.",
                     "title": "JSON Implies Data Type",
                     "type": "boolean"
@@ -89,15 +102,11 @@
                     "type": "boolean"
                 }
             },
-            "required": [
-                "cType",
-                "dataType"
-            ],
             "type": "object"
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveDataType_"
         }

--- a/generated/schemas/afw/_AdaptiveEnvironmentRegistryType_.json
+++ b/generated/schemas/afw/_AdaptiveEnvironmentRegistryType_.json
@@ -1,40 +1,83 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveEnvironmentRegistryType_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveEnvironmentRegistryType_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveEnvironmentRegistryType_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "An environment registry type.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveEnvironmentRegistryType_.propertyTypes": {
+            "markdownDescription": "An environment registry type.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "allowReregister": {
                     "description": "Indicates reregister of a key is allowed.",
+                    "markdownDescription": "**Allow Reregister**\n\nIndicates reregister of a key is allowed.",
                     "title": "Allow Reregister",
                     "type": "boolean"
                 },
                 "autoRegister": {
                     "description": "Indicates if entries are automatically added for this type.",
+                    "markdownDescription": "**Auto Register**\n\nIndicates if entries are automatically added for this type.",
                     "title": "Auto Register",
                     "type": "boolean"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "Description of registry type.",
+                    "markdownDescription": "**Description**\n\nDescription of registry type.",
                     "title": "Description",
                     "type": "string"
                 },
                 "objectType": {
                     "description": "There is an /afw/<objectType>/<key> object for each registered entry.",
+                    "markdownDescription": "**Object Type**\n\nThere is an /afw/<objectType>/<key> object for each registered entry.",
                     "title": "Object Type",
                     "type": "string"
                 },
                 "registryType": {
                     "description": "Registry type.",
+                    "markdownDescription": "**Registry Type**\n\nRegistry type.",
+                    "title": "Registry Type",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveEnvironmentRegistryType_",
+            "type": "object"
+        },
+        "_AdaptiveEnvironmentRegistryType_.propertyTypes": {
+            "properties": {
+                "allowReregister": {
+                    "description": "Indicates reregister of a key is allowed.",
+                    "markdownDescription": "**Allow Reregister**\n\nIndicates reregister of a key is allowed.",
+                    "title": "Allow Reregister",
+                    "type": "boolean"
+                },
+                "autoRegister": {
+                    "description": "Indicates if entries are automatically added for this type.",
+                    "markdownDescription": "**Auto Register**\n\nIndicates if entries are automatically added for this type.",
+                    "title": "Auto Register",
+                    "type": "boolean"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "Description of registry type.",
+                    "markdownDescription": "**Description**\n\nDescription of registry type.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "objectType": {
+                    "description": "There is an /afw/<objectType>/<key> object for each registered entry.",
+                    "markdownDescription": "**Object Type**\n\nThere is an /afw/<objectType>/<key> object for each registered entry.",
+                    "title": "Object Type",
+                    "type": "string"
+                },
+                "registryType": {
+                    "description": "Registry type.",
+                    "markdownDescription": "**Registry Type**\n\nRegistry type.",
                     "title": "Registry Type",
                     "type": "string"
                 }
@@ -43,9 +86,49 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveEnvironmentRegistryType_"
+    "additionalProperties": false,
+    "description": "An environment registry type.",
+    "markdownDescription": "An environment registry type.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "allowReregister": {
+            "description": "Indicates reregister of a key is allowed.",
+            "markdownDescription": "**Allow Reregister**\n\nIndicates reregister of a key is allowed.",
+            "title": "Allow Reregister",
+            "type": "boolean"
+        },
+        "autoRegister": {
+            "description": "Indicates if entries are automatically added for this type.",
+            "markdownDescription": "**Auto Register**\n\nIndicates if entries are automatically added for this type.",
+            "title": "Auto Register",
+            "type": "boolean"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "Description of registry type.",
+            "markdownDescription": "**Description**\n\nDescription of registry type.",
+            "title": "Description",
+            "type": "string"
+        },
+        "objectType": {
+            "description": "There is an /afw/<objectType>/<key> object for each registered entry.",
+            "markdownDescription": "**Object Type**\n\nThere is an /afw/<objectType>/<key> object for each registered entry.",
+            "title": "Object Type",
+            "type": "string"
+        },
+        "registryType": {
+            "description": "Registry type.",
+            "markdownDescription": "**Registry Type**\n\nRegistry type.",
+            "title": "Registry Type",
+            "type": "string"
         }
-    ]
+    },
+    "title": "_AdaptiveEnvironmentRegistryType_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveEnvironmentRegistryType_.json
+++ b/generated/schemas/afw/_AdaptiveEnvironmentRegistryType_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveEnvironmentRegistryType_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveEnvironmentRegistryType_.propertyTypes"
                 }
@@ -43,7 +43,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveEnvironmentRegistryType_"
         }

--- a/generated/schemas/afw/_AdaptiveEnvironmentRegistry_.json
+++ b/generated/schemas/afw/_AdaptiveEnvironmentRegistry_.json
@@ -5,7 +5,7 @@
                 "description": "This object contains a property named for each registry type and that property has a property for each entry of that type. These entries are object of the object type appropriate for the registry type.",
                 "type": "object"
             },
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveEnvironmentRegistry_.propertyTypes"
                 }
@@ -19,7 +19,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveEnvironmentRegistry_"
         }

--- a/generated/schemas/afw/_AdaptiveEnvironmentRegistry_.json
+++ b/generated/schemas/afw/_AdaptiveEnvironmentRegistry_.json
@@ -1,16 +1,24 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveEnvironmentRegistry_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveEnvironmentRegistry_": {
             "additionalProperties": {
                 "description": "This object contains a property named for each registry type and that property has a property for each entry of that type. These entries are object of the object type appropriate for the registry type.",
+                "markdownDescription": "This object contains a property named for each registry type and that property has a property for each entry of that type. These entries are object of the object type appropriate for the registry type.",
                 "type": "object"
             },
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveEnvironmentRegistry_.propertyTypes"
-                }
-            ],
             "description": "This object contains a property named for each registry type and that property has a property for each entry of that type. These entries are object of the object type appropriate for the registry type.",
+            "markdownDescription": "This object contains a property named for each registry type and that property has a property for each entry of that type. These entries are object of the object type appropriate for the registry type.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                }
+            },
+            "title": "_AdaptiveEnvironmentRegistry_",
             "type": "object"
         },
         "_AdaptiveEnvironmentRegistry_.propertyTypes": {
@@ -19,9 +27,22 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveEnvironmentRegistry_"
+    "additionalProperties": {
+        "description": "This object contains a property named for each registry type and that property has a property for each entry of that type. These entries are object of the object type appropriate for the registry type.",
+        "markdownDescription": "This object contains a property named for each registry type and that property has a property for each entry of that type. These entries are object of the object type appropriate for the registry type.",
+        "type": "object"
+    },
+    "description": "This object contains a property named for each registry type and that property has a property for each entry of that type. These entries are object of the object type appropriate for the registry type.",
+    "markdownDescription": "This object contains a property named for each registry type and that property has a property for each entry of that type. These entries are object of the object type appropriate for the registry type.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
         }
-    ]
+    },
+    "title": "_AdaptiveEnvironmentRegistry_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveEnvironmentVariables_.json
+++ b/generated/schemas/afw/_AdaptiveEnvironmentVariables_.json
@@ -5,7 +5,7 @@
                 "description": "Environment variables of process.",
                 "type": "string"
             },
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveEnvironmentVariables_.propertyTypes"
                 }
@@ -19,7 +19,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveEnvironmentVariables_"
         }

--- a/generated/schemas/afw/_AdaptiveEnvironmentVariables_.json
+++ b/generated/schemas/afw/_AdaptiveEnvironmentVariables_.json
@@ -1,16 +1,24 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveEnvironmentVariables_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveEnvironmentVariables_": {
             "additionalProperties": {
                 "description": "Environment variables of process.",
+                "markdownDescription": "Environment variables of process.",
                 "type": "string"
             },
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveEnvironmentVariables_.propertyTypes"
-                }
-            ],
             "description": "Environment variables of process.",
+            "markdownDescription": "Environment variables of process.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                }
+            },
+            "title": "_AdaptiveEnvironmentVariables_",
             "type": "object"
         },
         "_AdaptiveEnvironmentVariables_.propertyTypes": {
@@ -19,9 +27,22 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveEnvironmentVariables_"
+    "additionalProperties": {
+        "description": "Environment variables of process.",
+        "markdownDescription": "Environment variables of process.",
+        "type": "string"
+    },
+    "description": "Environment variables of process.",
+    "markdownDescription": "Environment variables of process.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
         }
-    ]
+    },
+    "title": "_AdaptiveEnvironmentVariables_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveErrorRVDecoder_.json
+++ b/generated/schemas/afw/_AdaptiveErrorRVDecoder_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveErrorRVDecoder_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveErrorRVDecoder_.propertyTypes"
                 }
@@ -22,7 +22,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveErrorRVDecoder_"
         }

--- a/generated/schemas/afw/_AdaptiveErrorRVDecoder_.json
+++ b/generated/schemas/afw/_AdaptiveErrorRVDecoder_.json
@@ -1,19 +1,33 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveErrorRVDecoder_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveErrorRVDecoder_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveErrorRVDecoder_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "A registry type error_rv_decoder entry.",
-            "type": "object",
-            "unevaluatedProperties": false
+            "markdownDescription": "A registry type error_rv_decoder entry.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "key": {
+                    "description": "Key of entry.",
+                    "markdownDescription": "**Key**\n\nKey of entry.",
+                    "title": "Key",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveErrorRVDecoder_",
+            "type": "object"
         },
         "_AdaptiveErrorRVDecoder_.propertyTypes": {
             "properties": {
                 "key": {
                     "description": "Key of entry.",
+                    "markdownDescription": "**Key**\n\nKey of entry.",
                     "title": "Key",
                     "type": "string"
                 }
@@ -22,9 +36,24 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveErrorRVDecoder_"
+    "additionalProperties": false,
+    "description": "A registry type error_rv_decoder entry.",
+    "markdownDescription": "A registry type error_rv_decoder entry.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "key": {
+            "description": "Key of entry.",
+            "markdownDescription": "**Key**\n\nKey of entry.",
+            "title": "Key",
+            "type": "string"
         }
-    ]
+    },
+    "title": "_AdaptiveErrorRVDecoder_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveExtension_.json
+++ b/generated/schemas/afw/_AdaptiveExtension_.json
@@ -1,29 +1,57 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveExtension_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveExtension_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveExtension_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Run time information for a loaded extension.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveExtension_.propertyTypes": {
+            "markdownDescription": "Run time information for a loaded extension.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "afwCompiledVersion": {
                     "description": "Version of libafw this extension was compiled against.",
+                    "markdownDescription": "**AFW Version**\n\nVersion of libafw this extension was compiled against.",
                     "title": "AFW Version",
                     "type": "string"
                 },
                 "extensionId": {
                     "description": "Id of extension.",
+                    "markdownDescription": "**Extension Id**\n\nId of extension.",
                     "title": "Extension Id",
                     "type": "string"
                 },
                 "extensionVersion": {
                     "description": "Version of this extension.",
+                    "markdownDescription": "**Version**\n\nVersion of this extension.",
+                    "title": "Version",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveExtension_",
+            "type": "object"
+        },
+        "_AdaptiveExtension_.propertyTypes": {
+            "properties": {
+                "afwCompiledVersion": {
+                    "description": "Version of libafw this extension was compiled against.",
+                    "markdownDescription": "**AFW Version**\n\nVersion of libafw this extension was compiled against.",
+                    "title": "AFW Version",
+                    "type": "string"
+                },
+                "extensionId": {
+                    "description": "Id of extension.",
+                    "markdownDescription": "**Extension Id**\n\nId of extension.",
+                    "title": "Extension Id",
+                    "type": "string"
+                },
+                "extensionVersion": {
+                    "description": "Version of this extension.",
+                    "markdownDescription": "**Version**\n\nVersion of this extension.",
                     "title": "Version",
                     "type": "string"
                 }
@@ -32,9 +60,36 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveExtension_"
+    "additionalProperties": false,
+    "description": "Run time information for a loaded extension.",
+    "markdownDescription": "Run time information for a loaded extension.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "afwCompiledVersion": {
+            "description": "Version of libafw this extension was compiled against.",
+            "markdownDescription": "**AFW Version**\n\nVersion of libafw this extension was compiled against.",
+            "title": "AFW Version",
+            "type": "string"
+        },
+        "extensionId": {
+            "description": "Id of extension.",
+            "markdownDescription": "**Extension Id**\n\nId of extension.",
+            "title": "Extension Id",
+            "type": "string"
+        },
+        "extensionVersion": {
+            "description": "Version of this extension.",
+            "markdownDescription": "**Version**\n\nVersion of this extension.",
+            "title": "Version",
+            "type": "string"
         }
-    ]
+    },
+    "title": "_AdaptiveExtension_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveExtension_.json
+++ b/generated/schemas/afw/_AdaptiveExtension_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveExtension_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveExtension_.propertyTypes"
                 }
@@ -32,7 +32,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveExtension_"
         }

--- a/generated/schemas/afw/_AdaptiveFile_vfs.json
+++ b/generated/schemas/afw/_AdaptiveFile_vfs.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveFile_vfs": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveFile_vfs.propertyTypes"
                 }
@@ -13,6 +13,7 @@
         "_AdaptiveFile_vfs.propertyTypes": {
             "properties": {
                 "data": {
+                    "default": "",
                     "description": "This is the contents of the file. If this is a directory, data is a list of strings containing the name from its entries. If this is not a directory and the data is valid utf-8, data is a string otherwise, it is hexBinary. This property is ignored when adding a directory.",
                     "title": "Data"
                 },
@@ -52,7 +53,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveFile_vfs"
         }

--- a/generated/schemas/afw/_AdaptiveFile_vfs.json
+++ b/generated/schemas/afw/_AdaptiveFile_vfs.json
@@ -1,24 +1,27 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveFile_vfs. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveFile_vfs": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveFile_vfs.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "This is the single object type of objects in a vfs adapter.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveFile_vfs.propertyTypes": {
+            "markdownDescription": "This is the single object type of objects in a vfs adapter.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "data": {
                     "default": "",
                     "description": "This is the contents of the file. If this is a directory, data is a list of strings containing the name from its entries. If this is not a directory and the data is valid utf-8, data is a string otherwise, it is hexBinary. This property is ignored when adding a directory.",
+                    "markdownDescription": "**Data**\n\nThis is the contents of the file. If this is a directory, data is a list of strings containing the name from its entries. If this is not a directory and the data is valid utf-8, data is a string otherwise, it is hexBinary. This property is ignored when adding a directory.",
                     "title": "Data"
                 },
                 "isDirectory": {
                     "description": "This is true if this is a directory. This property is read-only. A slash ('/') at the end of an objectId is used to indicate this in requests.",
+                    "markdownDescription": "**Is Directory**\n\nThis is true if this is a directory. This property is read-only. A slash ('/') at the end of an objectId is used to indicate this in requests.",
                     "readOnly": true,
                     "title": "Is Directory",
                     "type": "boolean"
@@ -26,24 +29,76 @@
                 "timeAccessed": {
                     "description": "This is the time the file was last accessed.",
                     "format": "date-time",
+                    "markdownDescription": "**Time Accessed**\n\nThis is the time the file was last accessed.",
                     "title": "Time Accessed",
                     "type": "string"
                 },
                 "timeCreated": {
                     "description": "This is the time the file was created.",
                     "format": "date-time",
+                    "markdownDescription": "**Time Created**\n\nThis is the time the file was created.",
                     "title": "Time Created",
                     "type": "string"
                 },
                 "timeModified": {
                     "description": "This is the time the file was last modified.",
                     "format": "date-time",
+                    "markdownDescription": "**Time Modified**\n\nThis is the time the file was last modified.",
                     "title": "Time Modified",
                     "type": "string"
                 },
                 "vfsPath": {
                     "description": "This is the vfs path within this instance of Adaptive Framework. This property is read-only.",
                     "format": "uri-reference",
+                    "markdownDescription": "**VFS Path**\n\nThis is the vfs path within this instance of Adaptive Framework. This property is read-only.",
+                    "readOnly": true,
+                    "title": "VFS Path",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveFile_vfs",
+            "type": "object"
+        },
+        "_AdaptiveFile_vfs.propertyTypes": {
+            "properties": {
+                "data": {
+                    "default": "",
+                    "description": "This is the contents of the file. If this is a directory, data is a list of strings containing the name from its entries. If this is not a directory and the data is valid utf-8, data is a string otherwise, it is hexBinary. This property is ignored when adding a directory.",
+                    "markdownDescription": "**Data**\n\nThis is the contents of the file. If this is a directory, data is a list of strings containing the name from its entries. If this is not a directory and the data is valid utf-8, data is a string otherwise, it is hexBinary. This property is ignored when adding a directory.",
+                    "title": "Data"
+                },
+                "isDirectory": {
+                    "description": "This is true if this is a directory. This property is read-only. A slash ('/') at the end of an objectId is used to indicate this in requests.",
+                    "markdownDescription": "**Is Directory**\n\nThis is true if this is a directory. This property is read-only. A slash ('/') at the end of an objectId is used to indicate this in requests.",
+                    "readOnly": true,
+                    "title": "Is Directory",
+                    "type": "boolean"
+                },
+                "timeAccessed": {
+                    "description": "This is the time the file was last accessed.",
+                    "format": "date-time",
+                    "markdownDescription": "**Time Accessed**\n\nThis is the time the file was last accessed.",
+                    "title": "Time Accessed",
+                    "type": "string"
+                },
+                "timeCreated": {
+                    "description": "This is the time the file was created.",
+                    "format": "date-time",
+                    "markdownDescription": "**Time Created**\n\nThis is the time the file was created.",
+                    "title": "Time Created",
+                    "type": "string"
+                },
+                "timeModified": {
+                    "description": "This is the time the file was last modified.",
+                    "format": "date-time",
+                    "markdownDescription": "**Time Modified**\n\nThis is the time the file was last modified.",
+                    "title": "Time Modified",
+                    "type": "string"
+                },
+                "vfsPath": {
+                    "description": "This is the vfs path within this instance of Adaptive Framework. This property is read-only.",
+                    "format": "uri-reference",
+                    "markdownDescription": "**VFS Path**\n\nThis is the vfs path within this instance of Adaptive Framework. This property is read-only.",
                     "readOnly": true,
                     "title": "VFS Path",
                     "type": "string"
@@ -53,9 +108,60 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveFile_vfs"
+    "additionalProperties": false,
+    "description": "This is the single object type of objects in a vfs adapter.",
+    "markdownDescription": "This is the single object type of objects in a vfs adapter.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "data": {
+            "default": "",
+            "description": "This is the contents of the file. If this is a directory, data is a list of strings containing the name from its entries. If this is not a directory and the data is valid utf-8, data is a string otherwise, it is hexBinary. This property is ignored when adding a directory.",
+            "markdownDescription": "**Data**\n\nThis is the contents of the file. If this is a directory, data is a list of strings containing the name from its entries. If this is not a directory and the data is valid utf-8, data is a string otherwise, it is hexBinary. This property is ignored when adding a directory.",
+            "title": "Data"
+        },
+        "isDirectory": {
+            "description": "This is true if this is a directory. This property is read-only. A slash ('/') at the end of an objectId is used to indicate this in requests.",
+            "markdownDescription": "**Is Directory**\n\nThis is true if this is a directory. This property is read-only. A slash ('/') at the end of an objectId is used to indicate this in requests.",
+            "readOnly": true,
+            "title": "Is Directory",
+            "type": "boolean"
+        },
+        "timeAccessed": {
+            "description": "This is the time the file was last accessed.",
+            "format": "date-time",
+            "markdownDescription": "**Time Accessed**\n\nThis is the time the file was last accessed.",
+            "title": "Time Accessed",
+            "type": "string"
+        },
+        "timeCreated": {
+            "description": "This is the time the file was created.",
+            "format": "date-time",
+            "markdownDescription": "**Time Created**\n\nThis is the time the file was created.",
+            "title": "Time Created",
+            "type": "string"
+        },
+        "timeModified": {
+            "description": "This is the time the file was last modified.",
+            "format": "date-time",
+            "markdownDescription": "**Time Modified**\n\nThis is the time the file was last modified.",
+            "title": "Time Modified",
+            "type": "string"
+        },
+        "vfsPath": {
+            "description": "This is the vfs path within this instance of Adaptive Framework. This property is read-only.",
+            "format": "uri-reference",
+            "markdownDescription": "**VFS Path**\n\nThis is the vfs path within this instance of Adaptive Framework. This property is read-only.",
+            "readOnly": true,
+            "title": "VFS Path",
+            "type": "string"
         }
-    ]
+    },
+    "title": "_AdaptiveFile_vfs",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveFlag_.json
+++ b/generated/schemas/afw/_AdaptiveFlag_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveFlag_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveFlag_.propertyTypes"
                 }
@@ -68,7 +68,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveFlag_"
         }

--- a/generated/schemas/afw/_AdaptiveFlag_.json
+++ b/generated/schemas/afw/_AdaptiveFlag_.json
@@ -1,45 +1,52 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveFlag_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveFlag_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveFlag_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "An adaptive flag.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveFlag_.propertyTypes": {
+            "markdownDescription": "An adaptive flag.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "applicableFlags": {
                     "description": "All the applicable flags that are set when this flag is set.",
                     "items": {
                         "description": "All the applicable flags that are set when this flag is set.",
+                        "markdownDescription": "All the applicable flags that are set when this flag is set.",
                         "title": "All the applicable flags that are set when this flag is set",
                         "type": "string"
                     },
+                    "markdownDescription": "**Applicable Flags**\n\nAll the applicable flags that are set when this flag is set.",
                     "title": "Applicable Flags",
                     "type": "array"
                 },
                 "brief": {
                     "description": "Describes this flag briefly, starting with an uppercase letter and ending without a period.",
+                    "markdownDescription": "**Brief**\n\nDescribes this flag briefly, starting with an uppercase letter and ending without a period.",
                     "title": "Brief",
                     "type": "string"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "This is the description of this flag, which may provide more detail for documentation.",
+                    "markdownDescription": "**Description**\n\nThis is the description of this flag, which may provide more detail for documentation.",
                     "title": "Description",
                     "type": "string"
                 },
                 "flagId": {
                     "description": "This is the key for this flag in registry type flag and the objectId of its _AdaptiveFlag_ runtime object.",
+                    "markdownDescription": "**Flag Id**\n\nThis is the key for this flag in registry type flag and the objectId of its _AdaptiveFlag_ runtime object.",
                     "title": "Flag Id",
                     "type": "string"
                 },
                 "flagIndex": {
                     "description": "Index assigned when flag id is registered.",
+                    "markdownDescription": "**Index**\n\nIndex assigned when flag id is registered.",
                     "title": "Index",
                     "type": "integer"
                 },
@@ -47,9 +54,11 @@
                     "description": "All of the flags that include this flag. When setting flags in this array, this flag will also be set.",
                     "items": {
                         "description": "All of the flags that include this flag. When setting flags in this array, this flag will also be set.",
+                        "markdownDescription": "All of the flags that include this flag. When setting flags in this array, this flag will also be set.",
                         "title": "All of the flags that include this flag",
                         "type": "string"
                     },
+                    "markdownDescription": "**Included By**\n\nAll of the flags that include this flag. When setting flags in this array, this flag will also be set.",
                     "title": "Included By",
                     "type": "array"
                 },
@@ -57,9 +66,78 @@
                     "description": "All other flags that this flag includes. When setting this flat, all of the flags in this array will also be set",
                     "items": {
                         "description": "All other flags that this flag includes. When setting this flat, all of the flags in this array will also be set",
+                        "markdownDescription": "All other flags that this flag includes. When setting this flat, all of the flags in this array will also be set",
                         "title": "All other flags that this flag includes",
                         "type": "string"
                     },
+                    "markdownDescription": "**Includes**\n\nAll other flags that this flag includes. When setting this flat, all of the flags in this array will also be set",
+                    "title": "Includes",
+                    "type": "array"
+                }
+            },
+            "title": "_AdaptiveFlag_",
+            "type": "object"
+        },
+        "_AdaptiveFlag_.propertyTypes": {
+            "properties": {
+                "applicableFlags": {
+                    "description": "All the applicable flags that are set when this flag is set.",
+                    "items": {
+                        "description": "All the applicable flags that are set when this flag is set.",
+                        "markdownDescription": "All the applicable flags that are set when this flag is set.",
+                        "title": "All the applicable flags that are set when this flag is set",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Applicable Flags**\n\nAll the applicable flags that are set when this flag is set.",
+                    "title": "Applicable Flags",
+                    "type": "array"
+                },
+                "brief": {
+                    "description": "Describes this flag briefly, starting with an uppercase letter and ending without a period.",
+                    "markdownDescription": "**Brief**\n\nDescribes this flag briefly, starting with an uppercase letter and ending without a period.",
+                    "title": "Brief",
+                    "type": "string"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "This is the description of this flag, which may provide more detail for documentation.",
+                    "markdownDescription": "**Description**\n\nThis is the description of this flag, which may provide more detail for documentation.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "flagId": {
+                    "description": "This is the key for this flag in registry type flag and the objectId of its _AdaptiveFlag_ runtime object.",
+                    "markdownDescription": "**Flag Id**\n\nThis is the key for this flag in registry type flag and the objectId of its _AdaptiveFlag_ runtime object.",
+                    "title": "Flag Id",
+                    "type": "string"
+                },
+                "flagIndex": {
+                    "description": "Index assigned when flag id is registered.",
+                    "markdownDescription": "**Index**\n\nIndex assigned when flag id is registered.",
+                    "title": "Index",
+                    "type": "integer"
+                },
+                "includedByFlags": {
+                    "description": "All of the flags that include this flag. When setting flags in this array, this flag will also be set.",
+                    "items": {
+                        "description": "All of the flags that include this flag. When setting flags in this array, this flag will also be set.",
+                        "markdownDescription": "All of the flags that include this flag. When setting flags in this array, this flag will also be set.",
+                        "title": "All of the flags that include this flag",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Included By**\n\nAll of the flags that include this flag. When setting flags in this array, this flag will also be set.",
+                    "title": "Included By",
+                    "type": "array"
+                },
+                "includesFlags": {
+                    "description": "All other flags that this flag includes. When setting this flat, all of the flags in this array will also be set",
+                    "items": {
+                        "description": "All other flags that this flag includes. When setting this flat, all of the flags in this array will also be set",
+                        "markdownDescription": "All other flags that this flag includes. When setting this flat, all of the flags in this array will also be set",
+                        "title": "All other flags that this flag includes",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Includes**\n\nAll other flags that this flag includes. When setting this flat, all of the flags in this array will also be set",
                     "title": "Includes",
                     "type": "array"
                 }
@@ -68,9 +146,79 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveFlag_"
+    "additionalProperties": false,
+    "description": "An adaptive flag.",
+    "markdownDescription": "An adaptive flag.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "applicableFlags": {
+            "description": "All the applicable flags that are set when this flag is set.",
+            "items": {
+                "description": "All the applicable flags that are set when this flag is set.",
+                "markdownDescription": "All the applicable flags that are set when this flag is set.",
+                "title": "All the applicable flags that are set when this flag is set",
+                "type": "string"
+            },
+            "markdownDescription": "**Applicable Flags**\n\nAll the applicable flags that are set when this flag is set.",
+            "title": "Applicable Flags",
+            "type": "array"
+        },
+        "brief": {
+            "description": "Describes this flag briefly, starting with an uppercase letter and ending without a period.",
+            "markdownDescription": "**Brief**\n\nDescribes this flag briefly, starting with an uppercase letter and ending without a period.",
+            "title": "Brief",
+            "type": "string"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "This is the description of this flag, which may provide more detail for documentation.",
+            "markdownDescription": "**Description**\n\nThis is the description of this flag, which may provide more detail for documentation.",
+            "title": "Description",
+            "type": "string"
+        },
+        "flagId": {
+            "description": "This is the key for this flag in registry type flag and the objectId of its _AdaptiveFlag_ runtime object.",
+            "markdownDescription": "**Flag Id**\n\nThis is the key for this flag in registry type flag and the objectId of its _AdaptiveFlag_ runtime object.",
+            "title": "Flag Id",
+            "type": "string"
+        },
+        "flagIndex": {
+            "description": "Index assigned when flag id is registered.",
+            "markdownDescription": "**Index**\n\nIndex assigned when flag id is registered.",
+            "title": "Index",
+            "type": "integer"
+        },
+        "includedByFlags": {
+            "description": "All of the flags that include this flag. When setting flags in this array, this flag will also be set.",
+            "items": {
+                "description": "All of the flags that include this flag. When setting flags in this array, this flag will also be set.",
+                "markdownDescription": "All of the flags that include this flag. When setting flags in this array, this flag will also be set.",
+                "title": "All of the flags that include this flag",
+                "type": "string"
+            },
+            "markdownDescription": "**Included By**\n\nAll of the flags that include this flag. When setting flags in this array, this flag will also be set.",
+            "title": "Included By",
+            "type": "array"
+        },
+        "includesFlags": {
+            "description": "All other flags that this flag includes. When setting this flat, all of the flags in this array will also be set",
+            "items": {
+                "description": "All other flags that this flag includes. When setting this flat, all of the flags in this array will also be set",
+                "markdownDescription": "All other flags that this flag includes. When setting this flat, all of the flags in this array will also be set",
+                "title": "All other flags that this flag includes",
+                "type": "string"
+            },
+            "markdownDescription": "**Includes**\n\nAll other flags that this flag includes. When setting this flat, all of the flags in this array will also be set",
+            "title": "Includes",
+            "type": "array"
         }
-    ]
+    },
+    "title": "_AdaptiveFlag_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveFunctionCategory_.json
+++ b/generated/schemas/afw/_AdaptiveFunctionCategory_.json
@@ -1,12 +1,15 @@
 {
     "$defs": {
         "_AdaptiveFunctionCategory_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveFunctionCategory_.propertyTypes"
                 }
             ],
             "description": "Function category.",
+            "required": [
+                "category"
+            ],
             "type": "object",
             "unevaluatedProperties": false
         },
@@ -34,14 +37,11 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "category"
-            ],
             "type": "object"
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveFunctionCategory_"
         }

--- a/generated/schemas/afw/_AdaptiveFunctionCategory_.json
+++ b/generated/schemas/afw/_AdaptiveFunctionCategory_.json
@@ -1,38 +1,74 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveFunctionCategory_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveFunctionCategory_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveFunctionCategory_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Function category.",
-            "required": [
-                "category"
-            ],
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveFunctionCategory_.propertyTypes": {
+            "markdownDescription": "Function category.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "brief": {
                     "description": "This is a predicate for the function category with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for the function category with the first letter capitalized and without a trailing period.",
                     "title": "Brief",
                     "type": "string"
                 },
                 "category": {
                     "description": "Function category that this function belongs to. Categories group similar functions together logically.",
+                    "markdownDescription": "**Category**\n\nFunction category that this function belongs to. Categories group similar functions together logically.",
                     "title": "Category",
                     "type": "string"
                 },
                 "dataTypeCategory": {
                     "description": "This is a data type category.",
+                    "markdownDescription": "**Data Type Category**\n\nThis is a data type category.",
                     "title": "Data Type Category",
                     "type": "boolean"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "Description of function category in more detail, for documentation purposes.",
+                    "markdownDescription": "**Description**\n\nDescription of function category in more detail, for documentation purposes.",
+                    "title": "Description",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "category"
+            ],
+            "title": "_AdaptiveFunctionCategory_",
+            "type": "object"
+        },
+        "_AdaptiveFunctionCategory_.propertyTypes": {
+            "properties": {
+                "brief": {
+                    "description": "This is a predicate for the function category with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for the function category with the first letter capitalized and without a trailing period.",
+                    "title": "Brief",
+                    "type": "string"
+                },
+                "category": {
+                    "description": "Function category that this function belongs to. Categories group similar functions together logically.",
+                    "markdownDescription": "**Category**\n\nFunction category that this function belongs to. Categories group similar functions together logically.",
+                    "title": "Category",
+                    "type": "string"
+                },
+                "dataTypeCategory": {
+                    "description": "This is a data type category.",
+                    "markdownDescription": "**Data Type Category**\n\nThis is a data type category.",
+                    "title": "Data Type Category",
+                    "type": "boolean"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "Description of function category in more detail, for documentation purposes.",
+                    "markdownDescription": "**Description**\n\nDescription of function category in more detail, for documentation purposes.",
                     "title": "Description",
                     "type": "string"
                 }
@@ -41,9 +77,46 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveFunctionCategory_"
+    "additionalProperties": false,
+    "description": "Function category.",
+    "markdownDescription": "Function category.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "brief": {
+            "description": "This is a predicate for the function category with the first letter capitalized and without a trailing period.",
+            "markdownDescription": "**Brief**\n\nThis is a predicate for the function category with the first letter capitalized and without a trailing period.",
+            "title": "Brief",
+            "type": "string"
+        },
+        "category": {
+            "description": "Function category that this function belongs to. Categories group similar functions together logically.",
+            "markdownDescription": "**Category**\n\nFunction category that this function belongs to. Categories group similar functions together logically.",
+            "title": "Category",
+            "type": "string"
+        },
+        "dataTypeCategory": {
+            "description": "This is a data type category.",
+            "markdownDescription": "**Data Type Category**\n\nThis is a data type category.",
+            "title": "Data Type Category",
+            "type": "boolean"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "Description of function category in more detail, for documentation purposes.",
+            "markdownDescription": "**Description**\n\nDescription of function category in more detail, for documentation purposes.",
+            "title": "Description",
+            "type": "string"
         }
-    ]
+    },
+    "required": [
+        "category"
+    ],
+    "title": "_AdaptiveFunctionCategory_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveFunctionGenerate_.json
+++ b/generated/schemas/afw/_AdaptiveFunctionGenerate_.json
@@ -1,12 +1,16 @@
 {
     "$defs": {
         "_AdaptiveFunctionErrorThrown_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveFunctionErrorThrown_.propertyTypes"
                 }
             ],
             "description": "An object entry of _AdaptiveFunction_ errorsThrown array.",
+            "required": [
+                "error",
+                "reason"
+            ],
             "type": "object",
             "unevaluatedProperties": false
         },
@@ -23,19 +27,21 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "error",
-                "reason"
-            ],
             "type": "object"
         },
         "_AdaptiveFunctionGenerate_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveFunctionGenerate_.propertyTypes"
                 }
             ],
             "description": "This is the object type for objects in the generate/objects/_AdaptiveFunctionGenerate_/ of command, core, and extension source directories. These objects are used by the 'dev.py generate' script to generate _AdaptiveFunction_ objects.",
+            "required": [
+                "category",
+                "functionId",
+                "functionLabel",
+                "returns"
+            ],
             "type": "object",
             "unevaluatedProperties": false
         },
@@ -77,6 +83,7 @@
                     "type": "boolean"
                 },
                 "deprecated": {
+                    "default": false,
                     "description": "This indicates that the function is deprecated and may go away at some point.",
                     "title": "Deprecated",
                     "type": "boolean"
@@ -95,10 +102,13 @@
                 "errorsThrown": {
                     "description": "Errors that can be thrown by this function.",
                     "items": {
-                        "$ref": "#/$defs/_AdaptiveFunctionErrorThrown_",
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/_AdaptiveFunctionErrorThrown_"
+                            }
+                        ],
                         "description": "Errors that can be thrown by this function.",
-                        "title": "Errors thrown by this function",
-                        "type": "object"
+                        "title": "Errors thrown by this function"
                     },
                     "title": "Errors Thrown",
                     "type": "array"
@@ -126,20 +136,25 @@
                 "parameters": {
                     "description": "These are the function's parameters.",
                     "items": {
-                        "$ref": "#/$defs/_AdaptiveFunctionParameter_",
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/_AdaptiveFunctionParameter_"
+                            }
+                        ],
                         "description": "These are the function's parameters.",
-                        "title": "The function's parameters",
-                        "type": "object"
+                        "title": "The function's parameters"
                     },
                     "title": "Parameters",
                     "type": "array"
                 },
                 "polymorphic": {
+                    "default": false,
                     "description": "This indicates that this function can be called polymorphically without specifying the <Type>:: qualifier. The appropriate implementation of the function will be called based on the dataType and/or dataTypeParameter of the first function parameter value.",
                     "title": "Polymorphic",
                     "type": "boolean"
                 },
                 "polymorphicDataTypes": {
+                    "default": false,
                     "description": "This function will call the appropriate function when the first parameter is one of these data types.",
                     "items": {
                         "description": "This function will call the appropriate function when the first parameter is one of these data types.",
@@ -155,6 +170,7 @@
                     "type": "string"
                 },
                 "polymorphicExecuteFunctionEvaluatesFirstParameter": {
+                    "default": false,
                     "description": "If true, the first parameter evaluate is deferred to polymorphicExecuteFunction function. If false or not specified, standard polymorphic function processing evaluates the first parameter to determine the appropriate evaluate to call.",
                     "title": "Defer Evaluate",
                     "type": "boolean"
@@ -165,6 +181,7 @@
                     "type": "object"
                 },
                 "pure": {
+                    "default": false,
                     "description": "This indicates that, given exactly the same parameter values, this function will always return the same result and will not cause any side effects.",
                     "title": "Pure",
                     "type": "boolean"
@@ -175,10 +192,13 @@
                     "type": "boolean"
                 },
                 "returns": {
-                    "$ref": "#/$defs/_AdaptiveFunctionParameter_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveFunctionParameter_"
+                        }
+                    ],
                     "description": "The return parameter.",
-                    "title": "Returns",
-                    "type": "object"
+                    "title": "Returns"
                 },
                 "scriptSupport": {
                     "description": "This property can only be true for afw core functions that supports a statement in adaptive script. If true, there must be a #define in afw_value.h of the form 'AFW_VALUE_CALL_SCRIPT_SUPPORT_NUMBER_' followed by the upper case of the functionId to specify the special number associated with this function along with supporting code in afw_function_script.c.",
@@ -206,16 +226,10 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "category",
-                "functionId",
-                "functionLabel",
-                "returns"
-            ],
             "type": "object"
         },
         "_AdaptiveFunctionParameter_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveFunctionParameter_.propertyTypes"
                 }
@@ -232,6 +246,7 @@
                     "type": "string"
                 },
                 "canBeUndefined": {
+                    "default": false,
                     "description": "Indicates that parameter can be undefined (NULL) even if not optional.",
                     "title": "Optional",
                     "type": "boolean"
@@ -263,6 +278,7 @@
                     "type": "string"
                 },
                 "optional": {
+                    "default": false,
                     "description": "This indicates that parameter is optional and can be undefined (NULL).",
                     "title": "Optional",
                     "type": "boolean"
@@ -282,7 +298,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveFunctionGenerate_"
         }

--- a/generated/schemas/afw/_AdaptiveFunctionGenerate_.json
+++ b/generated/schemas/afw/_AdaptiveFunctionGenerate_.json
@@ -1,28 +1,49 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveFunctionGenerate_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveFunctionErrorThrown_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveFunctionErrorThrown_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "An object entry of _AdaptiveFunction_ errorsThrown array.",
-            "required": [
-                "error",
-                "reason"
-            ],
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveFunctionErrorThrown_.propertyTypes": {
+            "markdownDescription": "An object entry of _AdaptiveFunction_ errorsThrown array.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "error": {
                     "description": "This is the error id of the error that can be thrown.",
+                    "markdownDescription": "**Error**\n\nThis is the error id of the error that can be thrown.",
                     "title": "Error",
                     "type": "string"
                 },
                 "reason": {
                     "description": "This is the reason the error can be thrown.",
+                    "markdownDescription": "**Reason**\n\nThis is the reason the error can be thrown.",
+                    "title": "Reason",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "error",
+                "reason"
+            ],
+            "title": "_AdaptiveFunctionErrorThrown_",
+            "type": "object"
+        },
+        "_AdaptiveFunctionErrorThrown_.propertyTypes": {
+            "properties": {
+                "error": {
+                    "description": "This is the error id of the error that can be thrown.",
+                    "markdownDescription": "**Error**\n\nThis is the error id of the error that can be thrown.",
+                    "title": "Error",
+                    "type": "string"
+                },
+                "reason": {
+                    "description": "This is the reason the error can be thrown.",
+                    "markdownDescription": "**Reason**\n\nThis is the reason the error can be thrown.",
                     "title": "Reason",
                     "type": "string"
                 }
@@ -30,72 +51,76 @@
             "type": "object"
         },
         "_AdaptiveFunctionGenerate_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveFunctionGenerate_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "This is the object type for objects in the generate/objects/_AdaptiveFunctionGenerate_/ of command, core, and extension source directories. These objects are used by the 'dev.py generate' script to generate _AdaptiveFunction_ objects.",
-            "required": [
-                "category",
-                "functionId",
-                "functionLabel",
-                "returns"
-            ],
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveFunctionGenerate_.propertyTypes": {
+            "markdownDescription": "This is the object type for objects in the generate/objects/_AdaptiveFunctionGenerate_/ of command, core, and extension source directories. These objects are used by the 'dev.py generate' script to generate _AdaptiveFunction_ objects.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "additionalArgCheck": {
                     "description": "Additional argument checking is needed. This is residual from before auto casting so may be deprecated in the future.",
+                    "markdownDescription": "**Additional Arg Check**\n\nAdditional argument checking is needed. This is residual from before auto casting so may be deprecated in the future.",
                     "title": "Additional Arg Check",
                     "type": "boolean"
                 },
                 "afwCamelCaseFunctionLabel": {
                     "description": "This is the functionLabel prefixed with 'afw' and converted to camel case.",
+                    "markdownDescription": "**Prefixed Camel Case**\n\nThis is the functionLabel prefixed with 'afw' and converted to camel case.",
                     "title": "Prefixed Camel Case",
                     "type": "string"
                 },
                 "brief": {
                     "description": "This is a predicate for the function with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for the function with the first letter capitalized and without a trailing period.",
                     "title": "Brief",
                     "type": "string"
                 },
                 "camelCaseFunctionLabel": {
                     "description": "This is the functionLabel converted to camel case.",
+                    "markdownDescription": "**Camel Case**\n\nThis is the functionLabel converted to camel case.",
                     "title": "Camel Case",
                     "type": "string"
                 },
                 "category": {
                     "description": "Function category.",
+                    "markdownDescription": "**Category**\n\nFunction category.",
                     "title": "Category",
                     "type": "string"
                 },
                 "dataType": {
                     "description": "If present, this is a method for this data type.",
+                    "markdownDescription": "**Data Type**\n\nIf present, this is a method for this data type.",
                     "title": "Data Type",
                     "type": "string"
                 },
                 "dataTypeMethod": {
                     "description": "If true, this is a data type method that can be called polymorphically or by prefixing the function with the data type followed by double colons ('::').",
+                    "markdownDescription": "**Data Type Method**\n\nIf true, this is a data type method that can be called polymorphically or by prefixing the function with the data type followed by double colons ('::').",
                     "title": "Data Type Method",
                     "type": "boolean"
                 },
                 "deprecated": {
                     "default": false,
                     "description": "This indicates that the function is deprecated and may go away at some point.",
+                    "markdownDescription": "**Deprecated**\n\nThis indicates that the function is deprecated and may go away at some point.",
                     "title": "Deprecated",
                     "type": "boolean"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "This is the function's description, used for documentation purposes.",
+                    "markdownDescription": "**Description**\n\nThis is the function's description, used for documentation purposes.",
                     "title": "Description",
                     "type": "string"
                 },
                 "details": {
                     "description": "This is a sentence that contains details about the other properties of this function.",
+                    "markdownDescription": "**Details**\n\nThis is a sentence that contains details about the other properties of this function.",
                     "title": "Details",
                     "type": "string"
                 },
@@ -108,28 +133,35 @@
                             }
                         ],
                         "description": "Errors that can be thrown by this function.",
-                        "title": "Errors thrown by this function"
+                        "markdownDescription": "Errors that can be thrown by this function.",
+                        "title": "Errors thrown by this function",
+                        "type": "object"
                     },
+                    "markdownDescription": "**Errors Thrown**\n\nErrors that can be thrown by this function.",
                     "title": "Errors Thrown",
                     "type": "array"
                 },
                 "functionId": {
                     "description": "This is the function's id.",
+                    "markdownDescription": "**Function**\n\nThis is the function's id.",
                     "title": "Function",
                     "type": "string"
                 },
                 "functionLabel": {
                     "description": "This is the function's label.",
+                    "markdownDescription": "**Function Label**\n\nThis is the function's label.",
                     "title": "Function Label",
                     "type": "string"
                 },
                 "functionSignature": {
                     "description": "This is the function's signature.",
+                    "markdownDescription": "**Function Signature**\n\nThis is the function's signature.",
                     "title": "Function Signature",
                     "type": "string"
                 },
                 "op": {
                     "description": "This is the function's operator. This is not used at the moment, but may be used in a future expression syntax.",
+                    "markdownDescription": "**Operator**\n\nThis is the function's operator. This is not used at the moment, but may be used in a future expression syntax.",
                     "title": "Operator",
                     "type": "string"
                 },
@@ -142,14 +174,18 @@
                             }
                         ],
                         "description": "These are the function's parameters.",
-                        "title": "The function's parameters"
+                        "markdownDescription": "These are the function's parameters.",
+                        "title": "The function's parameters",
+                        "type": "object"
                     },
+                    "markdownDescription": "**Parameters**\n\nThese are the function's parameters.",
                     "title": "Parameters",
                     "type": "array"
                 },
                 "polymorphic": {
                     "default": false,
                     "description": "This indicates that this function can be called polymorphically without specifying the <Type>:: qualifier. The appropriate implementation of the function will be called based on the dataType and/or dataTypeParameter of the first function parameter value.",
+                    "markdownDescription": "**Polymorphic**\n\nThis indicates that this function can be called polymorphically without specifying the <Type>:: qualifier. The appropriate implementation of the function will be called based on the dataType and/or dataTypeParameter of the first function parameter value.",
                     "title": "Polymorphic",
                     "type": "boolean"
                 },
@@ -158,36 +194,43 @@
                     "description": "This function will call the appropriate function when the first parameter is one of these data types.",
                     "items": {
                         "description": "This function will call the appropriate function when the first parameter is one of these data types.",
+                        "markdownDescription": "This function will call the appropriate function when the first parameter is one of these data types.",
                         "title": "This function will call the appropriate function when the first parameter is one of these data types",
                         "type": "string"
                     },
+                    "markdownDescription": "**Polymorphic Data Types**\n\nThis function will call the appropriate function when the first parameter is one of these data types.",
                     "title": "Polymorphic Data Types",
                     "type": "array"
                 },
                 "polymorphicExecuteFunction": {
                     "description": "This is the label in the C source of the polymorphic execute function used for this function.",
+                    "markdownDescription": "**Polymorphic Function Label**\n\nThis is the label in the C source of the polymorphic execute function used for this function.",
                     "title": "Polymorphic Function Label",
                     "type": "string"
                 },
                 "polymorphicExecuteFunctionEvaluatesFirstParameter": {
                     "default": false,
                     "description": "If true, the first parameter evaluate is deferred to polymorphicExecuteFunction function. If false or not specified, standard polymorphic function processing evaluates the first parameter to determine the appropriate evaluate to call.",
+                    "markdownDescription": "**Defer Evaluate**\n\nIf true, the first parameter evaluate is deferred to polymorphicExecuteFunction function. If false or not specified, standard polymorphic function processing evaluates the first parameter to determine the appropriate evaluate to call.",
                     "title": "Defer Evaluate",
                     "type": "boolean"
                 },
                 "polymorphicOverrides": {
                     "description": "This allows overrides, for particular data types, of properties for this function.",
+                    "markdownDescription": "**Polymorphic Function Label**\n\nThis allows overrides, for particular data types, of properties for this function.",
                     "title": "Polymorphic Function Label",
                     "type": "object"
                 },
                 "pure": {
                     "default": false,
                     "description": "This indicates that, given exactly the same parameter values, this function will always return the same result and will not cause any side effects.",
+                    "markdownDescription": "**Pure**\n\nThis indicates that, given exactly the same parameter values, this function will always return the same result and will not cause any side effects.",
                     "title": "Pure",
                     "type": "boolean"
                 },
                 "requiresExecuteAccess": {
                     "description": "If true, this function requires 'execute' authorization access to be called. The 'resourceId' for the authorization check is the function object path, the 'actionId' is 'execute', and the 'object' is object type '_AdaptiveFunctionArguments_' which contains the function object and the arguments to the called function.\nNote that the construction of the current::object during authorization check requires that parameters passed in will be evaluated ahead of time. Therefore, if your function is designed to short circuit its execution path based on the value of one of its parameters, understand that functions with this flag set will still undergo evaluations anyway. In addition, type checking will not be applied to the parameters at the time of authorization, so your authorization policy must consider any type of parameter value to be passed in.",
+                    "markdownDescription": "**Requires Execute Access**\n\nIf true, this function requires 'execute' authorization access to be called. The 'resourceId' for the authorization check is the function object path, the 'actionId' is 'execute', and the 'object' is object type '_AdaptiveFunctionArguments_' which contains the function object and the arguments to the called function.\nNote that the construction of the current::object during authorization check requires that parameters passed in will be evaluated ahead of time. Therefore, if your function is designed to short circuit its execution path based on the value of one of its parameters, understand that functions with this flag set will still undergo evaluations anyway. In addition, type checking will not be applied to the parameters at the time of authorization, so your authorization policy must consider any type of parameter value to be passed in.",
                     "title": "Requires Execute Access",
                     "type": "boolean"
                 },
@@ -198,10 +241,13 @@
                         }
                     ],
                     "description": "The return parameter.",
-                    "title": "Returns"
+                    "markdownDescription": "**Returns**\n\nThe return parameter.",
+                    "title": "Returns",
+                    "type": "object"
                 },
                 "scriptSupport": {
                     "description": "This property can only be true for afw core functions that supports a statement in adaptive script. If true, there must be a #define in afw_value.h of the form 'AFW_VALUE_CALL_SCRIPT_SUPPORT_NUMBER_' followed by the upper case of the functionId to specify the special number associated with this function along with supporting code in afw_function_script.c.",
+                    "markdownDescription": "**Script support**\n\nThis property can only be true for afw core functions that supports a statement in adaptive script. If true, there must be a #define in afw_value.h of the form 'AFW_VALUE_CALL_SCRIPT_SUPPORT_NUMBER_' followed by the upper case of the functionId to specify the special number associated with this function along with supporting code in afw_function_script.c.",
                     "title": "Script support",
                     "type": "boolean"
                 },
@@ -209,19 +255,248 @@
                     "description": "Any side effects that this function may produce as a result of execution.",
                     "items": {
                         "description": "Any side effects that this function may produce as a result of execution.",
+                        "markdownDescription": "Any side effects that this function may produce as a result of execution.",
                         "title": "Side effects for this function",
                         "type": "string"
                     },
+                    "markdownDescription": "**Side Effects**\n\nAny side effects that this function may produce as a result of execution.",
                     "title": "Side Effects",
                     "type": "array"
                 },
                 "signatureOnly": {
                     "description": "This is a signature with an unimplemented execute function.",
+                    "markdownDescription": "**Signature Only**\n\nThis is a signature with an unimplemented execute function.",
                     "title": "Signature Only",
                     "type": "boolean"
                 },
                 "useExecuteFunction": {
                     "description": "This is the label in the C source of the execute function used for this function.",
+                    "markdownDescription": "**Use Execute Function**\n\nThis is the label in the C source of the execute function used for this function.",
+                    "title": "Use Execute Function",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "category",
+                "functionId",
+                "functionLabel",
+                "returns"
+            ],
+            "title": "_AdaptiveFunctionGenerate_",
+            "type": "object"
+        },
+        "_AdaptiveFunctionGenerate_.propertyTypes": {
+            "properties": {
+                "additionalArgCheck": {
+                    "description": "Additional argument checking is needed. This is residual from before auto casting so may be deprecated in the future.",
+                    "markdownDescription": "**Additional Arg Check**\n\nAdditional argument checking is needed. This is residual from before auto casting so may be deprecated in the future.",
+                    "title": "Additional Arg Check",
+                    "type": "boolean"
+                },
+                "afwCamelCaseFunctionLabel": {
+                    "description": "This is the functionLabel prefixed with 'afw' and converted to camel case.",
+                    "markdownDescription": "**Prefixed Camel Case**\n\nThis is the functionLabel prefixed with 'afw' and converted to camel case.",
+                    "title": "Prefixed Camel Case",
+                    "type": "string"
+                },
+                "brief": {
+                    "description": "This is a predicate for the function with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for the function with the first letter capitalized and without a trailing period.",
+                    "title": "Brief",
+                    "type": "string"
+                },
+                "camelCaseFunctionLabel": {
+                    "description": "This is the functionLabel converted to camel case.",
+                    "markdownDescription": "**Camel Case**\n\nThis is the functionLabel converted to camel case.",
+                    "title": "Camel Case",
+                    "type": "string"
+                },
+                "category": {
+                    "description": "Function category.",
+                    "markdownDescription": "**Category**\n\nFunction category.",
+                    "title": "Category",
+                    "type": "string"
+                },
+                "dataType": {
+                    "description": "If present, this is a method for this data type.",
+                    "markdownDescription": "**Data Type**\n\nIf present, this is a method for this data type.",
+                    "title": "Data Type",
+                    "type": "string"
+                },
+                "dataTypeMethod": {
+                    "description": "If true, this is a data type method that can be called polymorphically or by prefixing the function with the data type followed by double colons ('::').",
+                    "markdownDescription": "**Data Type Method**\n\nIf true, this is a data type method that can be called polymorphically or by prefixing the function with the data type followed by double colons ('::').",
+                    "title": "Data Type Method",
+                    "type": "boolean"
+                },
+                "deprecated": {
+                    "default": false,
+                    "description": "This indicates that the function is deprecated and may go away at some point.",
+                    "markdownDescription": "**Deprecated**\n\nThis indicates that the function is deprecated and may go away at some point.",
+                    "title": "Deprecated",
+                    "type": "boolean"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "This is the function's description, used for documentation purposes.",
+                    "markdownDescription": "**Description**\n\nThis is the function's description, used for documentation purposes.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "details": {
+                    "description": "This is a sentence that contains details about the other properties of this function.",
+                    "markdownDescription": "**Details**\n\nThis is a sentence that contains details about the other properties of this function.",
+                    "title": "Details",
+                    "type": "string"
+                },
+                "errorsThrown": {
+                    "description": "Errors that can be thrown by this function.",
+                    "items": {
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/_AdaptiveFunctionErrorThrown_"
+                            }
+                        ],
+                        "description": "Errors that can be thrown by this function.",
+                        "markdownDescription": "Errors that can be thrown by this function.",
+                        "title": "Errors thrown by this function",
+                        "type": "object"
+                    },
+                    "markdownDescription": "**Errors Thrown**\n\nErrors that can be thrown by this function.",
+                    "title": "Errors Thrown",
+                    "type": "array"
+                },
+                "functionId": {
+                    "description": "This is the function's id.",
+                    "markdownDescription": "**Function**\n\nThis is the function's id.",
+                    "title": "Function",
+                    "type": "string"
+                },
+                "functionLabel": {
+                    "description": "This is the function's label.",
+                    "markdownDescription": "**Function Label**\n\nThis is the function's label.",
+                    "title": "Function Label",
+                    "type": "string"
+                },
+                "functionSignature": {
+                    "description": "This is the function's signature.",
+                    "markdownDescription": "**Function Signature**\n\nThis is the function's signature.",
+                    "title": "Function Signature",
+                    "type": "string"
+                },
+                "op": {
+                    "description": "This is the function's operator. This is not used at the moment, but may be used in a future expression syntax.",
+                    "markdownDescription": "**Operator**\n\nThis is the function's operator. This is not used at the moment, but may be used in a future expression syntax.",
+                    "title": "Operator",
+                    "type": "string"
+                },
+                "parameters": {
+                    "description": "These are the function's parameters.",
+                    "items": {
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/_AdaptiveFunctionParameter_"
+                            }
+                        ],
+                        "description": "These are the function's parameters.",
+                        "markdownDescription": "These are the function's parameters.",
+                        "title": "The function's parameters",
+                        "type": "object"
+                    },
+                    "markdownDescription": "**Parameters**\n\nThese are the function's parameters.",
+                    "title": "Parameters",
+                    "type": "array"
+                },
+                "polymorphic": {
+                    "default": false,
+                    "description": "This indicates that this function can be called polymorphically without specifying the <Type>:: qualifier. The appropriate implementation of the function will be called based on the dataType and/or dataTypeParameter of the first function parameter value.",
+                    "markdownDescription": "**Polymorphic**\n\nThis indicates that this function can be called polymorphically without specifying the <Type>:: qualifier. The appropriate implementation of the function will be called based on the dataType and/or dataTypeParameter of the first function parameter value.",
+                    "title": "Polymorphic",
+                    "type": "boolean"
+                },
+                "polymorphicDataTypes": {
+                    "default": false,
+                    "description": "This function will call the appropriate function when the first parameter is one of these data types.",
+                    "items": {
+                        "description": "This function will call the appropriate function when the first parameter is one of these data types.",
+                        "markdownDescription": "This function will call the appropriate function when the first parameter is one of these data types.",
+                        "title": "This function will call the appropriate function when the first parameter is one of these data types",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Polymorphic Data Types**\n\nThis function will call the appropriate function when the first parameter is one of these data types.",
+                    "title": "Polymorphic Data Types",
+                    "type": "array"
+                },
+                "polymorphicExecuteFunction": {
+                    "description": "This is the label in the C source of the polymorphic execute function used for this function.",
+                    "markdownDescription": "**Polymorphic Function Label**\n\nThis is the label in the C source of the polymorphic execute function used for this function.",
+                    "title": "Polymorphic Function Label",
+                    "type": "string"
+                },
+                "polymorphicExecuteFunctionEvaluatesFirstParameter": {
+                    "default": false,
+                    "description": "If true, the first parameter evaluate is deferred to polymorphicExecuteFunction function. If false or not specified, standard polymorphic function processing evaluates the first parameter to determine the appropriate evaluate to call.",
+                    "markdownDescription": "**Defer Evaluate**\n\nIf true, the first parameter evaluate is deferred to polymorphicExecuteFunction function. If false or not specified, standard polymorphic function processing evaluates the first parameter to determine the appropriate evaluate to call.",
+                    "title": "Defer Evaluate",
+                    "type": "boolean"
+                },
+                "polymorphicOverrides": {
+                    "description": "This allows overrides, for particular data types, of properties for this function.",
+                    "markdownDescription": "**Polymorphic Function Label**\n\nThis allows overrides, for particular data types, of properties for this function.",
+                    "title": "Polymorphic Function Label",
+                    "type": "object"
+                },
+                "pure": {
+                    "default": false,
+                    "description": "This indicates that, given exactly the same parameter values, this function will always return the same result and will not cause any side effects.",
+                    "markdownDescription": "**Pure**\n\nThis indicates that, given exactly the same parameter values, this function will always return the same result and will not cause any side effects.",
+                    "title": "Pure",
+                    "type": "boolean"
+                },
+                "requiresExecuteAccess": {
+                    "description": "If true, this function requires 'execute' authorization access to be called. The 'resourceId' for the authorization check is the function object path, the 'actionId' is 'execute', and the 'object' is object type '_AdaptiveFunctionArguments_' which contains the function object and the arguments to the called function.\nNote that the construction of the current::object during authorization check requires that parameters passed in will be evaluated ahead of time. Therefore, if your function is designed to short circuit its execution path based on the value of one of its parameters, understand that functions with this flag set will still undergo evaluations anyway. In addition, type checking will not be applied to the parameters at the time of authorization, so your authorization policy must consider any type of parameter value to be passed in.",
+                    "markdownDescription": "**Requires Execute Access**\n\nIf true, this function requires 'execute' authorization access to be called. The 'resourceId' for the authorization check is the function object path, the 'actionId' is 'execute', and the 'object' is object type '_AdaptiveFunctionArguments_' which contains the function object and the arguments to the called function.\nNote that the construction of the current::object during authorization check requires that parameters passed in will be evaluated ahead of time. Therefore, if your function is designed to short circuit its execution path based on the value of one of its parameters, understand that functions with this flag set will still undergo evaluations anyway. In addition, type checking will not be applied to the parameters at the time of authorization, so your authorization policy must consider any type of parameter value to be passed in.",
+                    "title": "Requires Execute Access",
+                    "type": "boolean"
+                },
+                "returns": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveFunctionParameter_"
+                        }
+                    ],
+                    "description": "The return parameter.",
+                    "markdownDescription": "**Returns**\n\nThe return parameter.",
+                    "title": "Returns",
+                    "type": "object"
+                },
+                "scriptSupport": {
+                    "description": "This property can only be true for afw core functions that supports a statement in adaptive script. If true, there must be a #define in afw_value.h of the form 'AFW_VALUE_CALL_SCRIPT_SUPPORT_NUMBER_' followed by the upper case of the functionId to specify the special number associated with this function along with supporting code in afw_function_script.c.",
+                    "markdownDescription": "**Script support**\n\nThis property can only be true for afw core functions that supports a statement in adaptive script. If true, there must be a #define in afw_value.h of the form 'AFW_VALUE_CALL_SCRIPT_SUPPORT_NUMBER_' followed by the upper case of the functionId to specify the special number associated with this function along with supporting code in afw_function_script.c.",
+                    "title": "Script support",
+                    "type": "boolean"
+                },
+                "sideEffects": {
+                    "description": "Any side effects that this function may produce as a result of execution.",
+                    "items": {
+                        "description": "Any side effects that this function may produce as a result of execution.",
+                        "markdownDescription": "Any side effects that this function may produce as a result of execution.",
+                        "title": "Side effects for this function",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Side Effects**\n\nAny side effects that this function may produce as a result of execution.",
+                    "title": "Side Effects",
+                    "type": "array"
+                },
+                "signatureOnly": {
+                    "description": "This is a signature with an unimplemented execute function.",
+                    "markdownDescription": "**Signature Only**\n\nThis is a signature with an unimplemented execute function.",
+                    "title": "Signature Only",
+                    "type": "boolean"
+                },
+                "useExecuteFunction": {
+                    "description": "This is the label in the C source of the execute function used for this function.",
+                    "markdownDescription": "**Use Execute Function**\n\nThis is the label in the C source of the execute function used for this function.",
                     "title": "Use Execute Function",
                     "type": "string"
                 }
@@ -229,67 +504,146 @@
             "type": "object"
         },
         "_AdaptiveFunctionParameter_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveFunctionParameter_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Adaptive function parameter meta.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveFunctionParameter_.propertyTypes": {
+            "markdownDescription": "Adaptive function parameter meta.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "brief": {
                     "description": "This is a predicate for the parameter with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for the parameter with the first letter capitalized and without a trailing period.",
                     "title": "Brief",
                     "type": "string"
                 },
                 "canBeUndefined": {
                     "default": false,
                     "description": "Indicates that parameter can be undefined (NULL) even if not optional.",
+                    "markdownDescription": "**Optional**\n\nIndicates that parameter can be undefined (NULL) even if not optional.",
                     "title": "Optional",
                     "type": "boolean"
                 },
                 "dataType": {
                     "description": "This is the data type id for this parameter's value.",
+                    "markdownDescription": "**Data Type**\n\nThis is the data type id for this parameter's value.",
                     "title": "Data Type",
                     "type": "string"
                 },
                 "dataTypeParameter": {
                     "description": "See the data type's dataTypeParameterType property to determine how to interpret this.",
+                    "markdownDescription": "**Data Type Parameter**\n\nSee the data type's dataTypeParameterType property to determine how to interpret this.",
                     "title": "Data Type Parameter",
                     "type": "string"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "This is the description of this parameter.",
+                    "markdownDescription": "**Description**\n\nThis is the description of this parameter.",
                     "title": "Description",
                     "type": "string"
                 },
                 "minArgs": {
                     "description": "This is the minimum number of values that can be specified for this parameter. If -1, the parameter can be specified exactly once. This can only have a value other than -1 on last parameter where it can have a value of -1 to 127.",
+                    "markdownDescription": "**Min Args**\n\nThis is the minimum number of values that can be specified for this parameter. If -1, the parameter can be specified exactly once. This can only have a value other than -1 on last parameter where it can have a value of -1 to 127.",
                     "title": "Min Args",
                     "type": "integer"
                 },
                 "name": {
                     "description": "This is the name of this parameter.",
+                    "markdownDescription": "**Name**\n\nThis is the name of this parameter.",
                     "title": "Name",
                     "type": "string"
                 },
                 "optional": {
                     "default": false,
                     "description": "This indicates that parameter is optional and can be undefined (NULL).",
+                    "markdownDescription": "**Optional**\n\nThis indicates that parameter is optional and can be undefined (NULL).",
                     "title": "Optional",
                     "type": "boolean"
                 },
                 "polymorphicDataType": {
                     "description": "The dataType for this parameter is <Type>.",
+                    "markdownDescription": "**Polymorphic Data Type**\n\nThe dataType for this parameter is <Type>.",
                     "title": "Polymorphic Data Type",
                     "type": "boolean"
                 },
                 "polymorphicDataTypeParameter": {
                     "description": "The dataTypeParameter for this parameter is <Type>.",
+                    "markdownDescription": "**Polymorphic Data Type Parameter**\n\nThe dataTypeParameter for this parameter is <Type>.",
+                    "title": "Polymorphic Data Type Parameter",
+                    "type": "boolean"
+                }
+            },
+            "title": "_AdaptiveFunctionParameter_",
+            "type": "object"
+        },
+        "_AdaptiveFunctionParameter_.propertyTypes": {
+            "properties": {
+                "brief": {
+                    "description": "This is a predicate for the parameter with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for the parameter with the first letter capitalized and without a trailing period.",
+                    "title": "Brief",
+                    "type": "string"
+                },
+                "canBeUndefined": {
+                    "default": false,
+                    "description": "Indicates that parameter can be undefined (NULL) even if not optional.",
+                    "markdownDescription": "**Optional**\n\nIndicates that parameter can be undefined (NULL) even if not optional.",
+                    "title": "Optional",
+                    "type": "boolean"
+                },
+                "dataType": {
+                    "description": "This is the data type id for this parameter's value.",
+                    "markdownDescription": "**Data Type**\n\nThis is the data type id for this parameter's value.",
+                    "title": "Data Type",
+                    "type": "string"
+                },
+                "dataTypeParameter": {
+                    "description": "See the data type's dataTypeParameterType property to determine how to interpret this.",
+                    "markdownDescription": "**Data Type Parameter**\n\nSee the data type's dataTypeParameterType property to determine how to interpret this.",
+                    "title": "Data Type Parameter",
+                    "type": "string"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "This is the description of this parameter.",
+                    "markdownDescription": "**Description**\n\nThis is the description of this parameter.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "minArgs": {
+                    "description": "This is the minimum number of values that can be specified for this parameter. If -1, the parameter can be specified exactly once. This can only have a value other than -1 on last parameter where it can have a value of -1 to 127.",
+                    "markdownDescription": "**Min Args**\n\nThis is the minimum number of values that can be specified for this parameter. If -1, the parameter can be specified exactly once. This can only have a value other than -1 on last parameter where it can have a value of -1 to 127.",
+                    "title": "Min Args",
+                    "type": "integer"
+                },
+                "name": {
+                    "description": "This is the name of this parameter.",
+                    "markdownDescription": "**Name**\n\nThis is the name of this parameter.",
+                    "title": "Name",
+                    "type": "string"
+                },
+                "optional": {
+                    "default": false,
+                    "description": "This indicates that parameter is optional and can be undefined (NULL).",
+                    "markdownDescription": "**Optional**\n\nThis indicates that parameter is optional and can be undefined (NULL).",
+                    "title": "Optional",
+                    "type": "boolean"
+                },
+                "polymorphicDataType": {
+                    "description": "The dataType for this parameter is <Type>.",
+                    "markdownDescription": "**Polymorphic Data Type**\n\nThe dataType for this parameter is <Type>.",
+                    "title": "Polymorphic Data Type",
+                    "type": "boolean"
+                },
+                "polymorphicDataTypeParameter": {
+                    "description": "The dataTypeParameter for this parameter is <Type>.",
+                    "markdownDescription": "**Polymorphic Data Type Parameter**\n\nThe dataTypeParameter for this parameter is <Type>.",
                     "title": "Polymorphic Data Type Parameter",
                     "type": "boolean"
                 }
@@ -298,9 +652,237 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveFunctionGenerate_"
+    "additionalProperties": false,
+    "description": "This is the object type for objects in the generate/objects/_AdaptiveFunctionGenerate_/ of command, core, and extension source directories. These objects are used by the 'dev.py generate' script to generate _AdaptiveFunction_ objects.",
+    "markdownDescription": "This is the object type for objects in the generate/objects/_AdaptiveFunctionGenerate_/ of command, core, and extension source directories. These objects are used by the 'dev.py generate' script to generate _AdaptiveFunction_ objects.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "additionalArgCheck": {
+            "description": "Additional argument checking is needed. This is residual from before auto casting so may be deprecated in the future.",
+            "markdownDescription": "**Additional Arg Check**\n\nAdditional argument checking is needed. This is residual from before auto casting so may be deprecated in the future.",
+            "title": "Additional Arg Check",
+            "type": "boolean"
+        },
+        "afwCamelCaseFunctionLabel": {
+            "description": "This is the functionLabel prefixed with 'afw' and converted to camel case.",
+            "markdownDescription": "**Prefixed Camel Case**\n\nThis is the functionLabel prefixed with 'afw' and converted to camel case.",
+            "title": "Prefixed Camel Case",
+            "type": "string"
+        },
+        "brief": {
+            "description": "This is a predicate for the function with the first letter capitalized and without a trailing period.",
+            "markdownDescription": "**Brief**\n\nThis is a predicate for the function with the first letter capitalized and without a trailing period.",
+            "title": "Brief",
+            "type": "string"
+        },
+        "camelCaseFunctionLabel": {
+            "description": "This is the functionLabel converted to camel case.",
+            "markdownDescription": "**Camel Case**\n\nThis is the functionLabel converted to camel case.",
+            "title": "Camel Case",
+            "type": "string"
+        },
+        "category": {
+            "description": "Function category.",
+            "markdownDescription": "**Category**\n\nFunction category.",
+            "title": "Category",
+            "type": "string"
+        },
+        "dataType": {
+            "description": "If present, this is a method for this data type.",
+            "markdownDescription": "**Data Type**\n\nIf present, this is a method for this data type.",
+            "title": "Data Type",
+            "type": "string"
+        },
+        "dataTypeMethod": {
+            "description": "If true, this is a data type method that can be called polymorphically or by prefixing the function with the data type followed by double colons ('::').",
+            "markdownDescription": "**Data Type Method**\n\nIf true, this is a data type method that can be called polymorphically or by prefixing the function with the data type followed by double colons ('::').",
+            "title": "Data Type Method",
+            "type": "boolean"
+        },
+        "deprecated": {
+            "default": false,
+            "description": "This indicates that the function is deprecated and may go away at some point.",
+            "markdownDescription": "**Deprecated**\n\nThis indicates that the function is deprecated and may go away at some point.",
+            "title": "Deprecated",
+            "type": "boolean"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "This is the function's description, used for documentation purposes.",
+            "markdownDescription": "**Description**\n\nThis is the function's description, used for documentation purposes.",
+            "title": "Description",
+            "type": "string"
+        },
+        "details": {
+            "description": "This is a sentence that contains details about the other properties of this function.",
+            "markdownDescription": "**Details**\n\nThis is a sentence that contains details about the other properties of this function.",
+            "title": "Details",
+            "type": "string"
+        },
+        "errorsThrown": {
+            "description": "Errors that can be thrown by this function.",
+            "items": {
+                "allOf": [
+                    {
+                        "$ref": "#/$defs/_AdaptiveFunctionErrorThrown_"
+                    }
+                ],
+                "description": "Errors that can be thrown by this function.",
+                "markdownDescription": "Errors that can be thrown by this function.",
+                "title": "Errors thrown by this function",
+                "type": "object"
+            },
+            "markdownDescription": "**Errors Thrown**\n\nErrors that can be thrown by this function.",
+            "title": "Errors Thrown",
+            "type": "array"
+        },
+        "functionId": {
+            "description": "This is the function's id.",
+            "markdownDescription": "**Function**\n\nThis is the function's id.",
+            "title": "Function",
+            "type": "string"
+        },
+        "functionLabel": {
+            "description": "This is the function's label.",
+            "markdownDescription": "**Function Label**\n\nThis is the function's label.",
+            "title": "Function Label",
+            "type": "string"
+        },
+        "functionSignature": {
+            "description": "This is the function's signature.",
+            "markdownDescription": "**Function Signature**\n\nThis is the function's signature.",
+            "title": "Function Signature",
+            "type": "string"
+        },
+        "op": {
+            "description": "This is the function's operator. This is not used at the moment, but may be used in a future expression syntax.",
+            "markdownDescription": "**Operator**\n\nThis is the function's operator. This is not used at the moment, but may be used in a future expression syntax.",
+            "title": "Operator",
+            "type": "string"
+        },
+        "parameters": {
+            "description": "These are the function's parameters.",
+            "items": {
+                "allOf": [
+                    {
+                        "$ref": "#/$defs/_AdaptiveFunctionParameter_"
+                    }
+                ],
+                "description": "These are the function's parameters.",
+                "markdownDescription": "These are the function's parameters.",
+                "title": "The function's parameters",
+                "type": "object"
+            },
+            "markdownDescription": "**Parameters**\n\nThese are the function's parameters.",
+            "title": "Parameters",
+            "type": "array"
+        },
+        "polymorphic": {
+            "default": false,
+            "description": "This indicates that this function can be called polymorphically without specifying the <Type>:: qualifier. The appropriate implementation of the function will be called based on the dataType and/or dataTypeParameter of the first function parameter value.",
+            "markdownDescription": "**Polymorphic**\n\nThis indicates that this function can be called polymorphically without specifying the <Type>:: qualifier. The appropriate implementation of the function will be called based on the dataType and/or dataTypeParameter of the first function parameter value.",
+            "title": "Polymorphic",
+            "type": "boolean"
+        },
+        "polymorphicDataTypes": {
+            "default": false,
+            "description": "This function will call the appropriate function when the first parameter is one of these data types.",
+            "items": {
+                "description": "This function will call the appropriate function when the first parameter is one of these data types.",
+                "markdownDescription": "This function will call the appropriate function when the first parameter is one of these data types.",
+                "title": "This function will call the appropriate function when the first parameter is one of these data types",
+                "type": "string"
+            },
+            "markdownDescription": "**Polymorphic Data Types**\n\nThis function will call the appropriate function when the first parameter is one of these data types.",
+            "title": "Polymorphic Data Types",
+            "type": "array"
+        },
+        "polymorphicExecuteFunction": {
+            "description": "This is the label in the C source of the polymorphic execute function used for this function.",
+            "markdownDescription": "**Polymorphic Function Label**\n\nThis is the label in the C source of the polymorphic execute function used for this function.",
+            "title": "Polymorphic Function Label",
+            "type": "string"
+        },
+        "polymorphicExecuteFunctionEvaluatesFirstParameter": {
+            "default": false,
+            "description": "If true, the first parameter evaluate is deferred to polymorphicExecuteFunction function. If false or not specified, standard polymorphic function processing evaluates the first parameter to determine the appropriate evaluate to call.",
+            "markdownDescription": "**Defer Evaluate**\n\nIf true, the first parameter evaluate is deferred to polymorphicExecuteFunction function. If false or not specified, standard polymorphic function processing evaluates the first parameter to determine the appropriate evaluate to call.",
+            "title": "Defer Evaluate",
+            "type": "boolean"
+        },
+        "polymorphicOverrides": {
+            "description": "This allows overrides, for particular data types, of properties for this function.",
+            "markdownDescription": "**Polymorphic Function Label**\n\nThis allows overrides, for particular data types, of properties for this function.",
+            "title": "Polymorphic Function Label",
+            "type": "object"
+        },
+        "pure": {
+            "default": false,
+            "description": "This indicates that, given exactly the same parameter values, this function will always return the same result and will not cause any side effects.",
+            "markdownDescription": "**Pure**\n\nThis indicates that, given exactly the same parameter values, this function will always return the same result and will not cause any side effects.",
+            "title": "Pure",
+            "type": "boolean"
+        },
+        "requiresExecuteAccess": {
+            "description": "If true, this function requires 'execute' authorization access to be called. The 'resourceId' for the authorization check is the function object path, the 'actionId' is 'execute', and the 'object' is object type '_AdaptiveFunctionArguments_' which contains the function object and the arguments to the called function.\nNote that the construction of the current::object during authorization check requires that parameters passed in will be evaluated ahead of time. Therefore, if your function is designed to short circuit its execution path based on the value of one of its parameters, understand that functions with this flag set will still undergo evaluations anyway. In addition, type checking will not be applied to the parameters at the time of authorization, so your authorization policy must consider any type of parameter value to be passed in.",
+            "markdownDescription": "**Requires Execute Access**\n\nIf true, this function requires 'execute' authorization access to be called. The 'resourceId' for the authorization check is the function object path, the 'actionId' is 'execute', and the 'object' is object type '_AdaptiveFunctionArguments_' which contains the function object and the arguments to the called function.\nNote that the construction of the current::object during authorization check requires that parameters passed in will be evaluated ahead of time. Therefore, if your function is designed to short circuit its execution path based on the value of one of its parameters, understand that functions with this flag set will still undergo evaluations anyway. In addition, type checking will not be applied to the parameters at the time of authorization, so your authorization policy must consider any type of parameter value to be passed in.",
+            "title": "Requires Execute Access",
+            "type": "boolean"
+        },
+        "returns": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveFunctionParameter_"
+                }
+            ],
+            "description": "The return parameter.",
+            "markdownDescription": "**Returns**\n\nThe return parameter.",
+            "title": "Returns",
+            "type": "object"
+        },
+        "scriptSupport": {
+            "description": "This property can only be true for afw core functions that supports a statement in adaptive script. If true, there must be a #define in afw_value.h of the form 'AFW_VALUE_CALL_SCRIPT_SUPPORT_NUMBER_' followed by the upper case of the functionId to specify the special number associated with this function along with supporting code in afw_function_script.c.",
+            "markdownDescription": "**Script support**\n\nThis property can only be true for afw core functions that supports a statement in adaptive script. If true, there must be a #define in afw_value.h of the form 'AFW_VALUE_CALL_SCRIPT_SUPPORT_NUMBER_' followed by the upper case of the functionId to specify the special number associated with this function along with supporting code in afw_function_script.c.",
+            "title": "Script support",
+            "type": "boolean"
+        },
+        "sideEffects": {
+            "description": "Any side effects that this function may produce as a result of execution.",
+            "items": {
+                "description": "Any side effects that this function may produce as a result of execution.",
+                "markdownDescription": "Any side effects that this function may produce as a result of execution.",
+                "title": "Side effects for this function",
+                "type": "string"
+            },
+            "markdownDescription": "**Side Effects**\n\nAny side effects that this function may produce as a result of execution.",
+            "title": "Side Effects",
+            "type": "array"
+        },
+        "signatureOnly": {
+            "description": "This is a signature with an unimplemented execute function.",
+            "markdownDescription": "**Signature Only**\n\nThis is a signature with an unimplemented execute function.",
+            "title": "Signature Only",
+            "type": "boolean"
+        },
+        "useExecuteFunction": {
+            "description": "This is the label in the C source of the execute function used for this function.",
+            "markdownDescription": "**Use Execute Function**\n\nThis is the label in the C source of the execute function used for this function.",
+            "title": "Use Execute Function",
+            "type": "string"
         }
-    ]
+    },
+    "required": [
+        "category",
+        "functionId",
+        "functionLabel",
+        "returns"
+    ],
+    "title": "_AdaptiveFunctionGenerate_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveFunction_.json
+++ b/generated/schemas/afw/_AdaptiveFunction_.json
@@ -1,12 +1,16 @@
 {
     "$defs": {
         "_AdaptiveFunctionErrorThrown_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveFunctionErrorThrown_.propertyTypes"
                 }
             ],
             "description": "An object entry of _AdaptiveFunction_ errorsThrown array.",
+            "required": [
+                "error",
+                "reason"
+            ],
             "type": "object",
             "unevaluatedProperties": false
         },
@@ -23,14 +27,10 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "error",
-                "reason"
-            ],
             "type": "object"
         },
         "_AdaptiveFunctionParameter_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveFunctionParameter_.propertyTypes"
                 }
@@ -47,6 +47,7 @@
                     "type": "string"
                 },
                 "canBeUndefined": {
+                    "default": false,
                     "description": "Indicates that parameter can be undefined (NULL) even if not optional.",
                     "title": "Optional",
                     "type": "boolean"
@@ -78,6 +79,7 @@
                     "type": "string"
                 },
                 "optional": {
+                    "default": false,
                     "description": "This indicates that parameter is optional and can be undefined (NULL).",
                     "title": "Optional",
                     "type": "boolean"
@@ -96,12 +98,19 @@
             "type": "object"
         },
         "_AdaptiveFunction_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveFunction_.propertyTypes"
                 }
             ],
             "description": "An adaptive function.",
+            "required": [
+                "category",
+                "functionId",
+                "functionLabel",
+                "functionResourceId",
+                "returns"
+            ],
             "type": "object",
             "unevaluatedProperties": false
         },
@@ -138,6 +147,7 @@
                     "type": "integer"
                 },
                 "deprecated": {
+                    "default": false,
                     "description": "This indicates that the function is deprecated and may go away at some point.",
                     "title": "Deprecated",
                     "type": "boolean"
@@ -151,10 +161,13 @@
                 "errorsThrown": {
                     "description": "These are errors that can possibly be thrown by this function.",
                     "items": {
-                        "$ref": "#/$defs/_AdaptiveFunctionErrorThrown_",
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/_AdaptiveFunctionErrorThrown_"
+                            }
+                        ],
                         "description": "These are errors that can possibly be thrown by this function.",
-                        "title": "Errors thrown",
-                        "type": "object"
+                        "title": "Errors thrown"
                     },
                     "title": "Errors Thrown",
                     "type": "array"
@@ -203,20 +216,25 @@
                 "parameters": {
                     "description": "These are the function's parameters.",
                     "items": {
-                        "$ref": "#/$defs/_AdaptiveFunctionParameter_",
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/_AdaptiveFunctionParameter_"
+                            }
+                        ],
                         "description": "These are the function's parameters.",
-                        "title": "The function's parameters",
-                        "type": "object"
+                        "title": "The function's parameters"
                     },
                     "title": "Parameters",
                     "type": "array"
                 },
                 "polymorphic": {
+                    "default": false,
                     "description": "This indicates that this function can be called polymorphically without specifying the <Type>:: qualifier. The appropriate implementation of the function will be called based on the dataType and/or dataTypeParameter of the first function parameter value.",
                     "title": "Polymorphic",
                     "type": "boolean"
                 },
                 "polymorphicDataTypes": {
+                    "default": false,
                     "description": "This function will call the appropriate function when the first parameter is one of these data types.",
                     "items": {
                         "description": "This function will call the appropriate function when the first parameter is one of these data types.",
@@ -227,6 +245,7 @@
                     "type": "array"
                 },
                 "pure": {
+                    "default": false,
                     "description": "This indicates that, given exactly the same parameter values, this function will always return the same result and will not cause any side effects.",
                     "title": "Pure",
                     "type": "boolean"
@@ -237,10 +256,13 @@
                     "type": "boolean"
                 },
                 "returns": {
-                    "$ref": "#/$defs/_AdaptiveFunctionParameter_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveFunctionParameter_"
+                        }
+                    ],
                     "description": "The return parameter.",
-                    "title": "Returns",
-                    "type": "object"
+                    "title": "Returns"
                 },
                 "sideEffects": {
                     "description": "Any side effects that this function may produce as a result of execution.",
@@ -263,18 +285,11 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "category",
-                "functionId",
-                "functionLabel",
-                "functionResourceId",
-                "returns"
-            ],
             "type": "object"
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveFunction_"
         }

--- a/generated/schemas/afw/_AdaptiveFunction_.json
+++ b/generated/schemas/afw/_AdaptiveFunction_.json
@@ -1,28 +1,49 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveFunction_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveFunctionErrorThrown_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveFunctionErrorThrown_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "An object entry of _AdaptiveFunction_ errorsThrown array.",
-            "required": [
-                "error",
-                "reason"
-            ],
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveFunctionErrorThrown_.propertyTypes": {
+            "markdownDescription": "An object entry of _AdaptiveFunction_ errorsThrown array.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "error": {
                     "description": "This is the error id of the error that can be thrown.",
+                    "markdownDescription": "**Error**\n\nThis is the error id of the error that can be thrown.",
                     "title": "Error",
                     "type": "string"
                 },
                 "reason": {
                     "description": "This is the reason the error can be thrown.",
+                    "markdownDescription": "**Reason**\n\nThis is the reason the error can be thrown.",
+                    "title": "Reason",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "error",
+                "reason"
+            ],
+            "title": "_AdaptiveFunctionErrorThrown_",
+            "type": "object"
+        },
+        "_AdaptiveFunctionErrorThrown_.propertyTypes": {
+            "properties": {
+                "error": {
+                    "description": "This is the error id of the error that can be thrown.",
+                    "markdownDescription": "**Error**\n\nThis is the error id of the error that can be thrown.",
+                    "title": "Error",
+                    "type": "string"
+                },
+                "reason": {
+                    "description": "This is the reason the error can be thrown.",
+                    "markdownDescription": "**Reason**\n\nThis is the reason the error can be thrown.",
                     "title": "Reason",
                     "type": "string"
                 }
@@ -30,67 +51,146 @@
             "type": "object"
         },
         "_AdaptiveFunctionParameter_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveFunctionParameter_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Adaptive function parameter meta.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveFunctionParameter_.propertyTypes": {
+            "markdownDescription": "Adaptive function parameter meta.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "brief": {
                     "description": "This is a predicate for the parameter with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for the parameter with the first letter capitalized and without a trailing period.",
                     "title": "Brief",
                     "type": "string"
                 },
                 "canBeUndefined": {
                     "default": false,
                     "description": "Indicates that parameter can be undefined (NULL) even if not optional.",
+                    "markdownDescription": "**Optional**\n\nIndicates that parameter can be undefined (NULL) even if not optional.",
                     "title": "Optional",
                     "type": "boolean"
                 },
                 "dataType": {
                     "description": "This is the data type id for this parameter's value.",
+                    "markdownDescription": "**Data Type**\n\nThis is the data type id for this parameter's value.",
                     "title": "Data Type",
                     "type": "string"
                 },
                 "dataTypeParameter": {
                     "description": "See the data type's dataTypeParameterType property to determine how to interpret this.",
+                    "markdownDescription": "**Data Type Parameter**\n\nSee the data type's dataTypeParameterType property to determine how to interpret this.",
                     "title": "Data Type Parameter",
                     "type": "string"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "This is the description of this parameter.",
+                    "markdownDescription": "**Description**\n\nThis is the description of this parameter.",
                     "title": "Description",
                     "type": "string"
                 },
                 "minArgs": {
                     "description": "This is the minimum number of values that can be specified for this parameter. If -1, the parameter can be specified exactly once. This can only have a value other than -1 on last parameter where it can have a value of -1 to 127.",
+                    "markdownDescription": "**Min Args**\n\nThis is the minimum number of values that can be specified for this parameter. If -1, the parameter can be specified exactly once. This can only have a value other than -1 on last parameter where it can have a value of -1 to 127.",
                     "title": "Min Args",
                     "type": "integer"
                 },
                 "name": {
                     "description": "This is the name of this parameter.",
+                    "markdownDescription": "**Name**\n\nThis is the name of this parameter.",
                     "title": "Name",
                     "type": "string"
                 },
                 "optional": {
                     "default": false,
                     "description": "This indicates that parameter is optional and can be undefined (NULL).",
+                    "markdownDescription": "**Optional**\n\nThis indicates that parameter is optional and can be undefined (NULL).",
                     "title": "Optional",
                     "type": "boolean"
                 },
                 "polymorphicDataType": {
                     "description": "The dataType for this parameter is <Type>.",
+                    "markdownDescription": "**Polymorphic Data Type**\n\nThe dataType for this parameter is <Type>.",
                     "title": "Polymorphic Data Type",
                     "type": "boolean"
                 },
                 "polymorphicDataTypeParameter": {
                     "description": "The dataTypeParameter for this parameter is <Type>.",
+                    "markdownDescription": "**Polymorphic Data Type Parameter**\n\nThe dataTypeParameter for this parameter is <Type>.",
+                    "title": "Polymorphic Data Type Parameter",
+                    "type": "boolean"
+                }
+            },
+            "title": "_AdaptiveFunctionParameter_",
+            "type": "object"
+        },
+        "_AdaptiveFunctionParameter_.propertyTypes": {
+            "properties": {
+                "brief": {
+                    "description": "This is a predicate for the parameter with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for the parameter with the first letter capitalized and without a trailing period.",
+                    "title": "Brief",
+                    "type": "string"
+                },
+                "canBeUndefined": {
+                    "default": false,
+                    "description": "Indicates that parameter can be undefined (NULL) even if not optional.",
+                    "markdownDescription": "**Optional**\n\nIndicates that parameter can be undefined (NULL) even if not optional.",
+                    "title": "Optional",
+                    "type": "boolean"
+                },
+                "dataType": {
+                    "description": "This is the data type id for this parameter's value.",
+                    "markdownDescription": "**Data Type**\n\nThis is the data type id for this parameter's value.",
+                    "title": "Data Type",
+                    "type": "string"
+                },
+                "dataTypeParameter": {
+                    "description": "See the data type's dataTypeParameterType property to determine how to interpret this.",
+                    "markdownDescription": "**Data Type Parameter**\n\nSee the data type's dataTypeParameterType property to determine how to interpret this.",
+                    "title": "Data Type Parameter",
+                    "type": "string"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "This is the description of this parameter.",
+                    "markdownDescription": "**Description**\n\nThis is the description of this parameter.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "minArgs": {
+                    "description": "This is the minimum number of values that can be specified for this parameter. If -1, the parameter can be specified exactly once. This can only have a value other than -1 on last parameter where it can have a value of -1 to 127.",
+                    "markdownDescription": "**Min Args**\n\nThis is the minimum number of values that can be specified for this parameter. If -1, the parameter can be specified exactly once. This can only have a value other than -1 on last parameter where it can have a value of -1 to 127.",
+                    "title": "Min Args",
+                    "type": "integer"
+                },
+                "name": {
+                    "description": "This is the name of this parameter.",
+                    "markdownDescription": "**Name**\n\nThis is the name of this parameter.",
+                    "title": "Name",
+                    "type": "string"
+                },
+                "optional": {
+                    "default": false,
+                    "description": "This indicates that parameter is optional and can be undefined (NULL).",
+                    "markdownDescription": "**Optional**\n\nThis indicates that parameter is optional and can be undefined (NULL).",
+                    "title": "Optional",
+                    "type": "boolean"
+                },
+                "polymorphicDataType": {
+                    "description": "The dataType for this parameter is <Type>.",
+                    "markdownDescription": "**Polymorphic Data Type**\n\nThe dataType for this parameter is <Type>.",
+                    "title": "Polymorphic Data Type",
+                    "type": "boolean"
+                },
+                "polymorphicDataTypeParameter": {
+                    "description": "The dataTypeParameter for this parameter is <Type>.",
+                    "markdownDescription": "**Polymorphic Data Type Parameter**\n\nThe dataTypeParameter for this parameter is <Type>.",
                     "title": "Polymorphic Data Type Parameter",
                     "type": "boolean"
                 }
@@ -98,63 +198,64 @@
             "type": "object"
         },
         "_AdaptiveFunction_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveFunction_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "An adaptive function.",
-            "required": [
-                "category",
-                "functionId",
-                "functionLabel",
-                "functionResourceId",
-                "returns"
-            ],
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveFunction_.propertyTypes": {
+            "markdownDescription": "An adaptive function.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "afwCamelCaseFunctionLabel": {
                     "description": "This is the functionLabel prefixed with 'afw' and converted to camel case.",
+                    "markdownDescription": "**Prefixed Camel Case**\n\nThis is the functionLabel prefixed with 'afw' and converted to camel case.",
                     "title": "Prefixed Camel Case",
                     "type": "string"
                 },
                 "brief": {
                     "description": "This is a predicate for the function with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for the function with the first letter capitalized and without a trailing period.",
                     "title": "Brief",
                     "type": "string"
                 },
                 "camelCaseFunctionLabel": {
                     "description": "This is the functionLabel converted to camel case.",
+                    "markdownDescription": "**Camel Case**\n\nThis is the functionLabel converted to camel case.",
                     "title": "Camel Case",
                     "type": "string"
                 },
                 "category": {
                     "description": "Function category.",
+                    "markdownDescription": "**Category**\n\nFunction category.",
                     "title": "Category",
                     "type": "string"
                 },
                 "dataType": {
                     "description": "If present, this is a method for this data type.",
+                    "markdownDescription": "**Data Type**\n\nIf present, this is a method for this data type.",
                     "title": "Data Type",
                     "type": "string"
                 },
                 "dataTypeMethodNumber": {
                     "description": "This is an internal number that is unique to the method name (the part after :: in functionId) of a dataTypeMethod function.",
+                    "markdownDescription": "**Method Number**\n\nThis is an internal number that is unique to the method name (the part after :: in functionId) of a dataTypeMethod function.",
                     "title": "Method Number",
                     "type": "integer"
                 },
                 "deprecated": {
                     "default": false,
                     "description": "This indicates that the function is deprecated and may go away at some point.",
+                    "markdownDescription": "**Deprecated**\n\nThis indicates that the function is deprecated and may go away at some point.",
                     "title": "Deprecated",
                     "type": "boolean"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "This is the function's description, used for documentation purposes.",
+                    "markdownDescription": "**Description**\n\nThis is the function's description, used for documentation purposes.",
                     "title": "Description",
                     "type": "string"
                 },
@@ -167,49 +268,60 @@
                             }
                         ],
                         "description": "These are errors that can possibly be thrown by this function.",
-                        "title": "Errors thrown"
+                        "markdownDescription": "These are errors that can possibly be thrown by this function.",
+                        "title": "Errors thrown",
+                        "type": "object"
                     },
+                    "markdownDescription": "**Errors Thrown**\n\nThese are errors that can possibly be thrown by this function.",
                     "title": "Errors Thrown",
                     "type": "array"
                 },
                 "functionDeclaration": {
                     "contentMediaType": "text/plain",
                     "description": "This is the function's declaration with whitespace and brief comments.",
+                    "markdownDescription": "**Function Declaration**\n\nThis is the function's declaration with whitespace and brief comments.",
                     "title": "Function Declaration",
                     "type": "string"
                 },
                 "functionId": {
                     "description": "This is the function's id.",
+                    "markdownDescription": "**Function**\n\nThis is the function's id.",
                     "title": "Function",
                     "type": "string"
                 },
                 "functionLabel": {
                     "description": "This is the function's label.",
+                    "markdownDescription": "**Function Label**\n\nThis is the function's label.",
                     "title": "Function Label",
                     "type": "string"
                 },
                 "functionResourceId": {
                     "description": "This is the function's resource id.",
+                    "markdownDescription": "**Function Resource Id**\n\nThis is the function's resource id.",
                     "title": "Function Resource Id",
                     "type": "string"
                 },
                 "functionSignature": {
                     "description": "This is the function's signature.",
+                    "markdownDescription": "**Signature**\n\nThis is the function's signature.",
                     "title": "Signature",
                     "type": "string"
                 },
                 "maximumNumberOfParameters": {
                     "description": "This is the maximum number of parameters or -1 if there is no maximum.",
+                    "markdownDescription": "**Maximum Parameters**\n\nThis is the maximum number of parameters or -1 if there is no maximum.",
                     "title": "Maximum Parameters",
                     "type": "integer"
                 },
                 "numberOfRequiredParameters": {
                     "description": "This is the number of required parameters.",
+                    "markdownDescription": "**Required Parameters**\n\nThis is the number of required parameters.",
                     "title": "Required Parameters",
                     "type": "integer"
                 },
                 "op": {
                     "description": "This is the function's operator. This is not used at the moment, but may be used in a future expression syntax.",
+                    "markdownDescription": "**Op**\n\nThis is the function's operator. This is not used at the moment, but may be used in a future expression syntax.",
                     "title": "Op",
                     "type": "string"
                 },
@@ -222,14 +334,18 @@
                             }
                         ],
                         "description": "These are the function's parameters.",
-                        "title": "The function's parameters"
+                        "markdownDescription": "These are the function's parameters.",
+                        "title": "The function's parameters",
+                        "type": "object"
                     },
+                    "markdownDescription": "**Parameters**\n\nThese are the function's parameters.",
                     "title": "Parameters",
                     "type": "array"
                 },
                 "polymorphic": {
                     "default": false,
                     "description": "This indicates that this function can be called polymorphically without specifying the <Type>:: qualifier. The appropriate implementation of the function will be called based on the dataType and/or dataTypeParameter of the first function parameter value.",
+                    "markdownDescription": "**Polymorphic**\n\nThis indicates that this function can be called polymorphically without specifying the <Type>:: qualifier. The appropriate implementation of the function will be called based on the dataType and/or dataTypeParameter of the first function parameter value.",
                     "title": "Polymorphic",
                     "type": "boolean"
                 },
@@ -238,20 +354,24 @@
                     "description": "This function will call the appropriate function when the first parameter is one of these data types.",
                     "items": {
                         "description": "This function will call the appropriate function when the first parameter is one of these data types.",
+                        "markdownDescription": "This function will call the appropriate function when the first parameter is one of these data types.",
                         "title": "This function will call the appropriate function when the first parameter is one of these data types",
                         "type": "string"
                     },
+                    "markdownDescription": "**Polymorphic Data Types**\n\nThis function will call the appropriate function when the first parameter is one of these data types.",
                     "title": "Polymorphic Data Types",
                     "type": "array"
                 },
                 "pure": {
                     "default": false,
                     "description": "This indicates that, given exactly the same parameter values, this function will always return the same result and will not cause any side effects.",
+                    "markdownDescription": "**Pure**\n\nThis indicates that, given exactly the same parameter values, this function will always return the same result and will not cause any side effects.",
                     "title": "Pure",
                     "type": "boolean"
                 },
                 "requiresExecuteAccess": {
                     "description": "If true, this function requires 'execute' access to be called. The 'resourceId' for the authorization check is the function object path, the 'actionId' is 'execute', and the 'object' is object type '_AdaptiveFunctionArguments_' which contains the function object and the arguments to the called function.",
+                    "markdownDescription": "**Requires Execute Access**\n\nIf true, this function requires 'execute' access to be called. The 'resourceId' for the authorization check is the function object path, the 'actionId' is 'execute', and the 'object' is object type '_AdaptiveFunctionArguments_' which contains the function object and the arguments to the called function.",
                     "title": "Requires Execute Access",
                     "type": "boolean"
                 },
@@ -262,25 +382,245 @@
                         }
                     ],
                     "description": "The return parameter.",
-                    "title": "Returns"
+                    "markdownDescription": "**Returns**\n\nThe return parameter.",
+                    "title": "Returns",
+                    "type": "object"
                 },
                 "sideEffects": {
                     "description": "Any side effects that this function may produce as a result of execution.",
                     "items": {
                         "description": "Any side effects that this function may produce as a result of execution.",
+                        "markdownDescription": "Any side effects that this function may produce as a result of execution.",
                         "title": "Side effects for this function.",
                         "type": "string"
                     },
+                    "markdownDescription": "**Side Effects**\n\nAny side effects that this function may produce as a result of execution.",
                     "title": "Side Effects",
                     "type": "array"
                 },
                 "signatureOnly": {
                     "description": "This is a signature with an unimplemented execute function.",
+                    "markdownDescription": "**Signature Only**\n\nThis is a signature with an unimplemented execute function.",
                     "title": "Signature Only",
                     "type": "boolean"
                 },
                 "untypedFunctionId": {
                     "description": "This is the function's id without <dataType>. If this function is not polymorphic, this is the same as functionId.",
+                    "markdownDescription": "**Function**\n\nThis is the function's id without <dataType>. If this function is not polymorphic, this is the same as functionId.",
+                    "title": "Function",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "category",
+                "functionId",
+                "functionLabel",
+                "functionResourceId",
+                "returns"
+            ],
+            "title": "_AdaptiveFunction_",
+            "type": "object"
+        },
+        "_AdaptiveFunction_.propertyTypes": {
+            "properties": {
+                "afwCamelCaseFunctionLabel": {
+                    "description": "This is the functionLabel prefixed with 'afw' and converted to camel case.",
+                    "markdownDescription": "**Prefixed Camel Case**\n\nThis is the functionLabel prefixed with 'afw' and converted to camel case.",
+                    "title": "Prefixed Camel Case",
+                    "type": "string"
+                },
+                "brief": {
+                    "description": "This is a predicate for the function with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for the function with the first letter capitalized and without a trailing period.",
+                    "title": "Brief",
+                    "type": "string"
+                },
+                "camelCaseFunctionLabel": {
+                    "description": "This is the functionLabel converted to camel case.",
+                    "markdownDescription": "**Camel Case**\n\nThis is the functionLabel converted to camel case.",
+                    "title": "Camel Case",
+                    "type": "string"
+                },
+                "category": {
+                    "description": "Function category.",
+                    "markdownDescription": "**Category**\n\nFunction category.",
+                    "title": "Category",
+                    "type": "string"
+                },
+                "dataType": {
+                    "description": "If present, this is a method for this data type.",
+                    "markdownDescription": "**Data Type**\n\nIf present, this is a method for this data type.",
+                    "title": "Data Type",
+                    "type": "string"
+                },
+                "dataTypeMethodNumber": {
+                    "description": "This is an internal number that is unique to the method name (the part after :: in functionId) of a dataTypeMethod function.",
+                    "markdownDescription": "**Method Number**\n\nThis is an internal number that is unique to the method name (the part after :: in functionId) of a dataTypeMethod function.",
+                    "title": "Method Number",
+                    "type": "integer"
+                },
+                "deprecated": {
+                    "default": false,
+                    "description": "This indicates that the function is deprecated and may go away at some point.",
+                    "markdownDescription": "**Deprecated**\n\nThis indicates that the function is deprecated and may go away at some point.",
+                    "title": "Deprecated",
+                    "type": "boolean"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "This is the function's description, used for documentation purposes.",
+                    "markdownDescription": "**Description**\n\nThis is the function's description, used for documentation purposes.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "errorsThrown": {
+                    "description": "These are errors that can possibly be thrown by this function.",
+                    "items": {
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/_AdaptiveFunctionErrorThrown_"
+                            }
+                        ],
+                        "description": "These are errors that can possibly be thrown by this function.",
+                        "markdownDescription": "These are errors that can possibly be thrown by this function.",
+                        "title": "Errors thrown",
+                        "type": "object"
+                    },
+                    "markdownDescription": "**Errors Thrown**\n\nThese are errors that can possibly be thrown by this function.",
+                    "title": "Errors Thrown",
+                    "type": "array"
+                },
+                "functionDeclaration": {
+                    "contentMediaType": "text/plain",
+                    "description": "This is the function's declaration with whitespace and brief comments.",
+                    "markdownDescription": "**Function Declaration**\n\nThis is the function's declaration with whitespace and brief comments.",
+                    "title": "Function Declaration",
+                    "type": "string"
+                },
+                "functionId": {
+                    "description": "This is the function's id.",
+                    "markdownDescription": "**Function**\n\nThis is the function's id.",
+                    "title": "Function",
+                    "type": "string"
+                },
+                "functionLabel": {
+                    "description": "This is the function's label.",
+                    "markdownDescription": "**Function Label**\n\nThis is the function's label.",
+                    "title": "Function Label",
+                    "type": "string"
+                },
+                "functionResourceId": {
+                    "description": "This is the function's resource id.",
+                    "markdownDescription": "**Function Resource Id**\n\nThis is the function's resource id.",
+                    "title": "Function Resource Id",
+                    "type": "string"
+                },
+                "functionSignature": {
+                    "description": "This is the function's signature.",
+                    "markdownDescription": "**Signature**\n\nThis is the function's signature.",
+                    "title": "Signature",
+                    "type": "string"
+                },
+                "maximumNumberOfParameters": {
+                    "description": "This is the maximum number of parameters or -1 if there is no maximum.",
+                    "markdownDescription": "**Maximum Parameters**\n\nThis is the maximum number of parameters or -1 if there is no maximum.",
+                    "title": "Maximum Parameters",
+                    "type": "integer"
+                },
+                "numberOfRequiredParameters": {
+                    "description": "This is the number of required parameters.",
+                    "markdownDescription": "**Required Parameters**\n\nThis is the number of required parameters.",
+                    "title": "Required Parameters",
+                    "type": "integer"
+                },
+                "op": {
+                    "description": "This is the function's operator. This is not used at the moment, but may be used in a future expression syntax.",
+                    "markdownDescription": "**Op**\n\nThis is the function's operator. This is not used at the moment, but may be used in a future expression syntax.",
+                    "title": "Op",
+                    "type": "string"
+                },
+                "parameters": {
+                    "description": "These are the function's parameters.",
+                    "items": {
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/_AdaptiveFunctionParameter_"
+                            }
+                        ],
+                        "description": "These are the function's parameters.",
+                        "markdownDescription": "These are the function's parameters.",
+                        "title": "The function's parameters",
+                        "type": "object"
+                    },
+                    "markdownDescription": "**Parameters**\n\nThese are the function's parameters.",
+                    "title": "Parameters",
+                    "type": "array"
+                },
+                "polymorphic": {
+                    "default": false,
+                    "description": "This indicates that this function can be called polymorphically without specifying the <Type>:: qualifier. The appropriate implementation of the function will be called based on the dataType and/or dataTypeParameter of the first function parameter value.",
+                    "markdownDescription": "**Polymorphic**\n\nThis indicates that this function can be called polymorphically without specifying the <Type>:: qualifier. The appropriate implementation of the function will be called based on the dataType and/or dataTypeParameter of the first function parameter value.",
+                    "title": "Polymorphic",
+                    "type": "boolean"
+                },
+                "polymorphicDataTypes": {
+                    "default": false,
+                    "description": "This function will call the appropriate function when the first parameter is one of these data types.",
+                    "items": {
+                        "description": "This function will call the appropriate function when the first parameter is one of these data types.",
+                        "markdownDescription": "This function will call the appropriate function when the first parameter is one of these data types.",
+                        "title": "This function will call the appropriate function when the first parameter is one of these data types",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Polymorphic Data Types**\n\nThis function will call the appropriate function when the first parameter is one of these data types.",
+                    "title": "Polymorphic Data Types",
+                    "type": "array"
+                },
+                "pure": {
+                    "default": false,
+                    "description": "This indicates that, given exactly the same parameter values, this function will always return the same result and will not cause any side effects.",
+                    "markdownDescription": "**Pure**\n\nThis indicates that, given exactly the same parameter values, this function will always return the same result and will not cause any side effects.",
+                    "title": "Pure",
+                    "type": "boolean"
+                },
+                "requiresExecuteAccess": {
+                    "description": "If true, this function requires 'execute' access to be called. The 'resourceId' for the authorization check is the function object path, the 'actionId' is 'execute', and the 'object' is object type '_AdaptiveFunctionArguments_' which contains the function object and the arguments to the called function.",
+                    "markdownDescription": "**Requires Execute Access**\n\nIf true, this function requires 'execute' access to be called. The 'resourceId' for the authorization check is the function object path, the 'actionId' is 'execute', and the 'object' is object type '_AdaptiveFunctionArguments_' which contains the function object and the arguments to the called function.",
+                    "title": "Requires Execute Access",
+                    "type": "boolean"
+                },
+                "returns": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveFunctionParameter_"
+                        }
+                    ],
+                    "description": "The return parameter.",
+                    "markdownDescription": "**Returns**\n\nThe return parameter.",
+                    "title": "Returns",
+                    "type": "object"
+                },
+                "sideEffects": {
+                    "description": "Any side effects that this function may produce as a result of execution.",
+                    "items": {
+                        "description": "Any side effects that this function may produce as a result of execution.",
+                        "markdownDescription": "Any side effects that this function may produce as a result of execution.",
+                        "title": "Side effects for this function.",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Side Effects**\n\nAny side effects that this function may produce as a result of execution.",
+                    "title": "Side Effects",
+                    "type": "array"
+                },
+                "signatureOnly": {
+                    "description": "This is a signature with an unimplemented execute function.",
+                    "markdownDescription": "**Signature Only**\n\nThis is a signature with an unimplemented execute function.",
+                    "title": "Signature Only",
+                    "type": "boolean"
+                },
+                "untypedFunctionId": {
+                    "description": "This is the function's id without <dataType>. If this function is not polymorphic, this is the same as functionId.",
+                    "markdownDescription": "**Function**\n\nThis is the function's id without <dataType>. If this function is not polymorphic, this is the same as functionId.",
                     "title": "Function",
                     "type": "string"
                 }
@@ -289,9 +629,226 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveFunction_"
+    "additionalProperties": false,
+    "description": "An adaptive function.",
+    "markdownDescription": "An adaptive function.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "afwCamelCaseFunctionLabel": {
+            "description": "This is the functionLabel prefixed with 'afw' and converted to camel case.",
+            "markdownDescription": "**Prefixed Camel Case**\n\nThis is the functionLabel prefixed with 'afw' and converted to camel case.",
+            "title": "Prefixed Camel Case",
+            "type": "string"
+        },
+        "brief": {
+            "description": "This is a predicate for the function with the first letter capitalized and without a trailing period.",
+            "markdownDescription": "**Brief**\n\nThis is a predicate for the function with the first letter capitalized and without a trailing period.",
+            "title": "Brief",
+            "type": "string"
+        },
+        "camelCaseFunctionLabel": {
+            "description": "This is the functionLabel converted to camel case.",
+            "markdownDescription": "**Camel Case**\n\nThis is the functionLabel converted to camel case.",
+            "title": "Camel Case",
+            "type": "string"
+        },
+        "category": {
+            "description": "Function category.",
+            "markdownDescription": "**Category**\n\nFunction category.",
+            "title": "Category",
+            "type": "string"
+        },
+        "dataType": {
+            "description": "If present, this is a method for this data type.",
+            "markdownDescription": "**Data Type**\n\nIf present, this is a method for this data type.",
+            "title": "Data Type",
+            "type": "string"
+        },
+        "dataTypeMethodNumber": {
+            "description": "This is an internal number that is unique to the method name (the part after :: in functionId) of a dataTypeMethod function.",
+            "markdownDescription": "**Method Number**\n\nThis is an internal number that is unique to the method name (the part after :: in functionId) of a dataTypeMethod function.",
+            "title": "Method Number",
+            "type": "integer"
+        },
+        "deprecated": {
+            "default": false,
+            "description": "This indicates that the function is deprecated and may go away at some point.",
+            "markdownDescription": "**Deprecated**\n\nThis indicates that the function is deprecated and may go away at some point.",
+            "title": "Deprecated",
+            "type": "boolean"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "This is the function's description, used for documentation purposes.",
+            "markdownDescription": "**Description**\n\nThis is the function's description, used for documentation purposes.",
+            "title": "Description",
+            "type": "string"
+        },
+        "errorsThrown": {
+            "description": "These are errors that can possibly be thrown by this function.",
+            "items": {
+                "allOf": [
+                    {
+                        "$ref": "#/$defs/_AdaptiveFunctionErrorThrown_"
+                    }
+                ],
+                "description": "These are errors that can possibly be thrown by this function.",
+                "markdownDescription": "These are errors that can possibly be thrown by this function.",
+                "title": "Errors thrown",
+                "type": "object"
+            },
+            "markdownDescription": "**Errors Thrown**\n\nThese are errors that can possibly be thrown by this function.",
+            "title": "Errors Thrown",
+            "type": "array"
+        },
+        "functionDeclaration": {
+            "contentMediaType": "text/plain",
+            "description": "This is the function's declaration with whitespace and brief comments.",
+            "markdownDescription": "**Function Declaration**\n\nThis is the function's declaration with whitespace and brief comments.",
+            "title": "Function Declaration",
+            "type": "string"
+        },
+        "functionId": {
+            "description": "This is the function's id.",
+            "markdownDescription": "**Function**\n\nThis is the function's id.",
+            "title": "Function",
+            "type": "string"
+        },
+        "functionLabel": {
+            "description": "This is the function's label.",
+            "markdownDescription": "**Function Label**\n\nThis is the function's label.",
+            "title": "Function Label",
+            "type": "string"
+        },
+        "functionResourceId": {
+            "description": "This is the function's resource id.",
+            "markdownDescription": "**Function Resource Id**\n\nThis is the function's resource id.",
+            "title": "Function Resource Id",
+            "type": "string"
+        },
+        "functionSignature": {
+            "description": "This is the function's signature.",
+            "markdownDescription": "**Signature**\n\nThis is the function's signature.",
+            "title": "Signature",
+            "type": "string"
+        },
+        "maximumNumberOfParameters": {
+            "description": "This is the maximum number of parameters or -1 if there is no maximum.",
+            "markdownDescription": "**Maximum Parameters**\n\nThis is the maximum number of parameters or -1 if there is no maximum.",
+            "title": "Maximum Parameters",
+            "type": "integer"
+        },
+        "numberOfRequiredParameters": {
+            "description": "This is the number of required parameters.",
+            "markdownDescription": "**Required Parameters**\n\nThis is the number of required parameters.",
+            "title": "Required Parameters",
+            "type": "integer"
+        },
+        "op": {
+            "description": "This is the function's operator. This is not used at the moment, but may be used in a future expression syntax.",
+            "markdownDescription": "**Op**\n\nThis is the function's operator. This is not used at the moment, but may be used in a future expression syntax.",
+            "title": "Op",
+            "type": "string"
+        },
+        "parameters": {
+            "description": "These are the function's parameters.",
+            "items": {
+                "allOf": [
+                    {
+                        "$ref": "#/$defs/_AdaptiveFunctionParameter_"
+                    }
+                ],
+                "description": "These are the function's parameters.",
+                "markdownDescription": "These are the function's parameters.",
+                "title": "The function's parameters",
+                "type": "object"
+            },
+            "markdownDescription": "**Parameters**\n\nThese are the function's parameters.",
+            "title": "Parameters",
+            "type": "array"
+        },
+        "polymorphic": {
+            "default": false,
+            "description": "This indicates that this function can be called polymorphically without specifying the <Type>:: qualifier. The appropriate implementation of the function will be called based on the dataType and/or dataTypeParameter of the first function parameter value.",
+            "markdownDescription": "**Polymorphic**\n\nThis indicates that this function can be called polymorphically without specifying the <Type>:: qualifier. The appropriate implementation of the function will be called based on the dataType and/or dataTypeParameter of the first function parameter value.",
+            "title": "Polymorphic",
+            "type": "boolean"
+        },
+        "polymorphicDataTypes": {
+            "default": false,
+            "description": "This function will call the appropriate function when the first parameter is one of these data types.",
+            "items": {
+                "description": "This function will call the appropriate function when the first parameter is one of these data types.",
+                "markdownDescription": "This function will call the appropriate function when the first parameter is one of these data types.",
+                "title": "This function will call the appropriate function when the first parameter is one of these data types",
+                "type": "string"
+            },
+            "markdownDescription": "**Polymorphic Data Types**\n\nThis function will call the appropriate function when the first parameter is one of these data types.",
+            "title": "Polymorphic Data Types",
+            "type": "array"
+        },
+        "pure": {
+            "default": false,
+            "description": "This indicates that, given exactly the same parameter values, this function will always return the same result and will not cause any side effects.",
+            "markdownDescription": "**Pure**\n\nThis indicates that, given exactly the same parameter values, this function will always return the same result and will not cause any side effects.",
+            "title": "Pure",
+            "type": "boolean"
+        },
+        "requiresExecuteAccess": {
+            "description": "If true, this function requires 'execute' access to be called. The 'resourceId' for the authorization check is the function object path, the 'actionId' is 'execute', and the 'object' is object type '_AdaptiveFunctionArguments_' which contains the function object and the arguments to the called function.",
+            "markdownDescription": "**Requires Execute Access**\n\nIf true, this function requires 'execute' access to be called. The 'resourceId' for the authorization check is the function object path, the 'actionId' is 'execute', and the 'object' is object type '_AdaptiveFunctionArguments_' which contains the function object and the arguments to the called function.",
+            "title": "Requires Execute Access",
+            "type": "boolean"
+        },
+        "returns": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveFunctionParameter_"
+                }
+            ],
+            "description": "The return parameter.",
+            "markdownDescription": "**Returns**\n\nThe return parameter.",
+            "title": "Returns",
+            "type": "object"
+        },
+        "sideEffects": {
+            "description": "Any side effects that this function may produce as a result of execution.",
+            "items": {
+                "description": "Any side effects that this function may produce as a result of execution.",
+                "markdownDescription": "Any side effects that this function may produce as a result of execution.",
+                "title": "Side effects for this function.",
+                "type": "string"
+            },
+            "markdownDescription": "**Side Effects**\n\nAny side effects that this function may produce as a result of execution.",
+            "title": "Side Effects",
+            "type": "array"
+        },
+        "signatureOnly": {
+            "description": "This is a signature with an unimplemented execute function.",
+            "markdownDescription": "**Signature Only**\n\nThis is a signature with an unimplemented execute function.",
+            "title": "Signature Only",
+            "type": "boolean"
+        },
+        "untypedFunctionId": {
+            "description": "This is the function's id without <dataType>. If this function is not polymorphic, this is the same as functionId.",
+            "markdownDescription": "**Function**\n\nThis is the function's id without <dataType>. If this function is not polymorphic, this is the same as functionId.",
+            "title": "Function",
+            "type": "string"
         }
-    ]
+    },
+    "required": [
+        "category",
+        "functionId",
+        "functionLabel",
+        "functionResourceId",
+        "returns"
+    ],
+    "title": "_AdaptiveFunction_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveInterface_.json
+++ b/generated/schemas/afw/_AdaptiveInterface_.json
@@ -1,28 +1,50 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveInterface_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveInterface_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveInterface_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Adaptive interface object.",
+            "markdownDescription": "Adaptive interface object.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "Description of this interface",
+                    "markdownDescription": "Description of this interface",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Interface name.",
+                    "markdownDescription": "**Name**\n\nInterface name.",
+                    "title": "Name",
+                    "type": "string"
+                }
+            },
             "required": [
                 "name"
             ],
-            "type": "object",
-            "unevaluatedProperties": false
+            "title": "_AdaptiveInterface_",
+            "type": "object"
         },
         "_AdaptiveInterface_.propertyTypes": {
             "properties": {
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "Description of this interface",
+                    "markdownDescription": "Description of this interface",
                     "title": "Description",
                     "type": "string"
                 },
                 "name": {
                     "description": "Interface name.",
+                    "markdownDescription": "**Name**\n\nInterface name.",
                     "title": "Name",
                     "type": "string"
                 }
@@ -31,9 +53,34 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveInterface_"
+    "additionalProperties": false,
+    "description": "Adaptive interface object.",
+    "markdownDescription": "Adaptive interface object.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "Description of this interface",
+            "markdownDescription": "Description of this interface",
+            "title": "Description",
+            "type": "string"
+        },
+        "name": {
+            "description": "Interface name.",
+            "markdownDescription": "**Name**\n\nInterface name.",
+            "title": "Name",
+            "type": "string"
         }
-    ]
+    },
+    "required": [
+        "name"
+    ],
+    "title": "_AdaptiveInterface_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveInterface_.json
+++ b/generated/schemas/afw/_AdaptiveInterface_.json
@@ -1,12 +1,15 @@
 {
     "$defs": {
         "_AdaptiveInterface_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveInterface_.propertyTypes"
                 }
             ],
             "description": "Adaptive interface object.",
+            "required": [
+                "name"
+            ],
             "type": "object",
             "unevaluatedProperties": false
         },
@@ -24,14 +27,11 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "name"
-            ],
             "type": "object"
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveInterface_"
         }

--- a/generated/schemas/afw/_AdaptiveLayoutComponentTypeCategory_.json
+++ b/generated/schemas/afw/_AdaptiveLayoutComponentTypeCategory_.json
@@ -1,33 +1,62 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveLayoutComponentTypeCategory_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveLayoutComponentTypeCategory_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveLayoutComponentTypeCategory_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Layout Component Type Category.",
-            "required": [
-                "category"
-            ],
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveLayoutComponentTypeCategory_.propertyTypes": {
+            "markdownDescription": "Layout Component Type Category.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "category": {
                     "description": "Layout Component Type category id. The layout component type category groups similar layout component types together logically.",
+                    "markdownDescription": "**Category**\n\nLayout Component Type category id. The layout component type category groups similar layout component types together logically.",
                     "title": "Category",
                     "type": "string"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "Description of layout component type category.",
+                    "markdownDescription": "**Description**\n\nDescription of layout component type category.",
                     "title": "Description",
                     "type": "string"
                 },
                 "label": {
                     "description": "Label to represent this category.",
+                    "markdownDescription": "**Label**\n\nLabel to represent this category.",
+                    "title": "Label",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "category"
+            ],
+            "title": "_AdaptiveLayoutComponentTypeCategory_",
+            "type": "object"
+        },
+        "_AdaptiveLayoutComponentTypeCategory_.propertyTypes": {
+            "properties": {
+                "category": {
+                    "description": "Layout Component Type category id. The layout component type category groups similar layout component types together logically.",
+                    "markdownDescription": "**Category**\n\nLayout Component Type category id. The layout component type category groups similar layout component types together logically.",
+                    "title": "Category",
+                    "type": "string"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "Description of layout component type category.",
+                    "markdownDescription": "**Description**\n\nDescription of layout component type category.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "label": {
+                    "description": "Label to represent this category.",
+                    "markdownDescription": "**Label**\n\nLabel to represent this category.",
                     "title": "Label",
                     "type": "string"
                 }
@@ -36,9 +65,40 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveLayoutComponentTypeCategory_"
+    "additionalProperties": false,
+    "description": "Layout Component Type Category.",
+    "markdownDescription": "Layout Component Type Category.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "category": {
+            "description": "Layout Component Type category id. The layout component type category groups similar layout component types together logically.",
+            "markdownDescription": "**Category**\n\nLayout Component Type category id. The layout component type category groups similar layout component types together logically.",
+            "title": "Category",
+            "type": "string"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "Description of layout component type category.",
+            "markdownDescription": "**Description**\n\nDescription of layout component type category.",
+            "title": "Description",
+            "type": "string"
+        },
+        "label": {
+            "description": "Label to represent this category.",
+            "markdownDescription": "**Label**\n\nLabel to represent this category.",
+            "title": "Label",
+            "type": "string"
         }
-    ]
+    },
+    "required": [
+        "category"
+    ],
+    "title": "_AdaptiveLayoutComponentTypeCategory_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveLayoutComponentTypeCategory_.json
+++ b/generated/schemas/afw/_AdaptiveLayoutComponentTypeCategory_.json
@@ -1,12 +1,15 @@
 {
     "$defs": {
         "_AdaptiveLayoutComponentTypeCategory_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveLayoutComponentTypeCategory_.propertyTypes"
                 }
             ],
             "description": "Layout Component Type Category.",
+            "required": [
+                "category"
+            ],
             "type": "object",
             "unevaluatedProperties": false
         },
@@ -29,14 +32,11 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "category"
-            ],
             "type": "object"
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveLayoutComponentTypeCategory_"
         }

--- a/generated/schemas/afw/_AdaptiveLayoutComponentType_.json
+++ b/generated/schemas/afw/_AdaptiveLayoutComponentType_.json
@@ -1,12 +1,15 @@
 {
     "$defs": {
         "_AdaptiveLayoutComponentType_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveLayoutComponentType_.propertyTypes"
                 }
             ],
             "description": "All adaptive layout component object types are derived from this object type.\n\nEach component type must have a corresponding object type with an id of '_AdaptiveLayoutComponentType_' followed by a unique component type id (componentType). These object types defines the properties of the object that is passed to their associated implementation.",
+            "required": [
+                "componentType"
+            ],
             "type": "object",
             "unevaluatedProperties": false
         },
@@ -54,14 +57,11 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "componentType"
-            ],
             "type": "object"
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveLayoutComponentType_"
         }

--- a/generated/schemas/afw/_AdaptiveLayoutComponentType_.json
+++ b/generated/schemas/afw/_AdaptiveLayoutComponentType_.json
@@ -1,58 +1,122 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveLayoutComponentType_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveLayoutComponentType_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveLayoutComponentType_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "All adaptive layout component object types are derived from this object type.\n\nEach component type must have a corresponding object type with an id of '_AdaptiveLayoutComponentType_' followed by a unique component type id (componentType). These object types defines the properties of the object that is passed to their associated implementation.",
-            "required": [
-                "componentType"
-            ],
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveLayoutComponentType_.propertyTypes": {
+            "markdownDescription": "All adaptive layout component object types are derived from this object type.\n\nEach component type must have a corresponding object type with an id of '_AdaptiveLayoutComponentType_' followed by a unique component type id (componentType). These object types defines the properties of the object that is passed to their associated implementation.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "brief": {
                     "description": "Brief description of this component type.",
+                    "markdownDescription": "**Brief**\n\nBrief description of this component type.",
                     "title": "Brief",
                     "type": "string"
                 },
                 "category": {
                     "description": "Represents the UI category to place this component in. Useful for selecting it from menus and any other visual representation that is helpful.",
+                    "markdownDescription": "**Category**\n\nRepresents the UI category to place this component in. Useful for selecting it from menus and any other visual representation that is helpful.",
                     "title": "Category",
                     "type": "string"
                 },
                 "componentType": {
                     "description": "Component type id is the object id for this Layout Component Type.",
+                    "markdownDescription": "**Component Type**\n\nComponent type id is the object id for this Layout Component Type.",
                     "title": "Component Type",
                     "type": "string"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "Description of this component type.",
+                    "markdownDescription": "**Description**\n\nDescription of this component type.",
                     "title": "Description",
                     "type": "string"
                 },
                 "implementationId": {
                     "description": "Id associated with the implementation for this component type.",
+                    "markdownDescription": "**Implementation Id**\n\nId associated with the implementation for this component type.",
                     "title": "Implementation Id",
                     "type": "string"
                 },
                 "implementationParameters": {
                     "description": "This object is passed to the implementation.",
+                    "markdownDescription": "**Implementation Parameters**\n\nThis object is passed to the implementation.",
                     "title": "Implementation Parameters",
                     "type": "object"
                 },
                 "instanceObjectType": {
                     "description": "Object type id of the instance parameters object.",
+                    "markdownDescription": "**Parameters Object Type**\n\nObject type id of the instance parameters object.",
                     "title": "Parameters Object Type",
                     "type": "string"
                 },
                 "label": {
                     "description": "Label to be used for this component type.",
+                    "markdownDescription": "**Label**\n\nLabel to be used for this component type.",
+                    "title": "Label",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "componentType"
+            ],
+            "title": "_AdaptiveLayoutComponentType_",
+            "type": "object"
+        },
+        "_AdaptiveLayoutComponentType_.propertyTypes": {
+            "properties": {
+                "brief": {
+                    "description": "Brief description of this component type.",
+                    "markdownDescription": "**Brief**\n\nBrief description of this component type.",
+                    "title": "Brief",
+                    "type": "string"
+                },
+                "category": {
+                    "description": "Represents the UI category to place this component in. Useful for selecting it from menus and any other visual representation that is helpful.",
+                    "markdownDescription": "**Category**\n\nRepresents the UI category to place this component in. Useful for selecting it from menus and any other visual representation that is helpful.",
+                    "title": "Category",
+                    "type": "string"
+                },
+                "componentType": {
+                    "description": "Component type id is the object id for this Layout Component Type.",
+                    "markdownDescription": "**Component Type**\n\nComponent type id is the object id for this Layout Component Type.",
+                    "title": "Component Type",
+                    "type": "string"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "Description of this component type.",
+                    "markdownDescription": "**Description**\n\nDescription of this component type.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "implementationId": {
+                    "description": "Id associated with the implementation for this component type.",
+                    "markdownDescription": "**Implementation Id**\n\nId associated with the implementation for this component type.",
+                    "title": "Implementation Id",
+                    "type": "string"
+                },
+                "implementationParameters": {
+                    "description": "This object is passed to the implementation.",
+                    "markdownDescription": "**Implementation Parameters**\n\nThis object is passed to the implementation.",
+                    "title": "Implementation Parameters",
+                    "type": "object"
+                },
+                "instanceObjectType": {
+                    "description": "Object type id of the instance parameters object.",
+                    "markdownDescription": "**Parameters Object Type**\n\nObject type id of the instance parameters object.",
+                    "title": "Parameters Object Type",
+                    "type": "string"
+                },
+                "label": {
+                    "description": "Label to be used for this component type.",
+                    "markdownDescription": "**Label**\n\nLabel to be used for this component type.",
                     "title": "Label",
                     "type": "string"
                 }
@@ -61,9 +125,70 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveLayoutComponentType_"
+    "additionalProperties": false,
+    "description": "All adaptive layout component object types are derived from this object type.\n\nEach component type must have a corresponding object type with an id of '_AdaptiveLayoutComponentType_' followed by a unique component type id (componentType). These object types defines the properties of the object that is passed to their associated implementation.",
+    "markdownDescription": "All adaptive layout component object types are derived from this object type.\n\nEach component type must have a corresponding object type with an id of '_AdaptiveLayoutComponentType_' followed by a unique component type id (componentType). These object types defines the properties of the object that is passed to their associated implementation.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "brief": {
+            "description": "Brief description of this component type.",
+            "markdownDescription": "**Brief**\n\nBrief description of this component type.",
+            "title": "Brief",
+            "type": "string"
+        },
+        "category": {
+            "description": "Represents the UI category to place this component in. Useful for selecting it from menus and any other visual representation that is helpful.",
+            "markdownDescription": "**Category**\n\nRepresents the UI category to place this component in. Useful for selecting it from menus and any other visual representation that is helpful.",
+            "title": "Category",
+            "type": "string"
+        },
+        "componentType": {
+            "description": "Component type id is the object id for this Layout Component Type.",
+            "markdownDescription": "**Component Type**\n\nComponent type id is the object id for this Layout Component Type.",
+            "title": "Component Type",
+            "type": "string"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "Description of this component type.",
+            "markdownDescription": "**Description**\n\nDescription of this component type.",
+            "title": "Description",
+            "type": "string"
+        },
+        "implementationId": {
+            "description": "Id associated with the implementation for this component type.",
+            "markdownDescription": "**Implementation Id**\n\nId associated with the implementation for this component type.",
+            "title": "Implementation Id",
+            "type": "string"
+        },
+        "implementationParameters": {
+            "description": "This object is passed to the implementation.",
+            "markdownDescription": "**Implementation Parameters**\n\nThis object is passed to the implementation.",
+            "title": "Implementation Parameters",
+            "type": "object"
+        },
+        "instanceObjectType": {
+            "description": "Object type id of the instance parameters object.",
+            "markdownDescription": "**Parameters Object Type**\n\nObject type id of the instance parameters object.",
+            "title": "Parameters Object Type",
+            "type": "string"
+        },
+        "label": {
+            "description": "Label to be used for this component type.",
+            "markdownDescription": "**Label**\n\nLabel to be used for this component type.",
+            "title": "Label",
+            "type": "string"
         }
-    ]
+    },
+    "required": [
+        "componentType"
+    ],
+    "title": "_AdaptiveLayoutComponentType_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveLdapAttributeType_.json
+++ b/generated/schemas/afw/_AdaptiveLdapAttributeType_.json
@@ -1,13 +1,36 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveLdapAttributeType_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveLdapAttributeType_": {
             "additionalProperties": true,
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveLdapAttributeType_.propertyTypes"
-                }
-            ],
             "description": "Object type for type=adapter adapter_type=ldap synthetic attribute type object.",
+            "markdownDescription": "Object type for type=adapter adapter_type=ldap synthetic attribute type object.",
+            "properties": {
+                "DESC": {
+                    "title": "Description",
+                    "type": "string"
+                },
+                "SINGLE_VALUE": {
+                    "title": "Is Single",
+                    "type": "boolean"
+                },
+                "SYNTAX": {
+                    "title": "Syntax",
+                    "type": "string"
+                },
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "numericoid": {
+                    "title": "Numeric OID",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveLdapAttributeType_",
             "type": "object"
         },
         "_AdaptiveLdapAttributeType_.propertyTypes": {
@@ -33,9 +56,34 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveLdapAttributeType_"
+    "additionalProperties": true,
+    "description": "Object type for type=adapter adapter_type=ldap synthetic attribute type object.",
+    "markdownDescription": "Object type for type=adapter adapter_type=ldap synthetic attribute type object.",
+    "properties": {
+        "DESC": {
+            "title": "Description",
+            "type": "string"
+        },
+        "SINGLE_VALUE": {
+            "title": "Is Single",
+            "type": "boolean"
+        },
+        "SYNTAX": {
+            "title": "Syntax",
+            "type": "string"
+        },
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "numericoid": {
+            "title": "Numeric OID",
+            "type": "string"
         }
-    ]
+    },
+    "title": "_AdaptiveLdapAttributeType_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveLdapAttributeType_.json
+++ b/generated/schemas/afw/_AdaptiveLdapAttributeType_.json
@@ -1,10 +1,8 @@
 {
     "$defs": {
         "_AdaptiveLdapAttributeType_": {
-            "additionalProperties": {
-                "description": "Object type for type=adapter adapter_type=ldap synthetic attribute type object."
-            },
-            "anyOf": [
+            "additionalProperties": true,
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveLdapAttributeType_.propertyTypes"
                 }
@@ -35,7 +33,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveLdapAttributeType_"
         }

--- a/generated/schemas/afw/_AdaptiveLdapMatchingRuleUse_.json
+++ b/generated/schemas/afw/_AdaptiveLdapMatchingRuleUse_.json
@@ -1,13 +1,20 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveLdapMatchingRuleUse_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveLdapMatchingRuleUse_": {
             "additionalProperties": true,
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveLdapMatchingRuleUse_.propertyTypes"
-                }
-            ],
             "description": "Object type for type=adapter adapter_type=ldap synthetic matching rule use object.",
+            "markdownDescription": "Object type for type=adapter adapter_type=ldap synthetic matching rule use object.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                }
+            },
+            "title": "_AdaptiveLdapMatchingRuleUse_",
             "type": "object"
         },
         "_AdaptiveLdapMatchingRuleUse_.propertyTypes": {
@@ -16,9 +23,18 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveLdapMatchingRuleUse_"
+    "additionalProperties": true,
+    "description": "Object type for type=adapter adapter_type=ldap synthetic matching rule use object.",
+    "markdownDescription": "Object type for type=adapter adapter_type=ldap synthetic matching rule use object.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
         }
-    ]
+    },
+    "title": "_AdaptiveLdapMatchingRuleUse_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveLdapMatchingRuleUse_.json
+++ b/generated/schemas/afw/_AdaptiveLdapMatchingRuleUse_.json
@@ -1,10 +1,8 @@
 {
     "$defs": {
         "_AdaptiveLdapMatchingRuleUse_": {
-            "additionalProperties": {
-                "description": "Object type for type=adapter adapter_type=ldap synthetic matching rule use object."
-            },
-            "anyOf": [
+            "additionalProperties": true,
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveLdapMatchingRuleUse_.propertyTypes"
                 }
@@ -18,7 +16,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveLdapMatchingRuleUse_"
         }

--- a/generated/schemas/afw/_AdaptiveLdapMatchingRule_.json
+++ b/generated/schemas/afw/_AdaptiveLdapMatchingRule_.json
@@ -1,10 +1,8 @@
 {
     "$defs": {
         "_AdaptiveLdapMatchingRule_": {
-            "additionalProperties": {
-                "description": "Object type for type=adapter adapter_type=ldap synthetic matching rule object."
-            },
-            "anyOf": [
+            "additionalProperties": true,
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveLdapMatchingRule_.propertyTypes"
                 }
@@ -18,7 +16,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveLdapMatchingRule_"
         }

--- a/generated/schemas/afw/_AdaptiveLdapMatchingRule_.json
+++ b/generated/schemas/afw/_AdaptiveLdapMatchingRule_.json
@@ -1,13 +1,20 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveLdapMatchingRule_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveLdapMatchingRule_": {
             "additionalProperties": true,
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveLdapMatchingRule_.propertyTypes"
-                }
-            ],
             "description": "Object type for type=adapter adapter_type=ldap synthetic matching rule object.",
+            "markdownDescription": "Object type for type=adapter adapter_type=ldap synthetic matching rule object.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                }
+            },
+            "title": "_AdaptiveLdapMatchingRule_",
             "type": "object"
         },
         "_AdaptiveLdapMatchingRule_.propertyTypes": {
@@ -16,9 +23,18 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveLdapMatchingRule_"
+    "additionalProperties": true,
+    "description": "Object type for type=adapter adapter_type=ldap synthetic matching rule object.",
+    "markdownDescription": "Object type for type=adapter adapter_type=ldap synthetic matching rule object.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
         }
-    ]
+    },
+    "title": "_AdaptiveLdapMatchingRule_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveLdapObjectClass_.json
+++ b/generated/schemas/afw/_AdaptiveLdapObjectClass_.json
@@ -1,10 +1,8 @@
 {
     "$defs": {
         "_AdaptiveLdapObjectClass_": {
-            "additionalProperties": {
-                "description": "Object type for type=adapter adapter_type=ldap synthetic object class object."
-            },
-            "anyOf": [
+            "additionalProperties": true,
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveLdapObjectClass_.propertyTypes"
                 }
@@ -78,7 +76,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveLdapObjectClass_"
         }

--- a/generated/schemas/afw/_AdaptiveLdapObjectClass_.json
+++ b/generated/schemas/afw/_AdaptiveLdapObjectClass_.json
@@ -1,24 +1,20 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveLdapObjectClass_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveLdapObjectClass_": {
             "additionalProperties": true,
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveLdapObjectClass_.propertyTypes"
-                }
-            ],
             "description": "Object type for type=adapter adapter_type=ldap synthetic object class object.",
-            "type": "object"
-        },
-        "_AdaptiveLdapObjectClass_.propertyTypes": {
+            "markdownDescription": "Object type for type=adapter adapter_type=ldap synthetic object class object.",
             "properties": {
                 "ABSTRACT": {
                     "description": "Abstract Class",
+                    "markdownDescription": "Abstract Class",
                     "title": "Abstract",
                     "type": "boolean"
                 },
                 "AUXILIARY": {
                     "description": "Auxiliary Class",
+                    "markdownDescription": "Auxiliary Class",
                     "title": "Auxiliary",
                     "type": "boolean"
                 },
@@ -30,8 +26,10 @@
                     "description": "Optional attributes of class.",
                     "items": {
                         "description": "Optional attributes of class.",
+                        "markdownDescription": "Optional attributes of class.",
                         "type": "string"
                     },
+                    "markdownDescription": "Optional attributes of class.",
                     "title": "Optional",
                     "type": "array"
                 },
@@ -39,8 +37,10 @@
                     "description": "Required attributes of class.",
                     "items": {
                         "description": "Required attributes of class.",
+                        "markdownDescription": "Required attributes of class.",
                         "type": "string"
                     },
+                    "markdownDescription": "Required attributes of class.",
                     "title": "Required",
                     "type": "array"
                 },
@@ -48,13 +48,16 @@
                     "description": "Name of class.",
                     "items": {
                         "description": "Name of class.",
+                        "markdownDescription": "Name of class.",
                         "type": "string"
                     },
+                    "markdownDescription": "Name of class.",
                     "title": "Name",
                     "type": "array"
                 },
                 "STRUCTURAL": {
                     "description": "Structural Class",
+                    "markdownDescription": "Structural Class",
                     "title": "Structural",
                     "type": "boolean"
                 },
@@ -62,8 +65,93 @@
                     "description": "Superior classes.",
                     "items": {
                         "description": "Superior classes.",
+                        "markdownDescription": "Superior classes.",
                         "type": "string"
                     },
+                    "markdownDescription": "Superior classes.",
+                    "title": "Sup",
+                    "type": "array"
+                },
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "numericoid": {
+                    "title": "Numeric OID",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveLdapObjectClass_",
+            "type": "object"
+        },
+        "_AdaptiveLdapObjectClass_.propertyTypes": {
+            "properties": {
+                "ABSTRACT": {
+                    "description": "Abstract Class",
+                    "markdownDescription": "Abstract Class",
+                    "title": "Abstract",
+                    "type": "boolean"
+                },
+                "AUXILIARY": {
+                    "description": "Auxiliary Class",
+                    "markdownDescription": "Auxiliary Class",
+                    "title": "Auxiliary",
+                    "type": "boolean"
+                },
+                "DESC": {
+                    "title": "Description",
+                    "type": "string"
+                },
+                "MAY": {
+                    "description": "Optional attributes of class.",
+                    "items": {
+                        "description": "Optional attributes of class.",
+                        "markdownDescription": "Optional attributes of class.",
+                        "type": "string"
+                    },
+                    "markdownDescription": "Optional attributes of class.",
+                    "title": "Optional",
+                    "type": "array"
+                },
+                "MUST": {
+                    "description": "Required attributes of class.",
+                    "items": {
+                        "description": "Required attributes of class.",
+                        "markdownDescription": "Required attributes of class.",
+                        "type": "string"
+                    },
+                    "markdownDescription": "Required attributes of class.",
+                    "title": "Required",
+                    "type": "array"
+                },
+                "NAME": {
+                    "description": "Name of class.",
+                    "items": {
+                        "description": "Name of class.",
+                        "markdownDescription": "Name of class.",
+                        "type": "string"
+                    },
+                    "markdownDescription": "Name of class.",
+                    "title": "Name",
+                    "type": "array"
+                },
+                "STRUCTURAL": {
+                    "description": "Structural Class",
+                    "markdownDescription": "Structural Class",
+                    "title": "Structural",
+                    "type": "boolean"
+                },
+                "SUP": {
+                    "description": "Superior classes.",
+                    "items": {
+                        "description": "Superior classes.",
+                        "markdownDescription": "Superior classes.",
+                        "type": "string"
+                    },
+                    "markdownDescription": "Superior classes.",
                     "title": "Sup",
                     "type": "array"
                 },
@@ -76,9 +164,88 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveLdapObjectClass_"
+    "additionalProperties": true,
+    "description": "Object type for type=adapter adapter_type=ldap synthetic object class object.",
+    "markdownDescription": "Object type for type=adapter adapter_type=ldap synthetic object class object.",
+    "properties": {
+        "ABSTRACT": {
+            "description": "Abstract Class",
+            "markdownDescription": "Abstract Class",
+            "title": "Abstract",
+            "type": "boolean"
+        },
+        "AUXILIARY": {
+            "description": "Auxiliary Class",
+            "markdownDescription": "Auxiliary Class",
+            "title": "Auxiliary",
+            "type": "boolean"
+        },
+        "DESC": {
+            "title": "Description",
+            "type": "string"
+        },
+        "MAY": {
+            "description": "Optional attributes of class.",
+            "items": {
+                "description": "Optional attributes of class.",
+                "markdownDescription": "Optional attributes of class.",
+                "type": "string"
+            },
+            "markdownDescription": "Optional attributes of class.",
+            "title": "Optional",
+            "type": "array"
+        },
+        "MUST": {
+            "description": "Required attributes of class.",
+            "items": {
+                "description": "Required attributes of class.",
+                "markdownDescription": "Required attributes of class.",
+                "type": "string"
+            },
+            "markdownDescription": "Required attributes of class.",
+            "title": "Required",
+            "type": "array"
+        },
+        "NAME": {
+            "description": "Name of class.",
+            "items": {
+                "description": "Name of class.",
+                "markdownDescription": "Name of class.",
+                "type": "string"
+            },
+            "markdownDescription": "Name of class.",
+            "title": "Name",
+            "type": "array"
+        },
+        "STRUCTURAL": {
+            "description": "Structural Class",
+            "markdownDescription": "Structural Class",
+            "title": "Structural",
+            "type": "boolean"
+        },
+        "SUP": {
+            "description": "Superior classes.",
+            "items": {
+                "description": "Superior classes.",
+                "markdownDescription": "Superior classes.",
+                "type": "string"
+            },
+            "markdownDescription": "Superior classes.",
+            "title": "Sup",
+            "type": "array"
+        },
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "numericoid": {
+            "title": "Numeric OID",
+            "type": "string"
         }
-    ]
+    },
+    "title": "_AdaptiveLdapObjectClass_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveLdapRootDse_.json
+++ b/generated/schemas/afw/_AdaptiveLdapRootDse_.json
@@ -1,10 +1,8 @@
 {
     "$defs": {
         "_AdaptiveLdapRootDse_": {
-            "additionalProperties": {
-                "description": "Object type for type=adapter adapter_type=ldap synthetic root dse object."
-            },
-            "anyOf": [
+            "additionalProperties": true,
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveLdapRootDse_.propertyTypes"
                 }
@@ -18,7 +16,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveLdapRootDse_"
         }

--- a/generated/schemas/afw/_AdaptiveLdapRootDse_.json
+++ b/generated/schemas/afw/_AdaptiveLdapRootDse_.json
@@ -1,13 +1,20 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveLdapRootDse_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveLdapRootDse_": {
             "additionalProperties": true,
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveLdapRootDse_.propertyTypes"
-                }
-            ],
             "description": "Object type for type=adapter adapter_type=ldap synthetic root dse object.",
+            "markdownDescription": "Object type for type=adapter adapter_type=ldap synthetic root dse object.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                }
+            },
+            "title": "_AdaptiveLdapRootDse_",
             "type": "object"
         },
         "_AdaptiveLdapRootDse_.propertyTypes": {
@@ -16,9 +23,18 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveLdapRootDse_"
+    "additionalProperties": true,
+    "description": "Object type for type=adapter adapter_type=ldap synthetic root dse object.",
+    "markdownDescription": "Object type for type=adapter adapter_type=ldap synthetic root dse object.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
         }
-    ]
+    },
+    "title": "_AdaptiveLdapRootDse_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveLdapSchema_.json
+++ b/generated/schemas/afw/_AdaptiveLdapSchema_.json
@@ -1,10 +1,8 @@
 {
     "$defs": {
         "_AdaptiveLdapSchema_": {
-            "additionalProperties": {
-                "description": "Object type for type=adapter adapter_type=ldap synthetic schema object."
-            },
-            "anyOf": [
+            "additionalProperties": true,
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveLdapSchema_.propertyTypes"
                 }
@@ -18,7 +16,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveLdapSchema_"
         }

--- a/generated/schemas/afw/_AdaptiveLdapSchema_.json
+++ b/generated/schemas/afw/_AdaptiveLdapSchema_.json
@@ -1,13 +1,20 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveLdapSchema_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveLdapSchema_": {
             "additionalProperties": true,
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveLdapSchema_.propertyTypes"
-                }
-            ],
             "description": "Object type for type=adapter adapter_type=ldap synthetic schema object.",
+            "markdownDescription": "Object type for type=adapter adapter_type=ldap synthetic schema object.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                }
+            },
+            "title": "_AdaptiveLdapSchema_",
             "type": "object"
         },
         "_AdaptiveLdapSchema_.propertyTypes": {
@@ -16,9 +23,18 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveLdapSchema_"
+    "additionalProperties": true,
+    "description": "Object type for type=adapter adapter_type=ldap synthetic schema object.",
+    "markdownDescription": "Object type for type=adapter adapter_type=ldap synthetic schema object.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
         }
-    ]
+    },
+    "title": "_AdaptiveLdapSchema_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveLdapSyntax_.json
+++ b/generated/schemas/afw/_AdaptiveLdapSyntax_.json
@@ -1,13 +1,28 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveLdapSyntax_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveLdapSyntax_": {
             "additionalProperties": true,
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveLdapSyntax_.propertyTypes"
-                }
-            ],
             "description": "Object type for type=adapter adapter_type=ldap synthetic syntax object.",
+            "markdownDescription": "Object type for type=adapter adapter_type=ldap synthetic syntax object.",
+            "properties": {
+                "DESC": {
+                    "title": "Description",
+                    "type": "string"
+                },
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "numericoid": {
+                    "title": "Numeric OID",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveLdapSyntax_",
             "type": "object"
         },
         "_AdaptiveLdapSyntax_.propertyTypes": {
@@ -25,9 +40,26 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveLdapSyntax_"
+    "additionalProperties": true,
+    "description": "Object type for type=adapter adapter_type=ldap synthetic syntax object.",
+    "markdownDescription": "Object type for type=adapter adapter_type=ldap synthetic syntax object.",
+    "properties": {
+        "DESC": {
+            "title": "Description",
+            "type": "string"
+        },
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "numericoid": {
+            "title": "Numeric OID",
+            "type": "string"
         }
-    ]
+    },
+    "title": "_AdaptiveLdapSyntax_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveLdapSyntax_.json
+++ b/generated/schemas/afw/_AdaptiveLdapSyntax_.json
@@ -1,10 +1,8 @@
 {
     "$defs": {
         "_AdaptiveLdapSyntax_": {
-            "additionalProperties": {
-                "description": "Object type for type=adapter adapter_type=ldap synthetic syntax object."
-            },
-            "anyOf": [
+            "additionalProperties": true,
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveLdapSyntax_.propertyTypes"
                 }
@@ -27,7 +25,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveLdapSyntax_"
         }

--- a/generated/schemas/afw/_AdaptiveLock_.json
+++ b/generated/schemas/afw/_AdaptiveLock_.json
@@ -1,40 +1,83 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveLock_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveLock_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveLock_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "An adaptive flag.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveLock_.propertyTypes": {
+            "markdownDescription": "An adaptive flag.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "brief": {
                     "description": "Brief predicate about this lock.",
+                    "markdownDescription": "**Brief**\n\nBrief predicate about this lock.",
                     "title": "Brief",
                     "type": "string"
                 },
                 "debugFlagId": {
                     "description": "Flag id of the lock's debug flag.",
+                    "markdownDescription": "**Debug Flag Id**\n\nFlag id of the lock's debug flag.",
                     "title": "Debug Flag Id",
                     "type": "string"
                 },
                 "debugFlagIndex": {
                     "description": "Index of the lock's debug flag.",
+                    "markdownDescription": "**Debug Flag Index**\n\nIndex of the lock's debug flag.",
                     "title": "Debug Flag Index",
                     "type": "integer"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "This is the description of this lock.",
+                    "markdownDescription": "**Description**\n\nThis is the description of this lock.",
                     "title": "Description",
                     "type": "string"
                 },
                 "lockId": {
                     "description": "This is the key for this lock in registry type flag and the objectId of its _AdaptiveLock_ runtime object.",
+                    "markdownDescription": "**Lock Id**\n\nThis is the key for this lock in registry type flag and the objectId of its _AdaptiveLock_ runtime object.",
+                    "title": "Lock Id",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveLock_",
+            "type": "object"
+        },
+        "_AdaptiveLock_.propertyTypes": {
+            "properties": {
+                "brief": {
+                    "description": "Brief predicate about this lock.",
+                    "markdownDescription": "**Brief**\n\nBrief predicate about this lock.",
+                    "title": "Brief",
+                    "type": "string"
+                },
+                "debugFlagId": {
+                    "description": "Flag id of the lock's debug flag.",
+                    "markdownDescription": "**Debug Flag Id**\n\nFlag id of the lock's debug flag.",
+                    "title": "Debug Flag Id",
+                    "type": "string"
+                },
+                "debugFlagIndex": {
+                    "description": "Index of the lock's debug flag.",
+                    "markdownDescription": "**Debug Flag Index**\n\nIndex of the lock's debug flag.",
+                    "title": "Debug Flag Index",
+                    "type": "integer"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "This is the description of this lock.",
+                    "markdownDescription": "**Description**\n\nThis is the description of this lock.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "lockId": {
+                    "description": "This is the key for this lock in registry type flag and the objectId of its _AdaptiveLock_ runtime object.",
+                    "markdownDescription": "**Lock Id**\n\nThis is the key for this lock in registry type flag and the objectId of its _AdaptiveLock_ runtime object.",
                     "title": "Lock Id",
                     "type": "string"
                 }
@@ -43,9 +86,49 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveLock_"
+    "additionalProperties": false,
+    "description": "An adaptive flag.",
+    "markdownDescription": "An adaptive flag.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "brief": {
+            "description": "Brief predicate about this lock.",
+            "markdownDescription": "**Brief**\n\nBrief predicate about this lock.",
+            "title": "Brief",
+            "type": "string"
+        },
+        "debugFlagId": {
+            "description": "Flag id of the lock's debug flag.",
+            "markdownDescription": "**Debug Flag Id**\n\nFlag id of the lock's debug flag.",
+            "title": "Debug Flag Id",
+            "type": "string"
+        },
+        "debugFlagIndex": {
+            "description": "Index of the lock's debug flag.",
+            "markdownDescription": "**Debug Flag Index**\n\nIndex of the lock's debug flag.",
+            "title": "Debug Flag Index",
+            "type": "integer"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "This is the description of this lock.",
+            "markdownDescription": "**Description**\n\nThis is the description of this lock.",
+            "title": "Description",
+            "type": "string"
+        },
+        "lockId": {
+            "description": "This is the key for this lock in registry type flag and the objectId of its _AdaptiveLock_ runtime object.",
+            "markdownDescription": "**Lock Id**\n\nThis is the key for this lock in registry type flag and the objectId of its _AdaptiveLock_ runtime object.",
+            "title": "Lock Id",
+            "type": "string"
         }
-    ]
+    },
+    "title": "_AdaptiveLock_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveLock_.json
+++ b/generated/schemas/afw/_AdaptiveLock_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveLock_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveLock_.propertyTypes"
                 }
@@ -43,7 +43,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveLock_"
         }

--- a/generated/schemas/afw/_AdaptiveLogType_.json
+++ b/generated/schemas/afw/_AdaptiveLogType_.json
@@ -1,25 +1,47 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveLogType_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveLogType_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveLogType_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "A registry type log_factory entry.",
-            "type": "object",
-            "unevaluatedProperties": false
+            "markdownDescription": "A registry type log_factory entry.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "Description of log type.",
+                    "markdownDescription": "**Description**\n\nDescription of log type.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "logType": {
+                    "description": "Type of log.",
+                    "markdownDescription": "**Log Type**\n\nType of log.",
+                    "title": "Log Type",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveLogType_",
+            "type": "object"
         },
         "_AdaptiveLogType_.propertyTypes": {
             "properties": {
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "Description of log type.",
+                    "markdownDescription": "**Description**\n\nDescription of log type.",
                     "title": "Description",
                     "type": "string"
                 },
                 "logType": {
                     "description": "Type of log.",
+                    "markdownDescription": "**Log Type**\n\nType of log.",
                     "title": "Log Type",
                     "type": "string"
                 }
@@ -28,9 +50,31 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveLogType_"
+    "additionalProperties": false,
+    "description": "A registry type log_factory entry.",
+    "markdownDescription": "A registry type log_factory entry.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "Description of log type.",
+            "markdownDescription": "**Description**\n\nDescription of log type.",
+            "title": "Description",
+            "type": "string"
+        },
+        "logType": {
+            "description": "Type of log.",
+            "markdownDescription": "**Log Type**\n\nType of log.",
+            "title": "Log Type",
+            "type": "string"
         }
-    ]
+    },
+    "title": "_AdaptiveLogType_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveLogType_.json
+++ b/generated/schemas/afw/_AdaptiveLogType_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveLogType_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveLogType_.propertyTypes"
                 }
@@ -28,7 +28,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveLogType_"
         }

--- a/generated/schemas/afw/_AdaptiveLog_.json
+++ b/generated/schemas/afw/_AdaptiveLog_.json
@@ -1,34 +1,69 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveLog_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveLog_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveLog_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Runtime log information.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveLog_.propertyTypes": {
+            "markdownDescription": "Runtime log information.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "logId": {
                     "description": "Log id.",
+                    "markdownDescription": "**Log Id**\n\nLog id.",
                     "title": "Log Id",
                     "type": "string"
                 },
                 "properties": {
                     "description": "This object contains some of properties from the associated conf object plus other runtime properties.",
+                    "markdownDescription": "**Properties**\n\nThis object contains some of properties from the associated conf object plus other runtime properties.",
                     "title": "Properties",
                     "type": "object"
                 },
                 "serviceId": {
                     "description": "The id of the associated service. The URI of the service is '/afw/_AdaptiveService_/' followed by this id.",
+                    "markdownDescription": "**Service Id**\n\nThe id of the associated service. The URI of the service is '/afw/_AdaptiveService_/' followed by this id.",
                     "title": "Service Id",
                     "type": "string"
                 },
                 "sourceLocation": {
                     "description": "This is a source location to help determine how this log was defined.",
+                    "markdownDescription": "**Source Location**\n\nThis is a source location to help determine how this log was defined.",
+                    "title": "Source Location",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveLog_",
+            "type": "object"
+        },
+        "_AdaptiveLog_.propertyTypes": {
+            "properties": {
+                "logId": {
+                    "description": "Log id.",
+                    "markdownDescription": "**Log Id**\n\nLog id.",
+                    "title": "Log Id",
+                    "type": "string"
+                },
+                "properties": {
+                    "description": "This object contains some of properties from the associated conf object plus other runtime properties.",
+                    "markdownDescription": "**Properties**\n\nThis object contains some of properties from the associated conf object plus other runtime properties.",
+                    "title": "Properties",
+                    "type": "object"
+                },
+                "serviceId": {
+                    "description": "The id of the associated service. The URI of the service is '/afw/_AdaptiveService_/' followed by this id.",
+                    "markdownDescription": "**Service Id**\n\nThe id of the associated service. The URI of the service is '/afw/_AdaptiveService_/' followed by this id.",
+                    "title": "Service Id",
+                    "type": "string"
+                },
+                "sourceLocation": {
+                    "description": "This is a source location to help determine how this log was defined.",
+                    "markdownDescription": "**Source Location**\n\nThis is a source location to help determine how this log was defined.",
                     "title": "Source Location",
                     "type": "string"
                 }
@@ -37,9 +72,42 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveLog_"
+    "additionalProperties": false,
+    "description": "Runtime log information.",
+    "markdownDescription": "Runtime log information.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "logId": {
+            "description": "Log id.",
+            "markdownDescription": "**Log Id**\n\nLog id.",
+            "title": "Log Id",
+            "type": "string"
+        },
+        "properties": {
+            "description": "This object contains some of properties from the associated conf object plus other runtime properties.",
+            "markdownDescription": "**Properties**\n\nThis object contains some of properties from the associated conf object plus other runtime properties.",
+            "title": "Properties",
+            "type": "object"
+        },
+        "serviceId": {
+            "description": "The id of the associated service. The URI of the service is '/afw/_AdaptiveService_/' followed by this id.",
+            "markdownDescription": "**Service Id**\n\nThe id of the associated service. The URI of the service is '/afw/_AdaptiveService_/' followed by this id.",
+            "title": "Service Id",
+            "type": "string"
+        },
+        "sourceLocation": {
+            "description": "This is a source location to help determine how this log was defined.",
+            "markdownDescription": "**Source Location**\n\nThis is a source location to help determine how this log was defined.",
+            "title": "Source Location",
+            "type": "string"
         }
-    ]
+    },
+    "title": "_AdaptiveLog_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveLog_.json
+++ b/generated/schemas/afw/_AdaptiveLog_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveLog_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveLog_.propertyTypes"
                 }
@@ -37,7 +37,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveLog_"
         }

--- a/generated/schemas/afw/_AdaptiveManifest_.json
+++ b/generated/schemas/afw/_AdaptiveManifest_.json
@@ -1,39 +1,40 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveManifest_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveManifest_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveManifest_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Adaptive Framework extension manifest.",
-            "required": [
-                "extensionId",
-                "modulePath"
-            ],
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveManifest_.propertyTypes": {
+            "markdownDescription": "Adaptive Framework extension manifest.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "brief": {
                     "description": "Brief description for this extension.",
+                    "markdownDescription": "**Brief**\n\nBrief description for this extension.",
                     "title": "Brief",
                     "type": "string"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "Description for this extension in more detail.",
+                    "markdownDescription": "**Description**\n\nDescription for this extension in more detail.",
                     "title": "Description",
                     "type": "string"
                 },
                 "extensionId": {
                     "description": "Extension id.",
+                    "markdownDescription": "**Extension**\n\nExtension id.",
                     "title": "Extension",
                     "type": "string"
                 },
                 "modulePath": {
                     "description": "Module path. A system appropriate suffix will be added ('.so' for Linux and '.dll' for Windows).",
+                    "markdownDescription": "**Module Path**\n\nModule path. A system appropriate suffix will be added ('.so' for Linux and '.dll' for Windows).",
                     "title": "Module Path",
                     "type": "string"
                 },
@@ -41,9 +42,11 @@
                     "description": "Each entry is the path of an afw adapter object supplied by this extension. This extension will be loaded by function afw_runtime_get_object() if needed.",
                     "items": {
                         "description": "Each entry is the path of an afw adapter object supplied by this extension. This extension will be loaded by function afw_runtime_get_object() if needed.",
+                        "markdownDescription": "Each entry is the path of an afw adapter object supplied by this extension. This extension will be loaded by function afw_runtime_get_object() if needed.",
                         "title": "List of object paths provided by this extension",
                         "type": "string"
                     },
+                    "markdownDescription": "**Provides Objects**\n\nEach entry is the path of an afw adapter object supplied by this extension. This extension will be loaded by function afw_runtime_get_object() if needed.",
                     "title": "Provides Objects",
                     "type": "array"
                 },
@@ -51,9 +54,70 @@
                     "description": "Each entry is a string of the form '<registry type>/<registry key>', where <registry type> is a valid registry type id and <registry key> is a registry key that is registered at runtime by the associated command, extension, server, etc. If this manifest is for an extension, the extension will be automatically loaded when afw_environment_registry_get() is called for a <registry type>/<registry key> combo that is not already registered. See afw/afw_environment.h for more information.",
                     "items": {
                         "description": "Each entry is a string of the form '<registry type>/<registry key>', where <registry type> is a valid registry type id and <registry key> is a registry key that is registered at runtime by the associated command, extension, server, etc. If this manifest is for an extension, the extension will be automatically loaded when afw_environment_registry_get() is called for a <registry type>/<registry key> combo that is not already registered. See afw/afw_environment.h for more information.",
+                        "markdownDescription": "Each entry is a string of the form '<registry type>/<registry key>', where <registry type> is a valid registry type id and <registry key> is a registry key that is registered at runtime by the associated command, extension, server, etc. If this manifest is for an extension, the extension will be automatically loaded when afw_environment_registry_get() is called for a <registry type>/<registry key> combo that is not already registered. See afw/afw_environment.h for more information.",
                         "title": "List of entries this extension registers",
                         "type": "string"
                     },
+                    "markdownDescription": "**Registers**\n\nEach entry is a string of the form '<registry type>/<registry key>', where <registry type> is a valid registry type id and <registry key> is a registry key that is registered at runtime by the associated command, extension, server, etc. If this manifest is for an extension, the extension will be automatically loaded when afw_environment_registry_get() is called for a <registry type>/<registry key> combo that is not already registered. See afw/afw_environment.h for more information.",
+                    "title": "Registers",
+                    "type": "array"
+                }
+            },
+            "required": [
+                "extensionId",
+                "modulePath"
+            ],
+            "title": "_AdaptiveManifest_",
+            "type": "object"
+        },
+        "_AdaptiveManifest_.propertyTypes": {
+            "properties": {
+                "brief": {
+                    "description": "Brief description for this extension.",
+                    "markdownDescription": "**Brief**\n\nBrief description for this extension.",
+                    "title": "Brief",
+                    "type": "string"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "Description for this extension in more detail.",
+                    "markdownDescription": "**Description**\n\nDescription for this extension in more detail.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "extensionId": {
+                    "description": "Extension id.",
+                    "markdownDescription": "**Extension**\n\nExtension id.",
+                    "title": "Extension",
+                    "type": "string"
+                },
+                "modulePath": {
+                    "description": "Module path. A system appropriate suffix will be added ('.so' for Linux and '.dll' for Windows).",
+                    "markdownDescription": "**Module Path**\n\nModule path. A system appropriate suffix will be added ('.so' for Linux and '.dll' for Windows).",
+                    "title": "Module Path",
+                    "type": "string"
+                },
+                "providesObjects": {
+                    "description": "Each entry is the path of an afw adapter object supplied by this extension. This extension will be loaded by function afw_runtime_get_object() if needed.",
+                    "items": {
+                        "description": "Each entry is the path of an afw adapter object supplied by this extension. This extension will be loaded by function afw_runtime_get_object() if needed.",
+                        "markdownDescription": "Each entry is the path of an afw adapter object supplied by this extension. This extension will be loaded by function afw_runtime_get_object() if needed.",
+                        "title": "List of object paths provided by this extension",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Provides Objects**\n\nEach entry is the path of an afw adapter object supplied by this extension. This extension will be loaded by function afw_runtime_get_object() if needed.",
+                    "title": "Provides Objects",
+                    "type": "array"
+                },
+                "registers": {
+                    "description": "Each entry is a string of the form '<registry type>/<registry key>', where <registry type> is a valid registry type id and <registry key> is a registry key that is registered at runtime by the associated command, extension, server, etc. If this manifest is for an extension, the extension will be automatically loaded when afw_environment_registry_get() is called for a <registry type>/<registry key> combo that is not already registered. See afw/afw_environment.h for more information.",
+                    "items": {
+                        "description": "Each entry is a string of the form '<registry type>/<registry key>', where <registry type> is a valid registry type id and <registry key> is a registry key that is registered at runtime by the associated command, extension, server, etc. If this manifest is for an extension, the extension will be automatically loaded when afw_environment_registry_get() is called for a <registry type>/<registry key> combo that is not already registered. See afw/afw_environment.h for more information.",
+                        "markdownDescription": "Each entry is a string of the form '<registry type>/<registry key>', where <registry type> is a valid registry type id and <registry key> is a registry key that is registered at runtime by the associated command, extension, server, etc. If this manifest is for an extension, the extension will be automatically loaded when afw_environment_registry_get() is called for a <registry type>/<registry key> combo that is not already registered. See afw/afw_environment.h for more information.",
+                        "title": "List of entries this extension registers",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Registers**\n\nEach entry is a string of the form '<registry type>/<registry key>', where <registry type> is a valid registry type id and <registry key> is a registry key that is registered at runtime by the associated command, extension, server, etc. If this manifest is for an extension, the extension will be automatically loaded when afw_environment_registry_get() is called for a <registry type>/<registry key> combo that is not already registered. See afw/afw_environment.h for more information.",
                     "title": "Registers",
                     "type": "array"
                 }
@@ -62,9 +126,71 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveManifest_"
+    "additionalProperties": false,
+    "description": "Adaptive Framework extension manifest.",
+    "markdownDescription": "Adaptive Framework extension manifest.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "brief": {
+            "description": "Brief description for this extension.",
+            "markdownDescription": "**Brief**\n\nBrief description for this extension.",
+            "title": "Brief",
+            "type": "string"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "Description for this extension in more detail.",
+            "markdownDescription": "**Description**\n\nDescription for this extension in more detail.",
+            "title": "Description",
+            "type": "string"
+        },
+        "extensionId": {
+            "description": "Extension id.",
+            "markdownDescription": "**Extension**\n\nExtension id.",
+            "title": "Extension",
+            "type": "string"
+        },
+        "modulePath": {
+            "description": "Module path. A system appropriate suffix will be added ('.so' for Linux and '.dll' for Windows).",
+            "markdownDescription": "**Module Path**\n\nModule path. A system appropriate suffix will be added ('.so' for Linux and '.dll' for Windows).",
+            "title": "Module Path",
+            "type": "string"
+        },
+        "providesObjects": {
+            "description": "Each entry is the path of an afw adapter object supplied by this extension. This extension will be loaded by function afw_runtime_get_object() if needed.",
+            "items": {
+                "description": "Each entry is the path of an afw adapter object supplied by this extension. This extension will be loaded by function afw_runtime_get_object() if needed.",
+                "markdownDescription": "Each entry is the path of an afw adapter object supplied by this extension. This extension will be loaded by function afw_runtime_get_object() if needed.",
+                "title": "List of object paths provided by this extension",
+                "type": "string"
+            },
+            "markdownDescription": "**Provides Objects**\n\nEach entry is the path of an afw adapter object supplied by this extension. This extension will be loaded by function afw_runtime_get_object() if needed.",
+            "title": "Provides Objects",
+            "type": "array"
+        },
+        "registers": {
+            "description": "Each entry is a string of the form '<registry type>/<registry key>', where <registry type> is a valid registry type id and <registry key> is a registry key that is registered at runtime by the associated command, extension, server, etc. If this manifest is for an extension, the extension will be automatically loaded when afw_environment_registry_get() is called for a <registry type>/<registry key> combo that is not already registered. See afw/afw_environment.h for more information.",
+            "items": {
+                "description": "Each entry is a string of the form '<registry type>/<registry key>', where <registry type> is a valid registry type id and <registry key> is a registry key that is registered at runtime by the associated command, extension, server, etc. If this manifest is for an extension, the extension will be automatically loaded when afw_environment_registry_get() is called for a <registry type>/<registry key> combo that is not already registered. See afw/afw_environment.h for more information.",
+                "markdownDescription": "Each entry is a string of the form '<registry type>/<registry key>', where <registry type> is a valid registry type id and <registry key> is a registry key that is registered at runtime by the associated command, extension, server, etc. If this manifest is for an extension, the extension will be automatically loaded when afw_environment_registry_get() is called for a <registry type>/<registry key> combo that is not already registered. See afw/afw_environment.h for more information.",
+                "title": "List of entries this extension registers",
+                "type": "string"
+            },
+            "markdownDescription": "**Registers**\n\nEach entry is a string of the form '<registry type>/<registry key>', where <registry type> is a valid registry type id and <registry key> is a registry key that is registered at runtime by the associated command, extension, server, etc. If this manifest is for an extension, the extension will be automatically loaded when afw_environment_registry_get() is called for a <registry type>/<registry key> combo that is not already registered. See afw/afw_environment.h for more information.",
+            "title": "Registers",
+            "type": "array"
         }
-    ]
+    },
+    "required": [
+        "extensionId",
+        "modulePath"
+    ],
+    "title": "_AdaptiveManifest_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveManifest_.json
+++ b/generated/schemas/afw/_AdaptiveManifest_.json
@@ -1,12 +1,16 @@
 {
     "$defs": {
         "_AdaptiveManifest_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveManifest_.propertyTypes"
                 }
             ],
             "description": "Adaptive Framework extension manifest.",
+            "required": [
+                "extensionId",
+                "modulePath"
+            ],
             "type": "object",
             "unevaluatedProperties": false
         },
@@ -54,15 +58,11 @@
                     "type": "array"
                 }
             },
-            "required": [
-                "extensionId",
-                "modulePath"
-            ],
             "type": "object"
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveManifest_"
         }

--- a/generated/schemas/afw/_AdaptiveModelCurrentOnAddObject_.json
+++ b/generated/schemas/afw/_AdaptiveModelCurrentOnAddObject_.json
@@ -1,54 +1,116 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveModelCurrentOnAddObject_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveModelCurrentOnAddObject_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveModelCurrentOnAddObject_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Qualifier current:: for model onAddObject.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveModelCurrentOnAddObject_.propertyTypes": {
+            "markdownDescription": "Qualifier current:: for model onAddObject.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "adapterId": {
                     "description": "The adapter id of the object being converted to mapped object.",
+                    "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
                     "title": "Adapter Id",
                     "type": "string"
                 },
                 "adapterTypeSpecific": {
                     "description": "This is the adapterTypeSpecific parameter value.",
+                    "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
                     "title": "Adapter Specific",
                     "type": "object"
                 },
                 "mappedAdapterId": {
                     "description": "The adapter id of the object being converted to object.",
+                    "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
                     "title": "Mapped Adapter Id",
                     "type": "string"
                 },
                 "mappedObjectType": {
                     "description": "The object type of the object being converted to object.",
+                    "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
                     "title": "Mapped Object Type",
                     "type": "string"
                 },
                 "object": {
                     "description": "This is object being added.",
+                    "markdownDescription": "**Object**\n\nThis is object being added.",
                     "title": "Object",
                     "type": "object"
                 },
                 "objectId": {
                     "description": "This is preferred objectId of the object being added.",
+                    "markdownDescription": "**Preferred Object Id**\n\nThis is preferred objectId of the object being added.",
                     "title": "Preferred Object Id",
                     "type": "string"
                 },
                 "objectType": {
                     "description": "The object type of the object being converted to mapped object.",
+                    "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
                     "title": "Object Type",
                     "type": "string"
                 },
                 "useDefaultProcessing": {
                     "description": "Return this value to cause default processing to occur.",
+                    "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
+                    "title": "Use Default Processing"
+                }
+            },
+            "title": "_AdaptiveModelCurrentOnAddObject_",
+            "type": "object"
+        },
+        "_AdaptiveModelCurrentOnAddObject_.propertyTypes": {
+            "properties": {
+                "adapterId": {
+                    "description": "The adapter id of the object being converted to mapped object.",
+                    "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
+                    "title": "Adapter Id",
+                    "type": "string"
+                },
+                "adapterTypeSpecific": {
+                    "description": "This is the adapterTypeSpecific parameter value.",
+                    "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
+                    "title": "Adapter Specific",
+                    "type": "object"
+                },
+                "mappedAdapterId": {
+                    "description": "The adapter id of the object being converted to object.",
+                    "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
+                    "title": "Mapped Adapter Id",
+                    "type": "string"
+                },
+                "mappedObjectType": {
+                    "description": "The object type of the object being converted to object.",
+                    "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
+                    "title": "Mapped Object Type",
+                    "type": "string"
+                },
+                "object": {
+                    "description": "This is object being added.",
+                    "markdownDescription": "**Object**\n\nThis is object being added.",
+                    "title": "Object",
+                    "type": "object"
+                },
+                "objectId": {
+                    "description": "This is preferred objectId of the object being added.",
+                    "markdownDescription": "**Preferred Object Id**\n\nThis is preferred objectId of the object being added.",
+                    "title": "Preferred Object Id",
+                    "type": "string"
+                },
+                "objectType": {
+                    "description": "The object type of the object being converted to mapped object.",
+                    "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
+                    "title": "Object Type",
+                    "type": "string"
+                },
+                "useDefaultProcessing": {
+                    "description": "Return this value to cause default processing to occur.",
+                    "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
                     "title": "Use Default Processing"
                 }
             },
@@ -56,9 +118,65 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveModelCurrentOnAddObject_"
+    "additionalProperties": false,
+    "description": "Qualifier current:: for model onAddObject.",
+    "markdownDescription": "Qualifier current:: for model onAddObject.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "adapterId": {
+            "description": "The adapter id of the object being converted to mapped object.",
+            "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
+            "title": "Adapter Id",
+            "type": "string"
+        },
+        "adapterTypeSpecific": {
+            "description": "This is the adapterTypeSpecific parameter value.",
+            "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
+            "title": "Adapter Specific",
+            "type": "object"
+        },
+        "mappedAdapterId": {
+            "description": "The adapter id of the object being converted to object.",
+            "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
+            "title": "Mapped Adapter Id",
+            "type": "string"
+        },
+        "mappedObjectType": {
+            "description": "The object type of the object being converted to object.",
+            "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
+            "title": "Mapped Object Type",
+            "type": "string"
+        },
+        "object": {
+            "description": "This is object being added.",
+            "markdownDescription": "**Object**\n\nThis is object being added.",
+            "title": "Object",
+            "type": "object"
+        },
+        "objectId": {
+            "description": "This is preferred objectId of the object being added.",
+            "markdownDescription": "**Preferred Object Id**\n\nThis is preferred objectId of the object being added.",
+            "title": "Preferred Object Id",
+            "type": "string"
+        },
+        "objectType": {
+            "description": "The object type of the object being converted to mapped object.",
+            "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
+            "title": "Object Type",
+            "type": "string"
+        },
+        "useDefaultProcessing": {
+            "description": "Return this value to cause default processing to occur.",
+            "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
+            "title": "Use Default Processing"
         }
-    ]
+    },
+    "title": "_AdaptiveModelCurrentOnAddObject_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveModelCurrentOnAddObject_.json
+++ b/generated/schemas/afw/_AdaptiveModelCurrentOnAddObject_.json
@@ -1,0 +1,64 @@
+{
+    "$defs": {
+        "_AdaptiveModelCurrentOnAddObject_": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveModelCurrentOnAddObject_.propertyTypes"
+                }
+            ],
+            "description": "Qualifier current:: for model onAddObject.",
+            "type": "object",
+            "unevaluatedProperties": false
+        },
+        "_AdaptiveModelCurrentOnAddObject_.propertyTypes": {
+            "properties": {
+                "adapterId": {
+                    "description": "The adapter id of the object being converted to mapped object.",
+                    "title": "Adapter Id",
+                    "type": "string"
+                },
+                "adapterTypeSpecific": {
+                    "description": "This is the adapterTypeSpecific parameter value.",
+                    "title": "Adapter Specific",
+                    "type": "object"
+                },
+                "mappedAdapterId": {
+                    "description": "The adapter id of the object being converted to object.",
+                    "title": "Mapped Adapter Id",
+                    "type": "string"
+                },
+                "mappedObjectType": {
+                    "description": "The object type of the object being converted to object.",
+                    "title": "Mapped Object Type",
+                    "type": "string"
+                },
+                "object": {
+                    "description": "This is object being added.",
+                    "title": "Object",
+                    "type": "object"
+                },
+                "objectId": {
+                    "description": "This is preferred objectId of the object being added.",
+                    "title": "Preferred Object Id",
+                    "type": "string"
+                },
+                "objectType": {
+                    "description": "The object type of the object being converted to mapped object.",
+                    "title": "Object Type",
+                    "type": "string"
+                },
+                "useDefaultProcessing": {
+                    "description": "Return this value to cause default processing to occur.",
+                    "title": "Use Default Processing"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "allOf": [
+        {
+            "$ref": "#/$defs/_AdaptiveModelCurrentOnAddObject_"
+        }
+    ]
+}

--- a/generated/schemas/afw/_AdaptiveModelCurrentOnDeleteObject_.json
+++ b/generated/schemas/afw/_AdaptiveModelCurrentOnDeleteObject_.json
@@ -1,0 +1,59 @@
+{
+    "$defs": {
+        "_AdaptiveModelCurrentOnDeleteObject_": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveModelCurrentOnDeleteObject_.propertyTypes"
+                }
+            ],
+            "description": "Qualifier current:: for model onDeleteObject.",
+            "type": "object",
+            "unevaluatedProperties": false
+        },
+        "_AdaptiveModelCurrentOnDeleteObject_.propertyTypes": {
+            "properties": {
+                "adapterId": {
+                    "description": "The adapter id of the object being converted to mapped object.",
+                    "title": "Adapter Id",
+                    "type": "string"
+                },
+                "adapterTypeSpecific": {
+                    "description": "This is the adapterTypeSpecific parameter value.",
+                    "title": "Adapter Specific",
+                    "type": "object"
+                },
+                "mappedAdapterId": {
+                    "description": "The adapter id of the object being converted to object.",
+                    "title": "Mapped Adapter Id",
+                    "type": "string"
+                },
+                "mappedObjectType": {
+                    "description": "The object type of the object being converted to object.",
+                    "title": "Mapped Object Type",
+                    "type": "string"
+                },
+                "objectId": {
+                    "description": "This is objectId of the object to delete.",
+                    "title": "Object Id",
+                    "type": "string"
+                },
+                "objectType": {
+                    "description": "The object type of the object being converted to mapped object.",
+                    "title": "Object Type",
+                    "type": "string"
+                },
+                "useDefaultProcessing": {
+                    "description": "Return this value to cause default processing to occur.",
+                    "title": "Use Default Processing"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "allOf": [
+        {
+            "$ref": "#/$defs/_AdaptiveModelCurrentOnDeleteObject_"
+        }
+    ]
+}

--- a/generated/schemas/afw/_AdaptiveModelCurrentOnDeleteObject_.json
+++ b/generated/schemas/afw/_AdaptiveModelCurrentOnDeleteObject_.json
@@ -1,49 +1,104 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveModelCurrentOnDeleteObject_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveModelCurrentOnDeleteObject_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveModelCurrentOnDeleteObject_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Qualifier current:: for model onDeleteObject.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveModelCurrentOnDeleteObject_.propertyTypes": {
+            "markdownDescription": "Qualifier current:: for model onDeleteObject.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "adapterId": {
                     "description": "The adapter id of the object being converted to mapped object.",
+                    "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
                     "title": "Adapter Id",
                     "type": "string"
                 },
                 "adapterTypeSpecific": {
                     "description": "This is the adapterTypeSpecific parameter value.",
+                    "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
                     "title": "Adapter Specific",
                     "type": "object"
                 },
                 "mappedAdapterId": {
                     "description": "The adapter id of the object being converted to object.",
+                    "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
                     "title": "Mapped Adapter Id",
                     "type": "string"
                 },
                 "mappedObjectType": {
                     "description": "The object type of the object being converted to object.",
+                    "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
                     "title": "Mapped Object Type",
                     "type": "string"
                 },
                 "objectId": {
                     "description": "This is objectId of the object to delete.",
+                    "markdownDescription": "**Object Id**\n\nThis is objectId of the object to delete.",
                     "title": "Object Id",
                     "type": "string"
                 },
                 "objectType": {
                     "description": "The object type of the object being converted to mapped object.",
+                    "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
                     "title": "Object Type",
                     "type": "string"
                 },
                 "useDefaultProcessing": {
                     "description": "Return this value to cause default processing to occur.",
+                    "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
+                    "title": "Use Default Processing"
+                }
+            },
+            "title": "_AdaptiveModelCurrentOnDeleteObject_",
+            "type": "object"
+        },
+        "_AdaptiveModelCurrentOnDeleteObject_.propertyTypes": {
+            "properties": {
+                "adapterId": {
+                    "description": "The adapter id of the object being converted to mapped object.",
+                    "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
+                    "title": "Adapter Id",
+                    "type": "string"
+                },
+                "adapterTypeSpecific": {
+                    "description": "This is the adapterTypeSpecific parameter value.",
+                    "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
+                    "title": "Adapter Specific",
+                    "type": "object"
+                },
+                "mappedAdapterId": {
+                    "description": "The adapter id of the object being converted to object.",
+                    "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
+                    "title": "Mapped Adapter Id",
+                    "type": "string"
+                },
+                "mappedObjectType": {
+                    "description": "The object type of the object being converted to object.",
+                    "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
+                    "title": "Mapped Object Type",
+                    "type": "string"
+                },
+                "objectId": {
+                    "description": "This is objectId of the object to delete.",
+                    "markdownDescription": "**Object Id**\n\nThis is objectId of the object to delete.",
+                    "title": "Object Id",
+                    "type": "string"
+                },
+                "objectType": {
+                    "description": "The object type of the object being converted to mapped object.",
+                    "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
+                    "title": "Object Type",
+                    "type": "string"
+                },
+                "useDefaultProcessing": {
+                    "description": "Return this value to cause default processing to occur.",
+                    "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
                     "title": "Use Default Processing"
                 }
             },
@@ -51,9 +106,59 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveModelCurrentOnDeleteObject_"
+    "additionalProperties": false,
+    "description": "Qualifier current:: for model onDeleteObject.",
+    "markdownDescription": "Qualifier current:: for model onDeleteObject.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "adapterId": {
+            "description": "The adapter id of the object being converted to mapped object.",
+            "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
+            "title": "Adapter Id",
+            "type": "string"
+        },
+        "adapterTypeSpecific": {
+            "description": "This is the adapterTypeSpecific parameter value.",
+            "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
+            "title": "Adapter Specific",
+            "type": "object"
+        },
+        "mappedAdapterId": {
+            "description": "The adapter id of the object being converted to object.",
+            "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
+            "title": "Mapped Adapter Id",
+            "type": "string"
+        },
+        "mappedObjectType": {
+            "description": "The object type of the object being converted to object.",
+            "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
+            "title": "Mapped Object Type",
+            "type": "string"
+        },
+        "objectId": {
+            "description": "This is objectId of the object to delete.",
+            "markdownDescription": "**Object Id**\n\nThis is objectId of the object to delete.",
+            "title": "Object Id",
+            "type": "string"
+        },
+        "objectType": {
+            "description": "The object type of the object being converted to mapped object.",
+            "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
+            "title": "Object Type",
+            "type": "string"
+        },
+        "useDefaultProcessing": {
+            "description": "Return this value to cause default processing to occur.",
+            "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
+            "title": "Use Default Processing"
         }
-    ]
+    },
+    "title": "_AdaptiveModelCurrentOnDeleteObject_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveModelCurrentOnGetInitialObjectId_.json
+++ b/generated/schemas/afw/_AdaptiveModelCurrentOnGetInitialObjectId_.json
@@ -1,0 +1,92 @@
+{
+    "$defs": {
+        "_AdaptiveModelCurrentOnGetInitialObjectId_": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveModelCurrentOnGetInitialObjectId_.propertyTypes"
+                }
+            ],
+            "description": "Qualifier current:: for model onGetInitialObjectId.",
+            "type": "object",
+            "unevaluatedProperties": false
+        },
+        "_AdaptiveModelCurrentOnGetInitialObjectId_.propertyTypes": {
+            "properties": {
+                "adapterId": {
+                    "description": "The adapter id of the object being converted to mapped object.",
+                    "title": "Adapter Id",
+                    "type": "string"
+                },
+                "adapterTypeSpecific": {
+                    "description": "This is the adapterTypeSpecific parameter value.",
+                    "title": "Adapter Specific",
+                    "type": "object"
+                },
+                "mappedAdapterId": {
+                    "description": "The adapter id of the object being converted to object.",
+                    "title": "Mapped Adapter Id",
+                    "type": "string"
+                },
+                "mappedObject": {
+                    "description": "This is mappedObject from adapter.",
+                    "title": "Mapped object id",
+                    "type": "object"
+                },
+                "mappedObjectId": {
+                    "description": "This is mappedObjectId from model.",
+                    "title": "Mapped object id",
+                    "type": "string"
+                },
+                "mappedObjectType": {
+                    "description": "The object type of the object being converted to object.",
+                    "title": "Mapped Object Type",
+                    "type": "string"
+                },
+                "mappedPropertyName": {
+                    "description": "This is mappedPropertyName from model.",
+                    "title": "Mapped Property Name",
+                    "type": "string"
+                },
+                "mappedValue": {
+                    "description": "This is the mappedValue from the model.",
+                    "title": "Mapped Value"
+                },
+                "object": {
+                    "description": "This is the object from request.",
+                    "title": "Object",
+                    "type": "object"
+                },
+                "objectId": {
+                    "description": "This is objectId of the object from request.",
+                    "title": "Object Id",
+                    "type": "string"
+                },
+                "objectType": {
+                    "description": "The object type of the object being converted to mapped object.",
+                    "title": "Object Type",
+                    "type": "string"
+                },
+                "propertyName": {
+                    "description": "This is the property name from request.",
+                    "title": "Object Id",
+                    "type": "string"
+                },
+                "useDefaultProcessing": {
+                    "description": "Return this value to cause default processing to occur.",
+                    "title": "Use Default Processing"
+                },
+                "value": {
+                    "description": "This is the value of the property from request.",
+                    "title": "Object Id"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "allOf": [
+        {
+            "$ref": "#/$defs/_AdaptiveModelCurrentOnGetInitialObjectId_"
+        }
+    ]
+}

--- a/generated/schemas/afw/_AdaptiveModelCurrentOnGetInitialObjectId_.json
+++ b/generated/schemas/afw/_AdaptiveModelCurrentOnGetInitialObjectId_.json
@@ -1,82 +1,184 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveModelCurrentOnGetInitialObjectId_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveModelCurrentOnGetInitialObjectId_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveModelCurrentOnGetInitialObjectId_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Qualifier current:: for model onGetInitialObjectId.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveModelCurrentOnGetInitialObjectId_.propertyTypes": {
+            "markdownDescription": "Qualifier current:: for model onGetInitialObjectId.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "adapterId": {
                     "description": "The adapter id of the object being converted to mapped object.",
+                    "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
                     "title": "Adapter Id",
                     "type": "string"
                 },
                 "adapterTypeSpecific": {
                     "description": "This is the adapterTypeSpecific parameter value.",
+                    "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
                     "title": "Adapter Specific",
                     "type": "object"
                 },
                 "mappedAdapterId": {
                     "description": "The adapter id of the object being converted to object.",
+                    "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
                     "title": "Mapped Adapter Id",
                     "type": "string"
                 },
                 "mappedObject": {
                     "description": "This is mappedObject from adapter.",
+                    "markdownDescription": "**Mapped object id**\n\nThis is mappedObject from adapter.",
                     "title": "Mapped object id",
                     "type": "object"
                 },
                 "mappedObjectId": {
                     "description": "This is mappedObjectId from model.",
+                    "markdownDescription": "**Mapped object id**\n\nThis is mappedObjectId from model.",
                     "title": "Mapped object id",
                     "type": "string"
                 },
                 "mappedObjectType": {
                     "description": "The object type of the object being converted to object.",
+                    "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
                     "title": "Mapped Object Type",
                     "type": "string"
                 },
                 "mappedPropertyName": {
                     "description": "This is mappedPropertyName from model.",
+                    "markdownDescription": "**Mapped Property Name**\n\nThis is mappedPropertyName from model.",
                     "title": "Mapped Property Name",
                     "type": "string"
                 },
                 "mappedValue": {
                     "description": "This is the mappedValue from the model.",
+                    "markdownDescription": "**Mapped Value**\n\nThis is the mappedValue from the model.",
                     "title": "Mapped Value"
                 },
                 "object": {
                     "description": "This is the object from request.",
+                    "markdownDescription": "**Object**\n\nThis is the object from request.",
                     "title": "Object",
                     "type": "object"
                 },
                 "objectId": {
                     "description": "This is objectId of the object from request.",
+                    "markdownDescription": "**Object Id**\n\nThis is objectId of the object from request.",
                     "title": "Object Id",
                     "type": "string"
                 },
                 "objectType": {
                     "description": "The object type of the object being converted to mapped object.",
+                    "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
                     "title": "Object Type",
                     "type": "string"
                 },
                 "propertyName": {
                     "description": "This is the property name from request.",
+                    "markdownDescription": "**Object Id**\n\nThis is the property name from request.",
                     "title": "Object Id",
                     "type": "string"
                 },
                 "useDefaultProcessing": {
                     "description": "Return this value to cause default processing to occur.",
+                    "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
                     "title": "Use Default Processing"
                 },
                 "value": {
                     "description": "This is the value of the property from request.",
+                    "markdownDescription": "**Object Id**\n\nThis is the value of the property from request.",
+                    "title": "Object Id"
+                }
+            },
+            "title": "_AdaptiveModelCurrentOnGetInitialObjectId_",
+            "type": "object"
+        },
+        "_AdaptiveModelCurrentOnGetInitialObjectId_.propertyTypes": {
+            "properties": {
+                "adapterId": {
+                    "description": "The adapter id of the object being converted to mapped object.",
+                    "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
+                    "title": "Adapter Id",
+                    "type": "string"
+                },
+                "adapterTypeSpecific": {
+                    "description": "This is the adapterTypeSpecific parameter value.",
+                    "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
+                    "title": "Adapter Specific",
+                    "type": "object"
+                },
+                "mappedAdapterId": {
+                    "description": "The adapter id of the object being converted to object.",
+                    "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
+                    "title": "Mapped Adapter Id",
+                    "type": "string"
+                },
+                "mappedObject": {
+                    "description": "This is mappedObject from adapter.",
+                    "markdownDescription": "**Mapped object id**\n\nThis is mappedObject from adapter.",
+                    "title": "Mapped object id",
+                    "type": "object"
+                },
+                "mappedObjectId": {
+                    "description": "This is mappedObjectId from model.",
+                    "markdownDescription": "**Mapped object id**\n\nThis is mappedObjectId from model.",
+                    "title": "Mapped object id",
+                    "type": "string"
+                },
+                "mappedObjectType": {
+                    "description": "The object type of the object being converted to object.",
+                    "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
+                    "title": "Mapped Object Type",
+                    "type": "string"
+                },
+                "mappedPropertyName": {
+                    "description": "This is mappedPropertyName from model.",
+                    "markdownDescription": "**Mapped Property Name**\n\nThis is mappedPropertyName from model.",
+                    "title": "Mapped Property Name",
+                    "type": "string"
+                },
+                "mappedValue": {
+                    "description": "This is the mappedValue from the model.",
+                    "markdownDescription": "**Mapped Value**\n\nThis is the mappedValue from the model.",
+                    "title": "Mapped Value"
+                },
+                "object": {
+                    "description": "This is the object from request.",
+                    "markdownDescription": "**Object**\n\nThis is the object from request.",
+                    "title": "Object",
+                    "type": "object"
+                },
+                "objectId": {
+                    "description": "This is objectId of the object from request.",
+                    "markdownDescription": "**Object Id**\n\nThis is objectId of the object from request.",
+                    "title": "Object Id",
+                    "type": "string"
+                },
+                "objectType": {
+                    "description": "The object type of the object being converted to mapped object.",
+                    "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
+                    "title": "Object Type",
+                    "type": "string"
+                },
+                "propertyName": {
+                    "description": "This is the property name from request.",
+                    "markdownDescription": "**Object Id**\n\nThis is the property name from request.",
+                    "title": "Object Id",
+                    "type": "string"
+                },
+                "useDefaultProcessing": {
+                    "description": "Return this value to cause default processing to occur.",
+                    "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
+                    "title": "Use Default Processing"
+                },
+                "value": {
+                    "description": "This is the value of the property from request.",
+                    "markdownDescription": "**Object Id**\n\nThis is the value of the property from request.",
                     "title": "Object Id"
                 }
             },
@@ -84,9 +186,99 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveModelCurrentOnGetInitialObjectId_"
+    "additionalProperties": false,
+    "description": "Qualifier current:: for model onGetInitialObjectId.",
+    "markdownDescription": "Qualifier current:: for model onGetInitialObjectId.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "adapterId": {
+            "description": "The adapter id of the object being converted to mapped object.",
+            "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
+            "title": "Adapter Id",
+            "type": "string"
+        },
+        "adapterTypeSpecific": {
+            "description": "This is the adapterTypeSpecific parameter value.",
+            "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
+            "title": "Adapter Specific",
+            "type": "object"
+        },
+        "mappedAdapterId": {
+            "description": "The adapter id of the object being converted to object.",
+            "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
+            "title": "Mapped Adapter Id",
+            "type": "string"
+        },
+        "mappedObject": {
+            "description": "This is mappedObject from adapter.",
+            "markdownDescription": "**Mapped object id**\n\nThis is mappedObject from adapter.",
+            "title": "Mapped object id",
+            "type": "object"
+        },
+        "mappedObjectId": {
+            "description": "This is mappedObjectId from model.",
+            "markdownDescription": "**Mapped object id**\n\nThis is mappedObjectId from model.",
+            "title": "Mapped object id",
+            "type": "string"
+        },
+        "mappedObjectType": {
+            "description": "The object type of the object being converted to object.",
+            "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
+            "title": "Mapped Object Type",
+            "type": "string"
+        },
+        "mappedPropertyName": {
+            "description": "This is mappedPropertyName from model.",
+            "markdownDescription": "**Mapped Property Name**\n\nThis is mappedPropertyName from model.",
+            "title": "Mapped Property Name",
+            "type": "string"
+        },
+        "mappedValue": {
+            "description": "This is the mappedValue from the model.",
+            "markdownDescription": "**Mapped Value**\n\nThis is the mappedValue from the model.",
+            "title": "Mapped Value"
+        },
+        "object": {
+            "description": "This is the object from request.",
+            "markdownDescription": "**Object**\n\nThis is the object from request.",
+            "title": "Object",
+            "type": "object"
+        },
+        "objectId": {
+            "description": "This is objectId of the object from request.",
+            "markdownDescription": "**Object Id**\n\nThis is objectId of the object from request.",
+            "title": "Object Id",
+            "type": "string"
+        },
+        "objectType": {
+            "description": "The object type of the object being converted to mapped object.",
+            "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
+            "title": "Object Type",
+            "type": "string"
+        },
+        "propertyName": {
+            "description": "This is the property name from request.",
+            "markdownDescription": "**Object Id**\n\nThis is the property name from request.",
+            "title": "Object Id",
+            "type": "string"
+        },
+        "useDefaultProcessing": {
+            "description": "Return this value to cause default processing to occur.",
+            "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
+            "title": "Use Default Processing"
+        },
+        "value": {
+            "description": "This is the value of the property from request.",
+            "markdownDescription": "**Object Id**\n\nThis is the value of the property from request.",
+            "title": "Object Id"
         }
-    ]
+    },
+    "title": "_AdaptiveModelCurrentOnGetInitialObjectId_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveModelCurrentOnGetInitialValue_.json
+++ b/generated/schemas/afw/_AdaptiveModelCurrentOnGetInitialValue_.json
@@ -1,0 +1,87 @@
+{
+    "$defs": {
+        "_AdaptiveModelCurrentOnGetInitialValue_": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveModelCurrentOnGetInitialValue_.propertyTypes"
+                }
+            ],
+            "description": "Qualifier current:: for model onGetInitialValue.",
+            "type": "object",
+            "unevaluatedProperties": false
+        },
+        "_AdaptiveModelCurrentOnGetInitialValue_.propertyTypes": {
+            "properties": {
+                "adapterId": {
+                    "description": "The adapter id of the object being converted to mapped object.",
+                    "title": "Adapter Id",
+                    "type": "string"
+                },
+                "adapterTypeSpecific": {
+                    "description": "This is the adapterTypeSpecific parameter value.",
+                    "title": "Adapter Specific",
+                    "type": "object"
+                },
+                "mappedAdapterId": {
+                    "description": "The adapter id of the object being converted to object.",
+                    "title": "Mapped Adapter Id",
+                    "type": "string"
+                },
+                "mappedObjectId": {
+                    "description": "This is mappedObjectId from model.",
+                    "title": "Mapped object id",
+                    "type": "string"
+                },
+                "mappedObjectType": {
+                    "description": "The object type of the object being converted to object.",
+                    "title": "Mapped Object Type",
+                    "type": "string"
+                },
+                "mappedPropertyName": {
+                    "description": "This is mappedPropertyName from model.",
+                    "title": "Mapped Property Name",
+                    "type": "string"
+                },
+                "mappedValue": {
+                    "description": "This is the mappedValue from the model.",
+                    "title": "Mapped Value"
+                },
+                "object": {
+                    "description": "This is the object from request.",
+                    "title": "Object",
+                    "type": "object"
+                },
+                "objectId": {
+                    "description": "This is objectId of the object from request.",
+                    "title": "Object Id",
+                    "type": "string"
+                },
+                "objectType": {
+                    "description": "The object type of the object being converted to mapped object.",
+                    "title": "Object Type",
+                    "type": "string"
+                },
+                "propertyName": {
+                    "description": "This is the property name from request.",
+                    "title": "Object Id",
+                    "type": "string"
+                },
+                "useDefaultProcessing": {
+                    "description": "Return this value to cause default processing to occur.",
+                    "title": "Use Default Processing"
+                },
+                "value": {
+                    "description": "This is the value of the property from request.",
+                    "title": "Object Id"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "allOf": [
+        {
+            "$ref": "#/$defs/_AdaptiveModelCurrentOnGetInitialValue_"
+        }
+    ]
+}

--- a/generated/schemas/afw/_AdaptiveModelCurrentOnGetInitialValue_.json
+++ b/generated/schemas/afw/_AdaptiveModelCurrentOnGetInitialValue_.json
@@ -1,77 +1,172 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveModelCurrentOnGetInitialValue_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveModelCurrentOnGetInitialValue_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveModelCurrentOnGetInitialValue_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Qualifier current:: for model onGetInitialValue.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveModelCurrentOnGetInitialValue_.propertyTypes": {
+            "markdownDescription": "Qualifier current:: for model onGetInitialValue.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "adapterId": {
                     "description": "The adapter id of the object being converted to mapped object.",
+                    "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
                     "title": "Adapter Id",
                     "type": "string"
                 },
                 "adapterTypeSpecific": {
                     "description": "This is the adapterTypeSpecific parameter value.",
+                    "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
                     "title": "Adapter Specific",
                     "type": "object"
                 },
                 "mappedAdapterId": {
                     "description": "The adapter id of the object being converted to object.",
+                    "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
                     "title": "Mapped Adapter Id",
                     "type": "string"
                 },
                 "mappedObjectId": {
                     "description": "This is mappedObjectId from model.",
+                    "markdownDescription": "**Mapped object id**\n\nThis is mappedObjectId from model.",
                     "title": "Mapped object id",
                     "type": "string"
                 },
                 "mappedObjectType": {
                     "description": "The object type of the object being converted to object.",
+                    "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
                     "title": "Mapped Object Type",
                     "type": "string"
                 },
                 "mappedPropertyName": {
                     "description": "This is mappedPropertyName from model.",
+                    "markdownDescription": "**Mapped Property Name**\n\nThis is mappedPropertyName from model.",
                     "title": "Mapped Property Name",
                     "type": "string"
                 },
                 "mappedValue": {
                     "description": "This is the mappedValue from the model.",
+                    "markdownDescription": "**Mapped Value**\n\nThis is the mappedValue from the model.",
                     "title": "Mapped Value"
                 },
                 "object": {
                     "description": "This is the object from request.",
+                    "markdownDescription": "**Object**\n\nThis is the object from request.",
                     "title": "Object",
                     "type": "object"
                 },
                 "objectId": {
                     "description": "This is objectId of the object from request.",
+                    "markdownDescription": "**Object Id**\n\nThis is objectId of the object from request.",
                     "title": "Object Id",
                     "type": "string"
                 },
                 "objectType": {
                     "description": "The object type of the object being converted to mapped object.",
+                    "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
                     "title": "Object Type",
                     "type": "string"
                 },
                 "propertyName": {
                     "description": "This is the property name from request.",
+                    "markdownDescription": "**Object Id**\n\nThis is the property name from request.",
                     "title": "Object Id",
                     "type": "string"
                 },
                 "useDefaultProcessing": {
                     "description": "Return this value to cause default processing to occur.",
+                    "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
                     "title": "Use Default Processing"
                 },
                 "value": {
                     "description": "This is the value of the property from request.",
+                    "markdownDescription": "**Object Id**\n\nThis is the value of the property from request.",
+                    "title": "Object Id"
+                }
+            },
+            "title": "_AdaptiveModelCurrentOnGetInitialValue_",
+            "type": "object"
+        },
+        "_AdaptiveModelCurrentOnGetInitialValue_.propertyTypes": {
+            "properties": {
+                "adapterId": {
+                    "description": "The adapter id of the object being converted to mapped object.",
+                    "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
+                    "title": "Adapter Id",
+                    "type": "string"
+                },
+                "adapterTypeSpecific": {
+                    "description": "This is the adapterTypeSpecific parameter value.",
+                    "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
+                    "title": "Adapter Specific",
+                    "type": "object"
+                },
+                "mappedAdapterId": {
+                    "description": "The adapter id of the object being converted to object.",
+                    "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
+                    "title": "Mapped Adapter Id",
+                    "type": "string"
+                },
+                "mappedObjectId": {
+                    "description": "This is mappedObjectId from model.",
+                    "markdownDescription": "**Mapped object id**\n\nThis is mappedObjectId from model.",
+                    "title": "Mapped object id",
+                    "type": "string"
+                },
+                "mappedObjectType": {
+                    "description": "The object type of the object being converted to object.",
+                    "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
+                    "title": "Mapped Object Type",
+                    "type": "string"
+                },
+                "mappedPropertyName": {
+                    "description": "This is mappedPropertyName from model.",
+                    "markdownDescription": "**Mapped Property Name**\n\nThis is mappedPropertyName from model.",
+                    "title": "Mapped Property Name",
+                    "type": "string"
+                },
+                "mappedValue": {
+                    "description": "This is the mappedValue from the model.",
+                    "markdownDescription": "**Mapped Value**\n\nThis is the mappedValue from the model.",
+                    "title": "Mapped Value"
+                },
+                "object": {
+                    "description": "This is the object from request.",
+                    "markdownDescription": "**Object**\n\nThis is the object from request.",
+                    "title": "Object",
+                    "type": "object"
+                },
+                "objectId": {
+                    "description": "This is objectId of the object from request.",
+                    "markdownDescription": "**Object Id**\n\nThis is objectId of the object from request.",
+                    "title": "Object Id",
+                    "type": "string"
+                },
+                "objectType": {
+                    "description": "The object type of the object being converted to mapped object.",
+                    "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
+                    "title": "Object Type",
+                    "type": "string"
+                },
+                "propertyName": {
+                    "description": "This is the property name from request.",
+                    "markdownDescription": "**Object Id**\n\nThis is the property name from request.",
+                    "title": "Object Id",
+                    "type": "string"
+                },
+                "useDefaultProcessing": {
+                    "description": "Return this value to cause default processing to occur.",
+                    "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
+                    "title": "Use Default Processing"
+                },
+                "value": {
+                    "description": "This is the value of the property from request.",
+                    "markdownDescription": "**Object Id**\n\nThis is the value of the property from request.",
                     "title": "Object Id"
                 }
             },
@@ -79,9 +174,93 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveModelCurrentOnGetInitialValue_"
+    "additionalProperties": false,
+    "description": "Qualifier current:: for model onGetInitialValue.",
+    "markdownDescription": "Qualifier current:: for model onGetInitialValue.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "adapterId": {
+            "description": "The adapter id of the object being converted to mapped object.",
+            "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
+            "title": "Adapter Id",
+            "type": "string"
+        },
+        "adapterTypeSpecific": {
+            "description": "This is the adapterTypeSpecific parameter value.",
+            "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
+            "title": "Adapter Specific",
+            "type": "object"
+        },
+        "mappedAdapterId": {
+            "description": "The adapter id of the object being converted to object.",
+            "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
+            "title": "Mapped Adapter Id",
+            "type": "string"
+        },
+        "mappedObjectId": {
+            "description": "This is mappedObjectId from model.",
+            "markdownDescription": "**Mapped object id**\n\nThis is mappedObjectId from model.",
+            "title": "Mapped object id",
+            "type": "string"
+        },
+        "mappedObjectType": {
+            "description": "The object type of the object being converted to object.",
+            "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
+            "title": "Mapped Object Type",
+            "type": "string"
+        },
+        "mappedPropertyName": {
+            "description": "This is mappedPropertyName from model.",
+            "markdownDescription": "**Mapped Property Name**\n\nThis is mappedPropertyName from model.",
+            "title": "Mapped Property Name",
+            "type": "string"
+        },
+        "mappedValue": {
+            "description": "This is the mappedValue from the model.",
+            "markdownDescription": "**Mapped Value**\n\nThis is the mappedValue from the model.",
+            "title": "Mapped Value"
+        },
+        "object": {
+            "description": "This is the object from request.",
+            "markdownDescription": "**Object**\n\nThis is the object from request.",
+            "title": "Object",
+            "type": "object"
+        },
+        "objectId": {
+            "description": "This is objectId of the object from request.",
+            "markdownDescription": "**Object Id**\n\nThis is objectId of the object from request.",
+            "title": "Object Id",
+            "type": "string"
+        },
+        "objectType": {
+            "description": "The object type of the object being converted to mapped object.",
+            "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
+            "title": "Object Type",
+            "type": "string"
+        },
+        "propertyName": {
+            "description": "This is the property name from request.",
+            "markdownDescription": "**Object Id**\n\nThis is the property name from request.",
+            "title": "Object Id",
+            "type": "string"
+        },
+        "useDefaultProcessing": {
+            "description": "Return this value to cause default processing to occur.",
+            "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
+            "title": "Use Default Processing"
+        },
+        "value": {
+            "description": "This is the value of the property from request.",
+            "markdownDescription": "**Object Id**\n\nThis is the value of the property from request.",
+            "title": "Object Id"
         }
-    ]
+    },
+    "title": "_AdaptiveModelCurrentOnGetInitialValue_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveModelCurrentOnGetObject_.json
+++ b/generated/schemas/afw/_AdaptiveModelCurrentOnGetObject_.json
@@ -1,54 +1,116 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveModelCurrentOnGetObject_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveModelCurrentOnGetObject_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveModelCurrentOnGetObject_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Qualifier current:: for model onGetObject.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveModelCurrentOnGetObject_.propertyTypes": {
+            "markdownDescription": "Qualifier current:: for model onGetObject.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "adapterId": {
                     "description": "The adapter id of the object being converted to mapped object.",
+                    "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
                     "title": "Adapter Id",
                     "type": "string"
                 },
                 "adapterTypeSpecific": {
                     "description": "This is the adapterTypeSpecific parameter value.",
+                    "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
                     "title": "Adapter Specific",
                     "type": "object"
                 },
                 "mapBackObject": {
                     "description": "The function to map back an object.",
+                    "markdownDescription": "**mapBackObject**\n\nThe function to map back an object.",
                     "title": "mapBackObject",
                     "type": "string"
                 },
                 "mappedAdapterId": {
                     "description": "The adapter id of the object being converted to object.",
+                    "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
                     "title": "Mapped Adapter Id",
                     "type": "string"
                 },
                 "mappedObjectType": {
                     "description": "The object type of the object being converted to object.",
+                    "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
                     "title": "Mapped Object Type",
                     "type": "string"
                 },
                 "objectId": {
                     "description": "This is objectId of the object to get.",
+                    "markdownDescription": "**Object Id**\n\nThis is objectId of the object to get.",
                     "title": "Object Id",
                     "type": "string"
                 },
                 "objectType": {
                     "description": "The object type of the object being converted to mapped object.",
+                    "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
                     "title": "Object Type",
                     "type": "string"
                 },
                 "useDefaultProcessing": {
                     "description": "Return this value to cause default processing to occur.",
+                    "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
+                    "title": "Use Default Processing"
+                }
+            },
+            "title": "_AdaptiveModelCurrentOnGetObject_",
+            "type": "object"
+        },
+        "_AdaptiveModelCurrentOnGetObject_.propertyTypes": {
+            "properties": {
+                "adapterId": {
+                    "description": "The adapter id of the object being converted to mapped object.",
+                    "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
+                    "title": "Adapter Id",
+                    "type": "string"
+                },
+                "adapterTypeSpecific": {
+                    "description": "This is the adapterTypeSpecific parameter value.",
+                    "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
+                    "title": "Adapter Specific",
+                    "type": "object"
+                },
+                "mapBackObject": {
+                    "description": "The function to map back an object.",
+                    "markdownDescription": "**mapBackObject**\n\nThe function to map back an object.",
+                    "title": "mapBackObject",
+                    "type": "string"
+                },
+                "mappedAdapterId": {
+                    "description": "The adapter id of the object being converted to object.",
+                    "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
+                    "title": "Mapped Adapter Id",
+                    "type": "string"
+                },
+                "mappedObjectType": {
+                    "description": "The object type of the object being converted to object.",
+                    "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
+                    "title": "Mapped Object Type",
+                    "type": "string"
+                },
+                "objectId": {
+                    "description": "This is objectId of the object to get.",
+                    "markdownDescription": "**Object Id**\n\nThis is objectId of the object to get.",
+                    "title": "Object Id",
+                    "type": "string"
+                },
+                "objectType": {
+                    "description": "The object type of the object being converted to mapped object.",
+                    "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
+                    "title": "Object Type",
+                    "type": "string"
+                },
+                "useDefaultProcessing": {
+                    "description": "Return this value to cause default processing to occur.",
+                    "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
                     "title": "Use Default Processing"
                 }
             },
@@ -56,9 +118,65 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveModelCurrentOnGetObject_"
+    "additionalProperties": false,
+    "description": "Qualifier current:: for model onGetObject.",
+    "markdownDescription": "Qualifier current:: for model onGetObject.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "adapterId": {
+            "description": "The adapter id of the object being converted to mapped object.",
+            "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
+            "title": "Adapter Id",
+            "type": "string"
+        },
+        "adapterTypeSpecific": {
+            "description": "This is the adapterTypeSpecific parameter value.",
+            "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
+            "title": "Adapter Specific",
+            "type": "object"
+        },
+        "mapBackObject": {
+            "description": "The function to map back an object.",
+            "markdownDescription": "**mapBackObject**\n\nThe function to map back an object.",
+            "title": "mapBackObject",
+            "type": "string"
+        },
+        "mappedAdapterId": {
+            "description": "The adapter id of the object being converted to object.",
+            "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
+            "title": "Mapped Adapter Id",
+            "type": "string"
+        },
+        "mappedObjectType": {
+            "description": "The object type of the object being converted to object.",
+            "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
+            "title": "Mapped Object Type",
+            "type": "string"
+        },
+        "objectId": {
+            "description": "This is objectId of the object to get.",
+            "markdownDescription": "**Object Id**\n\nThis is objectId of the object to get.",
+            "title": "Object Id",
+            "type": "string"
+        },
+        "objectType": {
+            "description": "The object type of the object being converted to mapped object.",
+            "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
+            "title": "Object Type",
+            "type": "string"
+        },
+        "useDefaultProcessing": {
+            "description": "Return this value to cause default processing to occur.",
+            "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
+            "title": "Use Default Processing"
         }
-    ]
+    },
+    "title": "_AdaptiveModelCurrentOnGetObject_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveModelCurrentOnGetObject_.json
+++ b/generated/schemas/afw/_AdaptiveModelCurrentOnGetObject_.json
@@ -1,0 +1,64 @@
+{
+    "$defs": {
+        "_AdaptiveModelCurrentOnGetObject_": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveModelCurrentOnGetObject_.propertyTypes"
+                }
+            ],
+            "description": "Qualifier current:: for model onGetObject.",
+            "type": "object",
+            "unevaluatedProperties": false
+        },
+        "_AdaptiveModelCurrentOnGetObject_.propertyTypes": {
+            "properties": {
+                "adapterId": {
+                    "description": "The adapter id of the object being converted to mapped object.",
+                    "title": "Adapter Id",
+                    "type": "string"
+                },
+                "adapterTypeSpecific": {
+                    "description": "This is the adapterTypeSpecific parameter value.",
+                    "title": "Adapter Specific",
+                    "type": "object"
+                },
+                "mapBackObject": {
+                    "description": "The function to map back an object.",
+                    "title": "mapBackObject",
+                    "type": "string"
+                },
+                "mappedAdapterId": {
+                    "description": "The adapter id of the object being converted to object.",
+                    "title": "Mapped Adapter Id",
+                    "type": "string"
+                },
+                "mappedObjectType": {
+                    "description": "The object type of the object being converted to object.",
+                    "title": "Mapped Object Type",
+                    "type": "string"
+                },
+                "objectId": {
+                    "description": "This is objectId of the object to get.",
+                    "title": "Object Id",
+                    "type": "string"
+                },
+                "objectType": {
+                    "description": "The object type of the object being converted to mapped object.",
+                    "title": "Object Type",
+                    "type": "string"
+                },
+                "useDefaultProcessing": {
+                    "description": "Return this value to cause default processing to occur.",
+                    "title": "Use Default Processing"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "allOf": [
+        {
+            "$ref": "#/$defs/_AdaptiveModelCurrentOnGetObject_"
+        }
+    ]
+}

--- a/generated/schemas/afw/_AdaptiveModelCurrentOnGetProperty_.json
+++ b/generated/schemas/afw/_AdaptiveModelCurrentOnGetProperty_.json
@@ -1,63 +1,138 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveModelCurrentOnGetProperty_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveModelCurrentOnGetProperty_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveModelCurrentOnGetProperty_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Qualifier current:: for model onGetProperty.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveModelCurrentOnGetProperty_.propertyTypes": {
+            "markdownDescription": "Qualifier current:: for model onGetProperty.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "adapterId": {
                     "description": "The adapter id of the object being converted to mapped object.",
+                    "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
                     "title": "Adapter Id",
                     "type": "string"
                 },
                 "adapterTypeSpecific": {
                     "description": "This is the adapterTypeSpecific parameter value.",
+                    "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
                     "title": "Adapter Specific",
                     "type": "object"
                 },
                 "mappedAdapterId": {
                     "description": "The adapter id of the object being converted to object.",
+                    "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
                     "title": "Mapped Adapter Id",
                     "type": "string"
                 },
                 "mappedObject": {
                     "description": "This is the object from mapped adapter.",
+                    "markdownDescription": "**Object**\n\nThis is the object from mapped adapter.",
                     "title": "Object",
                     "type": "object"
                 },
                 "mappedObjectId": {
                     "description": "This is objectId of mappedObject from mapped adapter.",
+                    "markdownDescription": "**Mapped object id**\n\nThis is objectId of mappedObject from mapped adapter.",
                     "title": "Mapped object id",
                     "type": "string"
                 },
                 "mappedObjectType": {
                     "description": "The object type of the object being converted to object.",
+                    "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
                     "title": "Mapped Object Type",
                     "type": "string"
                 },
                 "mappedPropertyName": {
                     "description": "This is propertyName in mappedObject from mapped adapter.",
+                    "markdownDescription": "**Mapped Property Name**\n\nThis is propertyName in mappedObject from mapped adapter.",
                     "title": "Mapped Property Name",
                     "type": "string"
                 },
                 "mappedValue": {
                     "description": "This is the value of mappedPropertyName from mapped adapter.",
+                    "markdownDescription": "**Mapped Value**\n\nThis is the value of mappedPropertyName from mapped adapter.",
                     "title": "Mapped Value"
                 },
                 "objectType": {
                     "description": "The object type of the object being converted to mapped object.",
+                    "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
                     "title": "Object Type",
                     "type": "string"
                 },
                 "useDefaultProcessing": {
                     "description": "Return this value to cause default processing to occur.",
+                    "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
+                    "title": "Use Default Processing"
+                }
+            },
+            "title": "_AdaptiveModelCurrentOnGetProperty_",
+            "type": "object"
+        },
+        "_AdaptiveModelCurrentOnGetProperty_.propertyTypes": {
+            "properties": {
+                "adapterId": {
+                    "description": "The adapter id of the object being converted to mapped object.",
+                    "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
+                    "title": "Adapter Id",
+                    "type": "string"
+                },
+                "adapterTypeSpecific": {
+                    "description": "This is the adapterTypeSpecific parameter value.",
+                    "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
+                    "title": "Adapter Specific",
+                    "type": "object"
+                },
+                "mappedAdapterId": {
+                    "description": "The adapter id of the object being converted to object.",
+                    "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
+                    "title": "Mapped Adapter Id",
+                    "type": "string"
+                },
+                "mappedObject": {
+                    "description": "This is the object from mapped adapter.",
+                    "markdownDescription": "**Object**\n\nThis is the object from mapped adapter.",
+                    "title": "Object",
+                    "type": "object"
+                },
+                "mappedObjectId": {
+                    "description": "This is objectId of mappedObject from mapped adapter.",
+                    "markdownDescription": "**Mapped object id**\n\nThis is objectId of mappedObject from mapped adapter.",
+                    "title": "Mapped object id",
+                    "type": "string"
+                },
+                "mappedObjectType": {
+                    "description": "The object type of the object being converted to object.",
+                    "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
+                    "title": "Mapped Object Type",
+                    "type": "string"
+                },
+                "mappedPropertyName": {
+                    "description": "This is propertyName in mappedObject from mapped adapter.",
+                    "markdownDescription": "**Mapped Property Name**\n\nThis is propertyName in mappedObject from mapped adapter.",
+                    "title": "Mapped Property Name",
+                    "type": "string"
+                },
+                "mappedValue": {
+                    "description": "This is the value of mappedPropertyName from mapped adapter.",
+                    "markdownDescription": "**Mapped Value**\n\nThis is the value of mappedPropertyName from mapped adapter.",
+                    "title": "Mapped Value"
+                },
+                "objectType": {
+                    "description": "The object type of the object being converted to mapped object.",
+                    "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
+                    "title": "Object Type",
+                    "type": "string"
+                },
+                "useDefaultProcessing": {
+                    "description": "Return this value to cause default processing to occur.",
+                    "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
                     "title": "Use Default Processing"
                 }
             },
@@ -65,9 +140,76 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveModelCurrentOnGetProperty_"
+    "additionalProperties": false,
+    "description": "Qualifier current:: for model onGetProperty.",
+    "markdownDescription": "Qualifier current:: for model onGetProperty.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "adapterId": {
+            "description": "The adapter id of the object being converted to mapped object.",
+            "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
+            "title": "Adapter Id",
+            "type": "string"
+        },
+        "adapterTypeSpecific": {
+            "description": "This is the adapterTypeSpecific parameter value.",
+            "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
+            "title": "Adapter Specific",
+            "type": "object"
+        },
+        "mappedAdapterId": {
+            "description": "The adapter id of the object being converted to object.",
+            "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
+            "title": "Mapped Adapter Id",
+            "type": "string"
+        },
+        "mappedObject": {
+            "description": "This is the object from mapped adapter.",
+            "markdownDescription": "**Object**\n\nThis is the object from mapped adapter.",
+            "title": "Object",
+            "type": "object"
+        },
+        "mappedObjectId": {
+            "description": "This is objectId of mappedObject from mapped adapter.",
+            "markdownDescription": "**Mapped object id**\n\nThis is objectId of mappedObject from mapped adapter.",
+            "title": "Mapped object id",
+            "type": "string"
+        },
+        "mappedObjectType": {
+            "description": "The object type of the object being converted to object.",
+            "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
+            "title": "Mapped Object Type",
+            "type": "string"
+        },
+        "mappedPropertyName": {
+            "description": "This is propertyName in mappedObject from mapped adapter.",
+            "markdownDescription": "**Mapped Property Name**\n\nThis is propertyName in mappedObject from mapped adapter.",
+            "title": "Mapped Property Name",
+            "type": "string"
+        },
+        "mappedValue": {
+            "description": "This is the value of mappedPropertyName from mapped adapter.",
+            "markdownDescription": "**Mapped Value**\n\nThis is the value of mappedPropertyName from mapped adapter.",
+            "title": "Mapped Value"
+        },
+        "objectType": {
+            "description": "The object type of the object being converted to mapped object.",
+            "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
+            "title": "Object Type",
+            "type": "string"
+        },
+        "useDefaultProcessing": {
+            "description": "Return this value to cause default processing to occur.",
+            "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
+            "title": "Use Default Processing"
         }
-    ]
+    },
+    "title": "_AdaptiveModelCurrentOnGetProperty_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveModelCurrentOnGetProperty_.json
+++ b/generated/schemas/afw/_AdaptiveModelCurrentOnGetProperty_.json
@@ -1,0 +1,73 @@
+{
+    "$defs": {
+        "_AdaptiveModelCurrentOnGetProperty_": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveModelCurrentOnGetProperty_.propertyTypes"
+                }
+            ],
+            "description": "Qualifier current:: for model onGetProperty.",
+            "type": "object",
+            "unevaluatedProperties": false
+        },
+        "_AdaptiveModelCurrentOnGetProperty_.propertyTypes": {
+            "properties": {
+                "adapterId": {
+                    "description": "The adapter id of the object being converted to mapped object.",
+                    "title": "Adapter Id",
+                    "type": "string"
+                },
+                "adapterTypeSpecific": {
+                    "description": "This is the adapterTypeSpecific parameter value.",
+                    "title": "Adapter Specific",
+                    "type": "object"
+                },
+                "mappedAdapterId": {
+                    "description": "The adapter id of the object being converted to object.",
+                    "title": "Mapped Adapter Id",
+                    "type": "string"
+                },
+                "mappedObject": {
+                    "description": "This is the object from mapped adapter.",
+                    "title": "Object",
+                    "type": "object"
+                },
+                "mappedObjectId": {
+                    "description": "This is objectId of mappedObject from mapped adapter.",
+                    "title": "Mapped object id",
+                    "type": "string"
+                },
+                "mappedObjectType": {
+                    "description": "The object type of the object being converted to object.",
+                    "title": "Mapped Object Type",
+                    "type": "string"
+                },
+                "mappedPropertyName": {
+                    "description": "This is propertyName in mappedObject from mapped adapter.",
+                    "title": "Mapped Property Name",
+                    "type": "string"
+                },
+                "mappedValue": {
+                    "description": "This is the value of mappedPropertyName from mapped adapter.",
+                    "title": "Mapped Value"
+                },
+                "objectType": {
+                    "description": "The object type of the object being converted to mapped object.",
+                    "title": "Object Type",
+                    "type": "string"
+                },
+                "useDefaultProcessing": {
+                    "description": "Return this value to cause default processing to occur.",
+                    "title": "Use Default Processing"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "allOf": [
+        {
+            "$ref": "#/$defs/_AdaptiveModelCurrentOnGetProperty_"
+        }
+    ]
+}

--- a/generated/schemas/afw/_AdaptiveModelCurrentOnModifyObject_.json
+++ b/generated/schemas/afw/_AdaptiveModelCurrentOnModifyObject_.json
@@ -1,54 +1,116 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveModelCurrentOnModifyObject_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveModelCurrentOnModifyObject_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveModelCurrentOnModifyObject_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Qualifier current:: for model onModifyObject.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveModelCurrentOnModifyObject_.propertyTypes": {
+            "markdownDescription": "Qualifier current:: for model onModifyObject.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "adapterId": {
                     "description": "The adapter id of the object being converted to mapped object.",
+                    "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
                     "title": "Adapter Id",
                     "type": "string"
                 },
                 "adapterTypeSpecific": {
                     "description": "This is the adapterTypeSpecific parameter value.",
+                    "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
                     "title": "Adapter Specific",
                     "type": "object"
                 },
                 "mappedAdapterId": {
                     "description": "The adapter id of the object being converted to object.",
+                    "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
                     "title": "Mapped Adapter Id",
                     "type": "string"
                 },
                 "mappedObjectType": {
                     "description": "The object type of the object being converted to object.",
+                    "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
                     "title": "Mapped Object Type",
                     "type": "string"
                 },
                 "modifyEntries": {
                     "description": "The modify entries.",
+                    "markdownDescription": "**Modify Entries**\n\nThe modify entries.",
                     "title": "Modify Entries",
                     "type": "array"
                 },
                 "objectId": {
                     "description": "This is objectId of the object to modify.",
+                    "markdownDescription": "**Object Id**\n\nThis is objectId of the object to modify.",
                     "title": "Object Id",
                     "type": "string"
                 },
                 "objectType": {
                     "description": "The object type of the object being converted to mapped object.",
+                    "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
                     "title": "Object Type",
                     "type": "string"
                 },
                 "useDefaultProcessing": {
                     "description": "Return this value to cause default processing to occur.",
+                    "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
+                    "title": "Use Default Processing"
+                }
+            },
+            "title": "_AdaptiveModelCurrentOnModifyObject_",
+            "type": "object"
+        },
+        "_AdaptiveModelCurrentOnModifyObject_.propertyTypes": {
+            "properties": {
+                "adapterId": {
+                    "description": "The adapter id of the object being converted to mapped object.",
+                    "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
+                    "title": "Adapter Id",
+                    "type": "string"
+                },
+                "adapterTypeSpecific": {
+                    "description": "This is the adapterTypeSpecific parameter value.",
+                    "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
+                    "title": "Adapter Specific",
+                    "type": "object"
+                },
+                "mappedAdapterId": {
+                    "description": "The adapter id of the object being converted to object.",
+                    "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
+                    "title": "Mapped Adapter Id",
+                    "type": "string"
+                },
+                "mappedObjectType": {
+                    "description": "The object type of the object being converted to object.",
+                    "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
+                    "title": "Mapped Object Type",
+                    "type": "string"
+                },
+                "modifyEntries": {
+                    "description": "The modify entries.",
+                    "markdownDescription": "**Modify Entries**\n\nThe modify entries.",
+                    "title": "Modify Entries",
+                    "type": "array"
+                },
+                "objectId": {
+                    "description": "This is objectId of the object to modify.",
+                    "markdownDescription": "**Object Id**\n\nThis is objectId of the object to modify.",
+                    "title": "Object Id",
+                    "type": "string"
+                },
+                "objectType": {
+                    "description": "The object type of the object being converted to mapped object.",
+                    "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
+                    "title": "Object Type",
+                    "type": "string"
+                },
+                "useDefaultProcessing": {
+                    "description": "Return this value to cause default processing to occur.",
+                    "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
                     "title": "Use Default Processing"
                 }
             },
@@ -56,9 +118,65 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveModelCurrentOnModifyObject_"
+    "additionalProperties": false,
+    "description": "Qualifier current:: for model onModifyObject.",
+    "markdownDescription": "Qualifier current:: for model onModifyObject.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "adapterId": {
+            "description": "The adapter id of the object being converted to mapped object.",
+            "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
+            "title": "Adapter Id",
+            "type": "string"
+        },
+        "adapterTypeSpecific": {
+            "description": "This is the adapterTypeSpecific parameter value.",
+            "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
+            "title": "Adapter Specific",
+            "type": "object"
+        },
+        "mappedAdapterId": {
+            "description": "The adapter id of the object being converted to object.",
+            "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
+            "title": "Mapped Adapter Id",
+            "type": "string"
+        },
+        "mappedObjectType": {
+            "description": "The object type of the object being converted to object.",
+            "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
+            "title": "Mapped Object Type",
+            "type": "string"
+        },
+        "modifyEntries": {
+            "description": "The modify entries.",
+            "markdownDescription": "**Modify Entries**\n\nThe modify entries.",
+            "title": "Modify Entries",
+            "type": "array"
+        },
+        "objectId": {
+            "description": "This is objectId of the object to modify.",
+            "markdownDescription": "**Object Id**\n\nThis is objectId of the object to modify.",
+            "title": "Object Id",
+            "type": "string"
+        },
+        "objectType": {
+            "description": "The object type of the object being converted to mapped object.",
+            "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
+            "title": "Object Type",
+            "type": "string"
+        },
+        "useDefaultProcessing": {
+            "description": "Return this value to cause default processing to occur.",
+            "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
+            "title": "Use Default Processing"
         }
-    ]
+    },
+    "title": "_AdaptiveModelCurrentOnModifyObject_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveModelCurrentOnModifyObject_.json
+++ b/generated/schemas/afw/_AdaptiveModelCurrentOnModifyObject_.json
@@ -1,0 +1,64 @@
+{
+    "$defs": {
+        "_AdaptiveModelCurrentOnModifyObject_": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveModelCurrentOnModifyObject_.propertyTypes"
+                }
+            ],
+            "description": "Qualifier current:: for model onModifyObject.",
+            "type": "object",
+            "unevaluatedProperties": false
+        },
+        "_AdaptiveModelCurrentOnModifyObject_.propertyTypes": {
+            "properties": {
+                "adapterId": {
+                    "description": "The adapter id of the object being converted to mapped object.",
+                    "title": "Adapter Id",
+                    "type": "string"
+                },
+                "adapterTypeSpecific": {
+                    "description": "This is the adapterTypeSpecific parameter value.",
+                    "title": "Adapter Specific",
+                    "type": "object"
+                },
+                "mappedAdapterId": {
+                    "description": "The adapter id of the object being converted to object.",
+                    "title": "Mapped Adapter Id",
+                    "type": "string"
+                },
+                "mappedObjectType": {
+                    "description": "The object type of the object being converted to object.",
+                    "title": "Mapped Object Type",
+                    "type": "string"
+                },
+                "modifyEntries": {
+                    "description": "The modify entries.",
+                    "title": "Modify Entries",
+                    "type": "array"
+                },
+                "objectId": {
+                    "description": "This is objectId of the object to modify.",
+                    "title": "Object Id",
+                    "type": "string"
+                },
+                "objectType": {
+                    "description": "The object type of the object being converted to mapped object.",
+                    "title": "Object Type",
+                    "type": "string"
+                },
+                "useDefaultProcessing": {
+                    "description": "Return this value to cause default processing to occur.",
+                    "title": "Use Default Processing"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "allOf": [
+        {
+            "$ref": "#/$defs/_AdaptiveModelCurrentOnModifyObject_"
+        }
+    ]
+}

--- a/generated/schemas/afw/_AdaptiveModelCurrentOnReplaceObject_.json
+++ b/generated/schemas/afw/_AdaptiveModelCurrentOnReplaceObject_.json
@@ -1,54 +1,116 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveModelCurrentOnReplaceObject_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveModelCurrentOnReplaceObject_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveModelCurrentOnReplaceObject_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Qualifier current:: for model onReplaceObject.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveModelCurrentOnReplaceObject_.propertyTypes": {
+            "markdownDescription": "Qualifier current:: for model onReplaceObject.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "adapterId": {
                     "description": "The adapter id of the object being converted to mapped object.",
+                    "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
                     "title": "Adapter Id",
                     "type": "string"
                 },
                 "adapterTypeSpecific": {
                     "description": "This is the adapterTypeSpecific parameter value.",
+                    "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
                     "title": "Adapter Specific",
                     "type": "object"
                 },
                 "mappedAdapterId": {
                     "description": "The adapter id of the object being converted to object.",
+                    "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
                     "title": "Mapped Adapter Id",
                     "type": "string"
                 },
                 "mappedObjectType": {
                     "description": "The object type of the object being converted to object.",
+                    "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
                     "title": "Mapped Object Type",
                     "type": "string"
                 },
                 "object": {
                     "description": "This is the replacement object.",
+                    "markdownDescription": "**Replacement Object**\n\nThis is the replacement object.",
                     "title": "Replacement Object",
                     "type": "object"
                 },
                 "objectId": {
                     "description": "This is objectId of the object to replace.",
+                    "markdownDescription": "**Object Id**\n\nThis is objectId of the object to replace.",
                     "title": "Object Id",
                     "type": "string"
                 },
                 "objectType": {
                     "description": "The object type of the object being converted to mapped object.",
+                    "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
                     "title": "Object Type",
                     "type": "string"
                 },
                 "useDefaultProcessing": {
                     "description": "Return this value to cause default processing to occur.",
+                    "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
+                    "title": "Use Default Processing"
+                }
+            },
+            "title": "_AdaptiveModelCurrentOnReplaceObject_",
+            "type": "object"
+        },
+        "_AdaptiveModelCurrentOnReplaceObject_.propertyTypes": {
+            "properties": {
+                "adapterId": {
+                    "description": "The adapter id of the object being converted to mapped object.",
+                    "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
+                    "title": "Adapter Id",
+                    "type": "string"
+                },
+                "adapterTypeSpecific": {
+                    "description": "This is the adapterTypeSpecific parameter value.",
+                    "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
+                    "title": "Adapter Specific",
+                    "type": "object"
+                },
+                "mappedAdapterId": {
+                    "description": "The adapter id of the object being converted to object.",
+                    "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
+                    "title": "Mapped Adapter Id",
+                    "type": "string"
+                },
+                "mappedObjectType": {
+                    "description": "The object type of the object being converted to object.",
+                    "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
+                    "title": "Mapped Object Type",
+                    "type": "string"
+                },
+                "object": {
+                    "description": "This is the replacement object.",
+                    "markdownDescription": "**Replacement Object**\n\nThis is the replacement object.",
+                    "title": "Replacement Object",
+                    "type": "object"
+                },
+                "objectId": {
+                    "description": "This is objectId of the object to replace.",
+                    "markdownDescription": "**Object Id**\n\nThis is objectId of the object to replace.",
+                    "title": "Object Id",
+                    "type": "string"
+                },
+                "objectType": {
+                    "description": "The object type of the object being converted to mapped object.",
+                    "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
+                    "title": "Object Type",
+                    "type": "string"
+                },
+                "useDefaultProcessing": {
+                    "description": "Return this value to cause default processing to occur.",
+                    "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
                     "title": "Use Default Processing"
                 }
             },
@@ -56,9 +118,65 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveModelCurrentOnReplaceObject_"
+    "additionalProperties": false,
+    "description": "Qualifier current:: for model onReplaceObject.",
+    "markdownDescription": "Qualifier current:: for model onReplaceObject.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "adapterId": {
+            "description": "The adapter id of the object being converted to mapped object.",
+            "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
+            "title": "Adapter Id",
+            "type": "string"
+        },
+        "adapterTypeSpecific": {
+            "description": "This is the adapterTypeSpecific parameter value.",
+            "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
+            "title": "Adapter Specific",
+            "type": "object"
+        },
+        "mappedAdapterId": {
+            "description": "The adapter id of the object being converted to object.",
+            "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
+            "title": "Mapped Adapter Id",
+            "type": "string"
+        },
+        "mappedObjectType": {
+            "description": "The object type of the object being converted to object.",
+            "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
+            "title": "Mapped Object Type",
+            "type": "string"
+        },
+        "object": {
+            "description": "This is the replacement object.",
+            "markdownDescription": "**Replacement Object**\n\nThis is the replacement object.",
+            "title": "Replacement Object",
+            "type": "object"
+        },
+        "objectId": {
+            "description": "This is objectId of the object to replace.",
+            "markdownDescription": "**Object Id**\n\nThis is objectId of the object to replace.",
+            "title": "Object Id",
+            "type": "string"
+        },
+        "objectType": {
+            "description": "The object type of the object being converted to mapped object.",
+            "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
+            "title": "Object Type",
+            "type": "string"
+        },
+        "useDefaultProcessing": {
+            "description": "Return this value to cause default processing to occur.",
+            "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
+            "title": "Use Default Processing"
         }
-    ]
+    },
+    "title": "_AdaptiveModelCurrentOnReplaceObject_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveModelCurrentOnReplaceObject_.json
+++ b/generated/schemas/afw/_AdaptiveModelCurrentOnReplaceObject_.json
@@ -1,0 +1,64 @@
+{
+    "$defs": {
+        "_AdaptiveModelCurrentOnReplaceObject_": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveModelCurrentOnReplaceObject_.propertyTypes"
+                }
+            ],
+            "description": "Qualifier current:: for model onReplaceObject.",
+            "type": "object",
+            "unevaluatedProperties": false
+        },
+        "_AdaptiveModelCurrentOnReplaceObject_.propertyTypes": {
+            "properties": {
+                "adapterId": {
+                    "description": "The adapter id of the object being converted to mapped object.",
+                    "title": "Adapter Id",
+                    "type": "string"
+                },
+                "adapterTypeSpecific": {
+                    "description": "This is the adapterTypeSpecific parameter value.",
+                    "title": "Adapter Specific",
+                    "type": "object"
+                },
+                "mappedAdapterId": {
+                    "description": "The adapter id of the object being converted to object.",
+                    "title": "Mapped Adapter Id",
+                    "type": "string"
+                },
+                "mappedObjectType": {
+                    "description": "The object type of the object being converted to object.",
+                    "title": "Mapped Object Type",
+                    "type": "string"
+                },
+                "object": {
+                    "description": "This is the replacement object.",
+                    "title": "Replacement Object",
+                    "type": "object"
+                },
+                "objectId": {
+                    "description": "This is objectId of the object to replace.",
+                    "title": "Object Id",
+                    "type": "string"
+                },
+                "objectType": {
+                    "description": "The object type of the object being converted to mapped object.",
+                    "title": "Object Type",
+                    "type": "string"
+                },
+                "useDefaultProcessing": {
+                    "description": "Return this value to cause default processing to occur.",
+                    "title": "Use Default Processing"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "allOf": [
+        {
+            "$ref": "#/$defs/_AdaptiveModelCurrentOnReplaceObject_"
+        }
+    ]
+}

--- a/generated/schemas/afw/_AdaptiveModelCurrentOnRetrieveObjects_.json
+++ b/generated/schemas/afw/_AdaptiveModelCurrentOnRetrieveObjects_.json
@@ -1,44 +1,51 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveModelCurrentOnRetrieveObjects_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveModelCurrentOnRetrieveObjects_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveModelCurrentOnRetrieveObjects_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Qualifier current:: for model onRetrieveObjects.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveModelCurrentOnRetrieveObjects_.propertyTypes": {
+            "markdownDescription": "Qualifier current:: for model onRetrieveObjects.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "adapterId": {
                     "description": "The adapter id of the object being converted to mapped object.",
+                    "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
                     "title": "Adapter Id",
                     "type": "string"
                 },
                 "adapterTypeSpecific": {
                     "description": "This is the adapterTypeSpecific parameter value.",
+                    "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
                     "title": "Adapter Specific",
                     "type": "object"
                 },
                 "mapBackObject": {
                     "description": "The function to map back an object.",
+                    "markdownDescription": "**mapBackObject**\n\nThe function to map back an object.",
                     "title": "mapBackObject",
                     "type": "string"
                 },
                 "mappedAdapterId": {
                     "description": "The adapter id of the object being converted to object.",
+                    "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
                     "title": "Mapped Adapter Id",
                     "type": "string"
                 },
                 "mappedObjectType": {
                     "description": "The object type of the object being converted to object.",
+                    "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
                     "title": "Mapped Object Type",
                     "type": "string"
                 },
                 "objectType": {
                     "description": "The object type of the object being converted to mapped object.",
+                    "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
                     "title": "Object Type",
                     "type": "string"
                 },
@@ -49,35 +56,100 @@
                         }
                     ],
                     "description": "The queryCriteria object.",
-                    "title": "queryCriteria"
+                    "markdownDescription": "**queryCriteria**\n\nThe queryCriteria object.",
+                    "title": "queryCriteria",
+                    "type": "object"
                 },
                 "returnObject": {
                     "description": "The function to call to return an object.",
+                    "markdownDescription": "**returnObject**\n\nThe function to call to return an object.",
                     "title": "returnObject",
                     "type": "string"
                 },
                 "useDefaultProcessing": {
                     "description": "Return this value to cause default processing to occur.",
+                    "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
+                    "title": "Use Default Processing"
+                }
+            },
+            "title": "_AdaptiveModelCurrentOnRetrieveObjects_",
+            "type": "object"
+        },
+        "_AdaptiveModelCurrentOnRetrieveObjects_.propertyTypes": {
+            "properties": {
+                "adapterId": {
+                    "description": "The adapter id of the object being converted to mapped object.",
+                    "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
+                    "title": "Adapter Id",
+                    "type": "string"
+                },
+                "adapterTypeSpecific": {
+                    "description": "This is the adapterTypeSpecific parameter value.",
+                    "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
+                    "title": "Adapter Specific",
+                    "type": "object"
+                },
+                "mapBackObject": {
+                    "description": "The function to map back an object.",
+                    "markdownDescription": "**mapBackObject**\n\nThe function to map back an object.",
+                    "title": "mapBackObject",
+                    "type": "string"
+                },
+                "mappedAdapterId": {
+                    "description": "The adapter id of the object being converted to object.",
+                    "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
+                    "title": "Mapped Adapter Id",
+                    "type": "string"
+                },
+                "mappedObjectType": {
+                    "description": "The object type of the object being converted to object.",
+                    "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
+                    "title": "Mapped Object Type",
+                    "type": "string"
+                },
+                "objectType": {
+                    "description": "The object type of the object being converted to mapped object.",
+                    "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
+                    "title": "Object Type",
+                    "type": "string"
+                },
+                "queryCriteria": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveQueryCriteria_"
+                        }
+                    ],
+                    "description": "The queryCriteria object.",
+                    "markdownDescription": "**queryCriteria**\n\nThe queryCriteria object.",
+                    "title": "queryCriteria",
+                    "type": "object"
+                },
+                "returnObject": {
+                    "description": "The function to call to return an object.",
+                    "markdownDescription": "**returnObject**\n\nThe function to call to return an object.",
+                    "title": "returnObject",
+                    "type": "string"
+                },
+                "useDefaultProcessing": {
+                    "description": "Return this value to cause default processing to occur.",
+                    "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
                     "title": "Use Default Processing"
                 }
             },
             "type": "object"
         },
         "_AdaptiveQueryCriteriaFilter_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveQueryCriteriaFilter_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "This is the object type for the filter property of the queryCriteria parameter of retrieve object functions.",
-            "required": [
-                "op"
-            ],
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveQueryCriteriaFilter_.propertyTypes": {
+            "markdownDescription": "This is the object type for the filter property of the queryCriteria parameter of retrieve object functions.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "filters": {
                     "description": "This is an array of _AdaptiveQueryCriteriaFilter_ objects for 'and' and 'or' operations. This property is allowed and required if the operation is 'and' or 'or'.",
                     "items": {
@@ -87,8 +159,11 @@
                             }
                         ],
                         "description": "This is an array of _AdaptiveQueryCriteriaFilter_ objects for 'and' and 'or' operations. This property is allowed and required if the operation is 'and' or 'or'.",
-                        "title": "Filters"
+                        "markdownDescription": "This is an array of _AdaptiveQueryCriteriaFilter_ objects for 'and' and 'or' operations. This property is allowed and required if the operation is 'and' or 'or'.",
+                        "title": "Filters",
+                        "type": "object"
                     },
+                    "markdownDescription": "**Filters**\n\nThis is an array of _AdaptiveQueryCriteriaFilter_ objects for 'and' and 'or' operations. This property is allowed and required if the operation is 'and' or 'or'.",
                     "title": "Filters",
                     "type": "array"
                 },
@@ -108,16 +183,77 @@
                         "contains",
                         "in"
                     ],
+                    "markdownDescription": "**Operation**\n\nThis is the filter operations.",
                     "title": "Operation",
                     "type": "string"
                 },
                 "property": {
                     "description": "This is the name of the property used for the filter operation. This property is allowed and required if the operation is not 'and' or 'or'.",
+                    "markdownDescription": "**Property Name**\n\nThis is the name of the property used for the filter operation. This property is allowed and required if the operation is not 'and' or 'or'.",
                     "title": "Property Name",
                     "type": "string"
                 },
                 "value": {
                     "description": "This is the value of the property used for the filter operation. This property is allowed and required if the operation is not 'and' or 'or'.",
+                    "markdownDescription": "**Value**\n\nThis is the value of the property used for the filter operation. This property is allowed and required if the operation is not 'and' or 'or'.",
+                    "title": "Value",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "op"
+            ],
+            "title": "_AdaptiveQueryCriteriaFilter_",
+            "type": "object"
+        },
+        "_AdaptiveQueryCriteriaFilter_.propertyTypes": {
+            "properties": {
+                "filters": {
+                    "description": "This is an array of _AdaptiveQueryCriteriaFilter_ objects for 'and' and 'or' operations. This property is allowed and required if the operation is 'and' or 'or'.",
+                    "items": {
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/_AdaptiveQueryCriteriaFilter_"
+                            }
+                        ],
+                        "description": "This is an array of _AdaptiveQueryCriteriaFilter_ objects for 'and' and 'or' operations. This property is allowed and required if the operation is 'and' or 'or'.",
+                        "markdownDescription": "This is an array of _AdaptiveQueryCriteriaFilter_ objects for 'and' and 'or' operations. This property is allowed and required if the operation is 'and' or 'or'.",
+                        "title": "Filters",
+                        "type": "object"
+                    },
+                    "markdownDescription": "**Filters**\n\nThis is an array of _AdaptiveQueryCriteriaFilter_ objects for 'and' and 'or' operations. This property is allowed and required if the operation is 'and' or 'or'.",
+                    "title": "Filters",
+                    "type": "array"
+                },
+                "op": {
+                    "description": "This is the filter operations.",
+                    "enum": [
+                        "and",
+                        "or",
+                        "eq",
+                        "ne",
+                        "lt",
+                        "le",
+                        "lte",
+                        "gt",
+                        "ge",
+                        "match",
+                        "contains",
+                        "in"
+                    ],
+                    "markdownDescription": "**Operation**\n\nThis is the filter operations.",
+                    "title": "Operation",
+                    "type": "string"
+                },
+                "property": {
+                    "description": "This is the name of the property used for the filter operation. This property is allowed and required if the operation is not 'and' or 'or'.",
+                    "markdownDescription": "**Property Name**\n\nThis is the name of the property used for the filter operation. This property is allowed and required if the operation is not 'and' or 'or'.",
+                    "title": "Property Name",
+                    "type": "string"
+                },
+                "value": {
+                    "description": "This is the value of the property used for the filter operation. This property is allowed and required if the operation is not 'and' or 'or'.",
+                    "markdownDescription": "**Value**\n\nThis is the value of the property used for the filter operation. This property is allowed and required if the operation is not 'and' or 'or'.",
                     "title": "Value",
                     "type": "string"
                 }
@@ -125,15 +261,61 @@
             "type": "object"
         },
         "_AdaptiveQueryCriteria_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveQueryCriteria_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "The queryCriteria object.",
+            "markdownDescription": "The queryCriteria object.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "filter": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveQueryCriteriaFilter_"
+                        }
+                    ],
+                    "description": "This filters the objects that will be returned. If not specified, all objects will be returned.",
+                    "markdownDescription": "**Filter**\n\nThis filters the objects that will be returned. If not specified, all objects will be returned.",
+                    "title": "Filter",
+                    "type": "object"
+                },
+                "select": {
+                    "description": "This is an array of the names of properties to include in result. If not specified, all properties are returned.",
+                    "items": {
+                        "description": "This is an array of the names of properties to include in result. If not specified, all properties are returned.",
+                        "markdownDescription": "This is an array of the names of properties to include in result. If not specified, all properties are returned.",
+                        "title": "Properties to include",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Include Properties**\n\nThis is an array of the names of properties to include in result. If not specified, all properties are returned.",
+                    "title": "Include Properties",
+                    "type": "array"
+                },
+                "sort": {
+                    "description": "This is an array of then names of properties used to sort the returned objects in highest to lowest order. Optionally, the property name can be prefixed with a minus sign ('-') to indicate descending order. FIXME '-' is probably not a good idea.",
+                    "items": {
+                        "description": "This is an array of then names of properties used to sort the returned objects in highest to lowest order. Optionally, the property name can be prefixed with a minus sign ('-') to indicate descending order. FIXME '-' is probably not a good idea.",
+                        "markdownDescription": "This is an array of then names of properties used to sort the returned objects in highest to lowest order. Optionally, the property name can be prefixed with a minus sign ('-') to indicate descending order. FIXME '-' is probably not a good idea.",
+                        "title": "Sort order",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Sort Order**\n\nThis is an array of then names of properties used to sort the returned objects in highest to lowest order. Optionally, the property name can be prefixed with a minus sign ('-') to indicate descending order. FIXME '-' is probably not a good idea.",
+                    "title": "Sort Order",
+                    "type": "array"
+                },
+                "urlEncodedRQLString": {
+                    "description": "This is a URL encoded RQL string. This parameter is mutually exclusive with all other properties.",
+                    "markdownDescription": "**URL RQL String**\n\nThis is a URL encoded RQL string. This parameter is mutually exclusive with all other properties.",
+                    "title": "URL RQL String",
+                    "type": "string"
+                }
+            },
             "title": "queryCriteria",
-            "type": "object",
-            "unevaluatedProperties": false
+            "type": "object"
         },
         "_AdaptiveQueryCriteria_.propertyTypes": {
             "properties": {
@@ -144,15 +326,19 @@
                         }
                     ],
                     "description": "This filters the objects that will be returned. If not specified, all objects will be returned.",
-                    "title": "Filter"
+                    "markdownDescription": "**Filter**\n\nThis filters the objects that will be returned. If not specified, all objects will be returned.",
+                    "title": "Filter",
+                    "type": "object"
                 },
                 "select": {
                     "description": "This is an array of the names of properties to include in result. If not specified, all properties are returned.",
                     "items": {
                         "description": "This is an array of the names of properties to include in result. If not specified, all properties are returned.",
+                        "markdownDescription": "This is an array of the names of properties to include in result. If not specified, all properties are returned.",
                         "title": "Properties to include",
                         "type": "string"
                     },
+                    "markdownDescription": "**Include Properties**\n\nThis is an array of the names of properties to include in result. If not specified, all properties are returned.",
                     "title": "Include Properties",
                     "type": "array"
                 },
@@ -160,14 +346,17 @@
                     "description": "This is an array of then names of properties used to sort the returned objects in highest to lowest order. Optionally, the property name can be prefixed with a minus sign ('-') to indicate descending order. FIXME '-' is probably not a good idea.",
                     "items": {
                         "description": "This is an array of then names of properties used to sort the returned objects in highest to lowest order. Optionally, the property name can be prefixed with a minus sign ('-') to indicate descending order. FIXME '-' is probably not a good idea.",
+                        "markdownDescription": "This is an array of then names of properties used to sort the returned objects in highest to lowest order. Optionally, the property name can be prefixed with a minus sign ('-') to indicate descending order. FIXME '-' is probably not a good idea.",
                         "title": "Sort order",
                         "type": "string"
                     },
+                    "markdownDescription": "**Sort Order**\n\nThis is an array of then names of properties used to sort the returned objects in highest to lowest order. Optionally, the property name can be prefixed with a minus sign ('-') to indicate descending order. FIXME '-' is probably not a good idea.",
                     "title": "Sort Order",
                     "type": "array"
                 },
                 "urlEncodedRQLString": {
                     "description": "This is a URL encoded RQL string. This parameter is mutually exclusive with all other properties.",
+                    "markdownDescription": "**URL RQL String**\n\nThis is a URL encoded RQL string. This parameter is mutually exclusive with all other properties.",
                     "title": "URL RQL String",
                     "type": "string"
                 }
@@ -176,9 +365,76 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveModelCurrentOnRetrieveObjects_"
+    "additionalProperties": false,
+    "description": "Qualifier current:: for model onRetrieveObjects.",
+    "markdownDescription": "Qualifier current:: for model onRetrieveObjects.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "adapterId": {
+            "description": "The adapter id of the object being converted to mapped object.",
+            "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
+            "title": "Adapter Id",
+            "type": "string"
+        },
+        "adapterTypeSpecific": {
+            "description": "This is the adapterTypeSpecific parameter value.",
+            "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
+            "title": "Adapter Specific",
+            "type": "object"
+        },
+        "mapBackObject": {
+            "description": "The function to map back an object.",
+            "markdownDescription": "**mapBackObject**\n\nThe function to map back an object.",
+            "title": "mapBackObject",
+            "type": "string"
+        },
+        "mappedAdapterId": {
+            "description": "The adapter id of the object being converted to object.",
+            "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
+            "title": "Mapped Adapter Id",
+            "type": "string"
+        },
+        "mappedObjectType": {
+            "description": "The object type of the object being converted to object.",
+            "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
+            "title": "Mapped Object Type",
+            "type": "string"
+        },
+        "objectType": {
+            "description": "The object type of the object being converted to mapped object.",
+            "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
+            "title": "Object Type",
+            "type": "string"
+        },
+        "queryCriteria": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveQueryCriteria_"
+                }
+            ],
+            "description": "The queryCriteria object.",
+            "markdownDescription": "**queryCriteria**\n\nThe queryCriteria object.",
+            "title": "queryCriteria",
+            "type": "object"
+        },
+        "returnObject": {
+            "description": "The function to call to return an object.",
+            "markdownDescription": "**returnObject**\n\nThe function to call to return an object.",
+            "title": "returnObject",
+            "type": "string"
+        },
+        "useDefaultProcessing": {
+            "description": "Return this value to cause default processing to occur.",
+            "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
+            "title": "Use Default Processing"
         }
-    ]
+    },
+    "title": "_AdaptiveModelCurrentOnRetrieveObjects_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveModelCurrentOnRetrieveObjects_.json
+++ b/generated/schemas/afw/_AdaptiveModelCurrentOnRetrieveObjects_.json
@@ -1,0 +1,184 @@
+{
+    "$defs": {
+        "_AdaptiveModelCurrentOnRetrieveObjects_": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveModelCurrentOnRetrieveObjects_.propertyTypes"
+                }
+            ],
+            "description": "Qualifier current:: for model onRetrieveObjects.",
+            "type": "object",
+            "unevaluatedProperties": false
+        },
+        "_AdaptiveModelCurrentOnRetrieveObjects_.propertyTypes": {
+            "properties": {
+                "adapterId": {
+                    "description": "The adapter id of the object being converted to mapped object.",
+                    "title": "Adapter Id",
+                    "type": "string"
+                },
+                "adapterTypeSpecific": {
+                    "description": "This is the adapterTypeSpecific parameter value.",
+                    "title": "Adapter Specific",
+                    "type": "object"
+                },
+                "mapBackObject": {
+                    "description": "The function to map back an object.",
+                    "title": "mapBackObject",
+                    "type": "string"
+                },
+                "mappedAdapterId": {
+                    "description": "The adapter id of the object being converted to object.",
+                    "title": "Mapped Adapter Id",
+                    "type": "string"
+                },
+                "mappedObjectType": {
+                    "description": "The object type of the object being converted to object.",
+                    "title": "Mapped Object Type",
+                    "type": "string"
+                },
+                "objectType": {
+                    "description": "The object type of the object being converted to mapped object.",
+                    "title": "Object Type",
+                    "type": "string"
+                },
+                "queryCriteria": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveQueryCriteria_"
+                        }
+                    ],
+                    "description": "The queryCriteria object.",
+                    "title": "queryCriteria"
+                },
+                "returnObject": {
+                    "description": "The function to call to return an object.",
+                    "title": "returnObject",
+                    "type": "string"
+                },
+                "useDefaultProcessing": {
+                    "description": "Return this value to cause default processing to occur.",
+                    "title": "Use Default Processing"
+                }
+            },
+            "type": "object"
+        },
+        "_AdaptiveQueryCriteriaFilter_": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveQueryCriteriaFilter_.propertyTypes"
+                }
+            ],
+            "description": "This is the object type for the filter property of the queryCriteria parameter of retrieve object functions.",
+            "required": [
+                "op"
+            ],
+            "type": "object",
+            "unevaluatedProperties": false
+        },
+        "_AdaptiveQueryCriteriaFilter_.propertyTypes": {
+            "properties": {
+                "filters": {
+                    "description": "This is an array of _AdaptiveQueryCriteriaFilter_ objects for 'and' and 'or' operations. This property is allowed and required if the operation is 'and' or 'or'.",
+                    "items": {
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/_AdaptiveQueryCriteriaFilter_"
+                            }
+                        ],
+                        "description": "This is an array of _AdaptiveQueryCriteriaFilter_ objects for 'and' and 'or' operations. This property is allowed and required if the operation is 'and' or 'or'.",
+                        "title": "Filters"
+                    },
+                    "title": "Filters",
+                    "type": "array"
+                },
+                "op": {
+                    "description": "This is the filter operations.",
+                    "enum": [
+                        "and",
+                        "or",
+                        "eq",
+                        "ne",
+                        "lt",
+                        "le",
+                        "lte",
+                        "gt",
+                        "ge",
+                        "match",
+                        "contains",
+                        "in"
+                    ],
+                    "title": "Operation",
+                    "type": "string"
+                },
+                "property": {
+                    "description": "This is the name of the property used for the filter operation. This property is allowed and required if the operation is not 'and' or 'or'.",
+                    "title": "Property Name",
+                    "type": "string"
+                },
+                "value": {
+                    "description": "This is the value of the property used for the filter operation. This property is allowed and required if the operation is not 'and' or 'or'.",
+                    "title": "Value",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "_AdaptiveQueryCriteria_": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveQueryCriteria_.propertyTypes"
+                }
+            ],
+            "description": "The queryCriteria object.",
+            "title": "queryCriteria",
+            "type": "object",
+            "unevaluatedProperties": false
+        },
+        "_AdaptiveQueryCriteria_.propertyTypes": {
+            "properties": {
+                "filter": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveQueryCriteriaFilter_"
+                        }
+                    ],
+                    "description": "This filters the objects that will be returned. If not specified, all objects will be returned.",
+                    "title": "Filter"
+                },
+                "select": {
+                    "description": "This is an array of the names of properties to include in result. If not specified, all properties are returned.",
+                    "items": {
+                        "description": "This is an array of the names of properties to include in result. If not specified, all properties are returned.",
+                        "title": "Properties to include",
+                        "type": "string"
+                    },
+                    "title": "Include Properties",
+                    "type": "array"
+                },
+                "sort": {
+                    "description": "This is an array of then names of properties used to sort the returned objects in highest to lowest order. Optionally, the property name can be prefixed with a minus sign ('-') to indicate descending order. FIXME '-' is probably not a good idea.",
+                    "items": {
+                        "description": "This is an array of then names of properties used to sort the returned objects in highest to lowest order. Optionally, the property name can be prefixed with a minus sign ('-') to indicate descending order. FIXME '-' is probably not a good idea.",
+                        "title": "Sort order",
+                        "type": "string"
+                    },
+                    "title": "Sort Order",
+                    "type": "array"
+                },
+                "urlEncodedRQLString": {
+                    "description": "This is a URL encoded RQL string. This parameter is mutually exclusive with all other properties.",
+                    "title": "URL RQL String",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "allOf": [
+        {
+            "$ref": "#/$defs/_AdaptiveModelCurrentOnRetrieveObjects_"
+        }
+    ]
+}

--- a/generated/schemas/afw/_AdaptiveModelCurrentOnSetProperty_.json
+++ b/generated/schemas/afw/_AdaptiveModelCurrentOnSetProperty_.json
@@ -1,0 +1,73 @@
+{
+    "$defs": {
+        "_AdaptiveModelCurrentOnSetProperty_": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveModelCurrentOnSetProperty_.propertyTypes"
+                }
+            ],
+            "description": "Qualifier current:: for model onSetProperty.",
+            "type": "object",
+            "unevaluatedProperties": false
+        },
+        "_AdaptiveModelCurrentOnSetProperty_.propertyTypes": {
+            "properties": {
+                "adapterId": {
+                    "description": "The adapter id of the object being converted to mapped object.",
+                    "title": "Adapter Id",
+                    "type": "string"
+                },
+                "adapterTypeSpecific": {
+                    "description": "This is the adapterTypeSpecific parameter value.",
+                    "title": "Adapter Specific",
+                    "type": "object"
+                },
+                "mappedAdapterId": {
+                    "description": "The adapter id of the object being converted to object.",
+                    "title": "Mapped Adapter Id",
+                    "type": "string"
+                },
+                "mappedObjectType": {
+                    "description": "The object type of the object being converted to object.",
+                    "title": "Mapped Object Type",
+                    "type": "string"
+                },
+                "object": {
+                    "description": "This is the object from request.",
+                    "title": "Object",
+                    "type": "object"
+                },
+                "objectId": {
+                    "description": "This is objectId of the object from request.",
+                    "title": "Object Id",
+                    "type": "string"
+                },
+                "objectType": {
+                    "description": "The object type of the object being converted to mapped object.",
+                    "title": "Object Type",
+                    "type": "string"
+                },
+                "propertyName": {
+                    "description": "This is the property name from request.",
+                    "title": "Object Id",
+                    "type": "string"
+                },
+                "useDefaultProcessing": {
+                    "description": "Return this value to cause default processing to occur.",
+                    "title": "Use Default Processing"
+                },
+                "value": {
+                    "description": "This is the value of the property from request.",
+                    "title": "Object Id"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "allOf": [
+        {
+            "$ref": "#/$defs/_AdaptiveModelCurrentOnSetProperty_"
+        }
+    ]
+}

--- a/generated/schemas/afw/_AdaptiveModelCurrentOnSetProperty_.json
+++ b/generated/schemas/afw/_AdaptiveModelCurrentOnSetProperty_.json
@@ -1,63 +1,138 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveModelCurrentOnSetProperty_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveModelCurrentOnSetProperty_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveModelCurrentOnSetProperty_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Qualifier current:: for model onSetProperty.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveModelCurrentOnSetProperty_.propertyTypes": {
+            "markdownDescription": "Qualifier current:: for model onSetProperty.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "adapterId": {
                     "description": "The adapter id of the object being converted to mapped object.",
+                    "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
                     "title": "Adapter Id",
                     "type": "string"
                 },
                 "adapterTypeSpecific": {
                     "description": "This is the adapterTypeSpecific parameter value.",
+                    "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
                     "title": "Adapter Specific",
                     "type": "object"
                 },
                 "mappedAdapterId": {
                     "description": "The adapter id of the object being converted to object.",
+                    "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
                     "title": "Mapped Adapter Id",
                     "type": "string"
                 },
                 "mappedObjectType": {
                     "description": "The object type of the object being converted to object.",
+                    "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
                     "title": "Mapped Object Type",
                     "type": "string"
                 },
                 "object": {
                     "description": "This is the object from request.",
+                    "markdownDescription": "**Object**\n\nThis is the object from request.",
                     "title": "Object",
                     "type": "object"
                 },
                 "objectId": {
                     "description": "This is objectId of the object from request.",
+                    "markdownDescription": "**Object Id**\n\nThis is objectId of the object from request.",
                     "title": "Object Id",
                     "type": "string"
                 },
                 "objectType": {
                     "description": "The object type of the object being converted to mapped object.",
+                    "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
                     "title": "Object Type",
                     "type": "string"
                 },
                 "propertyName": {
                     "description": "This is the property name from request.",
+                    "markdownDescription": "**Object Id**\n\nThis is the property name from request.",
                     "title": "Object Id",
                     "type": "string"
                 },
                 "useDefaultProcessing": {
                     "description": "Return this value to cause default processing to occur.",
+                    "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
                     "title": "Use Default Processing"
                 },
                 "value": {
                     "description": "This is the value of the property from request.",
+                    "markdownDescription": "**Object Id**\n\nThis is the value of the property from request.",
+                    "title": "Object Id"
+                }
+            },
+            "title": "_AdaptiveModelCurrentOnSetProperty_",
+            "type": "object"
+        },
+        "_AdaptiveModelCurrentOnSetProperty_.propertyTypes": {
+            "properties": {
+                "adapterId": {
+                    "description": "The adapter id of the object being converted to mapped object.",
+                    "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
+                    "title": "Adapter Id",
+                    "type": "string"
+                },
+                "adapterTypeSpecific": {
+                    "description": "This is the adapterTypeSpecific parameter value.",
+                    "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
+                    "title": "Adapter Specific",
+                    "type": "object"
+                },
+                "mappedAdapterId": {
+                    "description": "The adapter id of the object being converted to object.",
+                    "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
+                    "title": "Mapped Adapter Id",
+                    "type": "string"
+                },
+                "mappedObjectType": {
+                    "description": "The object type of the object being converted to object.",
+                    "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
+                    "title": "Mapped Object Type",
+                    "type": "string"
+                },
+                "object": {
+                    "description": "This is the object from request.",
+                    "markdownDescription": "**Object**\n\nThis is the object from request.",
+                    "title": "Object",
+                    "type": "object"
+                },
+                "objectId": {
+                    "description": "This is objectId of the object from request.",
+                    "markdownDescription": "**Object Id**\n\nThis is objectId of the object from request.",
+                    "title": "Object Id",
+                    "type": "string"
+                },
+                "objectType": {
+                    "description": "The object type of the object being converted to mapped object.",
+                    "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
+                    "title": "Object Type",
+                    "type": "string"
+                },
+                "propertyName": {
+                    "description": "This is the property name from request.",
+                    "markdownDescription": "**Object Id**\n\nThis is the property name from request.",
+                    "title": "Object Id",
+                    "type": "string"
+                },
+                "useDefaultProcessing": {
+                    "description": "Return this value to cause default processing to occur.",
+                    "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
+                    "title": "Use Default Processing"
+                },
+                "value": {
+                    "description": "This is the value of the property from request.",
+                    "markdownDescription": "**Object Id**\n\nThis is the value of the property from request.",
                     "title": "Object Id"
                 }
             },
@@ -65,9 +140,76 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveModelCurrentOnSetProperty_"
+    "additionalProperties": false,
+    "description": "Qualifier current:: for model onSetProperty.",
+    "markdownDescription": "Qualifier current:: for model onSetProperty.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "adapterId": {
+            "description": "The adapter id of the object being converted to mapped object.",
+            "markdownDescription": "**Adapter Id**\n\nThe adapter id of the object being converted to mapped object.",
+            "title": "Adapter Id",
+            "type": "string"
+        },
+        "adapterTypeSpecific": {
+            "description": "This is the adapterTypeSpecific parameter value.",
+            "markdownDescription": "**Adapter Specific**\n\nThis is the adapterTypeSpecific parameter value.",
+            "title": "Adapter Specific",
+            "type": "object"
+        },
+        "mappedAdapterId": {
+            "description": "The adapter id of the object being converted to object.",
+            "markdownDescription": "**Mapped Adapter Id**\n\nThe adapter id of the object being converted to object.",
+            "title": "Mapped Adapter Id",
+            "type": "string"
+        },
+        "mappedObjectType": {
+            "description": "The object type of the object being converted to object.",
+            "markdownDescription": "**Mapped Object Type**\n\nThe object type of the object being converted to object.",
+            "title": "Mapped Object Type",
+            "type": "string"
+        },
+        "object": {
+            "description": "This is the object from request.",
+            "markdownDescription": "**Object**\n\nThis is the object from request.",
+            "title": "Object",
+            "type": "object"
+        },
+        "objectId": {
+            "description": "This is objectId of the object from request.",
+            "markdownDescription": "**Object Id**\n\nThis is objectId of the object from request.",
+            "title": "Object Id",
+            "type": "string"
+        },
+        "objectType": {
+            "description": "The object type of the object being converted to mapped object.",
+            "markdownDescription": "**Object Type**\n\nThe object type of the object being converted to mapped object.",
+            "title": "Object Type",
+            "type": "string"
+        },
+        "propertyName": {
+            "description": "This is the property name from request.",
+            "markdownDescription": "**Object Id**\n\nThis is the property name from request.",
+            "title": "Object Id",
+            "type": "string"
+        },
+        "useDefaultProcessing": {
+            "description": "Return this value to cause default processing to occur.",
+            "markdownDescription": "**Use Default Processing**\n\nReturn this value to cause default processing to occur.",
+            "title": "Use Default Processing"
+        },
+        "value": {
+            "description": "This is the value of the property from request.",
+            "markdownDescription": "**Object Id**\n\nThis is the value of the property from request.",
+            "title": "Object Id"
         }
-    ]
+    },
+    "title": "_AdaptiveModelCurrentOnSetProperty_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveModelPropertyType_.json
+++ b/generated/schemas/afw/_AdaptiveModelPropertyType_.json
@@ -1,126 +1,65 @@
 {
     "$defs": {
-        "_AdaptiveObjectType_": {
+        "_AdaptiveModelPropertyType_": {
             "allOf": [
                 {
-                    "$ref": "#/$defs/_AdaptiveObjectType_.propertyTypes"
+                    "$ref": "#/$defs/_AdaptiveModelPropertyType_.propertyTypes"
+                },
+                {
+                    "$ref": "#/$defs/_AdaptiveValueMeta_.propertyTypes"
                 }
             ],
-            "description": "The adaptive object type of all adaptive object type objects.",
+            "description": "The object type for properties in the 'propertyTypes' property of instances of _AdaptiveModelObjectType_. This includes all of the properties from _AdaptiveValueMeta_ plus additional private properties used by Adaptive Framework to support the property.",
             "type": "object",
             "unevaluatedProperties": false
         },
-        "_AdaptiveObjectType_.propertyTypes": {
+        "_AdaptiveModelPropertyType_.propertyTypes": {
             "properties": {
-                "allowAdd": {
+                "allowRead": {
                     "default": true,
-                    "description": "If false, objects of this type can NEVER be added via an adapter. If true, objects of this type can be added via an adapter as long as allowed by authorization policy and the adapter.",
-                    "title": "Allow Add",
+                    "description": "Indicates that this property can be read. If true, the property will be included in get_object() and retrieve_objects() requests.",
+                    "title": "Allow Read",
                     "type": "boolean"
                 },
-                "allowChange": {
-                    "default": true,
-                    "description": "If false, objects of this type can NEVER be changed via an adapter. If true, objects of this type can be changed via an adapter as long as allowed by authorization policy and the adapter.",
-                    "title": "Allow Change",
-                    "type": "boolean"
-                },
-                "allowDelete": {
-                    "default": true,
-                    "description": "If false, objects of this type can NEVER be deleted via an adapter. If true, objects of this type can be deleted via an adapter as long as allowed by authorization policy and the adapter.",
-                    "title": "Allow Delete",
-                    "type": "boolean"
-                },
-                "allowEntity": {
-                    "default": true,
-                    "description": "Instances of this object type can exist as an entity object, not just an embedded object.",
-                    "title": "Allow Entity",
-                    "type": "boolean"
-                },
-                "collectionURIs": {
-                    "description": "This is the URIs of the collections this object type is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
-                    "items": {
-                        "description": "This is the URIs of the collections this object type is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
-                        "format": "uri-reference",
-                        "title": "The URIs of the collections this object type is a part of",
-                        "type": "string"
-                    },
-                    "title": "Collection URIs",
-                    "type": "array"
-                },
-                "description": {
-                    "contentMediaType": "text/plain",
-                    "description": "The description of the object type.",
-                    "title": "Description",
-                    "type": "string"
-                },
-                "descriptionPropertyName": {
-                    "description": "The name of the property in an instance that is used as the 'description' property in the meta for instances of this object type. If not specified, no description will be available.",
-                    "title": "Description Property Name",
-                    "type": "string"
-                },
-                "label": {
-                    "description": "Label used to identify this instance.",
-                    "title": "Label",
-                    "type": "string"
-                },
-                "objectIdPropertyName": {
-                    "description": "The name of the property in an instance that is used as the 'objectId' property in the meta for instances of this object type. If not specified, the internal adapter objectId for an object is used.",
-                    "title": "Object Id Property Name",
-                    "type": "string"
-                },
-                "objectType": {
-                    "description": "The object id of the object type.",
-                    "title": "Object Type",
-                    "type": "string"
-                },
-                "originURI": {
-                    "description": "The origin URI of this object type. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
-                    "format": "uri-reference",
-                    "title": "Origin URI",
-                    "type": "string"
-                },
-                "otherProperties": {
+                "custom": {
                     "allOf": [
                         {
-                            "$ref": "#/$defs/_AdaptiveValueMeta_"
+                            "$ref": "#/$defs/_AdaptiveTemplateProperties_"
                         }
                     ],
-                    "description": "If specified, this is the property type for properties that are not explicitly specified. If otherProperties is not specified, only explicitly specified properties are allowed.",
-                    "title": "Other Properties"
+                    "description": "Property type level qualifier custom:: variables available to model expressions.",
+                    "title": "Custom"
                 },
-                "propertyTypes": {
-                    "allOf": [
-                        {
-                            "$ref": "#/$defs/_AdaptivePropertyTypes_"
-                        }
-                    ],
-                    "description": "An object whose properties contain the _AdaptiveValueMeta_ for properties with corresponding name in instances of this _AdaptiveObjectType_.",
-                    "title": "Property Types"
-                },
-                "referenceURI": {
-                    "description": "URI of more reference information about this object.",
-                    "format": "uri-reference",
-                    "title": "Reference URI",
+                "mappedPropertyName": {
+                    "description": "This is the property name of this property used internally by an adapter. If not specified, propertyName is used.",
+                    "title": "Mapped Property Name",
                     "type": "string"
                 },
-                "runtime": {
-                    "allOf": [
-                        {
-                            "$ref": "#/$defs/_AdaptiveRuntimeObject_"
-                        }
-                    ],
-                    "description": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
-                    "title": "Runtime"
+                "method": {
+                    "description": "This is a method for this object that can be called in expressions. This script value must be a lambda function expressed in adaptive script syntax.",
+                    "title": "Method",
+                    "type": "string"
                 },
-                "tags": {
-                    "description": "This is an array of keywords and terms associated with this object type. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
-                    "items": {
-                        "description": "This is an array of keywords and terms associated with this object type. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
-                        "title": "List of keywords associated with this object type",
-                        "type": "string"
-                    },
-                    "title": "Tags",
-                    "type": "array"
+                "onGetInitialValue": {
+                    "description": "This is a script value is evaluated to set the value of this property when producing an instance of this object for add object requests.",
+                    "title": "On Get Initial Value",
+                    "type": "string"
+                },
+                "onGetProperty": {
+                    "description": "This script is evaluated to produce the value of this property when getting an object. If a value of null is returned, the property will not be included in the resulting object.",
+                    "title": "On Get Property",
+                    "type": "string"
+                },
+                "onSetProperty": {
+                    "description": "This script is evaluated to produce the value of this property for add/modify/replace object requests. If initialValue is specified, setProperty is ignored for add object requests. If setProperty is not specified and the property exists in the current object, that value is used. If setProperty is specified, but the evaluation returns a value of null, the property will not be included in the mapped object.",
+                    "title": "On Set Property",
+                    "type": "string"
+                },
+                "transitory": {
+                    "default": false,
+                    "description": "Indicates that this property is transitory and will not be persisted by the adapter. The value can be produced by setValue or supplied in the request.",
+                    "title": "Transitory",
+                    "type": "boolean"
                 }
             },
             "type": "object"
@@ -138,98 +77,6 @@
         },
         "_AdaptiveObject_.propertyTypes": {
             "properties": {},
-            "type": "object"
-        },
-        "_AdaptivePropertyTypes_": {
-            "additionalProperties": {
-                "allOf": [
-                    {
-                        "$ref": "#/$defs/_AdaptiveValueMeta_"
-                    }
-                ],
-                "description": "Object type of the propertyTypes property of an object type."
-            },
-            "description": "An object whose properties contain the _AdaptiveValueMeta_ for properties with corresponding name in instances of this _AdaptiveObjectType_.",
-            "properties": {
-                "_meta_": {
-                    "description": "This is the special Meta object that has deltas between this instance and its Adaptive Object Type.",
-                    "properties": {
-                        "parentPaths": {
-                            "description": "This is a list of paths to the parent object type.",
-                            "items": {
-                                "description": "This is a path to a parent object type.",
-                                "title": "Parent Path",
-                                "type": "string"
-                            },
-                            "title": "Parent Paths",
-                            "type": "array"
-                        }
-                    },
-                    "title": "Meta"
-                }
-            },
-            "title": "Property Types",
-            "type": "object"
-        },
-        "_AdaptiveRuntimeLabels_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveRuntimeLabels_.propertyTypes"
-                }
-            ],
-            "description": "Labels.",
-            "title": "Labels",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveRuntimeLabels_.propertyTypes": {
-            "properties": {
-                "indirectObjectId": {
-                    "description": "Indicates that the objectId in the associated struct is a pointer.",
-                    "title": "Indirect Object Id",
-                    "type": "boolean"
-                },
-                "objectId": {
-                    "description": "The name of member in the struct that contains the objectId.",
-                    "title": "Object Id",
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "_AdaptiveRuntimeObject_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveRuntimeObject_.propertyTypes"
-                }
-            ],
-            "description": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
-            "title": "Runtime",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveRuntimeObject_.propertyTypes": {
-            "properties": {
-                "indirect": {
-                    "description": "Indicates that the runtime struct is a pointer. If a property of this object type has runtime.onGetValueCFunctionName specified, the is ignored and runtime structure is always indirect.",
-                    "title": "Indirect",
-                    "type": "boolean"
-                },
-                "labels": {
-                    "allOf": [
-                        {
-                            "$ref": "#/$defs/_AdaptiveRuntimeLabels_"
-                        }
-                    ],
-                    "description": "Labels.",
-                    "title": "Labels"
-                },
-                "typedef": {
-                    "description": "The typedef of the struct for the runtime object.",
-                    "title": "Typedef",
-                    "type": "string"
-                }
-            },
             "type": "object"
         },
         "_AdaptiveRuntimeProperty_": {
@@ -268,16 +115,23 @@
             },
             "type": "object"
         },
-        "_AdaptiveValueMeta_": {
+        "_AdaptiveTemplateProperties_": {
+            "additionalProperties": {
+                "description": "Each property is a template value.",
+                "type": "string"
+            },
             "allOf": [
                 {
-                    "$ref": "#/$defs/_AdaptiveValueMeta_.propertyTypes"
+                    "$ref": "#/$defs/_AdaptiveTemplateProperties_.propertyTypes"
                 }
             ],
-            "description": "If specified, this is the property type for properties that are not explicitly specified. If otherProperties is not specified, only explicitly specified properties are allowed.",
-            "title": "Other Properties",
-            "type": "object",
-            "unevaluatedProperties": false
+            "description": "Property type level qualifier custom:: variables available to model expressions.",
+            "title": "Custom",
+            "type": "object"
+        },
+        "_AdaptiveTemplateProperties_.propertyTypes": {
+            "properties": {},
+            "type": "object"
         },
         "_AdaptiveValueMeta_.propertyTypes": {
             "properties": {
@@ -453,7 +307,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "allOf": [
         {
-            "$ref": "#/$defs/_AdaptiveObjectType_"
+            "$ref": "#/$defs/_AdaptiveModelPropertyType_"
         }
     ]
 }

--- a/generated/schemas/afw/_AdaptiveModelPropertyType_.json
+++ b/generated/schemas/afw/_AdaptiveModelPropertyType_.json
@@ -1,23 +1,284 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveModelPropertyType_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveModelPropertyType_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveModelPropertyType_.propertyTypes"
-                },
-                {
-                    "$ref": "#/$defs/_AdaptiveValueMeta_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "The object type for properties in the 'propertyTypes' property of instances of _AdaptiveModelObjectType_. This includes all of the properties from _AdaptiveValueMeta_ plus additional private properties used by Adaptive Framework to support the property.",
+            "markdownDescription": "The object type for properties in the 'propertyTypes' property of instances of _AdaptiveModelObjectType_. This includes all of the properties from _AdaptiveValueMeta_ plus additional private properties used by Adaptive Framework to support the property.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "additionalConstraints": {
+                    "description": "Additional constraint for the value.",
+                    "markdownDescription": "**Additional Constraints**\n\nAdditional constraint for the value.",
+                    "title": "Additional Constraints",
+                    "type": "string"
+                },
+                "allowQuery": {
+                    "description": "If false, this value can NEVER be queried. If true, this value can be queried if allowed by authorization policy.",
+                    "markdownDescription": "**Allow Query**\n\nIf false, this value can NEVER be queried. If true, this value can be queried if allowed by authorization policy.",
+                    "title": "Allow Query",
+                    "type": "boolean"
+                },
+                "allowRead": {
+                    "default": true,
+                    "description": "Indicates that this property can be read. If true, the property will be included in get_object() and retrieve_objects() requests.",
+                    "markdownDescription": "**Allow Read**\n\nIndicates that this property can be read. If true, the property will be included in get_object() and retrieve_objects() requests.",
+                    "title": "Allow Read",
+                    "type": "boolean"
+                },
+                "allowWrite": {
+                    "description": "If true, the value can be written if allowed by authorization policy as long as allowChange for the instance is also true. If false, the value can only be written if required is true when adding a new object.",
+                    "markdownDescription": "**Allow Write**\n\nIf true, the value can be written if allowed by authorization policy as long as allowChange for the instance is also true. If false, the value can only be written if required is true when adding a new object.",
+                    "title": "Allow Write",
+                    "type": "boolean"
+                },
+                "allowedValues": {
+                    "description": "This is an array of the allowed values for this adaptive value. The dataType and dataTypeParameter of these values is the same as for the adaptive value itself.",
+                    "markdownDescription": "**Allowed Values**\n\nThis is an array of the allowed values for this adaptive value. The dataType and dataTypeParameter of these values is the same as for the adaptive value itself.",
+                    "title": "Allowed Values",
+                    "type": "array"
+                },
+                "brief": {
+                    "description": "This is a predicate for this value, with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for this value, with the first letter capitalized and without a trailing period.",
+                    "title": "Brief",
+                    "type": "string"
+                },
+                "collectionURIs": {
+                    "description": "This is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                    "items": {
+                        "description": "This is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                        "format": "uri-reference",
+                        "markdownDescription": "This is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                        "title": "The URIs of the collection that this value is a part of",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Collection URIs**\n\nThis is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                    "title": "Collection URIs",
+                    "type": "array"
+                },
+                "contextType": {
+                    "description": "For data types that are evaluated (evaluate property true), this is the context type used for the evaluation.",
+                    "markdownDescription": "**Context Type**\n\nFor data types that are evaluated (evaluate property true), this is the context type used for the evaluation.",
+                    "title": "Context Type",
+                    "type": "string"
+                },
+                "custom": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveTemplateProperties_"
+                        }
+                    ],
+                    "description": "Property type level qualifier custom:: variables available to model expressions.",
+                    "markdownDescription": "**Custom**\n\nProperty type level qualifier custom:: variables available to model expressions.",
+                    "title": "Custom",
+                    "type": "object"
+                },
+                "dataType": {
+                    "description": "Data type of this value.",
+                    "markdownDescription": "**Data Type**\n\nData type of this value.",
+                    "title": "Data Type",
+                    "type": "string"
+                },
+                "dataTypeParameter": {
+                    "description": "See the data type's dataTypeParameterType property to determine how to interpret this.",
+                    "markdownDescription": "**Data Type Parameter**\n\nSee the data type's dataTypeParameterType property to determine how to interpret this.",
+                    "title": "Data Type Parameter",
+                    "type": "string"
+                },
+                "dataTypeParameterFormatted": {
+                    "description": "This is the same as dataTypeParameter with possible comments and whitespace. This is especially useful for data type function to document its signature. If this property is not present, dataTypeParameter can be used in its place.",
+                    "markdownDescription": "**Formatted Data Type Parameter**\n\nThis is the same as dataTypeParameter with possible comments and whitespace. This is especially useful for data type function to document its signature. If this property is not present, dataTypeParameter can be used in its place.",
+                    "title": "Formatted Data Type Parameter",
+                    "type": "string"
+                },
+                "defaultValue": {
+                    "description": "This is the default value. The dataType and dataTypeParameter properties apply to this value. If needed, this value will be normalized.",
+                    "markdownDescription": "**Default Value**\n\nThis is the default value. The dataType and dataTypeParameter properties apply to this value. If needed, this value will be normalized.",
+                    "title": "Default Value"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "The description of this value.",
+                    "markdownDescription": "**Description**\n\nThe description of this value.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "hints": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveObject_"
+                        }
+                    ],
+                    "description": "Hints that can optionally be used by UI to render this value.",
+                    "markdownDescription": "**Hints**\n\nHints that can optionally be used by UI to render this value.",
+                    "title": "Hints",
+                    "type": "object"
+                },
+                "label": {
+                    "description": "Label used to identify this value.",
+                    "markdownDescription": "**Label**\n\nLabel used to identify this value.",
+                    "title": "Label",
+                    "type": "string"
+                },
+                "mappedPropertyName": {
+                    "description": "This is the property name of this property used internally by an adapter. If not specified, propertyName is used.",
+                    "markdownDescription": "**Mapped Property Name**\n\nThis is the property name of this property used internally by an adapter. If not specified, propertyName is used.",
+                    "title": "Mapped Property Name",
+                    "type": "string"
+                },
+                "maxLength": {
+                    "description": "This is maximum length of the to_string() for this value. If not specified, there is no maximum length.",
+                    "markdownDescription": "**Maximum Length**\n\nThis is maximum length of the to_string() for this value. If not specified, there is no maximum length.",
+                    "title": "Maximum Length",
+                    "type": "integer"
+                },
+                "maxNormalLength": {
+                    "description": "This is maximum normal length of the to_string() for this value.  If not specified, maxLength is used.",
+                    "markdownDescription": "**Normal Maximum Length**\n\nThis is maximum normal length of the to_string() for this value.  If not specified, maxLength is used.",
+                    "title": "Normal Maximum Length",
+                    "type": "integer"
+                },
+                "maxValue": {
+                    "description": "This is the maximum for this value. If not specified, there is no maximum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "markdownDescription": "**Maximum Value**\n\nThis is the maximum for this value. If not specified, there is no maximum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "title": "Maximum Value"
+                },
+                "method": {
+                    "description": "This is a method for this object that can be called in expressions. This script value must be a lambda function expressed in adaptive script syntax.",
+                    "markdownDescription": "**Method**\n\nThis is a method for this object that can be called in expressions. This script value must be a lambda function expressed in adaptive script syntax.",
+                    "title": "Method",
+                    "type": "string"
+                },
+                "minLength": {
+                    "description": "This is minimum length of the to_string() for this value. If not specified, there is no minimum length.",
+                    "markdownDescription": "**Minimum Length**\n\nThis is minimum length of the to_string() for this value. If not specified, there is no minimum length.",
+                    "title": "Minimum Length",
+                    "type": "integer"
+                },
+                "minValue": {
+                    "description": "This is the minimum for this. If not specified, there is no minimum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "markdownDescription": "**Minimum Value**\n\nThis is the minimum for this. If not specified, there is no minimum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "title": "Minimum Value"
+                },
+                "onGetInitialValue": {
+                    "description": "This is a script value is evaluated to set the value of this property when producing an instance of this object for add object requests.",
+                    "markdownDescription": "**On Get Initial Value**\n\nThis is a script value is evaluated to set the value of this property when producing an instance of this object for add object requests.",
+                    "title": "On Get Initial Value",
+                    "type": "string"
+                },
+                "onGetProperty": {
+                    "description": "This script is evaluated to produce the value of this property when getting an object. If a value of null is returned, the property will not be included in the resulting object.",
+                    "markdownDescription": "**On Get Property**\n\nThis script is evaluated to produce the value of this property when getting an object. If a value of null is returned, the property will not be included in the resulting object.",
+                    "title": "On Get Property",
+                    "type": "string"
+                },
+                "onSetProperty": {
+                    "description": "This script is evaluated to produce the value of this property for add/modify/replace object requests. If initialValue is specified, setProperty is ignored for add object requests. If setProperty is not specified and the property exists in the current object, that value is used. If setProperty is specified, but the evaluation returns a value of null, the property will not be included in the mapped object.",
+                    "markdownDescription": "**On Set Property**\n\nThis script is evaluated to produce the value of this property for add/modify/replace object requests. If initialValue is specified, setProperty is ignored for add object requests. If setProperty is not specified and the property exists in the current object, that value is used. If setProperty is specified, but the evaluation returns a value of null, the property will not be included in the mapped object.",
+                    "title": "On Set Property",
+                    "type": "string"
+                },
+                "originURI": {
+                    "description": "The origin URI of this value meta. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
+                    "format": "uri-reference",
+                    "markdownDescription": "**Origin URI**\n\nThe origin URI of this value meta. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
+                    "title": "Origin URI",
+                    "type": "string"
+                },
+                "possibleValues": {
+                    "description": "Possible values of this value. This can be the typed value or the string value.",
+                    "markdownDescription": "**Possible Values**\n\nPossible values of this value. This can be the typed value or the string value.",
+                    "title": "Possible Values",
+                    "type": "array"
+                },
+                "referenceURI": {
+                    "description": "URI of more reference information about this value meta.",
+                    "format": "uri-reference",
+                    "markdownDescription": "**Reference URI**\n\nURI of more reference information about this value meta.",
+                    "title": "Reference URI",
+                    "type": "string"
+                },
+                "required": {
+                    "default": false,
+                    "description": "Indicates that value is required.",
+                    "markdownDescription": "**Required**\n\nIndicates that value is required.",
+                    "title": "Required",
+                    "type": "boolean"
+                },
+                "runtime": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveRuntimeProperty_"
+                        }
+                    ],
+                    "description": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
+                    "markdownDescription": "**Runtime**\n\nThis is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
+                    "title": "Runtime",
+                    "type": "object"
+                },
+                "skeleton": {
+                    "description": "This is a skeleton example that can optionally be used by an application as an initial value. For example, if this is a new data type 'template' value, this can be the text used to prime the edit window with sample Adaptive Script code including comments.",
+                    "markdownDescription": "**Skeleton**\n\nThis is a skeleton example that can optionally be used by an application as an initial value. For example, if this is a new data type 'template' value, this can be the text used to prime the edit window with sample Adaptive Script code including comments.",
+                    "title": "Skeleton"
+                },
+                "tags": {
+                    "description": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                    "items": {
+                        "description": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                        "markdownDescription": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                        "title": "List of keywords and terms associated with values with this meta",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Tags**\n\nThis is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                    "title": "Tags",
+                    "type": "array"
+                },
+                "testDataParameter": {
+                    "description": "This contains additional information about values with this meta that is used to produce test data.",
+                    "markdownDescription": "**Test Data Parameter**\n\nThis contains additional information about values with this meta that is used to produce test data.",
+                    "title": "Test Data Parameter",
+                    "type": "string"
+                },
+                "transitory": {
+                    "default": false,
+                    "description": "Indicates that this property is transitory and will not be persisted by the adapter. The value can be produced by setValue or supplied in the request.",
+                    "markdownDescription": "**Transitory**\n\nIndicates that this property is transitory and will not be persisted by the adapter. The value can be produced by setValue or supplied in the request.",
+                    "title": "Transitory",
+                    "type": "boolean"
+                },
+                "unique": {
+                    "description": "Value of property must be unique within object type.",
+                    "markdownDescription": "**Unique**\n\nValue of property must be unique within object type.",
+                    "title": "Unique",
+                    "type": "boolean"
+                },
+                "valueInfId": {
+                    "description": "This is a runtime property that is the implementation id of the value interface.",
+                    "markdownDescription": "**valueInf**\n\nThis is a runtime property that is the implementation id of the value interface.",
+                    "readOnly": true,
+                    "title": "valueInf",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveModelPropertyType_",
             "type": "object",
-            "unevaluatedProperties": false
+            "x-afw-inheritedObjectTypes": [
+                "_AdaptiveValueMeta_"
+            ]
         },
         "_AdaptiveModelPropertyType_.propertyTypes": {
             "properties": {
                 "allowRead": {
                     "default": true,
                     "description": "Indicates that this property can be read. If true, the property will be included in get_object() and retrieve_objects() requests.",
+                    "markdownDescription": "**Allow Read**\n\nIndicates that this property can be read. If true, the property will be included in get_object() and retrieve_objects() requests.",
                     "title": "Allow Read",
                     "type": "boolean"
                 },
@@ -28,36 +289,44 @@
                         }
                     ],
                     "description": "Property type level qualifier custom:: variables available to model expressions.",
-                    "title": "Custom"
+                    "markdownDescription": "**Custom**\n\nProperty type level qualifier custom:: variables available to model expressions.",
+                    "title": "Custom",
+                    "type": "object"
                 },
                 "mappedPropertyName": {
                     "description": "This is the property name of this property used internally by an adapter. If not specified, propertyName is used.",
+                    "markdownDescription": "**Mapped Property Name**\n\nThis is the property name of this property used internally by an adapter. If not specified, propertyName is used.",
                     "title": "Mapped Property Name",
                     "type": "string"
                 },
                 "method": {
                     "description": "This is a method for this object that can be called in expressions. This script value must be a lambda function expressed in adaptive script syntax.",
+                    "markdownDescription": "**Method**\n\nThis is a method for this object that can be called in expressions. This script value must be a lambda function expressed in adaptive script syntax.",
                     "title": "Method",
                     "type": "string"
                 },
                 "onGetInitialValue": {
                     "description": "This is a script value is evaluated to set the value of this property when producing an instance of this object for add object requests.",
+                    "markdownDescription": "**On Get Initial Value**\n\nThis is a script value is evaluated to set the value of this property when producing an instance of this object for add object requests.",
                     "title": "On Get Initial Value",
                     "type": "string"
                 },
                 "onGetProperty": {
                     "description": "This script is evaluated to produce the value of this property when getting an object. If a value of null is returned, the property will not be included in the resulting object.",
+                    "markdownDescription": "**On Get Property**\n\nThis script is evaluated to produce the value of this property when getting an object. If a value of null is returned, the property will not be included in the resulting object.",
                     "title": "On Get Property",
                     "type": "string"
                 },
                 "onSetProperty": {
                     "description": "This script is evaluated to produce the value of this property for add/modify/replace object requests. If initialValue is specified, setProperty is ignored for add object requests. If setProperty is not specified and the property exists in the current object, that value is used. If setProperty is specified, but the evaluation returns a value of null, the property will not be included in the mapped object.",
+                    "markdownDescription": "**On Set Property**\n\nThis script is evaluated to produce the value of this property for add/modify/replace object requests. If initialValue is specified, setProperty is ignored for add object requests. If setProperty is not specified and the property exists in the current object, that value is used. If setProperty is specified, but the evaluation returns a value of null, the property will not be included in the mapped object.",
                     "title": "On Set Property",
                     "type": "string"
                 },
                 "transitory": {
                     "default": false,
                     "description": "Indicates that this property is transitory and will not be persisted by the adapter. The value can be produced by setValue or supplied in the request.",
+                    "markdownDescription": "**Transitory**\n\nIndicates that this property is transitory and will not be persisted by the adapter. The value can be produced by setValue or supplied in the request.",
                     "title": "Transitory",
                     "type": "boolean"
                 }
@@ -66,12 +335,17 @@
         },
         "_AdaptiveObject_": {
             "additionalProperties": true,
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveObject_.propertyTypes"
-                }
-            ],
             "description": "Hints that can optionally be used by UI to render this value.",
+            "markdownDescription": "Hints that can optionally be used by UI to render this value.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                }
+            },
             "title": "Hints",
             "type": "object"
         },
@@ -80,35 +354,68 @@
             "type": "object"
         },
         "_AdaptiveRuntimeProperty_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveRuntimeProperty_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
-            "title": "Runtime",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveRuntimeProperty_.propertyTypes": {
+            "markdownDescription": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "memberName": {
                     "description": "The member name of this property in the runtime struct if other than the property name.",
+                    "markdownDescription": "**Member Name**\n\nThe member name of this property in the runtime struct if other than the property name.",
                     "title": "Member Name",
                     "type": "string"
                 },
                 "onGetValueCFunctionName": {
                     "description": "This is the name of the c callback function called to get the value of this property at runtime. If this property is specified, valueAccessor is ignored.",
+                    "markdownDescription": "**onGetValueCFunctionName**\n\nThis is the name of the c callback function called to get the value of this property at runtime. If this property is specified, valueAccessor is ignored.",
                     "title": "onGetValueCFunctionName",
                     "type": "string"
                 },
                 "valueAccessor": {
                     "description": "The name of the registered value accessor used to access this property. The default is default. See afw_runtime_value_accessor.h for the built in accessors.",
+                    "markdownDescription": "**Value Accessor**\n\nThe name of the registered value accessor used to access this property. The default is default. See afw_runtime_value_accessor.h for the built in accessors.",
                     "title": "Value Accessor",
                     "type": "string"
                 },
                 "zeroOffset": {
                     "description": "Indicates that the value accessor is called with a pointer to the struct and a 0 offset.",
+                    "markdownDescription": "**Zero Offset**\n\nIndicates that the value accessor is called with a pointer to the struct and a 0 offset.",
+                    "title": "Zero Offset",
+                    "type": "boolean"
+                }
+            },
+            "title": "Runtime",
+            "type": "object"
+        },
+        "_AdaptiveRuntimeProperty_.propertyTypes": {
+            "properties": {
+                "memberName": {
+                    "description": "The member name of this property in the runtime struct if other than the property name.",
+                    "markdownDescription": "**Member Name**\n\nThe member name of this property in the runtime struct if other than the property name.",
+                    "title": "Member Name",
+                    "type": "string"
+                },
+                "onGetValueCFunctionName": {
+                    "description": "This is the name of the c callback function called to get the value of this property at runtime. If this property is specified, valueAccessor is ignored.",
+                    "markdownDescription": "**onGetValueCFunctionName**\n\nThis is the name of the c callback function called to get the value of this property at runtime. If this property is specified, valueAccessor is ignored.",
+                    "title": "onGetValueCFunctionName",
+                    "type": "string"
+                },
+                "valueAccessor": {
+                    "description": "The name of the registered value accessor used to access this property. The default is default. See afw_runtime_value_accessor.h for the built in accessors.",
+                    "markdownDescription": "**Value Accessor**\n\nThe name of the registered value accessor used to access this property. The default is default. See afw_runtime_value_accessor.h for the built in accessors.",
+                    "title": "Value Accessor",
+                    "type": "string"
+                },
+                "zeroOffset": {
+                    "description": "Indicates that the value accessor is called with a pointer to the struct and a 0 offset.",
+                    "markdownDescription": "**Zero Offset**\n\nIndicates that the value accessor is called with a pointer to the struct and a 0 offset.",
                     "title": "Zero Offset",
                     "type": "boolean"
                 }
@@ -118,14 +425,20 @@
         "_AdaptiveTemplateProperties_": {
             "additionalProperties": {
                 "description": "Each property is a template value.",
+                "markdownDescription": "Each property is a template value.",
                 "type": "string"
             },
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveTemplateProperties_.propertyTypes"
-                }
-            ],
             "description": "Property type level qualifier custom:: variables available to model expressions.",
+            "markdownDescription": "Property type level qualifier custom:: variables available to model expressions.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                }
+            },
             "title": "Custom",
             "type": "object"
         },
@@ -137,26 +450,31 @@
             "properties": {
                 "additionalConstraints": {
                     "description": "Additional constraint for the value.",
+                    "markdownDescription": "**Additional Constraints**\n\nAdditional constraint for the value.",
                     "title": "Additional Constraints",
                     "type": "string"
                 },
                 "allowQuery": {
                     "description": "If false, this value can NEVER be queried. If true, this value can be queried if allowed by authorization policy.",
+                    "markdownDescription": "**Allow Query**\n\nIf false, this value can NEVER be queried. If true, this value can be queried if allowed by authorization policy.",
                     "title": "Allow Query",
                     "type": "boolean"
                 },
                 "allowWrite": {
                     "description": "If true, the value can be written if allowed by authorization policy as long as allowChange for the instance is also true. If false, the value can only be written if required is true when adding a new object.",
+                    "markdownDescription": "**Allow Write**\n\nIf true, the value can be written if allowed by authorization policy as long as allowChange for the instance is also true. If false, the value can only be written if required is true when adding a new object.",
                     "title": "Allow Write",
                     "type": "boolean"
                 },
                 "allowedValues": {
                     "description": "This is an array of the allowed values for this adaptive value. The dataType and dataTypeParameter of these values is the same as for the adaptive value itself.",
+                    "markdownDescription": "**Allowed Values**\n\nThis is an array of the allowed values for this adaptive value. The dataType and dataTypeParameter of these values is the same as for the adaptive value itself.",
                     "title": "Allowed Values",
                     "type": "array"
                 },
                 "brief": {
                     "description": "This is a predicate for this value, with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for this value, with the first letter capitalized and without a trailing period.",
                     "title": "Brief",
                     "type": "string"
                 },
@@ -165,39 +483,47 @@
                     "items": {
                         "description": "This is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
                         "format": "uri-reference",
+                        "markdownDescription": "This is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
                         "title": "The URIs of the collection that this value is a part of",
                         "type": "string"
                     },
+                    "markdownDescription": "**Collection URIs**\n\nThis is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
                     "title": "Collection URIs",
                     "type": "array"
                 },
                 "contextType": {
                     "description": "For data types that are evaluated (evaluate property true), this is the context type used for the evaluation.",
+                    "markdownDescription": "**Context Type**\n\nFor data types that are evaluated (evaluate property true), this is the context type used for the evaluation.",
                     "title": "Context Type",
                     "type": "string"
                 },
                 "dataType": {
                     "description": "Data type of this value.",
+                    "markdownDescription": "**Data Type**\n\nData type of this value.",
                     "title": "Data Type",
                     "type": "string"
                 },
                 "dataTypeParameter": {
                     "description": "See the data type's dataTypeParameterType property to determine how to interpret this.",
+                    "markdownDescription": "**Data Type Parameter**\n\nSee the data type's dataTypeParameterType property to determine how to interpret this.",
                     "title": "Data Type Parameter",
                     "type": "string"
                 },
                 "dataTypeParameterFormatted": {
                     "description": "This is the same as dataTypeParameter with possible comments and whitespace. This is especially useful for data type function to document its signature. If this property is not present, dataTypeParameter can be used in its place.",
+                    "markdownDescription": "**Formatted Data Type Parameter**\n\nThis is the same as dataTypeParameter with possible comments and whitespace. This is especially useful for data type function to document its signature. If this property is not present, dataTypeParameter can be used in its place.",
                     "title": "Formatted Data Type Parameter",
                     "type": "string"
                 },
                 "defaultValue": {
                     "description": "This is the default value. The dataType and dataTypeParameter properties apply to this value. If needed, this value will be normalized.",
+                    "markdownDescription": "**Default Value**\n\nThis is the default value. The dataType and dataTypeParameter properties apply to this value. If needed, this value will be normalized.",
                     "title": "Default Value"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "The description of this value.",
+                    "markdownDescription": "**Description**\n\nThe description of this value.",
                     "title": "Description",
                     "type": "string"
                 },
@@ -208,56 +534,68 @@
                         }
                     ],
                     "description": "Hints that can optionally be used by UI to render this value.",
-                    "title": "Hints"
+                    "markdownDescription": "**Hints**\n\nHints that can optionally be used by UI to render this value.",
+                    "title": "Hints",
+                    "type": "object"
                 },
                 "label": {
                     "description": "Label used to identify this value.",
+                    "markdownDescription": "**Label**\n\nLabel used to identify this value.",
                     "title": "Label",
                     "type": "string"
                 },
                 "maxLength": {
                     "description": "This is maximum length of the to_string() for this value. If not specified, there is no maximum length.",
+                    "markdownDescription": "**Maximum Length**\n\nThis is maximum length of the to_string() for this value. If not specified, there is no maximum length.",
                     "title": "Maximum Length",
                     "type": "integer"
                 },
                 "maxNormalLength": {
                     "description": "This is maximum normal length of the to_string() for this value.  If not specified, maxLength is used.",
+                    "markdownDescription": "**Normal Maximum Length**\n\nThis is maximum normal length of the to_string() for this value.  If not specified, maxLength is used.",
                     "title": "Normal Maximum Length",
                     "type": "integer"
                 },
                 "maxValue": {
                     "description": "This is the maximum for this value. If not specified, there is no maximum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "markdownDescription": "**Maximum Value**\n\nThis is the maximum for this value. If not specified, there is no maximum value. The dataType and dataTypeParameter of this value is the same as for the value.",
                     "title": "Maximum Value"
                 },
                 "minLength": {
                     "description": "This is minimum length of the to_string() for this value. If not specified, there is no minimum length.",
+                    "markdownDescription": "**Minimum Length**\n\nThis is minimum length of the to_string() for this value. If not specified, there is no minimum length.",
                     "title": "Minimum Length",
                     "type": "integer"
                 },
                 "minValue": {
                     "description": "This is the minimum for this. If not specified, there is no minimum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "markdownDescription": "**Minimum Value**\n\nThis is the minimum for this. If not specified, there is no minimum value. The dataType and dataTypeParameter of this value is the same as for the value.",
                     "title": "Minimum Value"
                 },
                 "originURI": {
                     "description": "The origin URI of this value meta. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
                     "format": "uri-reference",
+                    "markdownDescription": "**Origin URI**\n\nThe origin URI of this value meta. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
                     "title": "Origin URI",
                     "type": "string"
                 },
                 "possibleValues": {
                     "description": "Possible values of this value. This can be the typed value or the string value.",
+                    "markdownDescription": "**Possible Values**\n\nPossible values of this value. This can be the typed value or the string value.",
                     "title": "Possible Values",
                     "type": "array"
                 },
                 "referenceURI": {
                     "description": "URI of more reference information about this value meta.",
                     "format": "uri-reference",
+                    "markdownDescription": "**Reference URI**\n\nURI of more reference information about this value meta.",
                     "title": "Reference URI",
                     "type": "string"
                 },
                 "required": {
                     "default": false,
                     "description": "Indicates that value is required.",
+                    "markdownDescription": "**Required**\n\nIndicates that value is required.",
                     "title": "Required",
                     "type": "boolean"
                 },
@@ -268,34 +606,42 @@
                         }
                     ],
                     "description": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
-                    "title": "Runtime"
+                    "markdownDescription": "**Runtime**\n\nThis is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
+                    "title": "Runtime",
+                    "type": "object"
                 },
                 "skeleton": {
                     "description": "This is a skeleton example that can optionally be used by an application as an initial value. For example, if this is a new data type 'template' value, this can be the text used to prime the edit window with sample Adaptive Script code including comments.",
+                    "markdownDescription": "**Skeleton**\n\nThis is a skeleton example that can optionally be used by an application as an initial value. For example, if this is a new data type 'template' value, this can be the text used to prime the edit window with sample Adaptive Script code including comments.",
                     "title": "Skeleton"
                 },
                 "tags": {
                     "description": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
                     "items": {
                         "description": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                        "markdownDescription": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
                         "title": "List of keywords and terms associated with values with this meta",
                         "type": "string"
                     },
+                    "markdownDescription": "**Tags**\n\nThis is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
                     "title": "Tags",
                     "type": "array"
                 },
                 "testDataParameter": {
                     "description": "This contains additional information about values with this meta that is used to produce test data.",
+                    "markdownDescription": "**Test Data Parameter**\n\nThis contains additional information about values with this meta that is used to produce test data.",
                     "title": "Test Data Parameter",
                     "type": "string"
                 },
                 "unique": {
                     "description": "Value of property must be unique within object type.",
+                    "markdownDescription": "**Unique**\n\nValue of property must be unique within object type.",
                     "title": "Unique",
                     "type": "boolean"
                 },
                 "valueInfId": {
                     "description": "This is a runtime property that is the implementation id of the value interface.",
+                    "markdownDescription": "**valueInf**\n\nThis is a runtime property that is the implementation id of the value interface.",
                     "readOnly": true,
                     "title": "valueInf",
                     "type": "string"
@@ -305,9 +651,274 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveModelPropertyType_"
+    "additionalProperties": false,
+    "description": "The object type for properties in the 'propertyTypes' property of instances of _AdaptiveModelObjectType_. This includes all of the properties from _AdaptiveValueMeta_ plus additional private properties used by Adaptive Framework to support the property.",
+    "markdownDescription": "The object type for properties in the 'propertyTypes' property of instances of _AdaptiveModelObjectType_. This includes all of the properties from _AdaptiveValueMeta_ plus additional private properties used by Adaptive Framework to support the property.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "additionalConstraints": {
+            "description": "Additional constraint for the value.",
+            "markdownDescription": "**Additional Constraints**\n\nAdditional constraint for the value.",
+            "title": "Additional Constraints",
+            "type": "string"
+        },
+        "allowQuery": {
+            "description": "If false, this value can NEVER be queried. If true, this value can be queried if allowed by authorization policy.",
+            "markdownDescription": "**Allow Query**\n\nIf false, this value can NEVER be queried. If true, this value can be queried if allowed by authorization policy.",
+            "title": "Allow Query",
+            "type": "boolean"
+        },
+        "allowRead": {
+            "default": true,
+            "description": "Indicates that this property can be read. If true, the property will be included in get_object() and retrieve_objects() requests.",
+            "markdownDescription": "**Allow Read**\n\nIndicates that this property can be read. If true, the property will be included in get_object() and retrieve_objects() requests.",
+            "title": "Allow Read",
+            "type": "boolean"
+        },
+        "allowWrite": {
+            "description": "If true, the value can be written if allowed by authorization policy as long as allowChange for the instance is also true. If false, the value can only be written if required is true when adding a new object.",
+            "markdownDescription": "**Allow Write**\n\nIf true, the value can be written if allowed by authorization policy as long as allowChange for the instance is also true. If false, the value can only be written if required is true when adding a new object.",
+            "title": "Allow Write",
+            "type": "boolean"
+        },
+        "allowedValues": {
+            "description": "This is an array of the allowed values for this adaptive value. The dataType and dataTypeParameter of these values is the same as for the adaptive value itself.",
+            "markdownDescription": "**Allowed Values**\n\nThis is an array of the allowed values for this adaptive value. The dataType and dataTypeParameter of these values is the same as for the adaptive value itself.",
+            "title": "Allowed Values",
+            "type": "array"
+        },
+        "brief": {
+            "description": "This is a predicate for this value, with the first letter capitalized and without a trailing period.",
+            "markdownDescription": "**Brief**\n\nThis is a predicate for this value, with the first letter capitalized and without a trailing period.",
+            "title": "Brief",
+            "type": "string"
+        },
+        "collectionURIs": {
+            "description": "This is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+            "items": {
+                "description": "This is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                "format": "uri-reference",
+                "markdownDescription": "This is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                "title": "The URIs of the collection that this value is a part of",
+                "type": "string"
+            },
+            "markdownDescription": "**Collection URIs**\n\nThis is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+            "title": "Collection URIs",
+            "type": "array"
+        },
+        "contextType": {
+            "description": "For data types that are evaluated (evaluate property true), this is the context type used for the evaluation.",
+            "markdownDescription": "**Context Type**\n\nFor data types that are evaluated (evaluate property true), this is the context type used for the evaluation.",
+            "title": "Context Type",
+            "type": "string"
+        },
+        "custom": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveTemplateProperties_"
+                }
+            ],
+            "description": "Property type level qualifier custom:: variables available to model expressions.",
+            "markdownDescription": "**Custom**\n\nProperty type level qualifier custom:: variables available to model expressions.",
+            "title": "Custom",
+            "type": "object"
+        },
+        "dataType": {
+            "description": "Data type of this value.",
+            "markdownDescription": "**Data Type**\n\nData type of this value.",
+            "title": "Data Type",
+            "type": "string"
+        },
+        "dataTypeParameter": {
+            "description": "See the data type's dataTypeParameterType property to determine how to interpret this.",
+            "markdownDescription": "**Data Type Parameter**\n\nSee the data type's dataTypeParameterType property to determine how to interpret this.",
+            "title": "Data Type Parameter",
+            "type": "string"
+        },
+        "dataTypeParameterFormatted": {
+            "description": "This is the same as dataTypeParameter with possible comments and whitespace. This is especially useful for data type function to document its signature. If this property is not present, dataTypeParameter can be used in its place.",
+            "markdownDescription": "**Formatted Data Type Parameter**\n\nThis is the same as dataTypeParameter with possible comments and whitespace. This is especially useful for data type function to document its signature. If this property is not present, dataTypeParameter can be used in its place.",
+            "title": "Formatted Data Type Parameter",
+            "type": "string"
+        },
+        "defaultValue": {
+            "description": "This is the default value. The dataType and dataTypeParameter properties apply to this value. If needed, this value will be normalized.",
+            "markdownDescription": "**Default Value**\n\nThis is the default value. The dataType and dataTypeParameter properties apply to this value. If needed, this value will be normalized.",
+            "title": "Default Value"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "The description of this value.",
+            "markdownDescription": "**Description**\n\nThe description of this value.",
+            "title": "Description",
+            "type": "string"
+        },
+        "hints": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveObject_"
+                }
+            ],
+            "description": "Hints that can optionally be used by UI to render this value.",
+            "markdownDescription": "**Hints**\n\nHints that can optionally be used by UI to render this value.",
+            "title": "Hints",
+            "type": "object"
+        },
+        "label": {
+            "description": "Label used to identify this value.",
+            "markdownDescription": "**Label**\n\nLabel used to identify this value.",
+            "title": "Label",
+            "type": "string"
+        },
+        "mappedPropertyName": {
+            "description": "This is the property name of this property used internally by an adapter. If not specified, propertyName is used.",
+            "markdownDescription": "**Mapped Property Name**\n\nThis is the property name of this property used internally by an adapter. If not specified, propertyName is used.",
+            "title": "Mapped Property Name",
+            "type": "string"
+        },
+        "maxLength": {
+            "description": "This is maximum length of the to_string() for this value. If not specified, there is no maximum length.",
+            "markdownDescription": "**Maximum Length**\n\nThis is maximum length of the to_string() for this value. If not specified, there is no maximum length.",
+            "title": "Maximum Length",
+            "type": "integer"
+        },
+        "maxNormalLength": {
+            "description": "This is maximum normal length of the to_string() for this value.  If not specified, maxLength is used.",
+            "markdownDescription": "**Normal Maximum Length**\n\nThis is maximum normal length of the to_string() for this value.  If not specified, maxLength is used.",
+            "title": "Normal Maximum Length",
+            "type": "integer"
+        },
+        "maxValue": {
+            "description": "This is the maximum for this value. If not specified, there is no maximum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+            "markdownDescription": "**Maximum Value**\n\nThis is the maximum for this value. If not specified, there is no maximum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+            "title": "Maximum Value"
+        },
+        "method": {
+            "description": "This is a method for this object that can be called in expressions. This script value must be a lambda function expressed in adaptive script syntax.",
+            "markdownDescription": "**Method**\n\nThis is a method for this object that can be called in expressions. This script value must be a lambda function expressed in adaptive script syntax.",
+            "title": "Method",
+            "type": "string"
+        },
+        "minLength": {
+            "description": "This is minimum length of the to_string() for this value. If not specified, there is no minimum length.",
+            "markdownDescription": "**Minimum Length**\n\nThis is minimum length of the to_string() for this value. If not specified, there is no minimum length.",
+            "title": "Minimum Length",
+            "type": "integer"
+        },
+        "minValue": {
+            "description": "This is the minimum for this. If not specified, there is no minimum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+            "markdownDescription": "**Minimum Value**\n\nThis is the minimum for this. If not specified, there is no minimum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+            "title": "Minimum Value"
+        },
+        "onGetInitialValue": {
+            "description": "This is a script value is evaluated to set the value of this property when producing an instance of this object for add object requests.",
+            "markdownDescription": "**On Get Initial Value**\n\nThis is a script value is evaluated to set the value of this property when producing an instance of this object for add object requests.",
+            "title": "On Get Initial Value",
+            "type": "string"
+        },
+        "onGetProperty": {
+            "description": "This script is evaluated to produce the value of this property when getting an object. If a value of null is returned, the property will not be included in the resulting object.",
+            "markdownDescription": "**On Get Property**\n\nThis script is evaluated to produce the value of this property when getting an object. If a value of null is returned, the property will not be included in the resulting object.",
+            "title": "On Get Property",
+            "type": "string"
+        },
+        "onSetProperty": {
+            "description": "This script is evaluated to produce the value of this property for add/modify/replace object requests. If initialValue is specified, setProperty is ignored for add object requests. If setProperty is not specified and the property exists in the current object, that value is used. If setProperty is specified, but the evaluation returns a value of null, the property will not be included in the mapped object.",
+            "markdownDescription": "**On Set Property**\n\nThis script is evaluated to produce the value of this property for add/modify/replace object requests. If initialValue is specified, setProperty is ignored for add object requests. If setProperty is not specified and the property exists in the current object, that value is used. If setProperty is specified, but the evaluation returns a value of null, the property will not be included in the mapped object.",
+            "title": "On Set Property",
+            "type": "string"
+        },
+        "originURI": {
+            "description": "The origin URI of this value meta. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
+            "format": "uri-reference",
+            "markdownDescription": "**Origin URI**\n\nThe origin URI of this value meta. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
+            "title": "Origin URI",
+            "type": "string"
+        },
+        "possibleValues": {
+            "description": "Possible values of this value. This can be the typed value or the string value.",
+            "markdownDescription": "**Possible Values**\n\nPossible values of this value. This can be the typed value or the string value.",
+            "title": "Possible Values",
+            "type": "array"
+        },
+        "referenceURI": {
+            "description": "URI of more reference information about this value meta.",
+            "format": "uri-reference",
+            "markdownDescription": "**Reference URI**\n\nURI of more reference information about this value meta.",
+            "title": "Reference URI",
+            "type": "string"
+        },
+        "required": {
+            "default": false,
+            "description": "Indicates that value is required.",
+            "markdownDescription": "**Required**\n\nIndicates that value is required.",
+            "title": "Required",
+            "type": "boolean"
+        },
+        "runtime": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveRuntimeProperty_"
+                }
+            ],
+            "description": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
+            "markdownDescription": "**Runtime**\n\nThis is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
+            "title": "Runtime",
+            "type": "object"
+        },
+        "skeleton": {
+            "description": "This is a skeleton example that can optionally be used by an application as an initial value. For example, if this is a new data type 'template' value, this can be the text used to prime the edit window with sample Adaptive Script code including comments.",
+            "markdownDescription": "**Skeleton**\n\nThis is a skeleton example that can optionally be used by an application as an initial value. For example, if this is a new data type 'template' value, this can be the text used to prime the edit window with sample Adaptive Script code including comments.",
+            "title": "Skeleton"
+        },
+        "tags": {
+            "description": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+            "items": {
+                "description": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                "markdownDescription": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                "title": "List of keywords and terms associated with values with this meta",
+                "type": "string"
+            },
+            "markdownDescription": "**Tags**\n\nThis is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+            "title": "Tags",
+            "type": "array"
+        },
+        "testDataParameter": {
+            "description": "This contains additional information about values with this meta that is used to produce test data.",
+            "markdownDescription": "**Test Data Parameter**\n\nThis contains additional information about values with this meta that is used to produce test data.",
+            "title": "Test Data Parameter",
+            "type": "string"
+        },
+        "transitory": {
+            "default": false,
+            "description": "Indicates that this property is transitory and will not be persisted by the adapter. The value can be produced by setValue or supplied in the request.",
+            "markdownDescription": "**Transitory**\n\nIndicates that this property is transitory and will not be persisted by the adapter. The value can be produced by setValue or supplied in the request.",
+            "title": "Transitory",
+            "type": "boolean"
+        },
+        "unique": {
+            "description": "Value of property must be unique within object type.",
+            "markdownDescription": "**Unique**\n\nValue of property must be unique within object type.",
+            "title": "Unique",
+            "type": "boolean"
+        },
+        "valueInfId": {
+            "description": "This is a runtime property that is the implementation id of the value interface.",
+            "markdownDescription": "**valueInf**\n\nThis is a runtime property that is the implementation id of the value interface.",
+            "readOnly": true,
+            "title": "valueInf",
+            "type": "string"
         }
+    },
+    "title": "_AdaptiveModelPropertyType_",
+    "type": "object",
+    "x-afw-inheritedObjectTypes": [
+        "_AdaptiveValueMeta_"
     ]
 }

--- a/generated/schemas/afw/_AdaptiveModel_.json
+++ b/generated/schemas/afw/_AdaptiveModel_.json
@@ -1,17 +1,214 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveModel_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveModelObjectType_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveModelObjectType_.propertyTypes"
-                },
-                {
-                    "$ref": "#/$defs/_AdaptiveObjectType_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Defines an Object Type definition in this Adaptive Model.",
+            "markdownDescription": "Defines an Object Type definition in this Adaptive Model.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "allowAdd": {
+                    "default": true,
+                    "description": "If false, objects of this type can NEVER be added via an adapter. If true, objects of this type can be added via an adapter as long as allowed by authorization policy and the adapter.",
+                    "markdownDescription": "**Allow Add**\n\nIf false, objects of this type can NEVER be added via an adapter. If true, objects of this type can be added via an adapter as long as allowed by authorization policy and the adapter.",
+                    "title": "Allow Add",
+                    "type": "boolean"
+                },
+                "allowChange": {
+                    "default": true,
+                    "description": "If false, objects of this type can NEVER be changed via an adapter. If true, objects of this type can be changed via an adapter as long as allowed by authorization policy and the adapter.",
+                    "markdownDescription": "**Allow Change**\n\nIf false, objects of this type can NEVER be changed via an adapter. If true, objects of this type can be changed via an adapter as long as allowed by authorization policy and the adapter.",
+                    "title": "Allow Change",
+                    "type": "boolean"
+                },
+                "allowDelete": {
+                    "default": true,
+                    "description": "If false, objects of this type can NEVER be deleted via an adapter. If true, objects of this type can be deleted via an adapter as long as allowed by authorization policy and the adapter.",
+                    "markdownDescription": "**Allow Delete**\n\nIf false, objects of this type can NEVER be deleted via an adapter. If true, objects of this type can be deleted via an adapter as long as allowed by authorization policy and the adapter.",
+                    "title": "Allow Delete",
+                    "type": "boolean"
+                },
+                "allowEntity": {
+                    "default": true,
+                    "description": "Instances of this object type can exist as an entity object, not just an embedded object.",
+                    "markdownDescription": "**Allow Entity**\n\nInstances of this object type can exist as an entity object, not just an embedded object.",
+                    "title": "Allow Entity",
+                    "type": "boolean"
+                },
+                "collectionURIs": {
+                    "description": "This is the URIs of the collections this object type is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                    "items": {
+                        "description": "This is the URIs of the collections this object type is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                        "format": "uri-reference",
+                        "markdownDescription": "This is the URIs of the collections this object type is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                        "title": "The URIs of the collections this object type is a part of",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Collection URIs**\n\nThis is the URIs of the collections this object type is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                    "title": "Collection URIs",
+                    "type": "array"
+                },
+                "custom": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveTemplateProperties_"
+                        }
+                    ],
+                    "description": "Object type level qualifier custom:: variables available to model expressions.",
+                    "markdownDescription": "**Custom**\n\nObject type level qualifier custom:: variables available to model expressions.",
+                    "title": "Custom",
+                    "type": "object"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "The description of the object type.",
+                    "markdownDescription": "**Description**\n\nThe description of the object type.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "descriptionPropertyName": {
+                    "description": "The name of the property in an instance that is used as the 'description' property in the meta for instances of this object type. If not specified, no description will be available.",
+                    "markdownDescription": "**Description Property Name**\n\nThe name of the property in an instance that is used as the 'description' property in the meta for instances of this object type. If not specified, no description will be available.",
+                    "title": "Description Property Name",
+                    "type": "string"
+                },
+                "label": {
+                    "description": "Label used to identify this instance.",
+                    "markdownDescription": "**Label**\n\nLabel used to identify this instance.",
+                    "title": "Label",
+                    "type": "string"
+                },
+                "mappedObjectType": {
+                    "description": "This is the objectType used internally by the adapter for this object type. It not specified, current::objectType is used.",
+                    "markdownDescription": "**Mapped Object Type**\n\nThis is the objectType used internally by the adapter for this object type. It not specified, current::objectType is used.",
+                    "title": "Mapped Object Type",
+                    "type": "string"
+                },
+                "objectIdPropertyName": {
+                    "description": "The name of the property in an instance that is used as the 'objectId' property in the meta for instances of this object type. If not specified, the internal adapter objectId for an object is used.",
+                    "markdownDescription": "**Object Id Property Name**\n\nThe name of the property in an instance that is used as the 'objectId' property in the meta for instances of this object type. If not specified, the internal adapter objectId for an object is used.",
+                    "title": "Object Id Property Name",
+                    "type": "string"
+                },
+                "objectType": {
+                    "description": "The object id of the object type.",
+                    "markdownDescription": "**Object Type**\n\nThe object id of the object type.",
+                    "title": "Object Type",
+                    "type": "string"
+                },
+                "onAddObject": {
+                    "description": "This can be specified to override default add_object() processing. It can return current::useDefaultProcessing if default processing should occur as if onAddObject was not specified.",
+                    "markdownDescription": "**On add_object**\n\nThis can be specified to override default add_object() processing. It can return current::useDefaultProcessing if default processing should occur as if onAddObject was not specified.",
+                    "title": "On add_object",
+                    "type": "string"
+                },
+                "onDeleteObject": {
+                    "description": "This can be specified to override default delete_object() processing. It can return current::useDefaultProcessing if default processing should occur as if onDeleteObject was not specified.",
+                    "markdownDescription": "**On delete_object**\n\nThis can be specified to override default delete_object() processing. It can return current::useDefaultProcessing if default processing should occur as if onDeleteObject was not specified.",
+                    "title": "On delete_object",
+                    "type": "string"
+                },
+                "onGetInitialObjectId": {
+                    "description": "This optional script value is evaluated to determine the objectId on add requests. If not specified, current::objectId is used and if that is not specified, the adapter must be capable of assigning one. Even if specified, the adapter is free to ignore this.",
+                    "markdownDescription": "**On Get Initial ObjectId**\n\nThis optional script value is evaluated to determine the objectId on add requests. If not specified, current::objectId is used and if that is not specified, the adapter must be capable of assigning one. Even if specified, the adapter is free to ignore this.",
+                    "title": "On Get Initial ObjectId",
+                    "type": "string"
+                },
+                "onGetObject": {
+                    "description": "This can be specified to override default get_object() processing. The script can return an object or undefined if object was to found. It can also return current::useDefaultProcessing if default processing should occur as if onGetObject was not specified.",
+                    "markdownDescription": "**On get_object**\n\nThis can be specified to override default get_object() processing. The script can return an object or undefined if object was to found. It can also return current::useDefaultProcessing if default processing should occur as if onGetObject was not specified.",
+                    "title": "On get_object",
+                    "type": "string"
+                },
+                "onModifyObject": {
+                    "description": "This can be specified to override default modify_object() processing. It can return current::useDefaultProcessing if default processing should occur as if onModifyObject was not specified.",
+                    "markdownDescription": "**On modify_object**\n\nThis can be specified to override default modify_object() processing. It can return current::useDefaultProcessing if default processing should occur as if onModifyObject was not specified.",
+                    "title": "On modify_object",
+                    "type": "string"
+                },
+                "onReplaceObject": {
+                    "description": "This can be specified to override default replace_object() processing. It can return current::useDefaultProcessing if default processing should occur as if onReplaceObjects was not specified.",
+                    "markdownDescription": "**On replace_object**\n\nThis can be specified to override default replace_object() processing. It can return current::useDefaultProcessing if default processing should occur as if onReplaceObjects was not specified.",
+                    "title": "On replace_object",
+                    "type": "string"
+                },
+                "onRetrieveObjects": {
+                    "description": "This can be specified to override default retrieve_objects() processing. This script should call current::returnObject(object) with each object to return. It can also return current::useDefaultProcessing if default processing should occur as if onRetrieveObjects was not specified.",
+                    "markdownDescription": "**On retrieve_objects**\n\nThis can be specified to override default retrieve_objects() processing. This script should call current::returnObject(object) with each object to return. It can also return current::useDefaultProcessing if default processing should occur as if onRetrieveObjects was not specified.",
+                    "title": "On retrieve_objects",
+                    "type": "string"
+                },
+                "originURI": {
+                    "description": "The origin URI of this object type. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
+                    "format": "uri-reference",
+                    "markdownDescription": "**Origin URI**\n\nThe origin URI of this object type. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
+                    "title": "Origin URI",
+                    "type": "string"
+                },
+                "otherProperties": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveValueMeta_"
+                        }
+                    ],
+                    "description": "If specified, this is the property type for properties that are not explicitly specified. If otherProperties is not specified, only explicitly specified properties are allowed.",
+                    "markdownDescription": "**Other Properties**\n\nIf specified, this is the property type for properties that are not explicitly specified. If otherProperties is not specified, only explicitly specified properties are allowed.",
+                    "title": "Other Properties",
+                    "type": "object"
+                },
+                "propertyTypes": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveModelPropertyTypes_"
+                        }
+                    ],
+                    "description": "The name of the properties in this object corresponds to the property name of an instance of this object type and is its property type object.",
+                    "markdownDescription": "**Property Types**\n\nThe name of the properties in this object corresponds to the property name of an instance of this object type and is its property type object.",
+                    "title": "Property Types",
+                    "type": "object"
+                },
+                "referenceURI": {
+                    "description": "URI of more reference information about this object.",
+                    "format": "uri-reference",
+                    "markdownDescription": "**Reference URI**\n\nURI of more reference information about this object.",
+                    "title": "Reference URI",
+                    "type": "string"
+                },
+                "runtime": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveRuntimeObject_"
+                        }
+                    ],
+                    "description": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
+                    "markdownDescription": "**Runtime**\n\nThis is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
+                    "title": "Runtime",
+                    "type": "object"
+                },
+                "tags": {
+                    "description": "This is an array of keywords and terms associated with this object type. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                    "items": {
+                        "description": "This is an array of keywords and terms associated with this object type. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                        "markdownDescription": "This is an array of keywords and terms associated with this object type. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                        "title": "List of keywords associated with this object type",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Tags**\n\nThis is an array of keywords and terms associated with this object type. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                    "title": "Tags",
+                    "type": "array"
+                }
+            },
+            "title": "_AdaptiveModelObjectType_",
             "type": "object",
-            "unevaluatedProperties": false
+            "x-afw-inheritedObjectTypes": [
+                "_AdaptiveObjectType_"
+            ]
         },
         "_AdaptiveModelObjectType_.propertyTypes": {
             "properties": {
@@ -22,45 +219,55 @@
                         }
                     ],
                     "description": "Object type level qualifier custom:: variables available to model expressions.",
-                    "title": "Custom"
+                    "markdownDescription": "**Custom**\n\nObject type level qualifier custom:: variables available to model expressions.",
+                    "title": "Custom",
+                    "type": "object"
                 },
                 "mappedObjectType": {
                     "description": "This is the objectType used internally by the adapter for this object type. It not specified, current::objectType is used.",
+                    "markdownDescription": "**Mapped Object Type**\n\nThis is the objectType used internally by the adapter for this object type. It not specified, current::objectType is used.",
                     "title": "Mapped Object Type",
                     "type": "string"
                 },
                 "onAddObject": {
                     "description": "This can be specified to override default add_object() processing. It can return current::useDefaultProcessing if default processing should occur as if onAddObject was not specified.",
+                    "markdownDescription": "**On add_object**\n\nThis can be specified to override default add_object() processing. It can return current::useDefaultProcessing if default processing should occur as if onAddObject was not specified.",
                     "title": "On add_object",
                     "type": "string"
                 },
                 "onDeleteObject": {
                     "description": "This can be specified to override default delete_object() processing. It can return current::useDefaultProcessing if default processing should occur as if onDeleteObject was not specified.",
+                    "markdownDescription": "**On delete_object**\n\nThis can be specified to override default delete_object() processing. It can return current::useDefaultProcessing if default processing should occur as if onDeleteObject was not specified.",
                     "title": "On delete_object",
                     "type": "string"
                 },
                 "onGetInitialObjectId": {
                     "description": "This optional script value is evaluated to determine the objectId on add requests. If not specified, current::objectId is used and if that is not specified, the adapter must be capable of assigning one. Even if specified, the adapter is free to ignore this.",
+                    "markdownDescription": "**On Get Initial ObjectId**\n\nThis optional script value is evaluated to determine the objectId on add requests. If not specified, current::objectId is used and if that is not specified, the adapter must be capable of assigning one. Even if specified, the adapter is free to ignore this.",
                     "title": "On Get Initial ObjectId",
                     "type": "string"
                 },
                 "onGetObject": {
                     "description": "This can be specified to override default get_object() processing. The script can return an object or undefined if object was to found. It can also return current::useDefaultProcessing if default processing should occur as if onGetObject was not specified.",
+                    "markdownDescription": "**On get_object**\n\nThis can be specified to override default get_object() processing. The script can return an object or undefined if object was to found. It can also return current::useDefaultProcessing if default processing should occur as if onGetObject was not specified.",
                     "title": "On get_object",
                     "type": "string"
                 },
                 "onModifyObject": {
                     "description": "This can be specified to override default modify_object() processing. It can return current::useDefaultProcessing if default processing should occur as if onModifyObject was not specified.",
+                    "markdownDescription": "**On modify_object**\n\nThis can be specified to override default modify_object() processing. It can return current::useDefaultProcessing if default processing should occur as if onModifyObject was not specified.",
                     "title": "On modify_object",
                     "type": "string"
                 },
                 "onReplaceObject": {
                     "description": "This can be specified to override default replace_object() processing. It can return current::useDefaultProcessing if default processing should occur as if onReplaceObjects was not specified.",
+                    "markdownDescription": "**On replace_object**\n\nThis can be specified to override default replace_object() processing. It can return current::useDefaultProcessing if default processing should occur as if onReplaceObjects was not specified.",
                     "title": "On replace_object",
                     "type": "string"
                 },
                 "onRetrieveObjects": {
                     "description": "This can be specified to override default retrieve_objects() processing. This script should call current::returnObject(object) with each object to return. It can also return current::useDefaultProcessing if default processing should occur as if onRetrieveObjects was not specified.",
+                    "markdownDescription": "**On retrieve_objects**\n\nThis can be specified to override default retrieve_objects() processing. This script should call current::returnObject(object) with each object to return. It can also return current::useDefaultProcessing if default processing should occur as if onRetrieveObjects was not specified.",
                     "title": "On retrieve_objects",
                     "type": "string"
                 },
@@ -71,7 +278,9 @@
                         }
                     ],
                     "description": "The name of the properties in this object corresponds to the property name of an instance of this object type and is its property type object.",
-                    "title": "Property Types"
+                    "markdownDescription": "**Property Types**\n\nThe name of the properties in this object corresponds to the property name of an instance of this object type and is its property type object.",
+                    "title": "Property Types",
+                    "type": "object"
                 }
             },
             "type": "object"
@@ -84,14 +293,21 @@
                     }
                 ],
                 "description": "The adaptive object type of all object that contains _AdaptiveModelObjectTypes_ objects as properties.",
-                "title": "Defines an Object Type definition in this Adaptive Model"
+                "markdownDescription": "**Defines an Object Type definition in this Adaptive Model**\n\nThe adaptive object type of all object that contains _AdaptiveModelObjectTypes_ objects as properties.",
+                "title": "Defines an Object Type definition in this Adaptive Model",
+                "type": "object"
             },
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveModelObjectTypes_.propertyTypes"
-                }
-            ],
             "description": "Model for an object type.",
+            "markdownDescription": "Model for an object type.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                }
+            },
             "title": "Object Types",
             "type": "object"
         },
@@ -100,23 +316,283 @@
             "type": "object"
         },
         "_AdaptiveModelPropertyType_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveModelPropertyType_.propertyTypes"
-                },
-                {
-                    "$ref": "#/$defs/_AdaptiveValueMeta_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Defines a Property Type within this Adaptive Model Object Type definition.",
+            "markdownDescription": "Defines a Property Type within this Adaptive Model Object Type definition.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "additionalConstraints": {
+                    "description": "Additional constraint for the value.",
+                    "markdownDescription": "**Additional Constraints**\n\nAdditional constraint for the value.",
+                    "title": "Additional Constraints",
+                    "type": "string"
+                },
+                "allowQuery": {
+                    "description": "If false, this value can NEVER be queried. If true, this value can be queried if allowed by authorization policy.",
+                    "markdownDescription": "**Allow Query**\n\nIf false, this value can NEVER be queried. If true, this value can be queried if allowed by authorization policy.",
+                    "title": "Allow Query",
+                    "type": "boolean"
+                },
+                "allowRead": {
+                    "default": true,
+                    "description": "Indicates that this property can be read. If true, the property will be included in get_object() and retrieve_objects() requests.",
+                    "markdownDescription": "**Allow Read**\n\nIndicates that this property can be read. If true, the property will be included in get_object() and retrieve_objects() requests.",
+                    "title": "Allow Read",
+                    "type": "boolean"
+                },
+                "allowWrite": {
+                    "description": "If true, the value can be written if allowed by authorization policy as long as allowChange for the instance is also true. If false, the value can only be written if required is true when adding a new object.",
+                    "markdownDescription": "**Allow Write**\n\nIf true, the value can be written if allowed by authorization policy as long as allowChange for the instance is also true. If false, the value can only be written if required is true when adding a new object.",
+                    "title": "Allow Write",
+                    "type": "boolean"
+                },
+                "allowedValues": {
+                    "description": "This is an array of the allowed values for this adaptive value. The dataType and dataTypeParameter of these values is the same as for the adaptive value itself.",
+                    "markdownDescription": "**Allowed Values**\n\nThis is an array of the allowed values for this adaptive value. The dataType and dataTypeParameter of these values is the same as for the adaptive value itself.",
+                    "title": "Allowed Values",
+                    "type": "array"
+                },
+                "brief": {
+                    "description": "This is a predicate for this value, with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for this value, with the first letter capitalized and without a trailing period.",
+                    "title": "Brief",
+                    "type": "string"
+                },
+                "collectionURIs": {
+                    "description": "This is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                    "items": {
+                        "description": "This is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                        "format": "uri-reference",
+                        "markdownDescription": "This is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                        "title": "The URIs of the collection that this value is a part of",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Collection URIs**\n\nThis is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                    "title": "Collection URIs",
+                    "type": "array"
+                },
+                "contextType": {
+                    "description": "For data types that are evaluated (evaluate property true), this is the context type used for the evaluation.",
+                    "markdownDescription": "**Context Type**\n\nFor data types that are evaluated (evaluate property true), this is the context type used for the evaluation.",
+                    "title": "Context Type",
+                    "type": "string"
+                },
+                "custom": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveTemplateProperties_"
+                        }
+                    ],
+                    "description": "Property type level qualifier custom:: variables available to model expressions.",
+                    "markdownDescription": "**Custom**\n\nProperty type level qualifier custom:: variables available to model expressions.",
+                    "title": "Custom",
+                    "type": "object"
+                },
+                "dataType": {
+                    "description": "Data type of this value.",
+                    "markdownDescription": "**Data Type**\n\nData type of this value.",
+                    "title": "Data Type",
+                    "type": "string"
+                },
+                "dataTypeParameter": {
+                    "description": "See the data type's dataTypeParameterType property to determine how to interpret this.",
+                    "markdownDescription": "**Data Type Parameter**\n\nSee the data type's dataTypeParameterType property to determine how to interpret this.",
+                    "title": "Data Type Parameter",
+                    "type": "string"
+                },
+                "dataTypeParameterFormatted": {
+                    "description": "This is the same as dataTypeParameter with possible comments and whitespace. This is especially useful for data type function to document its signature. If this property is not present, dataTypeParameter can be used in its place.",
+                    "markdownDescription": "**Formatted Data Type Parameter**\n\nThis is the same as dataTypeParameter with possible comments and whitespace. This is especially useful for data type function to document its signature. If this property is not present, dataTypeParameter can be used in its place.",
+                    "title": "Formatted Data Type Parameter",
+                    "type": "string"
+                },
+                "defaultValue": {
+                    "description": "This is the default value. The dataType and dataTypeParameter properties apply to this value. If needed, this value will be normalized.",
+                    "markdownDescription": "**Default Value**\n\nThis is the default value. The dataType and dataTypeParameter properties apply to this value. If needed, this value will be normalized.",
+                    "title": "Default Value"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "The description of this value.",
+                    "markdownDescription": "**Description**\n\nThe description of this value.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "hints": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveObject_"
+                        }
+                    ],
+                    "description": "Hints that can optionally be used by UI to render this value.",
+                    "markdownDescription": "**Hints**\n\nHints that can optionally be used by UI to render this value.",
+                    "title": "Hints",
+                    "type": "object"
+                },
+                "label": {
+                    "description": "Label used to identify this value.",
+                    "markdownDescription": "**Label**\n\nLabel used to identify this value.",
+                    "title": "Label",
+                    "type": "string"
+                },
+                "mappedPropertyName": {
+                    "description": "This is the property name of this property used internally by an adapter. If not specified, propertyName is used.",
+                    "markdownDescription": "**Mapped Property Name**\n\nThis is the property name of this property used internally by an adapter. If not specified, propertyName is used.",
+                    "title": "Mapped Property Name",
+                    "type": "string"
+                },
+                "maxLength": {
+                    "description": "This is maximum length of the to_string() for this value. If not specified, there is no maximum length.",
+                    "markdownDescription": "**Maximum Length**\n\nThis is maximum length of the to_string() for this value. If not specified, there is no maximum length.",
+                    "title": "Maximum Length",
+                    "type": "integer"
+                },
+                "maxNormalLength": {
+                    "description": "This is maximum normal length of the to_string() for this value.  If not specified, maxLength is used.",
+                    "markdownDescription": "**Normal Maximum Length**\n\nThis is maximum normal length of the to_string() for this value.  If not specified, maxLength is used.",
+                    "title": "Normal Maximum Length",
+                    "type": "integer"
+                },
+                "maxValue": {
+                    "description": "This is the maximum for this value. If not specified, there is no maximum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "markdownDescription": "**Maximum Value**\n\nThis is the maximum for this value. If not specified, there is no maximum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "title": "Maximum Value"
+                },
+                "method": {
+                    "description": "This is a method for this object that can be called in expressions. This script value must be a lambda function expressed in adaptive script syntax.",
+                    "markdownDescription": "**Method**\n\nThis is a method for this object that can be called in expressions. This script value must be a lambda function expressed in adaptive script syntax.",
+                    "title": "Method",
+                    "type": "string"
+                },
+                "minLength": {
+                    "description": "This is minimum length of the to_string() for this value. If not specified, there is no minimum length.",
+                    "markdownDescription": "**Minimum Length**\n\nThis is minimum length of the to_string() for this value. If not specified, there is no minimum length.",
+                    "title": "Minimum Length",
+                    "type": "integer"
+                },
+                "minValue": {
+                    "description": "This is the minimum for this. If not specified, there is no minimum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "markdownDescription": "**Minimum Value**\n\nThis is the minimum for this. If not specified, there is no minimum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "title": "Minimum Value"
+                },
+                "onGetInitialValue": {
+                    "description": "This is a script value is evaluated to set the value of this property when producing an instance of this object for add object requests.",
+                    "markdownDescription": "**On Get Initial Value**\n\nThis is a script value is evaluated to set the value of this property when producing an instance of this object for add object requests.",
+                    "title": "On Get Initial Value",
+                    "type": "string"
+                },
+                "onGetProperty": {
+                    "description": "This script is evaluated to produce the value of this property when getting an object. If a value of null is returned, the property will not be included in the resulting object.",
+                    "markdownDescription": "**On Get Property**\n\nThis script is evaluated to produce the value of this property when getting an object. If a value of null is returned, the property will not be included in the resulting object.",
+                    "title": "On Get Property",
+                    "type": "string"
+                },
+                "onSetProperty": {
+                    "description": "This script is evaluated to produce the value of this property for add/modify/replace object requests. If initialValue is specified, setProperty is ignored for add object requests. If setProperty is not specified and the property exists in the current object, that value is used. If setProperty is specified, but the evaluation returns a value of null, the property will not be included in the mapped object.",
+                    "markdownDescription": "**On Set Property**\n\nThis script is evaluated to produce the value of this property for add/modify/replace object requests. If initialValue is specified, setProperty is ignored for add object requests. If setProperty is not specified and the property exists in the current object, that value is used. If setProperty is specified, but the evaluation returns a value of null, the property will not be included in the mapped object.",
+                    "title": "On Set Property",
+                    "type": "string"
+                },
+                "originURI": {
+                    "description": "The origin URI of this value meta. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
+                    "format": "uri-reference",
+                    "markdownDescription": "**Origin URI**\n\nThe origin URI of this value meta. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
+                    "title": "Origin URI",
+                    "type": "string"
+                },
+                "possibleValues": {
+                    "description": "Possible values of this value. This can be the typed value or the string value.",
+                    "markdownDescription": "**Possible Values**\n\nPossible values of this value. This can be the typed value or the string value.",
+                    "title": "Possible Values",
+                    "type": "array"
+                },
+                "referenceURI": {
+                    "description": "URI of more reference information about this value meta.",
+                    "format": "uri-reference",
+                    "markdownDescription": "**Reference URI**\n\nURI of more reference information about this value meta.",
+                    "title": "Reference URI",
+                    "type": "string"
+                },
+                "required": {
+                    "default": false,
+                    "description": "Indicates that value is required.",
+                    "markdownDescription": "**Required**\n\nIndicates that value is required.",
+                    "title": "Required",
+                    "type": "boolean"
+                },
+                "runtime": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveRuntimeProperty_"
+                        }
+                    ],
+                    "description": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
+                    "markdownDescription": "**Runtime**\n\nThis is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
+                    "title": "Runtime",
+                    "type": "object"
+                },
+                "skeleton": {
+                    "description": "This is a skeleton example that can optionally be used by an application as an initial value. For example, if this is a new data type 'template' value, this can be the text used to prime the edit window with sample Adaptive Script code including comments.",
+                    "markdownDescription": "**Skeleton**\n\nThis is a skeleton example that can optionally be used by an application as an initial value. For example, if this is a new data type 'template' value, this can be the text used to prime the edit window with sample Adaptive Script code including comments.",
+                    "title": "Skeleton"
+                },
+                "tags": {
+                    "description": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                    "items": {
+                        "description": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                        "markdownDescription": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                        "title": "List of keywords and terms associated with values with this meta",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Tags**\n\nThis is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                    "title": "Tags",
+                    "type": "array"
+                },
+                "testDataParameter": {
+                    "description": "This contains additional information about values with this meta that is used to produce test data.",
+                    "markdownDescription": "**Test Data Parameter**\n\nThis contains additional information about values with this meta that is used to produce test data.",
+                    "title": "Test Data Parameter",
+                    "type": "string"
+                },
+                "transitory": {
+                    "default": false,
+                    "description": "Indicates that this property is transitory and will not be persisted by the adapter. The value can be produced by setValue or supplied in the request.",
+                    "markdownDescription": "**Transitory**\n\nIndicates that this property is transitory and will not be persisted by the adapter. The value can be produced by setValue or supplied in the request.",
+                    "title": "Transitory",
+                    "type": "boolean"
+                },
+                "unique": {
+                    "description": "Value of property must be unique within object type.",
+                    "markdownDescription": "**Unique**\n\nValue of property must be unique within object type.",
+                    "title": "Unique",
+                    "type": "boolean"
+                },
+                "valueInfId": {
+                    "description": "This is a runtime property that is the implementation id of the value interface.",
+                    "markdownDescription": "**valueInf**\n\nThis is a runtime property that is the implementation id of the value interface.",
+                    "readOnly": true,
+                    "title": "valueInf",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveModelPropertyType_",
             "type": "object",
-            "unevaluatedProperties": false
+            "x-afw-inheritedObjectTypes": [
+                "_AdaptiveValueMeta_"
+            ]
         },
         "_AdaptiveModelPropertyType_.propertyTypes": {
             "properties": {
                 "allowRead": {
                     "default": true,
                     "description": "Indicates that this property can be read. If true, the property will be included in get_object() and retrieve_objects() requests.",
+                    "markdownDescription": "**Allow Read**\n\nIndicates that this property can be read. If true, the property will be included in get_object() and retrieve_objects() requests.",
                     "title": "Allow Read",
                     "type": "boolean"
                 },
@@ -127,36 +603,44 @@
                         }
                     ],
                     "description": "Property type level qualifier custom:: variables available to model expressions.",
-                    "title": "Custom"
+                    "markdownDescription": "**Custom**\n\nProperty type level qualifier custom:: variables available to model expressions.",
+                    "title": "Custom",
+                    "type": "object"
                 },
                 "mappedPropertyName": {
                     "description": "This is the property name of this property used internally by an adapter. If not specified, propertyName is used.",
+                    "markdownDescription": "**Mapped Property Name**\n\nThis is the property name of this property used internally by an adapter. If not specified, propertyName is used.",
                     "title": "Mapped Property Name",
                     "type": "string"
                 },
                 "method": {
                     "description": "This is a method for this object that can be called in expressions. This script value must be a lambda function expressed in adaptive script syntax.",
+                    "markdownDescription": "**Method**\n\nThis is a method for this object that can be called in expressions. This script value must be a lambda function expressed in adaptive script syntax.",
                     "title": "Method",
                     "type": "string"
                 },
                 "onGetInitialValue": {
                     "description": "This is a script value is evaluated to set the value of this property when producing an instance of this object for add object requests.",
+                    "markdownDescription": "**On Get Initial Value**\n\nThis is a script value is evaluated to set the value of this property when producing an instance of this object for add object requests.",
                     "title": "On Get Initial Value",
                     "type": "string"
                 },
                 "onGetProperty": {
                     "description": "This script is evaluated to produce the value of this property when getting an object. If a value of null is returned, the property will not be included in the resulting object.",
+                    "markdownDescription": "**On Get Property**\n\nThis script is evaluated to produce the value of this property when getting an object. If a value of null is returned, the property will not be included in the resulting object.",
                     "title": "On Get Property",
                     "type": "string"
                 },
                 "onSetProperty": {
                     "description": "This script is evaluated to produce the value of this property for add/modify/replace object requests. If initialValue is specified, setProperty is ignored for add object requests. If setProperty is not specified and the property exists in the current object, that value is used. If setProperty is specified, but the evaluation returns a value of null, the property will not be included in the mapped object.",
+                    "markdownDescription": "**On Set Property**\n\nThis script is evaluated to produce the value of this property for add/modify/replace object requests. If initialValue is specified, setProperty is ignored for add object requests. If setProperty is not specified and the property exists in the current object, that value is used. If setProperty is specified, but the evaluation returns a value of null, the property will not be included in the mapped object.",
                     "title": "On Set Property",
                     "type": "string"
                 },
                 "transitory": {
                     "default": false,
                     "description": "Indicates that this property is transitory and will not be persisted by the adapter. The value can be produced by setValue or supplied in the request.",
+                    "markdownDescription": "**Transitory**\n\nIndicates that this property is transitory and will not be persisted by the adapter. The value can be produced by setValue or supplied in the request.",
                     "title": "Transitory",
                     "type": "boolean"
                 }
@@ -171,14 +655,21 @@
                     }
                 ],
                 "description": "Object type of the propertyTypes property of instances of _AdaptiveModelObjectType_.",
-                "title": "Defines a Property Type within this Adaptive Model Object Type definition"
+                "markdownDescription": "**Defines a Property Type within this Adaptive Model Object Type definition**\n\nObject type of the propertyTypes property of instances of _AdaptiveModelObjectType_.",
+                "title": "Defines a Property Type within this Adaptive Model Object Type definition",
+                "type": "object"
             },
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveModelPropertyTypes_.propertyTypes"
-                }
-            ],
             "description": "The name of the properties in this object corresponds to the property name of an instance of this object type and is its property type object.",
+            "markdownDescription": "The name of the properties in this object corresponds to the property name of an instance of this object type and is its property type object.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                }
+            },
             "title": "Property Types",
             "type": "object"
         },
@@ -187,25 +678,27 @@
             "type": "object"
         },
         "_AdaptiveModel_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveModel_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Adaptive map object type.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveModel_.propertyTypes": {
+            "markdownDescription": "Adaptive map object type.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "collectionURIs": {
                     "description": "This is the URIs of the collections this map is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
                     "items": {
                         "description": "This is the URIs of the collections this map is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
                         "format": "uri-reference",
+                        "markdownDescription": "This is the URIs of the collections this map is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
                         "title": "The URIs of the collections this map is part of",
                         "type": "string"
                     },
+                    "markdownDescription": "**Collection URIs**\n\nThis is the URIs of the collections this map is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
                     "title": "Collection URIs",
                     "type": "array"
                 },
@@ -216,16 +709,20 @@
                         }
                     ],
                     "description": "Qualifier custom:: variables available to model expressions.",
-                    "title": "Custom"
+                    "markdownDescription": "**Custom**\n\nQualifier custom:: variables available to model expressions.",
+                    "title": "Custom",
+                    "type": "object"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "Description of this model.",
+                    "markdownDescription": "**Description**\n\nDescription of this model.",
                     "title": "Description",
                     "type": "string"
                 },
                 "modelId": {
                     "description": "Object id of model.",
+                    "markdownDescription": "**Model**\n\nObject id of model.",
                     "title": "Model",
                     "type": "string"
                 },
@@ -236,12 +733,15 @@
                         }
                     ],
                     "description": "Model for an object type.",
+                    "markdownDescription": "**Object Types**\n\nModel for an object type.",
                     "readOnly": false,
-                    "title": "Object Types"
+                    "title": "Object Types",
+                    "type": "object"
                 },
                 "originURI": {
                     "description": "The origin URI of this model. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
                     "format": "uri-reference",
+                    "markdownDescription": "**Origin URI**\n\nThe origin URI of this model. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
                     "title": "Origin URI",
                     "type": "string"
                 },
@@ -252,7 +752,82 @@
                         }
                     ],
                     "description": "Property type objects that can be inherited by propertyTypes in objectTypes.",
-                    "title": "Property Types"
+                    "markdownDescription": "**Property Types**\n\nProperty type objects that can be inherited by propertyTypes in objectTypes.",
+                    "title": "Property Types",
+                    "type": "object"
+                }
+            },
+            "title": "_AdaptiveModel_",
+            "type": "object"
+        },
+        "_AdaptiveModel_.propertyTypes": {
+            "properties": {
+                "collectionURIs": {
+                    "description": "This is the URIs of the collections this map is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                    "items": {
+                        "description": "This is the URIs of the collections this map is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                        "format": "uri-reference",
+                        "markdownDescription": "This is the URIs of the collections this map is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                        "title": "The URIs of the collections this map is part of",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Collection URIs**\n\nThis is the URIs of the collections this map is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                    "title": "Collection URIs",
+                    "type": "array"
+                },
+                "custom": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveTemplateProperties_"
+                        }
+                    ],
+                    "description": "Qualifier custom:: variables available to model expressions.",
+                    "markdownDescription": "**Custom**\n\nQualifier custom:: variables available to model expressions.",
+                    "title": "Custom",
+                    "type": "object"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "Description of this model.",
+                    "markdownDescription": "**Description**\n\nDescription of this model.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "modelId": {
+                    "description": "Object id of model.",
+                    "markdownDescription": "**Model**\n\nObject id of model.",
+                    "title": "Model",
+                    "type": "string"
+                },
+                "objectTypes": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveModelObjectTypes_"
+                        }
+                    ],
+                    "description": "Model for an object type.",
+                    "markdownDescription": "**Object Types**\n\nModel for an object type.",
+                    "readOnly": false,
+                    "title": "Object Types",
+                    "type": "object"
+                },
+                "originURI": {
+                    "description": "The origin URI of this model. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
+                    "format": "uri-reference",
+                    "markdownDescription": "**Origin URI**\n\nThe origin URI of this model. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
+                    "title": "Origin URI",
+                    "type": "string"
+                },
+                "propertyTypes": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveModelPropertyTypes_"
+                        }
+                    ],
+                    "description": "Property type objects that can be inherited by propertyTypes in objectTypes.",
+                    "markdownDescription": "**Property Types**\n\nProperty type objects that can be inherited by propertyTypes in objectTypes.",
+                    "title": "Property Types",
+                    "type": "object"
                 }
             },
             "type": "object"
@@ -262,24 +837,28 @@
                 "allowAdd": {
                     "default": true,
                     "description": "If false, objects of this type can NEVER be added via an adapter. If true, objects of this type can be added via an adapter as long as allowed by authorization policy and the adapter.",
+                    "markdownDescription": "**Allow Add**\n\nIf false, objects of this type can NEVER be added via an adapter. If true, objects of this type can be added via an adapter as long as allowed by authorization policy and the adapter.",
                     "title": "Allow Add",
                     "type": "boolean"
                 },
                 "allowChange": {
                     "default": true,
                     "description": "If false, objects of this type can NEVER be changed via an adapter. If true, objects of this type can be changed via an adapter as long as allowed by authorization policy and the adapter.",
+                    "markdownDescription": "**Allow Change**\n\nIf false, objects of this type can NEVER be changed via an adapter. If true, objects of this type can be changed via an adapter as long as allowed by authorization policy and the adapter.",
                     "title": "Allow Change",
                     "type": "boolean"
                 },
                 "allowDelete": {
                     "default": true,
                     "description": "If false, objects of this type can NEVER be deleted via an adapter. If true, objects of this type can be deleted via an adapter as long as allowed by authorization policy and the adapter.",
+                    "markdownDescription": "**Allow Delete**\n\nIf false, objects of this type can NEVER be deleted via an adapter. If true, objects of this type can be deleted via an adapter as long as allowed by authorization policy and the adapter.",
                     "title": "Allow Delete",
                     "type": "boolean"
                 },
                 "allowEntity": {
                     "default": true,
                     "description": "Instances of this object type can exist as an entity object, not just an embedded object.",
+                    "markdownDescription": "**Allow Entity**\n\nInstances of this object type can exist as an entity object, not just an embedded object.",
                     "title": "Allow Entity",
                     "type": "boolean"
                 },
@@ -288,41 +867,49 @@
                     "items": {
                         "description": "This is the URIs of the collections this object type is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
                         "format": "uri-reference",
+                        "markdownDescription": "This is the URIs of the collections this object type is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
                         "title": "The URIs of the collections this object type is a part of",
                         "type": "string"
                     },
+                    "markdownDescription": "**Collection URIs**\n\nThis is the URIs of the collections this object type is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
                     "title": "Collection URIs",
                     "type": "array"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "The description of the object type.",
+                    "markdownDescription": "**Description**\n\nThe description of the object type.",
                     "title": "Description",
                     "type": "string"
                 },
                 "descriptionPropertyName": {
                     "description": "The name of the property in an instance that is used as the 'description' property in the meta for instances of this object type. If not specified, no description will be available.",
+                    "markdownDescription": "**Description Property Name**\n\nThe name of the property in an instance that is used as the 'description' property in the meta for instances of this object type. If not specified, no description will be available.",
                     "title": "Description Property Name",
                     "type": "string"
                 },
                 "label": {
                     "description": "Label used to identify this instance.",
+                    "markdownDescription": "**Label**\n\nLabel used to identify this instance.",
                     "title": "Label",
                     "type": "string"
                 },
                 "objectIdPropertyName": {
                     "description": "The name of the property in an instance that is used as the 'objectId' property in the meta for instances of this object type. If not specified, the internal adapter objectId for an object is used.",
+                    "markdownDescription": "**Object Id Property Name**\n\nThe name of the property in an instance that is used as the 'objectId' property in the meta for instances of this object type. If not specified, the internal adapter objectId for an object is used.",
                     "title": "Object Id Property Name",
                     "type": "string"
                 },
                 "objectType": {
                     "description": "The object id of the object type.",
+                    "markdownDescription": "**Object Type**\n\nThe object id of the object type.",
                     "title": "Object Type",
                     "type": "string"
                 },
                 "originURI": {
                     "description": "The origin URI of this object type. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
                     "format": "uri-reference",
+                    "markdownDescription": "**Origin URI**\n\nThe origin URI of this object type. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
                     "title": "Origin URI",
                     "type": "string"
                 },
@@ -333,7 +920,9 @@
                         }
                     ],
                     "description": "If specified, this is the property type for properties that are not explicitly specified. If otherProperties is not specified, only explicitly specified properties are allowed.",
-                    "title": "Other Properties"
+                    "markdownDescription": "**Other Properties**\n\nIf specified, this is the property type for properties that are not explicitly specified. If otherProperties is not specified, only explicitly specified properties are allowed.",
+                    "title": "Other Properties",
+                    "type": "object"
                 },
                 "propertyTypes": {
                     "allOf": [
@@ -342,11 +931,14 @@
                         }
                     ],
                     "description": "An object whose properties contain the _AdaptiveValueMeta_ for properties with corresponding name in instances of this _AdaptiveObjectType_.",
-                    "title": "Property Types"
+                    "markdownDescription": "**Property Types**\n\nAn object whose properties contain the _AdaptiveValueMeta_ for properties with corresponding name in instances of this _AdaptiveObjectType_.",
+                    "title": "Property Types",
+                    "type": "object"
                 },
                 "referenceURI": {
                     "description": "URI of more reference information about this object.",
                     "format": "uri-reference",
+                    "markdownDescription": "**Reference URI**\n\nURI of more reference information about this object.",
                     "title": "Reference URI",
                     "type": "string"
                 },
@@ -357,15 +949,19 @@
                         }
                     ],
                     "description": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
-                    "title": "Runtime"
+                    "markdownDescription": "**Runtime**\n\nThis is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
+                    "title": "Runtime",
+                    "type": "object"
                 },
                 "tags": {
                     "description": "This is an array of keywords and terms associated with this object type. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
                     "items": {
                         "description": "This is an array of keywords and terms associated with this object type. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                        "markdownDescription": "This is an array of keywords and terms associated with this object type. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
                         "title": "List of keywords associated with this object type",
                         "type": "string"
                     },
+                    "markdownDescription": "**Tags**\n\nThis is an array of keywords and terms associated with this object type. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
                     "title": "Tags",
                     "type": "array"
                 }
@@ -374,12 +970,17 @@
         },
         "_AdaptiveObject_": {
             "additionalProperties": true,
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveObject_.propertyTypes"
-                }
-            ],
             "description": "Hints that can optionally be used by UI to render this value.",
+            "markdownDescription": "Hints that can optionally be used by UI to render this value.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                }
+            },
             "title": "Hints",
             "type": "object"
         },
@@ -394,9 +995,12 @@
                         "$ref": "#/$defs/_AdaptiveValueMeta_"
                     }
                 ],
-                "description": "Object type of the propertyTypes property of an object type."
+                "description": "Object type of the propertyTypes property of an object type.",
+                "markdownDescription": "Object type of the propertyTypes property of an object type.",
+                "type": "object"
             },
             "description": "An object whose properties contain the _AdaptiveValueMeta_ for properties with corresponding name in instances of this _AdaptiveObjectType_.",
+            "markdownDescription": "An object whose properties contain the _AdaptiveValueMeta_ for properties with corresponding name in instances of this _AdaptiveObjectType_.",
             "properties": {
                 "_meta_": {
                     "description": "This is the special Meta object that has deltas between this instance and its Adaptive Object Type.",
@@ -419,25 +1023,44 @@
             "type": "object"
         },
         "_AdaptiveRuntimeLabels_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveRuntimeLabels_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Labels.",
-            "title": "Labels",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveRuntimeLabels_.propertyTypes": {
+            "markdownDescription": "Labels.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "indirectObjectId": {
                     "description": "Indicates that the objectId in the associated struct is a pointer.",
+                    "markdownDescription": "**Indirect Object Id**\n\nIndicates that the objectId in the associated struct is a pointer.",
                     "title": "Indirect Object Id",
                     "type": "boolean"
                 },
                 "objectId": {
                     "description": "The name of member in the struct that contains the objectId.",
+                    "markdownDescription": "**Object Id**\n\nThe name of member in the struct that contains the objectId.",
+                    "title": "Object Id",
+                    "type": "string"
+                }
+            },
+            "title": "Labels",
+            "type": "object"
+        },
+        "_AdaptiveRuntimeLabels_.propertyTypes": {
+            "properties": {
+                "indirectObjectId": {
+                    "description": "Indicates that the objectId in the associated struct is a pointer.",
+                    "markdownDescription": "**Indirect Object Id**\n\nIndicates that the objectId in the associated struct is a pointer.",
+                    "title": "Indirect Object Id",
+                    "type": "boolean"
+                },
+                "objectId": {
+                    "description": "The name of member in the struct that contains the objectId.",
+                    "markdownDescription": "**Object Id**\n\nThe name of member in the struct that contains the objectId.",
                     "title": "Object Id",
                     "type": "string"
                 }
@@ -445,20 +1068,20 @@
             "type": "object"
         },
         "_AdaptiveRuntimeObject_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveRuntimeObject_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
-            "title": "Runtime",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveRuntimeObject_.propertyTypes": {
+            "markdownDescription": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "indirect": {
                     "description": "Indicates that the runtime struct is a pointer. If a property of this object type has runtime.onGetValueCFunctionName specified, the is ignored and runtime structure is always indirect.",
+                    "markdownDescription": "**Indirect**\n\nIndicates that the runtime struct is a pointer. If a property of this object type has runtime.onGetValueCFunctionName specified, the is ignored and runtime structure is always indirect.",
                     "title": "Indirect",
                     "type": "boolean"
                 },
@@ -469,10 +1092,42 @@
                         }
                     ],
                     "description": "Labels.",
-                    "title": "Labels"
+                    "markdownDescription": "**Labels**\n\nLabels.",
+                    "title": "Labels",
+                    "type": "object"
                 },
                 "typedef": {
                     "description": "The typedef of the struct for the runtime object.",
+                    "markdownDescription": "**Typedef**\n\nThe typedef of the struct for the runtime object.",
+                    "title": "Typedef",
+                    "type": "string"
+                }
+            },
+            "title": "Runtime",
+            "type": "object"
+        },
+        "_AdaptiveRuntimeObject_.propertyTypes": {
+            "properties": {
+                "indirect": {
+                    "description": "Indicates that the runtime struct is a pointer. If a property of this object type has runtime.onGetValueCFunctionName specified, the is ignored and runtime structure is always indirect.",
+                    "markdownDescription": "**Indirect**\n\nIndicates that the runtime struct is a pointer. If a property of this object type has runtime.onGetValueCFunctionName specified, the is ignored and runtime structure is always indirect.",
+                    "title": "Indirect",
+                    "type": "boolean"
+                },
+                "labels": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveRuntimeLabels_"
+                        }
+                    ],
+                    "description": "Labels.",
+                    "markdownDescription": "**Labels**\n\nLabels.",
+                    "title": "Labels",
+                    "type": "object"
+                },
+                "typedef": {
+                    "description": "The typedef of the struct for the runtime object.",
+                    "markdownDescription": "**Typedef**\n\nThe typedef of the struct for the runtime object.",
                     "title": "Typedef",
                     "type": "string"
                 }
@@ -480,35 +1135,68 @@
             "type": "object"
         },
         "_AdaptiveRuntimeProperty_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveRuntimeProperty_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
-            "title": "Runtime",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveRuntimeProperty_.propertyTypes": {
+            "markdownDescription": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "memberName": {
                     "description": "The member name of this property in the runtime struct if other than the property name.",
+                    "markdownDescription": "**Member Name**\n\nThe member name of this property in the runtime struct if other than the property name.",
                     "title": "Member Name",
                     "type": "string"
                 },
                 "onGetValueCFunctionName": {
                     "description": "This is the name of the c callback function called to get the value of this property at runtime. If this property is specified, valueAccessor is ignored.",
+                    "markdownDescription": "**onGetValueCFunctionName**\n\nThis is the name of the c callback function called to get the value of this property at runtime. If this property is specified, valueAccessor is ignored.",
                     "title": "onGetValueCFunctionName",
                     "type": "string"
                 },
                 "valueAccessor": {
                     "description": "The name of the registered value accessor used to access this property. The default is default. See afw_runtime_value_accessor.h for the built in accessors.",
+                    "markdownDescription": "**Value Accessor**\n\nThe name of the registered value accessor used to access this property. The default is default. See afw_runtime_value_accessor.h for the built in accessors.",
                     "title": "Value Accessor",
                     "type": "string"
                 },
                 "zeroOffset": {
                     "description": "Indicates that the value accessor is called with a pointer to the struct and a 0 offset.",
+                    "markdownDescription": "**Zero Offset**\n\nIndicates that the value accessor is called with a pointer to the struct and a 0 offset.",
+                    "title": "Zero Offset",
+                    "type": "boolean"
+                }
+            },
+            "title": "Runtime",
+            "type": "object"
+        },
+        "_AdaptiveRuntimeProperty_.propertyTypes": {
+            "properties": {
+                "memberName": {
+                    "description": "The member name of this property in the runtime struct if other than the property name.",
+                    "markdownDescription": "**Member Name**\n\nThe member name of this property in the runtime struct if other than the property name.",
+                    "title": "Member Name",
+                    "type": "string"
+                },
+                "onGetValueCFunctionName": {
+                    "description": "This is the name of the c callback function called to get the value of this property at runtime. If this property is specified, valueAccessor is ignored.",
+                    "markdownDescription": "**onGetValueCFunctionName**\n\nThis is the name of the c callback function called to get the value of this property at runtime. If this property is specified, valueAccessor is ignored.",
+                    "title": "onGetValueCFunctionName",
+                    "type": "string"
+                },
+                "valueAccessor": {
+                    "description": "The name of the registered value accessor used to access this property. The default is default. See afw_runtime_value_accessor.h for the built in accessors.",
+                    "markdownDescription": "**Value Accessor**\n\nThe name of the registered value accessor used to access this property. The default is default. See afw_runtime_value_accessor.h for the built in accessors.",
+                    "title": "Value Accessor",
+                    "type": "string"
+                },
+                "zeroOffset": {
+                    "description": "Indicates that the value accessor is called with a pointer to the struct and a 0 offset.",
+                    "markdownDescription": "**Zero Offset**\n\nIndicates that the value accessor is called with a pointer to the struct and a 0 offset.",
                     "title": "Zero Offset",
                     "type": "boolean"
                 }
@@ -518,14 +1206,20 @@
         "_AdaptiveTemplateProperties_": {
             "additionalProperties": {
                 "description": "Each property is a template value.",
+                "markdownDescription": "Each property is a template value.",
                 "type": "string"
             },
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveTemplateProperties_.propertyTypes"
-                }
-            ],
             "description": "Qualifier custom:: variables available to model expressions.",
+            "markdownDescription": "Qualifier custom:: variables available to model expressions.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                }
+            },
             "title": "Custom",
             "type": "object"
         },
@@ -534,40 +1228,44 @@
             "type": "object"
         },
         "_AdaptiveValueMeta_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveValueMeta_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "If specified, this is the property type for properties that are not explicitly specified. If otherProperties is not specified, only explicitly specified properties are allowed.",
-            "title": "Other Properties",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveValueMeta_.propertyTypes": {
+            "markdownDescription": "If specified, this is the property type for properties that are not explicitly specified. If otherProperties is not specified, only explicitly specified properties are allowed.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "additionalConstraints": {
                     "description": "Additional constraint for the value.",
+                    "markdownDescription": "**Additional Constraints**\n\nAdditional constraint for the value.",
                     "title": "Additional Constraints",
                     "type": "string"
                 },
                 "allowQuery": {
                     "description": "If false, this value can NEVER be queried. If true, this value can be queried if allowed by authorization policy.",
+                    "markdownDescription": "**Allow Query**\n\nIf false, this value can NEVER be queried. If true, this value can be queried if allowed by authorization policy.",
                     "title": "Allow Query",
                     "type": "boolean"
                 },
                 "allowWrite": {
                     "description": "If true, the value can be written if allowed by authorization policy as long as allowChange for the instance is also true. If false, the value can only be written if required is true when adding a new object.",
+                    "markdownDescription": "**Allow Write**\n\nIf true, the value can be written if allowed by authorization policy as long as allowChange for the instance is also true. If false, the value can only be written if required is true when adding a new object.",
                     "title": "Allow Write",
                     "type": "boolean"
                 },
                 "allowedValues": {
                     "description": "This is an array of the allowed values for this adaptive value. The dataType and dataTypeParameter of these values is the same as for the adaptive value itself.",
+                    "markdownDescription": "**Allowed Values**\n\nThis is an array of the allowed values for this adaptive value. The dataType and dataTypeParameter of these values is the same as for the adaptive value itself.",
                     "title": "Allowed Values",
                     "type": "array"
                 },
                 "brief": {
                     "description": "This is a predicate for this value, with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for this value, with the first letter capitalized and without a trailing period.",
                     "title": "Brief",
                     "type": "string"
                 },
@@ -576,39 +1274,47 @@
                     "items": {
                         "description": "This is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
                         "format": "uri-reference",
+                        "markdownDescription": "This is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
                         "title": "The URIs of the collection that this value is a part of",
                         "type": "string"
                     },
+                    "markdownDescription": "**Collection URIs**\n\nThis is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
                     "title": "Collection URIs",
                     "type": "array"
                 },
                 "contextType": {
                     "description": "For data types that are evaluated (evaluate property true), this is the context type used for the evaluation.",
+                    "markdownDescription": "**Context Type**\n\nFor data types that are evaluated (evaluate property true), this is the context type used for the evaluation.",
                     "title": "Context Type",
                     "type": "string"
                 },
                 "dataType": {
                     "description": "Data type of this value.",
+                    "markdownDescription": "**Data Type**\n\nData type of this value.",
                     "title": "Data Type",
                     "type": "string"
                 },
                 "dataTypeParameter": {
                     "description": "See the data type's dataTypeParameterType property to determine how to interpret this.",
+                    "markdownDescription": "**Data Type Parameter**\n\nSee the data type's dataTypeParameterType property to determine how to interpret this.",
                     "title": "Data Type Parameter",
                     "type": "string"
                 },
                 "dataTypeParameterFormatted": {
                     "description": "This is the same as dataTypeParameter with possible comments and whitespace. This is especially useful for data type function to document its signature. If this property is not present, dataTypeParameter can be used in its place.",
+                    "markdownDescription": "**Formatted Data Type Parameter**\n\nThis is the same as dataTypeParameter with possible comments and whitespace. This is especially useful for data type function to document its signature. If this property is not present, dataTypeParameter can be used in its place.",
                     "title": "Formatted Data Type Parameter",
                     "type": "string"
                 },
                 "defaultValue": {
                     "description": "This is the default value. The dataType and dataTypeParameter properties apply to this value. If needed, this value will be normalized.",
+                    "markdownDescription": "**Default Value**\n\nThis is the default value. The dataType and dataTypeParameter properties apply to this value. If needed, this value will be normalized.",
                     "title": "Default Value"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "The description of this value.",
+                    "markdownDescription": "**Description**\n\nThe description of this value.",
                     "title": "Description",
                     "type": "string"
                 },
@@ -619,56 +1325,68 @@
                         }
                     ],
                     "description": "Hints that can optionally be used by UI to render this value.",
-                    "title": "Hints"
+                    "markdownDescription": "**Hints**\n\nHints that can optionally be used by UI to render this value.",
+                    "title": "Hints",
+                    "type": "object"
                 },
                 "label": {
                     "description": "Label used to identify this value.",
+                    "markdownDescription": "**Label**\n\nLabel used to identify this value.",
                     "title": "Label",
                     "type": "string"
                 },
                 "maxLength": {
                     "description": "This is maximum length of the to_string() for this value. If not specified, there is no maximum length.",
+                    "markdownDescription": "**Maximum Length**\n\nThis is maximum length of the to_string() for this value. If not specified, there is no maximum length.",
                     "title": "Maximum Length",
                     "type": "integer"
                 },
                 "maxNormalLength": {
                     "description": "This is maximum normal length of the to_string() for this value.  If not specified, maxLength is used.",
+                    "markdownDescription": "**Normal Maximum Length**\n\nThis is maximum normal length of the to_string() for this value.  If not specified, maxLength is used.",
                     "title": "Normal Maximum Length",
                     "type": "integer"
                 },
                 "maxValue": {
                     "description": "This is the maximum for this value. If not specified, there is no maximum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "markdownDescription": "**Maximum Value**\n\nThis is the maximum for this value. If not specified, there is no maximum value. The dataType and dataTypeParameter of this value is the same as for the value.",
                     "title": "Maximum Value"
                 },
                 "minLength": {
                     "description": "This is minimum length of the to_string() for this value. If not specified, there is no minimum length.",
+                    "markdownDescription": "**Minimum Length**\n\nThis is minimum length of the to_string() for this value. If not specified, there is no minimum length.",
                     "title": "Minimum Length",
                     "type": "integer"
                 },
                 "minValue": {
                     "description": "This is the minimum for this. If not specified, there is no minimum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "markdownDescription": "**Minimum Value**\n\nThis is the minimum for this. If not specified, there is no minimum value. The dataType and dataTypeParameter of this value is the same as for the value.",
                     "title": "Minimum Value"
                 },
                 "originURI": {
                     "description": "The origin URI of this value meta. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
                     "format": "uri-reference",
+                    "markdownDescription": "**Origin URI**\n\nThe origin URI of this value meta. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
                     "title": "Origin URI",
                     "type": "string"
                 },
                 "possibleValues": {
                     "description": "Possible values of this value. This can be the typed value or the string value.",
+                    "markdownDescription": "**Possible Values**\n\nPossible values of this value. This can be the typed value or the string value.",
                     "title": "Possible Values",
                     "type": "array"
                 },
                 "referenceURI": {
                     "description": "URI of more reference information about this value meta.",
                     "format": "uri-reference",
+                    "markdownDescription": "**Reference URI**\n\nURI of more reference information about this value meta.",
                     "title": "Reference URI",
                     "type": "string"
                 },
                 "required": {
                     "default": false,
                     "description": "Indicates that value is required.",
+                    "markdownDescription": "**Required**\n\nIndicates that value is required.",
                     "title": "Required",
                     "type": "boolean"
                 },
@@ -679,34 +1397,246 @@
                         }
                     ],
                     "description": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
-                    "title": "Runtime"
+                    "markdownDescription": "**Runtime**\n\nThis is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
+                    "title": "Runtime",
+                    "type": "object"
                 },
                 "skeleton": {
                     "description": "This is a skeleton example that can optionally be used by an application as an initial value. For example, if this is a new data type 'template' value, this can be the text used to prime the edit window with sample Adaptive Script code including comments.",
+                    "markdownDescription": "**Skeleton**\n\nThis is a skeleton example that can optionally be used by an application as an initial value. For example, if this is a new data type 'template' value, this can be the text used to prime the edit window with sample Adaptive Script code including comments.",
                     "title": "Skeleton"
                 },
                 "tags": {
                     "description": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
                     "items": {
                         "description": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                        "markdownDescription": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
                         "title": "List of keywords and terms associated with values with this meta",
                         "type": "string"
                     },
+                    "markdownDescription": "**Tags**\n\nThis is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
                     "title": "Tags",
                     "type": "array"
                 },
                 "testDataParameter": {
                     "description": "This contains additional information about values with this meta that is used to produce test data.",
+                    "markdownDescription": "**Test Data Parameter**\n\nThis contains additional information about values with this meta that is used to produce test data.",
                     "title": "Test Data Parameter",
                     "type": "string"
                 },
                 "unique": {
                     "description": "Value of property must be unique within object type.",
+                    "markdownDescription": "**Unique**\n\nValue of property must be unique within object type.",
                     "title": "Unique",
                     "type": "boolean"
                 },
                 "valueInfId": {
                     "description": "This is a runtime property that is the implementation id of the value interface.",
+                    "markdownDescription": "**valueInf**\n\nThis is a runtime property that is the implementation id of the value interface.",
+                    "readOnly": true,
+                    "title": "valueInf",
+                    "type": "string"
+                }
+            },
+            "title": "Other Properties",
+            "type": "object"
+        },
+        "_AdaptiveValueMeta_.propertyTypes": {
+            "properties": {
+                "additionalConstraints": {
+                    "description": "Additional constraint for the value.",
+                    "markdownDescription": "**Additional Constraints**\n\nAdditional constraint for the value.",
+                    "title": "Additional Constraints",
+                    "type": "string"
+                },
+                "allowQuery": {
+                    "description": "If false, this value can NEVER be queried. If true, this value can be queried if allowed by authorization policy.",
+                    "markdownDescription": "**Allow Query**\n\nIf false, this value can NEVER be queried. If true, this value can be queried if allowed by authorization policy.",
+                    "title": "Allow Query",
+                    "type": "boolean"
+                },
+                "allowWrite": {
+                    "description": "If true, the value can be written if allowed by authorization policy as long as allowChange for the instance is also true. If false, the value can only be written if required is true when adding a new object.",
+                    "markdownDescription": "**Allow Write**\n\nIf true, the value can be written if allowed by authorization policy as long as allowChange for the instance is also true. If false, the value can only be written if required is true when adding a new object.",
+                    "title": "Allow Write",
+                    "type": "boolean"
+                },
+                "allowedValues": {
+                    "description": "This is an array of the allowed values for this adaptive value. The dataType and dataTypeParameter of these values is the same as for the adaptive value itself.",
+                    "markdownDescription": "**Allowed Values**\n\nThis is an array of the allowed values for this adaptive value. The dataType and dataTypeParameter of these values is the same as for the adaptive value itself.",
+                    "title": "Allowed Values",
+                    "type": "array"
+                },
+                "brief": {
+                    "description": "This is a predicate for this value, with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for this value, with the first letter capitalized and without a trailing period.",
+                    "title": "Brief",
+                    "type": "string"
+                },
+                "collectionURIs": {
+                    "description": "This is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                    "items": {
+                        "description": "This is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                        "format": "uri-reference",
+                        "markdownDescription": "This is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                        "title": "The URIs of the collection that this value is a part of",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Collection URIs**\n\nThis is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                    "title": "Collection URIs",
+                    "type": "array"
+                },
+                "contextType": {
+                    "description": "For data types that are evaluated (evaluate property true), this is the context type used for the evaluation.",
+                    "markdownDescription": "**Context Type**\n\nFor data types that are evaluated (evaluate property true), this is the context type used for the evaluation.",
+                    "title": "Context Type",
+                    "type": "string"
+                },
+                "dataType": {
+                    "description": "Data type of this value.",
+                    "markdownDescription": "**Data Type**\n\nData type of this value.",
+                    "title": "Data Type",
+                    "type": "string"
+                },
+                "dataTypeParameter": {
+                    "description": "See the data type's dataTypeParameterType property to determine how to interpret this.",
+                    "markdownDescription": "**Data Type Parameter**\n\nSee the data type's dataTypeParameterType property to determine how to interpret this.",
+                    "title": "Data Type Parameter",
+                    "type": "string"
+                },
+                "dataTypeParameterFormatted": {
+                    "description": "This is the same as dataTypeParameter with possible comments and whitespace. This is especially useful for data type function to document its signature. If this property is not present, dataTypeParameter can be used in its place.",
+                    "markdownDescription": "**Formatted Data Type Parameter**\n\nThis is the same as dataTypeParameter with possible comments and whitespace. This is especially useful for data type function to document its signature. If this property is not present, dataTypeParameter can be used in its place.",
+                    "title": "Formatted Data Type Parameter",
+                    "type": "string"
+                },
+                "defaultValue": {
+                    "description": "This is the default value. The dataType and dataTypeParameter properties apply to this value. If needed, this value will be normalized.",
+                    "markdownDescription": "**Default Value**\n\nThis is the default value. The dataType and dataTypeParameter properties apply to this value. If needed, this value will be normalized.",
+                    "title": "Default Value"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "The description of this value.",
+                    "markdownDescription": "**Description**\n\nThe description of this value.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "hints": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveObject_"
+                        }
+                    ],
+                    "description": "Hints that can optionally be used by UI to render this value.",
+                    "markdownDescription": "**Hints**\n\nHints that can optionally be used by UI to render this value.",
+                    "title": "Hints",
+                    "type": "object"
+                },
+                "label": {
+                    "description": "Label used to identify this value.",
+                    "markdownDescription": "**Label**\n\nLabel used to identify this value.",
+                    "title": "Label",
+                    "type": "string"
+                },
+                "maxLength": {
+                    "description": "This is maximum length of the to_string() for this value. If not specified, there is no maximum length.",
+                    "markdownDescription": "**Maximum Length**\n\nThis is maximum length of the to_string() for this value. If not specified, there is no maximum length.",
+                    "title": "Maximum Length",
+                    "type": "integer"
+                },
+                "maxNormalLength": {
+                    "description": "This is maximum normal length of the to_string() for this value.  If not specified, maxLength is used.",
+                    "markdownDescription": "**Normal Maximum Length**\n\nThis is maximum normal length of the to_string() for this value.  If not specified, maxLength is used.",
+                    "title": "Normal Maximum Length",
+                    "type": "integer"
+                },
+                "maxValue": {
+                    "description": "This is the maximum for this value. If not specified, there is no maximum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "markdownDescription": "**Maximum Value**\n\nThis is the maximum for this value. If not specified, there is no maximum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "title": "Maximum Value"
+                },
+                "minLength": {
+                    "description": "This is minimum length of the to_string() for this value. If not specified, there is no minimum length.",
+                    "markdownDescription": "**Minimum Length**\n\nThis is minimum length of the to_string() for this value. If not specified, there is no minimum length.",
+                    "title": "Minimum Length",
+                    "type": "integer"
+                },
+                "minValue": {
+                    "description": "This is the minimum for this. If not specified, there is no minimum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "markdownDescription": "**Minimum Value**\n\nThis is the minimum for this. If not specified, there is no minimum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "title": "Minimum Value"
+                },
+                "originURI": {
+                    "description": "The origin URI of this value meta. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
+                    "format": "uri-reference",
+                    "markdownDescription": "**Origin URI**\n\nThe origin URI of this value meta. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
+                    "title": "Origin URI",
+                    "type": "string"
+                },
+                "possibleValues": {
+                    "description": "Possible values of this value. This can be the typed value or the string value.",
+                    "markdownDescription": "**Possible Values**\n\nPossible values of this value. This can be the typed value or the string value.",
+                    "title": "Possible Values",
+                    "type": "array"
+                },
+                "referenceURI": {
+                    "description": "URI of more reference information about this value meta.",
+                    "format": "uri-reference",
+                    "markdownDescription": "**Reference URI**\n\nURI of more reference information about this value meta.",
+                    "title": "Reference URI",
+                    "type": "string"
+                },
+                "required": {
+                    "default": false,
+                    "description": "Indicates that value is required.",
+                    "markdownDescription": "**Required**\n\nIndicates that value is required.",
+                    "title": "Required",
+                    "type": "boolean"
+                },
+                "runtime": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveRuntimeProperty_"
+                        }
+                    ],
+                    "description": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
+                    "markdownDescription": "**Runtime**\n\nThis is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
+                    "title": "Runtime",
+                    "type": "object"
+                },
+                "skeleton": {
+                    "description": "This is a skeleton example that can optionally be used by an application as an initial value. For example, if this is a new data type 'template' value, this can be the text used to prime the edit window with sample Adaptive Script code including comments.",
+                    "markdownDescription": "**Skeleton**\n\nThis is a skeleton example that can optionally be used by an application as an initial value. For example, if this is a new data type 'template' value, this can be the text used to prime the edit window with sample Adaptive Script code including comments.",
+                    "title": "Skeleton"
+                },
+                "tags": {
+                    "description": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                    "items": {
+                        "description": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                        "markdownDescription": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                        "title": "List of keywords and terms associated with values with this meta",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Tags**\n\nThis is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                    "title": "Tags",
+                    "type": "array"
+                },
+                "testDataParameter": {
+                    "description": "This contains additional information about values with this meta that is used to produce test data.",
+                    "markdownDescription": "**Test Data Parameter**\n\nThis contains additional information about values with this meta that is used to produce test data.",
+                    "title": "Test Data Parameter",
+                    "type": "string"
+                },
+                "unique": {
+                    "description": "Value of property must be unique within object type.",
+                    "markdownDescription": "**Unique**\n\nValue of property must be unique within object type.",
+                    "title": "Unique",
+                    "type": "boolean"
+                },
+                "valueInfId": {
+                    "description": "This is a runtime property that is the implementation id of the value interface.",
+                    "markdownDescription": "**valueInf**\n\nThis is a runtime property that is the implementation id of the value interface.",
                     "readOnly": true,
                     "title": "valueInf",
                     "type": "string"
@@ -716,9 +1646,85 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveModel_"
+    "additionalProperties": false,
+    "description": "Adaptive map object type.",
+    "markdownDescription": "Adaptive map object type.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "collectionURIs": {
+            "description": "This is the URIs of the collections this map is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+            "items": {
+                "description": "This is the URIs of the collections this map is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                "format": "uri-reference",
+                "markdownDescription": "This is the URIs of the collections this map is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                "title": "The URIs of the collections this map is part of",
+                "type": "string"
+            },
+            "markdownDescription": "**Collection URIs**\n\nThis is the URIs of the collections this map is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+            "title": "Collection URIs",
+            "type": "array"
+        },
+        "custom": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveTemplateProperties_"
+                }
+            ],
+            "description": "Qualifier custom:: variables available to model expressions.",
+            "markdownDescription": "**Custom**\n\nQualifier custom:: variables available to model expressions.",
+            "title": "Custom",
+            "type": "object"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "Description of this model.",
+            "markdownDescription": "**Description**\n\nDescription of this model.",
+            "title": "Description",
+            "type": "string"
+        },
+        "modelId": {
+            "description": "Object id of model.",
+            "markdownDescription": "**Model**\n\nObject id of model.",
+            "title": "Model",
+            "type": "string"
+        },
+        "objectTypes": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveModelObjectTypes_"
+                }
+            ],
+            "description": "Model for an object type.",
+            "markdownDescription": "**Object Types**\n\nModel for an object type.",
+            "readOnly": false,
+            "title": "Object Types",
+            "type": "object"
+        },
+        "originURI": {
+            "description": "The origin URI of this model. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
+            "format": "uri-reference",
+            "markdownDescription": "**Origin URI**\n\nThe origin URI of this model. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
+            "title": "Origin URI",
+            "type": "string"
+        },
+        "propertyTypes": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveModelPropertyTypes_"
+                }
+            ],
+            "description": "Property type objects that can be inherited by propertyTypes in objectTypes.",
+            "markdownDescription": "**Property Types**\n\nProperty type objects that can be inherited by propertyTypes in objectTypes.",
+            "title": "Property Types",
+            "type": "object"
         }
-    ]
+    },
+    "title": "_AdaptiveModel_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveModel_.json
+++ b/generated/schemas/afw/_AdaptiveModel_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveModelObjectType_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveModelObjectType_.propertyTypes"
                 },
@@ -15,14 +15,14 @@
         },
         "_AdaptiveModelObjectType_.propertyTypes": {
             "properties": {
-                "_meta_": {
-                    "title": " Meta "
-                },
                 "custom": {
-                    "$ref": "#/$defs/_AdaptiveTemplateProperties_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveTemplateProperties_"
+                        }
+                    ],
                     "description": "Object type level qualifier custom:: variables available to model expressions.",
-                    "title": "Custom",
-                    "type": "object"
+                    "title": "Custom"
                 },
                 "mappedObjectType": {
                     "description": "This is the objectType used internally by the adapter for this object type. It not specified, current::objectType is used.",
@@ -65,21 +65,28 @@
                     "type": "string"
                 },
                 "propertyTypes": {
-                    "$ref": "#/$defs/_AdaptiveModelPropertyTypes_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveModelPropertyTypes_"
+                        }
+                    ],
                     "description": "The name of the properties in this object corresponds to the property name of an instance of this object type and is its property type object.",
-                    "title": "Property Types",
-                    "type": "object"
+                    "title": "Property Types"
                 }
             },
             "type": "object"
         },
         "_AdaptiveModelObjectTypes_": {
             "additionalProperties": {
-                "$ref": "#/$defs/_AdaptiveModelObjectType_",
+                "allOf": [
+                    {
+                        "$ref": "#/$defs/_AdaptiveModelObjectType_"
+                    }
+                ],
                 "description": "The adaptive object type of all object that contains _AdaptiveModelObjectTypes_ objects as properties.",
-                "type": "object"
+                "title": "Defines an Object Type definition in this Adaptive Model"
             },
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveModelObjectTypes_.propertyTypes"
                 }
@@ -93,7 +100,7 @@
             "type": "object"
         },
         "_AdaptiveModelPropertyType_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveModelPropertyType_.propertyTypes"
                 },
@@ -107,19 +114,20 @@
         },
         "_AdaptiveModelPropertyType_.propertyTypes": {
             "properties": {
-                "_meta_": {
-                    "title": " Meta "
-                },
                 "allowRead": {
+                    "default": true,
                     "description": "Indicates that this property can be read. If true, the property will be included in get_object() and retrieve_objects() requests.",
                     "title": "Allow Read",
                     "type": "boolean"
                 },
                 "custom": {
-                    "$ref": "#/$defs/_AdaptiveTemplateProperties_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveTemplateProperties_"
+                        }
+                    ],
                     "description": "Property type level qualifier custom:: variables available to model expressions.",
-                    "title": "Custom",
-                    "type": "object"
+                    "title": "Custom"
                 },
                 "mappedPropertyName": {
                     "description": "This is the property name of this property used internally by an adapter. If not specified, propertyName is used.",
@@ -147,6 +155,7 @@
                     "type": "string"
                 },
                 "transitory": {
+                    "default": false,
                     "description": "Indicates that this property is transitory and will not be persisted by the adapter. The value can be produced by setValue or supplied in the request.",
                     "title": "Transitory",
                     "type": "boolean"
@@ -156,11 +165,15 @@
         },
         "_AdaptiveModelPropertyTypes_": {
             "additionalProperties": {
-                "$ref": "#/$defs/_AdaptiveModelPropertyType_",
+                "allOf": [
+                    {
+                        "$ref": "#/$defs/_AdaptiveModelPropertyType_"
+                    }
+                ],
                 "description": "Object type of the propertyTypes property of instances of _AdaptiveModelObjectType_.",
-                "type": "object"
+                "title": "Defines a Property Type within this Adaptive Model Object Type definition"
             },
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveModelPropertyTypes_.propertyTypes"
                 }
@@ -174,7 +187,7 @@
             "type": "object"
         },
         "_AdaptiveModel_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveModel_.propertyTypes"
                 }
@@ -197,10 +210,13 @@
                     "type": "array"
                 },
                 "custom": {
-                    "$ref": "#/$defs/_AdaptiveTemplateProperties_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveTemplateProperties_"
+                        }
+                    ],
                     "description": "Qualifier custom:: variables available to model expressions.",
-                    "title": "Custom",
-                    "type": "object"
+                    "title": "Custom"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
@@ -214,11 +230,14 @@
                     "type": "string"
                 },
                 "objectTypes": {
-                    "$ref": "#/$defs/_AdaptiveModelObjectTypes_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveModelObjectTypes_"
+                        }
+                    ],
                     "description": "Model for an object type.",
                     "readOnly": false,
-                    "title": "Object Types",
-                    "type": "object"
+                    "title": "Object Types"
                 },
                 "originURI": {
                     "description": "The origin URI of this model. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
@@ -227,10 +246,13 @@
                     "type": "string"
                 },
                 "propertyTypes": {
-                    "$ref": "#/$defs/_AdaptiveModelPropertyTypes_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveModelPropertyTypes_"
+                        }
+                    ],
                     "description": "Property type objects that can be inherited by propertyTypes in objectTypes.",
-                    "title": "Property Types",
-                    "type": "object"
+                    "title": "Property Types"
                 }
             },
             "type": "object"
@@ -238,21 +260,25 @@
         "_AdaptiveObjectType_.propertyTypes": {
             "properties": {
                 "allowAdd": {
+                    "default": true,
                     "description": "If false, objects of this type can NEVER be added via an adapter. If true, objects of this type can be added via an adapter as long as allowed by authorization policy and the adapter.",
                     "title": "Allow Add",
                     "type": "boolean"
                 },
                 "allowChange": {
+                    "default": true,
                     "description": "If false, objects of this type can NEVER be changed via an adapter. If true, objects of this type can be changed via an adapter as long as allowed by authorization policy and the adapter.",
                     "title": "Allow Change",
                     "type": "boolean"
                 },
                 "allowDelete": {
+                    "default": true,
                     "description": "If false, objects of this type can NEVER be deleted via an adapter. If true, objects of this type can be deleted via an adapter as long as allowed by authorization policy and the adapter.",
                     "title": "Allow Delete",
                     "type": "boolean"
                 },
                 "allowEntity": {
+                    "default": true,
                     "description": "Instances of this object type can exist as an entity object, not just an embedded object.",
                     "title": "Allow Entity",
                     "type": "boolean"
@@ -301,16 +327,22 @@
                     "type": "string"
                 },
                 "otherProperties": {
-                    "$ref": "#/$defs/_AdaptiveValueMeta_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveValueMeta_"
+                        }
+                    ],
                     "description": "If specified, this is the property type for properties that are not explicitly specified. If otherProperties is not specified, only explicitly specified properties are allowed.",
-                    "title": "Other Properties",
-                    "type": "object"
+                    "title": "Other Properties"
                 },
                 "propertyTypes": {
-                    "$ref": "#/$defs/_AdaptivePropertyTypes_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptivePropertyTypes_"
+                        }
+                    ],
                     "description": "An object whose properties contain the _AdaptiveValueMeta_ for properties with corresponding name in instances of this _AdaptiveObjectType_.",
-                    "title": "Property Types",
-                    "type": "object"
+                    "title": "Property Types"
                 },
                 "referenceURI": {
                     "description": "URI of more reference information about this object.",
@@ -319,10 +351,13 @@
                     "type": "string"
                 },
                 "runtime": {
-                    "$ref": "#/$defs/_AdaptiveRuntimeObject_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveRuntimeObject_"
+                        }
+                    ],
                     "description": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
-                    "title": "Runtime",
-                    "type": "object"
+                    "title": "Runtime"
                 },
                 "tags": {
                     "description": "This is an array of keywords and terms associated with this object type. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
@@ -338,8 +373,8 @@
             "type": "object"
         },
         "_AdaptiveObject_": {
-            "additionalProperties": {},
-            "anyOf": [
+            "additionalProperties": true,
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveObject_.propertyTypes"
                 }
@@ -354,9 +389,12 @@
         },
         "_AdaptivePropertyTypes_": {
             "additionalProperties": {
-                "$ref": "#/$defs/_AdaptiveValueMeta_",
-                "description": "Object type of the propertyTypes property of an object type.",
-                "type": "object"
+                "allOf": [
+                    {
+                        "$ref": "#/$defs/_AdaptiveValueMeta_"
+                    }
+                ],
+                "description": "Object type of the propertyTypes property of an object type."
             },
             "description": "An object whose properties contain the _AdaptiveValueMeta_ for properties with corresponding name in instances of this _AdaptiveObjectType_.",
             "properties": {
@@ -381,7 +419,7 @@
             "type": "object"
         },
         "_AdaptiveRuntimeLabels_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveRuntimeLabels_.propertyTypes"
                 }
@@ -407,7 +445,7 @@
             "type": "object"
         },
         "_AdaptiveRuntimeObject_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveRuntimeObject_.propertyTypes"
                 }
@@ -425,10 +463,13 @@
                     "type": "boolean"
                 },
                 "labels": {
-                    "$ref": "#/$defs/_AdaptiveRuntimeLabels_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveRuntimeLabels_"
+                        }
+                    ],
                     "description": "Labels.",
-                    "title": "Labels",
-                    "type": "object"
+                    "title": "Labels"
                 },
                 "typedef": {
                     "description": "The typedef of the struct for the runtime object.",
@@ -439,7 +480,7 @@
             "type": "object"
         },
         "_AdaptiveRuntimeProperty_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveRuntimeProperty_.propertyTypes"
                 }
@@ -479,7 +520,7 @@
                 "description": "Each property is a template value.",
                 "type": "string"
             },
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveTemplateProperties_.propertyTypes"
                 }
@@ -493,7 +534,7 @@
             "type": "object"
         },
         "_AdaptiveValueMeta_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveValueMeta_.propertyTypes"
                 }
@@ -572,10 +613,13 @@
                     "type": "string"
                 },
                 "hints": {
-                    "$ref": "#/$defs/_AdaptiveObject_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveObject_"
+                        }
+                    ],
                     "description": "Hints that can optionally be used by UI to render this value.",
-                    "title": "Hints",
-                    "type": "object"
+                    "title": "Hints"
                 },
                 "label": {
                     "description": "Label used to identify this value.",
@@ -623,15 +667,19 @@
                     "type": "string"
                 },
                 "required": {
+                    "default": false,
                     "description": "Indicates that value is required.",
                     "title": "Required",
                     "type": "boolean"
                 },
                 "runtime": {
-                    "$ref": "#/$defs/_AdaptiveRuntimeProperty_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveRuntimeProperty_"
+                        }
+                    ],
                     "description": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
-                    "title": "Runtime",
-                    "type": "object"
+                    "title": "Runtime"
                 },
                 "skeleton": {
                     "description": "This is a skeleton example that can optionally be used by an application as an initial value. For example, if this is a new data type 'template' value, this can be the text used to prime the edit window with sample Adaptive Script code including comments.",
@@ -668,7 +716,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveModel_"
         }

--- a/generated/schemas/afw/_AdaptiveObjectOptions_.json
+++ b/generated/schemas/afw/_AdaptiveObjectOptions_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveObjectOptions_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveObjectOptions_.propertyTypes"
                 }
@@ -117,7 +117,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveObjectOptions_"
         }

--- a/generated/schemas/afw/_AdaptiveObjectOptions_.json
+++ b/generated/schemas/afw/_AdaptiveObjectOptions_.json
@@ -1,114 +1,261 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveObjectOptions_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveObjectOptions_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveObjectOptions_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "The options used for objects returned by Adaptive Framework.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveObjectOptions_.propertyTypes": {
+            "markdownDescription": "The options used for objects returned by Adaptive Framework.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "checkRequired": {
                     "description": "Indicates that object should be checked for missing required properties. This option implies the normalize option.",
+                    "markdownDescription": "**Check Required**\n\nIndicates that object should be checked for missing required properties. This option implies the normalize option.",
                     "title": "Check Required",
                     "type": "boolean"
                 },
                 "composite": {
                     "description": "Indicates that both direct and embedded inheritance should be performed.",
+                    "markdownDescription": "**Composite**\n\nIndicates that both direct and embedded inheritance should be performed.",
                     "title": "Composite",
                     "type": "boolean"
                 },
                 "debug": {
                     "description": "This will cause the errors in object meta to include additional debug information. If not specified, only the message will be included.",
+                    "markdownDescription": "**Debug**\n\nThis will cause the errors in object meta to include additional debug information. If not specified, only the message will be included.",
                     "title": "Debug",
                     "type": "boolean"
                 },
                 "includeDefaultValues": {
                     "description": "This indicates that default property values should be included. This option implies the normalize option.",
+                    "markdownDescription": "**Include Defaults**\n\nThis indicates that default property values should be included. This option implies the normalize option.",
                     "title": "Include Defaults",
                     "type": "boolean"
                 },
                 "includeDescendentObjectTypes": {
                     "description": "This only applies to retrieve objects requests and indicates that objects with the supplied object type along with objects with any of its descendent object types should be included in the search.",
+                    "markdownDescription": "**Include Descendent**\n\nThis only applies to retrieve objects requests and indicates that objects with the supplied object type along with objects with any of its descendent object types should be included in the search.",
                     "title": "Include Descendent",
                     "type": "boolean"
                 },
                 "inheritedFrom": {
                     "description": "Indicates that the inheritedFrom property in meta propertyTypes.<propertyName>, where <propertyName> is the associated property name, should be set. This option is ignored unless composite option is also set.",
+                    "markdownDescription": "**Inherited From**\n\nIndicates that the inheritedFrom property in meta propertyTypes.<propertyName>, where <propertyName> is the associated property name, should be set. This option is ignored unless composite option is also set.",
                     "title": "Inherited From",
                     "type": "boolean"
                 },
                 "integersAsString": {
                     "description": "This overrides the largeIntegersAsString option. If neither the integersAsString or large_integer_as_string is specified, integers will remain integers. If this option is specified, all data type integer values will be converted to the string data type.\\n\\nThis options is useful if a content type is used that represents integers as double (floating point) values.",
+                    "markdownDescription": "**Integers As String**\n\nThis overrides the largeIntegersAsString option. If neither the integersAsString or large_integer_as_string is specified, integers will remain integers. If this option is specified, all data type integer values will be converted to the string data type.\\n\\nThis options is useful if a content type is used that represents integers as double (floating point) values.",
                     "title": "Integers As String",
                     "type": "boolean"
                 },
                 "largeIntegersAsString": {
                     "description": "This option is overridden by the integersAsString option.\\n\\nIf this option is specified, all integers that have a magnitude that exceeds plus or minus 9007199254740991 (2^53-1) will be converted to the string data type.\\n\\nThis options is useful if integers of a content type are interpreted as double (floating point) values, but integers are normally small enough to be represented properly. An example is Javascript's use of JSON.",
+                    "markdownDescription": "**Large Integers As String**\n\nThis option is overridden by the integersAsString option.\\n\\nIf this option is specified, all integers that have a magnitude that exceeds plus or minus 9007199254740991 (2^53-1) will be converted to the string data type.\\n\\nThis options is useful if integers of a content type are interpreted as double (floating point) values, but integers are normally small enough to be represented properly. An example is Javascript's use of JSON.",
                     "title": "Large Integers As String",
                     "type": "boolean"
                 },
                 "metaFull": {
                     "description": "This indicates that all meta, including properties that are not part of delta from object type, are to be included. This overrides metaLimited.",
+                    "markdownDescription": "**Full meta**\n\nThis indicates that all meta, including properties that are not part of delta from object type, are to be included. This overrides metaLimited.",
                     "title": "Full meta",
                     "type": "boolean"
                 },
                 "metaLimited": {
                     "description": "Indicates that only requested and essential (parentPaths) meta is returned.",
+                    "markdownDescription": "**Limited meta**\n\nIndicates that only requested and essential (parentPaths) meta is returned.",
                     "title": "Limited meta",
                     "type": "boolean"
                 },
                 "normalize": {
                     "description": "Indicates that each object's object type should be processed, assigned each embedded object's object type, converting any properties to their correct data type, plus computing values when needed. If there is dataType or dataTypeParameter information available during normalization that is not in the associated _AdaptiveObjectType_, it will be added at the appropriate place in the object's meta.\\n\\nUse the includeDefaultValues option to include default values.",
+                    "markdownDescription": "**Normalize**\n\nIndicates that each object's object type should be processed, assigned each embedded object's object type, converting any properties to their correct data type, plus computing values when needed. If there is dataType or dataTypeParameter information available during normalization that is not in the associated _AdaptiveObjectType_, it will be added at the appropriate place in the object's meta.\\n\\nUse the includeDefaultValues option to include default values.",
                     "title": "Normalize",
                     "type": "boolean"
                 },
                 "objectId": {
                     "description": "Indicates that objectId property should be included in the meta for entity objects.",
+                    "markdownDescription": "**Object Id**\n\nIndicates that objectId property should be included in the meta for entity objects.",
                     "title": "Object Id",
                     "type": "boolean"
                 },
                 "objectType": {
                     "description": "Indicates that objectType property should be included in the meta for entity and embedded objects, if assigned.",
+                    "markdownDescription": "**Object Type**\n\nIndicates that objectType property should be included in the meta for entity and embedded objects, if assigned.",
                     "title": "Object Type",
                     "type": "boolean"
                 },
                 "objectTypes": {
                     "description": "Indicates that the objectTypes property should be added to the meta of the entity containing a property of each object type used by the entity and all of its embedded objects. This option implies normalize.",
+                    "markdownDescription": "**Object Types**\n\nIndicates that the objectTypes property should be added to the meta of the entity containing a property of each object type used by the entity and all of its embedded objects. This option implies normalize.",
                     "title": "Object Types",
                     "type": "boolean"
                 },
                 "path": {
                     "description": "Indicates that meta path should be included for entity objects.",
+                    "markdownDescription": "**Path**\n\nIndicates that meta path should be included for entity objects.",
                     "title": "Path",
                     "type": "boolean"
                 },
                 "pathEmbedded": {
                     "description": "Indicates that meta path should be included for embedded objects.",
+                    "markdownDescription": "**Path Embedded**\n\nIndicates that meta path should be included for embedded objects.",
                     "title": "Path Embedded",
                     "type": "boolean"
                 },
                 "reconcilable": {
                     "description": "Indicates that meta reconcilable should be included in entity's meta. If this is specified on a get_object or retrieve_objects request and a retrieved object is changed, calling reconcile_object() with the changed object will use the information in meta reconcilable to produce a modify request for only the changes. The reconcilable option assumes the path option and possibly other options as needed.",
+                    "markdownDescription": "**Reconcilable**\n\nIndicates that meta reconcilable should be included in entity's meta. If this is specified on a get_object or retrieve_objects request and a retrieved object is changed, calling reconcile_object() with the changed object will use the information in meta reconcilable to produce a modify request for only the changes. The reconcilable option assumes the path option and possibly other options as needed.",
                     "title": "Reconcilable",
                     "type": "boolean"
                 },
                 "resolvedParentPaths": {
                     "description": "Indicates that meta resolvedParentPaths should be included with an array of parent paths that have been resolved by the composite option.",
+                    "markdownDescription": "**Parent Paths**\n\nIndicates that meta resolvedParentPaths should be included with an array of parent paths that have been resolved by the composite option.",
                     "title": "Parent Paths",
                     "type": "boolean"
                 },
                 "typedValues": {
                     "description": "*** EXPERIMENTAL *** This option indicates that a value's type information (valueType, dataType, and objectType) should be included with each value. See the content type to determines how this is represented.",
+                    "markdownDescription": "**Typed Values**\n\n*** EXPERIMENTAL *** This option indicates that a value's type information (valueType, dataType, and objectType) should be included with each value. See the content type to determines how this is represented.",
                     "title": "Typed Values",
                     "type": "boolean"
                 },
                 "whitespace": {
                     "description": "This option can be optionally supported by a content type implementation. In the case of JSON, this indicates that newline, space, and tab characters should be included to make the output more readable.",
+                    "markdownDescription": "**Whitespace**\n\nThis option can be optionally supported by a content type implementation. In the case of JSON, this indicates that newline, space, and tab characters should be included to make the output more readable.",
+                    "title": "Whitespace",
+                    "type": "boolean"
+                }
+            },
+            "title": "_AdaptiveObjectOptions_",
+            "type": "object"
+        },
+        "_AdaptiveObjectOptions_.propertyTypes": {
+            "properties": {
+                "checkRequired": {
+                    "description": "Indicates that object should be checked for missing required properties. This option implies the normalize option.",
+                    "markdownDescription": "**Check Required**\n\nIndicates that object should be checked for missing required properties. This option implies the normalize option.",
+                    "title": "Check Required",
+                    "type": "boolean"
+                },
+                "composite": {
+                    "description": "Indicates that both direct and embedded inheritance should be performed.",
+                    "markdownDescription": "**Composite**\n\nIndicates that both direct and embedded inheritance should be performed.",
+                    "title": "Composite",
+                    "type": "boolean"
+                },
+                "debug": {
+                    "description": "This will cause the errors in object meta to include additional debug information. If not specified, only the message will be included.",
+                    "markdownDescription": "**Debug**\n\nThis will cause the errors in object meta to include additional debug information. If not specified, only the message will be included.",
+                    "title": "Debug",
+                    "type": "boolean"
+                },
+                "includeDefaultValues": {
+                    "description": "This indicates that default property values should be included. This option implies the normalize option.",
+                    "markdownDescription": "**Include Defaults**\n\nThis indicates that default property values should be included. This option implies the normalize option.",
+                    "title": "Include Defaults",
+                    "type": "boolean"
+                },
+                "includeDescendentObjectTypes": {
+                    "description": "This only applies to retrieve objects requests and indicates that objects with the supplied object type along with objects with any of its descendent object types should be included in the search.",
+                    "markdownDescription": "**Include Descendent**\n\nThis only applies to retrieve objects requests and indicates that objects with the supplied object type along with objects with any of its descendent object types should be included in the search.",
+                    "title": "Include Descendent",
+                    "type": "boolean"
+                },
+                "inheritedFrom": {
+                    "description": "Indicates that the inheritedFrom property in meta propertyTypes.<propertyName>, where <propertyName> is the associated property name, should be set. This option is ignored unless composite option is also set.",
+                    "markdownDescription": "**Inherited From**\n\nIndicates that the inheritedFrom property in meta propertyTypes.<propertyName>, where <propertyName> is the associated property name, should be set. This option is ignored unless composite option is also set.",
+                    "title": "Inherited From",
+                    "type": "boolean"
+                },
+                "integersAsString": {
+                    "description": "This overrides the largeIntegersAsString option. If neither the integersAsString or large_integer_as_string is specified, integers will remain integers. If this option is specified, all data type integer values will be converted to the string data type.\\n\\nThis options is useful if a content type is used that represents integers as double (floating point) values.",
+                    "markdownDescription": "**Integers As String**\n\nThis overrides the largeIntegersAsString option. If neither the integersAsString or large_integer_as_string is specified, integers will remain integers. If this option is specified, all data type integer values will be converted to the string data type.\\n\\nThis options is useful if a content type is used that represents integers as double (floating point) values.",
+                    "title": "Integers As String",
+                    "type": "boolean"
+                },
+                "largeIntegersAsString": {
+                    "description": "This option is overridden by the integersAsString option.\\n\\nIf this option is specified, all integers that have a magnitude that exceeds plus or minus 9007199254740991 (2^53-1) will be converted to the string data type.\\n\\nThis options is useful if integers of a content type are interpreted as double (floating point) values, but integers are normally small enough to be represented properly. An example is Javascript's use of JSON.",
+                    "markdownDescription": "**Large Integers As String**\n\nThis option is overridden by the integersAsString option.\\n\\nIf this option is specified, all integers that have a magnitude that exceeds plus or minus 9007199254740991 (2^53-1) will be converted to the string data type.\\n\\nThis options is useful if integers of a content type are interpreted as double (floating point) values, but integers are normally small enough to be represented properly. An example is Javascript's use of JSON.",
+                    "title": "Large Integers As String",
+                    "type": "boolean"
+                },
+                "metaFull": {
+                    "description": "This indicates that all meta, including properties that are not part of delta from object type, are to be included. This overrides metaLimited.",
+                    "markdownDescription": "**Full meta**\n\nThis indicates that all meta, including properties that are not part of delta from object type, are to be included. This overrides metaLimited.",
+                    "title": "Full meta",
+                    "type": "boolean"
+                },
+                "metaLimited": {
+                    "description": "Indicates that only requested and essential (parentPaths) meta is returned.",
+                    "markdownDescription": "**Limited meta**\n\nIndicates that only requested and essential (parentPaths) meta is returned.",
+                    "title": "Limited meta",
+                    "type": "boolean"
+                },
+                "normalize": {
+                    "description": "Indicates that each object's object type should be processed, assigned each embedded object's object type, converting any properties to their correct data type, plus computing values when needed. If there is dataType or dataTypeParameter information available during normalization that is not in the associated _AdaptiveObjectType_, it will be added at the appropriate place in the object's meta.\\n\\nUse the includeDefaultValues option to include default values.",
+                    "markdownDescription": "**Normalize**\n\nIndicates that each object's object type should be processed, assigned each embedded object's object type, converting any properties to their correct data type, plus computing values when needed. If there is dataType or dataTypeParameter information available during normalization that is not in the associated _AdaptiveObjectType_, it will be added at the appropriate place in the object's meta.\\n\\nUse the includeDefaultValues option to include default values.",
+                    "title": "Normalize",
+                    "type": "boolean"
+                },
+                "objectId": {
+                    "description": "Indicates that objectId property should be included in the meta for entity objects.",
+                    "markdownDescription": "**Object Id**\n\nIndicates that objectId property should be included in the meta for entity objects.",
+                    "title": "Object Id",
+                    "type": "boolean"
+                },
+                "objectType": {
+                    "description": "Indicates that objectType property should be included in the meta for entity and embedded objects, if assigned.",
+                    "markdownDescription": "**Object Type**\n\nIndicates that objectType property should be included in the meta for entity and embedded objects, if assigned.",
+                    "title": "Object Type",
+                    "type": "boolean"
+                },
+                "objectTypes": {
+                    "description": "Indicates that the objectTypes property should be added to the meta of the entity containing a property of each object type used by the entity and all of its embedded objects. This option implies normalize.",
+                    "markdownDescription": "**Object Types**\n\nIndicates that the objectTypes property should be added to the meta of the entity containing a property of each object type used by the entity and all of its embedded objects. This option implies normalize.",
+                    "title": "Object Types",
+                    "type": "boolean"
+                },
+                "path": {
+                    "description": "Indicates that meta path should be included for entity objects.",
+                    "markdownDescription": "**Path**\n\nIndicates that meta path should be included for entity objects.",
+                    "title": "Path",
+                    "type": "boolean"
+                },
+                "pathEmbedded": {
+                    "description": "Indicates that meta path should be included for embedded objects.",
+                    "markdownDescription": "**Path Embedded**\n\nIndicates that meta path should be included for embedded objects.",
+                    "title": "Path Embedded",
+                    "type": "boolean"
+                },
+                "reconcilable": {
+                    "description": "Indicates that meta reconcilable should be included in entity's meta. If this is specified on a get_object or retrieve_objects request and a retrieved object is changed, calling reconcile_object() with the changed object will use the information in meta reconcilable to produce a modify request for only the changes. The reconcilable option assumes the path option and possibly other options as needed.",
+                    "markdownDescription": "**Reconcilable**\n\nIndicates that meta reconcilable should be included in entity's meta. If this is specified on a get_object or retrieve_objects request and a retrieved object is changed, calling reconcile_object() with the changed object will use the information in meta reconcilable to produce a modify request for only the changes. The reconcilable option assumes the path option and possibly other options as needed.",
+                    "title": "Reconcilable",
+                    "type": "boolean"
+                },
+                "resolvedParentPaths": {
+                    "description": "Indicates that meta resolvedParentPaths should be included with an array of parent paths that have been resolved by the composite option.",
+                    "markdownDescription": "**Parent Paths**\n\nIndicates that meta resolvedParentPaths should be included with an array of parent paths that have been resolved by the composite option.",
+                    "title": "Parent Paths",
+                    "type": "boolean"
+                },
+                "typedValues": {
+                    "description": "*** EXPERIMENTAL *** This option indicates that a value's type information (valueType, dataType, and objectType) should be included with each value. See the content type to determines how this is represented.",
+                    "markdownDescription": "**Typed Values**\n\n*** EXPERIMENTAL *** This option indicates that a value's type information (valueType, dataType, and objectType) should be included with each value. See the content type to determines how this is represented.",
+                    "title": "Typed Values",
+                    "type": "boolean"
+                },
+                "whitespace": {
+                    "description": "This option can be optionally supported by a content type implementation. In the case of JSON, this indicates that newline, space, and tab characters should be included to make the output more readable.",
+                    "markdownDescription": "**Whitespace**\n\nThis option can be optionally supported by a content type implementation. In the case of JSON, this indicates that newline, space, and tab characters should be included to make the output more readable.",
                     "title": "Whitespace",
                     "type": "boolean"
                 }
@@ -117,9 +264,138 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveObjectOptions_"
+    "additionalProperties": false,
+    "description": "The options used for objects returned by Adaptive Framework.",
+    "markdownDescription": "The options used for objects returned by Adaptive Framework.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "checkRequired": {
+            "description": "Indicates that object should be checked for missing required properties. This option implies the normalize option.",
+            "markdownDescription": "**Check Required**\n\nIndicates that object should be checked for missing required properties. This option implies the normalize option.",
+            "title": "Check Required",
+            "type": "boolean"
+        },
+        "composite": {
+            "description": "Indicates that both direct and embedded inheritance should be performed.",
+            "markdownDescription": "**Composite**\n\nIndicates that both direct and embedded inheritance should be performed.",
+            "title": "Composite",
+            "type": "boolean"
+        },
+        "debug": {
+            "description": "This will cause the errors in object meta to include additional debug information. If not specified, only the message will be included.",
+            "markdownDescription": "**Debug**\n\nThis will cause the errors in object meta to include additional debug information. If not specified, only the message will be included.",
+            "title": "Debug",
+            "type": "boolean"
+        },
+        "includeDefaultValues": {
+            "description": "This indicates that default property values should be included. This option implies the normalize option.",
+            "markdownDescription": "**Include Defaults**\n\nThis indicates that default property values should be included. This option implies the normalize option.",
+            "title": "Include Defaults",
+            "type": "boolean"
+        },
+        "includeDescendentObjectTypes": {
+            "description": "This only applies to retrieve objects requests and indicates that objects with the supplied object type along with objects with any of its descendent object types should be included in the search.",
+            "markdownDescription": "**Include Descendent**\n\nThis only applies to retrieve objects requests and indicates that objects with the supplied object type along with objects with any of its descendent object types should be included in the search.",
+            "title": "Include Descendent",
+            "type": "boolean"
+        },
+        "inheritedFrom": {
+            "description": "Indicates that the inheritedFrom property in meta propertyTypes.<propertyName>, where <propertyName> is the associated property name, should be set. This option is ignored unless composite option is also set.",
+            "markdownDescription": "**Inherited From**\n\nIndicates that the inheritedFrom property in meta propertyTypes.<propertyName>, where <propertyName> is the associated property name, should be set. This option is ignored unless composite option is also set.",
+            "title": "Inherited From",
+            "type": "boolean"
+        },
+        "integersAsString": {
+            "description": "This overrides the largeIntegersAsString option. If neither the integersAsString or large_integer_as_string is specified, integers will remain integers. If this option is specified, all data type integer values will be converted to the string data type.\\n\\nThis options is useful if a content type is used that represents integers as double (floating point) values.",
+            "markdownDescription": "**Integers As String**\n\nThis overrides the largeIntegersAsString option. If neither the integersAsString or large_integer_as_string is specified, integers will remain integers. If this option is specified, all data type integer values will be converted to the string data type.\\n\\nThis options is useful if a content type is used that represents integers as double (floating point) values.",
+            "title": "Integers As String",
+            "type": "boolean"
+        },
+        "largeIntegersAsString": {
+            "description": "This option is overridden by the integersAsString option.\\n\\nIf this option is specified, all integers that have a magnitude that exceeds plus or minus 9007199254740991 (2^53-1) will be converted to the string data type.\\n\\nThis options is useful if integers of a content type are interpreted as double (floating point) values, but integers are normally small enough to be represented properly. An example is Javascript's use of JSON.",
+            "markdownDescription": "**Large Integers As String**\n\nThis option is overridden by the integersAsString option.\\n\\nIf this option is specified, all integers that have a magnitude that exceeds plus or minus 9007199254740991 (2^53-1) will be converted to the string data type.\\n\\nThis options is useful if integers of a content type are interpreted as double (floating point) values, but integers are normally small enough to be represented properly. An example is Javascript's use of JSON.",
+            "title": "Large Integers As String",
+            "type": "boolean"
+        },
+        "metaFull": {
+            "description": "This indicates that all meta, including properties that are not part of delta from object type, are to be included. This overrides metaLimited.",
+            "markdownDescription": "**Full meta**\n\nThis indicates that all meta, including properties that are not part of delta from object type, are to be included. This overrides metaLimited.",
+            "title": "Full meta",
+            "type": "boolean"
+        },
+        "metaLimited": {
+            "description": "Indicates that only requested and essential (parentPaths) meta is returned.",
+            "markdownDescription": "**Limited meta**\n\nIndicates that only requested and essential (parentPaths) meta is returned.",
+            "title": "Limited meta",
+            "type": "boolean"
+        },
+        "normalize": {
+            "description": "Indicates that each object's object type should be processed, assigned each embedded object's object type, converting any properties to their correct data type, plus computing values when needed. If there is dataType or dataTypeParameter information available during normalization that is not in the associated _AdaptiveObjectType_, it will be added at the appropriate place in the object's meta.\\n\\nUse the includeDefaultValues option to include default values.",
+            "markdownDescription": "**Normalize**\n\nIndicates that each object's object type should be processed, assigned each embedded object's object type, converting any properties to their correct data type, plus computing values when needed. If there is dataType or dataTypeParameter information available during normalization that is not in the associated _AdaptiveObjectType_, it will be added at the appropriate place in the object's meta.\\n\\nUse the includeDefaultValues option to include default values.",
+            "title": "Normalize",
+            "type": "boolean"
+        },
+        "objectId": {
+            "description": "Indicates that objectId property should be included in the meta for entity objects.",
+            "markdownDescription": "**Object Id**\n\nIndicates that objectId property should be included in the meta for entity objects.",
+            "title": "Object Id",
+            "type": "boolean"
+        },
+        "objectType": {
+            "description": "Indicates that objectType property should be included in the meta for entity and embedded objects, if assigned.",
+            "markdownDescription": "**Object Type**\n\nIndicates that objectType property should be included in the meta for entity and embedded objects, if assigned.",
+            "title": "Object Type",
+            "type": "boolean"
+        },
+        "objectTypes": {
+            "description": "Indicates that the objectTypes property should be added to the meta of the entity containing a property of each object type used by the entity and all of its embedded objects. This option implies normalize.",
+            "markdownDescription": "**Object Types**\n\nIndicates that the objectTypes property should be added to the meta of the entity containing a property of each object type used by the entity and all of its embedded objects. This option implies normalize.",
+            "title": "Object Types",
+            "type": "boolean"
+        },
+        "path": {
+            "description": "Indicates that meta path should be included for entity objects.",
+            "markdownDescription": "**Path**\n\nIndicates that meta path should be included for entity objects.",
+            "title": "Path",
+            "type": "boolean"
+        },
+        "pathEmbedded": {
+            "description": "Indicates that meta path should be included for embedded objects.",
+            "markdownDescription": "**Path Embedded**\n\nIndicates that meta path should be included for embedded objects.",
+            "title": "Path Embedded",
+            "type": "boolean"
+        },
+        "reconcilable": {
+            "description": "Indicates that meta reconcilable should be included in entity's meta. If this is specified on a get_object or retrieve_objects request and a retrieved object is changed, calling reconcile_object() with the changed object will use the information in meta reconcilable to produce a modify request for only the changes. The reconcilable option assumes the path option and possibly other options as needed.",
+            "markdownDescription": "**Reconcilable**\n\nIndicates that meta reconcilable should be included in entity's meta. If this is specified on a get_object or retrieve_objects request and a retrieved object is changed, calling reconcile_object() with the changed object will use the information in meta reconcilable to produce a modify request for only the changes. The reconcilable option assumes the path option and possibly other options as needed.",
+            "title": "Reconcilable",
+            "type": "boolean"
+        },
+        "resolvedParentPaths": {
+            "description": "Indicates that meta resolvedParentPaths should be included with an array of parent paths that have been resolved by the composite option.",
+            "markdownDescription": "**Parent Paths**\n\nIndicates that meta resolvedParentPaths should be included with an array of parent paths that have been resolved by the composite option.",
+            "title": "Parent Paths",
+            "type": "boolean"
+        },
+        "typedValues": {
+            "description": "*** EXPERIMENTAL *** This option indicates that a value's type information (valueType, dataType, and objectType) should be included with each value. See the content type to determines how this is represented.",
+            "markdownDescription": "**Typed Values**\n\n*** EXPERIMENTAL *** This option indicates that a value's type information (valueType, dataType, and objectType) should be included with each value. See the content type to determines how this is represented.",
+            "title": "Typed Values",
+            "type": "boolean"
+        },
+        "whitespace": {
+            "description": "This option can be optionally supported by a content type implementation. In the case of JSON, this indicates that newline, space, and tab characters should be included to make the output more readable.",
+            "markdownDescription": "**Whitespace**\n\nThis option can be optionally supported by a content type implementation. In the case of JSON, this indicates that newline, space, and tab characters should be included to make the output more readable.",
+            "title": "Whitespace",
+            "type": "boolean"
         }
-    ]
+    },
+    "title": "_AdaptiveObjectOptions_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveObjectType_.json
+++ b/generated/schemas/afw/_AdaptiveObjectType_.json
@@ -1,38 +1,43 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveObjectType_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveObjectType_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveObjectType_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "The adaptive object type of all adaptive object type objects.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveObjectType_.propertyTypes": {
+            "markdownDescription": "The adaptive object type of all adaptive object type objects.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "allowAdd": {
                     "default": true,
                     "description": "If false, objects of this type can NEVER be added via an adapter. If true, objects of this type can be added via an adapter as long as allowed by authorization policy and the adapter.",
+                    "markdownDescription": "**Allow Add**\n\nIf false, objects of this type can NEVER be added via an adapter. If true, objects of this type can be added via an adapter as long as allowed by authorization policy and the adapter.",
                     "title": "Allow Add",
                     "type": "boolean"
                 },
                 "allowChange": {
                     "default": true,
                     "description": "If false, objects of this type can NEVER be changed via an adapter. If true, objects of this type can be changed via an adapter as long as allowed by authorization policy and the adapter.",
+                    "markdownDescription": "**Allow Change**\n\nIf false, objects of this type can NEVER be changed via an adapter. If true, objects of this type can be changed via an adapter as long as allowed by authorization policy and the adapter.",
                     "title": "Allow Change",
                     "type": "boolean"
                 },
                 "allowDelete": {
                     "default": true,
                     "description": "If false, objects of this type can NEVER be deleted via an adapter. If true, objects of this type can be deleted via an adapter as long as allowed by authorization policy and the adapter.",
+                    "markdownDescription": "**Allow Delete**\n\nIf false, objects of this type can NEVER be deleted via an adapter. If true, objects of this type can be deleted via an adapter as long as allowed by authorization policy and the adapter.",
                     "title": "Allow Delete",
                     "type": "boolean"
                 },
                 "allowEntity": {
                     "default": true,
                     "description": "Instances of this object type can exist as an entity object, not just an embedded object.",
+                    "markdownDescription": "**Allow Entity**\n\nInstances of this object type can exist as an entity object, not just an embedded object.",
                     "title": "Allow Entity",
                     "type": "boolean"
                 },
@@ -41,41 +46,49 @@
                     "items": {
                         "description": "This is the URIs of the collections this object type is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
                         "format": "uri-reference",
+                        "markdownDescription": "This is the URIs of the collections this object type is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
                         "title": "The URIs of the collections this object type is a part of",
                         "type": "string"
                     },
+                    "markdownDescription": "**Collection URIs**\n\nThis is the URIs of the collections this object type is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
                     "title": "Collection URIs",
                     "type": "array"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "The description of the object type.",
+                    "markdownDescription": "**Description**\n\nThe description of the object type.",
                     "title": "Description",
                     "type": "string"
                 },
                 "descriptionPropertyName": {
                     "description": "The name of the property in an instance that is used as the 'description' property in the meta for instances of this object type. If not specified, no description will be available.",
+                    "markdownDescription": "**Description Property Name**\n\nThe name of the property in an instance that is used as the 'description' property in the meta for instances of this object type. If not specified, no description will be available.",
                     "title": "Description Property Name",
                     "type": "string"
                 },
                 "label": {
                     "description": "Label used to identify this instance.",
+                    "markdownDescription": "**Label**\n\nLabel used to identify this instance.",
                     "title": "Label",
                     "type": "string"
                 },
                 "objectIdPropertyName": {
                     "description": "The name of the property in an instance that is used as the 'objectId' property in the meta for instances of this object type. If not specified, the internal adapter objectId for an object is used.",
+                    "markdownDescription": "**Object Id Property Name**\n\nThe name of the property in an instance that is used as the 'objectId' property in the meta for instances of this object type. If not specified, the internal adapter objectId for an object is used.",
                     "title": "Object Id Property Name",
                     "type": "string"
                 },
                 "objectType": {
                     "description": "The object id of the object type.",
+                    "markdownDescription": "**Object Type**\n\nThe object id of the object type.",
                     "title": "Object Type",
                     "type": "string"
                 },
                 "originURI": {
                     "description": "The origin URI of this object type. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
                     "format": "uri-reference",
+                    "markdownDescription": "**Origin URI**\n\nThe origin URI of this object type. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
                     "title": "Origin URI",
                     "type": "string"
                 },
@@ -86,7 +99,9 @@
                         }
                     ],
                     "description": "If specified, this is the property type for properties that are not explicitly specified. If otherProperties is not specified, only explicitly specified properties are allowed.",
-                    "title": "Other Properties"
+                    "markdownDescription": "**Other Properties**\n\nIf specified, this is the property type for properties that are not explicitly specified. If otherProperties is not specified, only explicitly specified properties are allowed.",
+                    "title": "Other Properties",
+                    "type": "object"
                 },
                 "propertyTypes": {
                     "allOf": [
@@ -95,11 +110,14 @@
                         }
                     ],
                     "description": "An object whose properties contain the _AdaptiveValueMeta_ for properties with corresponding name in instances of this _AdaptiveObjectType_.",
-                    "title": "Property Types"
+                    "markdownDescription": "**Property Types**\n\nAn object whose properties contain the _AdaptiveValueMeta_ for properties with corresponding name in instances of this _AdaptiveObjectType_.",
+                    "title": "Property Types",
+                    "type": "object"
                 },
                 "referenceURI": {
                     "description": "URI of more reference information about this object.",
                     "format": "uri-reference",
+                    "markdownDescription": "**Reference URI**\n\nURI of more reference information about this object.",
                     "title": "Reference URI",
                     "type": "string"
                 },
@@ -110,15 +128,156 @@
                         }
                     ],
                     "description": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
-                    "title": "Runtime"
+                    "markdownDescription": "**Runtime**\n\nThis is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
+                    "title": "Runtime",
+                    "type": "object"
                 },
                 "tags": {
                     "description": "This is an array of keywords and terms associated with this object type. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
                     "items": {
                         "description": "This is an array of keywords and terms associated with this object type. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                        "markdownDescription": "This is an array of keywords and terms associated with this object type. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
                         "title": "List of keywords associated with this object type",
                         "type": "string"
                     },
+                    "markdownDescription": "**Tags**\n\nThis is an array of keywords and terms associated with this object type. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                    "title": "Tags",
+                    "type": "array"
+                }
+            },
+            "title": "_AdaptiveObjectType_",
+            "type": "object"
+        },
+        "_AdaptiveObjectType_.propertyTypes": {
+            "properties": {
+                "allowAdd": {
+                    "default": true,
+                    "description": "If false, objects of this type can NEVER be added via an adapter. If true, objects of this type can be added via an adapter as long as allowed by authorization policy and the adapter.",
+                    "markdownDescription": "**Allow Add**\n\nIf false, objects of this type can NEVER be added via an adapter. If true, objects of this type can be added via an adapter as long as allowed by authorization policy and the adapter.",
+                    "title": "Allow Add",
+                    "type": "boolean"
+                },
+                "allowChange": {
+                    "default": true,
+                    "description": "If false, objects of this type can NEVER be changed via an adapter. If true, objects of this type can be changed via an adapter as long as allowed by authorization policy and the adapter.",
+                    "markdownDescription": "**Allow Change**\n\nIf false, objects of this type can NEVER be changed via an adapter. If true, objects of this type can be changed via an adapter as long as allowed by authorization policy and the adapter.",
+                    "title": "Allow Change",
+                    "type": "boolean"
+                },
+                "allowDelete": {
+                    "default": true,
+                    "description": "If false, objects of this type can NEVER be deleted via an adapter. If true, objects of this type can be deleted via an adapter as long as allowed by authorization policy and the adapter.",
+                    "markdownDescription": "**Allow Delete**\n\nIf false, objects of this type can NEVER be deleted via an adapter. If true, objects of this type can be deleted via an adapter as long as allowed by authorization policy and the adapter.",
+                    "title": "Allow Delete",
+                    "type": "boolean"
+                },
+                "allowEntity": {
+                    "default": true,
+                    "description": "Instances of this object type can exist as an entity object, not just an embedded object.",
+                    "markdownDescription": "**Allow Entity**\n\nInstances of this object type can exist as an entity object, not just an embedded object.",
+                    "title": "Allow Entity",
+                    "type": "boolean"
+                },
+                "collectionURIs": {
+                    "description": "This is the URIs of the collections this object type is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                    "items": {
+                        "description": "This is the URIs of the collections this object type is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                        "format": "uri-reference",
+                        "markdownDescription": "This is the URIs of the collections this object type is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                        "title": "The URIs of the collections this object type is a part of",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Collection URIs**\n\nThis is the URIs of the collections this object type is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                    "title": "Collection URIs",
+                    "type": "array"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "The description of the object type.",
+                    "markdownDescription": "**Description**\n\nThe description of the object type.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "descriptionPropertyName": {
+                    "description": "The name of the property in an instance that is used as the 'description' property in the meta for instances of this object type. If not specified, no description will be available.",
+                    "markdownDescription": "**Description Property Name**\n\nThe name of the property in an instance that is used as the 'description' property in the meta for instances of this object type. If not specified, no description will be available.",
+                    "title": "Description Property Name",
+                    "type": "string"
+                },
+                "label": {
+                    "description": "Label used to identify this instance.",
+                    "markdownDescription": "**Label**\n\nLabel used to identify this instance.",
+                    "title": "Label",
+                    "type": "string"
+                },
+                "objectIdPropertyName": {
+                    "description": "The name of the property in an instance that is used as the 'objectId' property in the meta for instances of this object type. If not specified, the internal adapter objectId for an object is used.",
+                    "markdownDescription": "**Object Id Property Name**\n\nThe name of the property in an instance that is used as the 'objectId' property in the meta for instances of this object type. If not specified, the internal adapter objectId for an object is used.",
+                    "title": "Object Id Property Name",
+                    "type": "string"
+                },
+                "objectType": {
+                    "description": "The object id of the object type.",
+                    "markdownDescription": "**Object Type**\n\nThe object id of the object type.",
+                    "title": "Object Type",
+                    "type": "string"
+                },
+                "originURI": {
+                    "description": "The origin URI of this object type. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
+                    "format": "uri-reference",
+                    "markdownDescription": "**Origin URI**\n\nThe origin URI of this object type. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
+                    "title": "Origin URI",
+                    "type": "string"
+                },
+                "otherProperties": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveValueMeta_"
+                        }
+                    ],
+                    "description": "If specified, this is the property type for properties that are not explicitly specified. If otherProperties is not specified, only explicitly specified properties are allowed.",
+                    "markdownDescription": "**Other Properties**\n\nIf specified, this is the property type for properties that are not explicitly specified. If otherProperties is not specified, only explicitly specified properties are allowed.",
+                    "title": "Other Properties",
+                    "type": "object"
+                },
+                "propertyTypes": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptivePropertyTypes_"
+                        }
+                    ],
+                    "description": "An object whose properties contain the _AdaptiveValueMeta_ for properties with corresponding name in instances of this _AdaptiveObjectType_.",
+                    "markdownDescription": "**Property Types**\n\nAn object whose properties contain the _AdaptiveValueMeta_ for properties with corresponding name in instances of this _AdaptiveObjectType_.",
+                    "title": "Property Types",
+                    "type": "object"
+                },
+                "referenceURI": {
+                    "description": "URI of more reference information about this object.",
+                    "format": "uri-reference",
+                    "markdownDescription": "**Reference URI**\n\nURI of more reference information about this object.",
+                    "title": "Reference URI",
+                    "type": "string"
+                },
+                "runtime": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveRuntimeObject_"
+                        }
+                    ],
+                    "description": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
+                    "markdownDescription": "**Runtime**\n\nThis is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
+                    "title": "Runtime",
+                    "type": "object"
+                },
+                "tags": {
+                    "description": "This is an array of keywords and terms associated with this object type. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                    "items": {
+                        "description": "This is an array of keywords and terms associated with this object type. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                        "markdownDescription": "This is an array of keywords and terms associated with this object type. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                        "title": "List of keywords associated with this object type",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Tags**\n\nThis is an array of keywords and terms associated with this object type. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
                     "title": "Tags",
                     "type": "array"
                 }
@@ -127,12 +286,17 @@
         },
         "_AdaptiveObject_": {
             "additionalProperties": true,
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveObject_.propertyTypes"
-                }
-            ],
             "description": "Hints that can optionally be used by UI to render this value.",
+            "markdownDescription": "Hints that can optionally be used by UI to render this value.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                }
+            },
             "title": "Hints",
             "type": "object"
         },
@@ -147,9 +311,12 @@
                         "$ref": "#/$defs/_AdaptiveValueMeta_"
                     }
                 ],
-                "description": "Object type of the propertyTypes property of an object type."
+                "description": "Object type of the propertyTypes property of an object type.",
+                "markdownDescription": "Object type of the propertyTypes property of an object type.",
+                "type": "object"
             },
             "description": "An object whose properties contain the _AdaptiveValueMeta_ for properties with corresponding name in instances of this _AdaptiveObjectType_.",
+            "markdownDescription": "An object whose properties contain the _AdaptiveValueMeta_ for properties with corresponding name in instances of this _AdaptiveObjectType_.",
             "properties": {
                 "_meta_": {
                     "description": "This is the special Meta object that has deltas between this instance and its Adaptive Object Type.",
@@ -172,25 +339,44 @@
             "type": "object"
         },
         "_AdaptiveRuntimeLabels_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveRuntimeLabels_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Labels.",
-            "title": "Labels",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveRuntimeLabels_.propertyTypes": {
+            "markdownDescription": "Labels.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "indirectObjectId": {
                     "description": "Indicates that the objectId in the associated struct is a pointer.",
+                    "markdownDescription": "**Indirect Object Id**\n\nIndicates that the objectId in the associated struct is a pointer.",
                     "title": "Indirect Object Id",
                     "type": "boolean"
                 },
                 "objectId": {
                     "description": "The name of member in the struct that contains the objectId.",
+                    "markdownDescription": "**Object Id**\n\nThe name of member in the struct that contains the objectId.",
+                    "title": "Object Id",
+                    "type": "string"
+                }
+            },
+            "title": "Labels",
+            "type": "object"
+        },
+        "_AdaptiveRuntimeLabels_.propertyTypes": {
+            "properties": {
+                "indirectObjectId": {
+                    "description": "Indicates that the objectId in the associated struct is a pointer.",
+                    "markdownDescription": "**Indirect Object Id**\n\nIndicates that the objectId in the associated struct is a pointer.",
+                    "title": "Indirect Object Id",
+                    "type": "boolean"
+                },
+                "objectId": {
+                    "description": "The name of member in the struct that contains the objectId.",
+                    "markdownDescription": "**Object Id**\n\nThe name of member in the struct that contains the objectId.",
                     "title": "Object Id",
                     "type": "string"
                 }
@@ -198,20 +384,20 @@
             "type": "object"
         },
         "_AdaptiveRuntimeObject_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveRuntimeObject_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
-            "title": "Runtime",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveRuntimeObject_.propertyTypes": {
+            "markdownDescription": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "indirect": {
                     "description": "Indicates that the runtime struct is a pointer. If a property of this object type has runtime.onGetValueCFunctionName specified, the is ignored and runtime structure is always indirect.",
+                    "markdownDescription": "**Indirect**\n\nIndicates that the runtime struct is a pointer. If a property of this object type has runtime.onGetValueCFunctionName specified, the is ignored and runtime structure is always indirect.",
                     "title": "Indirect",
                     "type": "boolean"
                 },
@@ -222,10 +408,42 @@
                         }
                     ],
                     "description": "Labels.",
-                    "title": "Labels"
+                    "markdownDescription": "**Labels**\n\nLabels.",
+                    "title": "Labels",
+                    "type": "object"
                 },
                 "typedef": {
                     "description": "The typedef of the struct for the runtime object.",
+                    "markdownDescription": "**Typedef**\n\nThe typedef of the struct for the runtime object.",
+                    "title": "Typedef",
+                    "type": "string"
+                }
+            },
+            "title": "Runtime",
+            "type": "object"
+        },
+        "_AdaptiveRuntimeObject_.propertyTypes": {
+            "properties": {
+                "indirect": {
+                    "description": "Indicates that the runtime struct is a pointer. If a property of this object type has runtime.onGetValueCFunctionName specified, the is ignored and runtime structure is always indirect.",
+                    "markdownDescription": "**Indirect**\n\nIndicates that the runtime struct is a pointer. If a property of this object type has runtime.onGetValueCFunctionName specified, the is ignored and runtime structure is always indirect.",
+                    "title": "Indirect",
+                    "type": "boolean"
+                },
+                "labels": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveRuntimeLabels_"
+                        }
+                    ],
+                    "description": "Labels.",
+                    "markdownDescription": "**Labels**\n\nLabels.",
+                    "title": "Labels",
+                    "type": "object"
+                },
+                "typedef": {
+                    "description": "The typedef of the struct for the runtime object.",
+                    "markdownDescription": "**Typedef**\n\nThe typedef of the struct for the runtime object.",
                     "title": "Typedef",
                     "type": "string"
                 }
@@ -233,35 +451,68 @@
             "type": "object"
         },
         "_AdaptiveRuntimeProperty_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveRuntimeProperty_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
-            "title": "Runtime",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveRuntimeProperty_.propertyTypes": {
+            "markdownDescription": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "memberName": {
                     "description": "The member name of this property in the runtime struct if other than the property name.",
+                    "markdownDescription": "**Member Name**\n\nThe member name of this property in the runtime struct if other than the property name.",
                     "title": "Member Name",
                     "type": "string"
                 },
                 "onGetValueCFunctionName": {
                     "description": "This is the name of the c callback function called to get the value of this property at runtime. If this property is specified, valueAccessor is ignored.",
+                    "markdownDescription": "**onGetValueCFunctionName**\n\nThis is the name of the c callback function called to get the value of this property at runtime. If this property is specified, valueAccessor is ignored.",
                     "title": "onGetValueCFunctionName",
                     "type": "string"
                 },
                 "valueAccessor": {
                     "description": "The name of the registered value accessor used to access this property. The default is default. See afw_runtime_value_accessor.h for the built in accessors.",
+                    "markdownDescription": "**Value Accessor**\n\nThe name of the registered value accessor used to access this property. The default is default. See afw_runtime_value_accessor.h for the built in accessors.",
                     "title": "Value Accessor",
                     "type": "string"
                 },
                 "zeroOffset": {
                     "description": "Indicates that the value accessor is called with a pointer to the struct and a 0 offset.",
+                    "markdownDescription": "**Zero Offset**\n\nIndicates that the value accessor is called with a pointer to the struct and a 0 offset.",
+                    "title": "Zero Offset",
+                    "type": "boolean"
+                }
+            },
+            "title": "Runtime",
+            "type": "object"
+        },
+        "_AdaptiveRuntimeProperty_.propertyTypes": {
+            "properties": {
+                "memberName": {
+                    "description": "The member name of this property in the runtime struct if other than the property name.",
+                    "markdownDescription": "**Member Name**\n\nThe member name of this property in the runtime struct if other than the property name.",
+                    "title": "Member Name",
+                    "type": "string"
+                },
+                "onGetValueCFunctionName": {
+                    "description": "This is the name of the c callback function called to get the value of this property at runtime. If this property is specified, valueAccessor is ignored.",
+                    "markdownDescription": "**onGetValueCFunctionName**\n\nThis is the name of the c callback function called to get the value of this property at runtime. If this property is specified, valueAccessor is ignored.",
+                    "title": "onGetValueCFunctionName",
+                    "type": "string"
+                },
+                "valueAccessor": {
+                    "description": "The name of the registered value accessor used to access this property. The default is default. See afw_runtime_value_accessor.h for the built in accessors.",
+                    "markdownDescription": "**Value Accessor**\n\nThe name of the registered value accessor used to access this property. The default is default. See afw_runtime_value_accessor.h for the built in accessors.",
+                    "title": "Value Accessor",
+                    "type": "string"
+                },
+                "zeroOffset": {
+                    "description": "Indicates that the value accessor is called with a pointer to the struct and a 0 offset.",
+                    "markdownDescription": "**Zero Offset**\n\nIndicates that the value accessor is called with a pointer to the struct and a 0 offset.",
                     "title": "Zero Offset",
                     "type": "boolean"
                 }
@@ -269,40 +520,44 @@
             "type": "object"
         },
         "_AdaptiveValueMeta_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveValueMeta_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "If specified, this is the property type for properties that are not explicitly specified. If otherProperties is not specified, only explicitly specified properties are allowed.",
-            "title": "Other Properties",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveValueMeta_.propertyTypes": {
+            "markdownDescription": "If specified, this is the property type for properties that are not explicitly specified. If otherProperties is not specified, only explicitly specified properties are allowed.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "additionalConstraints": {
                     "description": "Additional constraint for the value.",
+                    "markdownDescription": "**Additional Constraints**\n\nAdditional constraint for the value.",
                     "title": "Additional Constraints",
                     "type": "string"
                 },
                 "allowQuery": {
                     "description": "If false, this value can NEVER be queried. If true, this value can be queried if allowed by authorization policy.",
+                    "markdownDescription": "**Allow Query**\n\nIf false, this value can NEVER be queried. If true, this value can be queried if allowed by authorization policy.",
                     "title": "Allow Query",
                     "type": "boolean"
                 },
                 "allowWrite": {
                     "description": "If true, the value can be written if allowed by authorization policy as long as allowChange for the instance is also true. If false, the value can only be written if required is true when adding a new object.",
+                    "markdownDescription": "**Allow Write**\n\nIf true, the value can be written if allowed by authorization policy as long as allowChange for the instance is also true. If false, the value can only be written if required is true when adding a new object.",
                     "title": "Allow Write",
                     "type": "boolean"
                 },
                 "allowedValues": {
                     "description": "This is an array of the allowed values for this adaptive value. The dataType and dataTypeParameter of these values is the same as for the adaptive value itself.",
+                    "markdownDescription": "**Allowed Values**\n\nThis is an array of the allowed values for this adaptive value. The dataType and dataTypeParameter of these values is the same as for the adaptive value itself.",
                     "title": "Allowed Values",
                     "type": "array"
                 },
                 "brief": {
                     "description": "This is a predicate for this value, with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for this value, with the first letter capitalized and without a trailing period.",
                     "title": "Brief",
                     "type": "string"
                 },
@@ -311,39 +566,47 @@
                     "items": {
                         "description": "This is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
                         "format": "uri-reference",
+                        "markdownDescription": "This is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
                         "title": "The URIs of the collection that this value is a part of",
                         "type": "string"
                     },
+                    "markdownDescription": "**Collection URIs**\n\nThis is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
                     "title": "Collection URIs",
                     "type": "array"
                 },
                 "contextType": {
                     "description": "For data types that are evaluated (evaluate property true), this is the context type used for the evaluation.",
+                    "markdownDescription": "**Context Type**\n\nFor data types that are evaluated (evaluate property true), this is the context type used for the evaluation.",
                     "title": "Context Type",
                     "type": "string"
                 },
                 "dataType": {
                     "description": "Data type of this value.",
+                    "markdownDescription": "**Data Type**\n\nData type of this value.",
                     "title": "Data Type",
                     "type": "string"
                 },
                 "dataTypeParameter": {
                     "description": "See the data type's dataTypeParameterType property to determine how to interpret this.",
+                    "markdownDescription": "**Data Type Parameter**\n\nSee the data type's dataTypeParameterType property to determine how to interpret this.",
                     "title": "Data Type Parameter",
                     "type": "string"
                 },
                 "dataTypeParameterFormatted": {
                     "description": "This is the same as dataTypeParameter with possible comments and whitespace. This is especially useful for data type function to document its signature. If this property is not present, dataTypeParameter can be used in its place.",
+                    "markdownDescription": "**Formatted Data Type Parameter**\n\nThis is the same as dataTypeParameter with possible comments and whitespace. This is especially useful for data type function to document its signature. If this property is not present, dataTypeParameter can be used in its place.",
                     "title": "Formatted Data Type Parameter",
                     "type": "string"
                 },
                 "defaultValue": {
                     "description": "This is the default value. The dataType and dataTypeParameter properties apply to this value. If needed, this value will be normalized.",
+                    "markdownDescription": "**Default Value**\n\nThis is the default value. The dataType and dataTypeParameter properties apply to this value. If needed, this value will be normalized.",
                     "title": "Default Value"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "The description of this value.",
+                    "markdownDescription": "**Description**\n\nThe description of this value.",
                     "title": "Description",
                     "type": "string"
                 },
@@ -354,56 +617,68 @@
                         }
                     ],
                     "description": "Hints that can optionally be used by UI to render this value.",
-                    "title": "Hints"
+                    "markdownDescription": "**Hints**\n\nHints that can optionally be used by UI to render this value.",
+                    "title": "Hints",
+                    "type": "object"
                 },
                 "label": {
                     "description": "Label used to identify this value.",
+                    "markdownDescription": "**Label**\n\nLabel used to identify this value.",
                     "title": "Label",
                     "type": "string"
                 },
                 "maxLength": {
                     "description": "This is maximum length of the to_string() for this value. If not specified, there is no maximum length.",
+                    "markdownDescription": "**Maximum Length**\n\nThis is maximum length of the to_string() for this value. If not specified, there is no maximum length.",
                     "title": "Maximum Length",
                     "type": "integer"
                 },
                 "maxNormalLength": {
                     "description": "This is maximum normal length of the to_string() for this value.  If not specified, maxLength is used.",
+                    "markdownDescription": "**Normal Maximum Length**\n\nThis is maximum normal length of the to_string() for this value.  If not specified, maxLength is used.",
                     "title": "Normal Maximum Length",
                     "type": "integer"
                 },
                 "maxValue": {
                     "description": "This is the maximum for this value. If not specified, there is no maximum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "markdownDescription": "**Maximum Value**\n\nThis is the maximum for this value. If not specified, there is no maximum value. The dataType and dataTypeParameter of this value is the same as for the value.",
                     "title": "Maximum Value"
                 },
                 "minLength": {
                     "description": "This is minimum length of the to_string() for this value. If not specified, there is no minimum length.",
+                    "markdownDescription": "**Minimum Length**\n\nThis is minimum length of the to_string() for this value. If not specified, there is no minimum length.",
                     "title": "Minimum Length",
                     "type": "integer"
                 },
                 "minValue": {
                     "description": "This is the minimum for this. If not specified, there is no minimum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "markdownDescription": "**Minimum Value**\n\nThis is the minimum for this. If not specified, there is no minimum value. The dataType and dataTypeParameter of this value is the same as for the value.",
                     "title": "Minimum Value"
                 },
                 "originURI": {
                     "description": "The origin URI of this value meta. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
                     "format": "uri-reference",
+                    "markdownDescription": "**Origin URI**\n\nThe origin URI of this value meta. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
                     "title": "Origin URI",
                     "type": "string"
                 },
                 "possibleValues": {
                     "description": "Possible values of this value. This can be the typed value or the string value.",
+                    "markdownDescription": "**Possible Values**\n\nPossible values of this value. This can be the typed value or the string value.",
                     "title": "Possible Values",
                     "type": "array"
                 },
                 "referenceURI": {
                     "description": "URI of more reference information about this value meta.",
                     "format": "uri-reference",
+                    "markdownDescription": "**Reference URI**\n\nURI of more reference information about this value meta.",
                     "title": "Reference URI",
                     "type": "string"
                 },
                 "required": {
                     "default": false,
                     "description": "Indicates that value is required.",
+                    "markdownDescription": "**Required**\n\nIndicates that value is required.",
                     "title": "Required",
                     "type": "boolean"
                 },
@@ -414,34 +689,246 @@
                         }
                     ],
                     "description": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
-                    "title": "Runtime"
+                    "markdownDescription": "**Runtime**\n\nThis is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
+                    "title": "Runtime",
+                    "type": "object"
                 },
                 "skeleton": {
                     "description": "This is a skeleton example that can optionally be used by an application as an initial value. For example, if this is a new data type 'template' value, this can be the text used to prime the edit window with sample Adaptive Script code including comments.",
+                    "markdownDescription": "**Skeleton**\n\nThis is a skeleton example that can optionally be used by an application as an initial value. For example, if this is a new data type 'template' value, this can be the text used to prime the edit window with sample Adaptive Script code including comments.",
                     "title": "Skeleton"
                 },
                 "tags": {
                     "description": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
                     "items": {
                         "description": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                        "markdownDescription": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
                         "title": "List of keywords and terms associated with values with this meta",
                         "type": "string"
                     },
+                    "markdownDescription": "**Tags**\n\nThis is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
                     "title": "Tags",
                     "type": "array"
                 },
                 "testDataParameter": {
                     "description": "This contains additional information about values with this meta that is used to produce test data.",
+                    "markdownDescription": "**Test Data Parameter**\n\nThis contains additional information about values with this meta that is used to produce test data.",
                     "title": "Test Data Parameter",
                     "type": "string"
                 },
                 "unique": {
                     "description": "Value of property must be unique within object type.",
+                    "markdownDescription": "**Unique**\n\nValue of property must be unique within object type.",
                     "title": "Unique",
                     "type": "boolean"
                 },
                 "valueInfId": {
                     "description": "This is a runtime property that is the implementation id of the value interface.",
+                    "markdownDescription": "**valueInf**\n\nThis is a runtime property that is the implementation id of the value interface.",
+                    "readOnly": true,
+                    "title": "valueInf",
+                    "type": "string"
+                }
+            },
+            "title": "Other Properties",
+            "type": "object"
+        },
+        "_AdaptiveValueMeta_.propertyTypes": {
+            "properties": {
+                "additionalConstraints": {
+                    "description": "Additional constraint for the value.",
+                    "markdownDescription": "**Additional Constraints**\n\nAdditional constraint for the value.",
+                    "title": "Additional Constraints",
+                    "type": "string"
+                },
+                "allowQuery": {
+                    "description": "If false, this value can NEVER be queried. If true, this value can be queried if allowed by authorization policy.",
+                    "markdownDescription": "**Allow Query**\n\nIf false, this value can NEVER be queried. If true, this value can be queried if allowed by authorization policy.",
+                    "title": "Allow Query",
+                    "type": "boolean"
+                },
+                "allowWrite": {
+                    "description": "If true, the value can be written if allowed by authorization policy as long as allowChange for the instance is also true. If false, the value can only be written if required is true when adding a new object.",
+                    "markdownDescription": "**Allow Write**\n\nIf true, the value can be written if allowed by authorization policy as long as allowChange for the instance is also true. If false, the value can only be written if required is true when adding a new object.",
+                    "title": "Allow Write",
+                    "type": "boolean"
+                },
+                "allowedValues": {
+                    "description": "This is an array of the allowed values for this adaptive value. The dataType and dataTypeParameter of these values is the same as for the adaptive value itself.",
+                    "markdownDescription": "**Allowed Values**\n\nThis is an array of the allowed values for this adaptive value. The dataType and dataTypeParameter of these values is the same as for the adaptive value itself.",
+                    "title": "Allowed Values",
+                    "type": "array"
+                },
+                "brief": {
+                    "description": "This is a predicate for this value, with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for this value, with the first letter capitalized and without a trailing period.",
+                    "title": "Brief",
+                    "type": "string"
+                },
+                "collectionURIs": {
+                    "description": "This is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                    "items": {
+                        "description": "This is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                        "format": "uri-reference",
+                        "markdownDescription": "This is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                        "title": "The URIs of the collection that this value is a part of",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Collection URIs**\n\nThis is the URIs of the collections that this value is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                    "title": "Collection URIs",
+                    "type": "array"
+                },
+                "contextType": {
+                    "description": "For data types that are evaluated (evaluate property true), this is the context type used for the evaluation.",
+                    "markdownDescription": "**Context Type**\n\nFor data types that are evaluated (evaluate property true), this is the context type used for the evaluation.",
+                    "title": "Context Type",
+                    "type": "string"
+                },
+                "dataType": {
+                    "description": "Data type of this value.",
+                    "markdownDescription": "**Data Type**\n\nData type of this value.",
+                    "title": "Data Type",
+                    "type": "string"
+                },
+                "dataTypeParameter": {
+                    "description": "See the data type's dataTypeParameterType property to determine how to interpret this.",
+                    "markdownDescription": "**Data Type Parameter**\n\nSee the data type's dataTypeParameterType property to determine how to interpret this.",
+                    "title": "Data Type Parameter",
+                    "type": "string"
+                },
+                "dataTypeParameterFormatted": {
+                    "description": "This is the same as dataTypeParameter with possible comments and whitespace. This is especially useful for data type function to document its signature. If this property is not present, dataTypeParameter can be used in its place.",
+                    "markdownDescription": "**Formatted Data Type Parameter**\n\nThis is the same as dataTypeParameter with possible comments and whitespace. This is especially useful for data type function to document its signature. If this property is not present, dataTypeParameter can be used in its place.",
+                    "title": "Formatted Data Type Parameter",
+                    "type": "string"
+                },
+                "defaultValue": {
+                    "description": "This is the default value. The dataType and dataTypeParameter properties apply to this value. If needed, this value will be normalized.",
+                    "markdownDescription": "**Default Value**\n\nThis is the default value. The dataType and dataTypeParameter properties apply to this value. If needed, this value will be normalized.",
+                    "title": "Default Value"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "The description of this value.",
+                    "markdownDescription": "**Description**\n\nThe description of this value.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "hints": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveObject_"
+                        }
+                    ],
+                    "description": "Hints that can optionally be used by UI to render this value.",
+                    "markdownDescription": "**Hints**\n\nHints that can optionally be used by UI to render this value.",
+                    "title": "Hints",
+                    "type": "object"
+                },
+                "label": {
+                    "description": "Label used to identify this value.",
+                    "markdownDescription": "**Label**\n\nLabel used to identify this value.",
+                    "title": "Label",
+                    "type": "string"
+                },
+                "maxLength": {
+                    "description": "This is maximum length of the to_string() for this value. If not specified, there is no maximum length.",
+                    "markdownDescription": "**Maximum Length**\n\nThis is maximum length of the to_string() for this value. If not specified, there is no maximum length.",
+                    "title": "Maximum Length",
+                    "type": "integer"
+                },
+                "maxNormalLength": {
+                    "description": "This is maximum normal length of the to_string() for this value.  If not specified, maxLength is used.",
+                    "markdownDescription": "**Normal Maximum Length**\n\nThis is maximum normal length of the to_string() for this value.  If not specified, maxLength is used.",
+                    "title": "Normal Maximum Length",
+                    "type": "integer"
+                },
+                "maxValue": {
+                    "description": "This is the maximum for this value. If not specified, there is no maximum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "markdownDescription": "**Maximum Value**\n\nThis is the maximum for this value. If not specified, there is no maximum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "title": "Maximum Value"
+                },
+                "minLength": {
+                    "description": "This is minimum length of the to_string() for this value. If not specified, there is no minimum length.",
+                    "markdownDescription": "**Minimum Length**\n\nThis is minimum length of the to_string() for this value. If not specified, there is no minimum length.",
+                    "title": "Minimum Length",
+                    "type": "integer"
+                },
+                "minValue": {
+                    "description": "This is the minimum for this. If not specified, there is no minimum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "markdownDescription": "**Minimum Value**\n\nThis is the minimum for this. If not specified, there is no minimum value. The dataType and dataTypeParameter of this value is the same as for the value.",
+                    "title": "Minimum Value"
+                },
+                "originURI": {
+                    "description": "The origin URI of this value meta. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
+                    "format": "uri-reference",
+                    "markdownDescription": "**Origin URI**\n\nThe origin URI of this value meta. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
+                    "title": "Origin URI",
+                    "type": "string"
+                },
+                "possibleValues": {
+                    "description": "Possible values of this value. This can be the typed value or the string value.",
+                    "markdownDescription": "**Possible Values**\n\nPossible values of this value. This can be the typed value or the string value.",
+                    "title": "Possible Values",
+                    "type": "array"
+                },
+                "referenceURI": {
+                    "description": "URI of more reference information about this value meta.",
+                    "format": "uri-reference",
+                    "markdownDescription": "**Reference URI**\n\nURI of more reference information about this value meta.",
+                    "title": "Reference URI",
+                    "type": "string"
+                },
+                "required": {
+                    "default": false,
+                    "description": "Indicates that value is required.",
+                    "markdownDescription": "**Required**\n\nIndicates that value is required.",
+                    "title": "Required",
+                    "type": "boolean"
+                },
+                "runtime": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveRuntimeProperty_"
+                        }
+                    ],
+                    "description": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
+                    "markdownDescription": "**Runtime**\n\nThis is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
+                    "title": "Runtime",
+                    "type": "object"
+                },
+                "skeleton": {
+                    "description": "This is a skeleton example that can optionally be used by an application as an initial value. For example, if this is a new data type 'template' value, this can be the text used to prime the edit window with sample Adaptive Script code including comments.",
+                    "markdownDescription": "**Skeleton**\n\nThis is a skeleton example that can optionally be used by an application as an initial value. For example, if this is a new data type 'template' value, this can be the text used to prime the edit window with sample Adaptive Script code including comments.",
+                    "title": "Skeleton"
+                },
+                "tags": {
+                    "description": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                    "items": {
+                        "description": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                        "markdownDescription": "This is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                        "title": "List of keywords and terms associated with values with this meta",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Tags**\n\nThis is an array of keywords and terms associated with values with the meta. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                    "title": "Tags",
+                    "type": "array"
+                },
+                "testDataParameter": {
+                    "description": "This contains additional information about values with this meta that is used to produce test data.",
+                    "markdownDescription": "**Test Data Parameter**\n\nThis contains additional information about values with this meta that is used to produce test data.",
+                    "title": "Test Data Parameter",
+                    "type": "string"
+                },
+                "unique": {
+                    "description": "Value of property must be unique within object type.",
+                    "markdownDescription": "**Unique**\n\nValue of property must be unique within object type.",
+                    "title": "Unique",
+                    "type": "boolean"
+                },
+                "valueInfId": {
+                    "description": "This is a runtime property that is the implementation id of the value interface.",
+                    "markdownDescription": "**valueInf**\n\nThis is a runtime property that is the implementation id of the value interface.",
                     "readOnly": true,
                     "title": "valueInf",
                     "type": "string"
@@ -451,9 +938,149 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveObjectType_"
+    "additionalProperties": false,
+    "description": "The adaptive object type of all adaptive object type objects.",
+    "markdownDescription": "The adaptive object type of all adaptive object type objects.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "allowAdd": {
+            "default": true,
+            "description": "If false, objects of this type can NEVER be added via an adapter. If true, objects of this type can be added via an adapter as long as allowed by authorization policy and the adapter.",
+            "markdownDescription": "**Allow Add**\n\nIf false, objects of this type can NEVER be added via an adapter. If true, objects of this type can be added via an adapter as long as allowed by authorization policy and the adapter.",
+            "title": "Allow Add",
+            "type": "boolean"
+        },
+        "allowChange": {
+            "default": true,
+            "description": "If false, objects of this type can NEVER be changed via an adapter. If true, objects of this type can be changed via an adapter as long as allowed by authorization policy and the adapter.",
+            "markdownDescription": "**Allow Change**\n\nIf false, objects of this type can NEVER be changed via an adapter. If true, objects of this type can be changed via an adapter as long as allowed by authorization policy and the adapter.",
+            "title": "Allow Change",
+            "type": "boolean"
+        },
+        "allowDelete": {
+            "default": true,
+            "description": "If false, objects of this type can NEVER be deleted via an adapter. If true, objects of this type can be deleted via an adapter as long as allowed by authorization policy and the adapter.",
+            "markdownDescription": "**Allow Delete**\n\nIf false, objects of this type can NEVER be deleted via an adapter. If true, objects of this type can be deleted via an adapter as long as allowed by authorization policy and the adapter.",
+            "title": "Allow Delete",
+            "type": "boolean"
+        },
+        "allowEntity": {
+            "default": true,
+            "description": "Instances of this object type can exist as an entity object, not just an embedded object.",
+            "markdownDescription": "**Allow Entity**\n\nInstances of this object type can exist as an entity object, not just an embedded object.",
+            "title": "Allow Entity",
+            "type": "boolean"
+        },
+        "collectionURIs": {
+            "description": "This is the URIs of the collections this object type is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+            "items": {
+                "description": "This is the URIs of the collections this object type is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                "format": "uri-reference",
+                "markdownDescription": "This is the URIs of the collections this object type is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+                "title": "The URIs of the collections this object type is a part of",
+                "type": "string"
+            },
+            "markdownDescription": "**Collection URIs**\n\nThis is the URIs of the collections this object type is a part of and preferably a URIs that can be used to locate an object with objects type _AdaptiveCollection_ that describes the collections. If a collection is used outside of the local instance, it should be a full URI. The URI can also be a local path of the collection object or just the collection's objectId if it resides in the in the same adapter.",
+            "title": "Collection URIs",
+            "type": "array"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "The description of the object type.",
+            "markdownDescription": "**Description**\n\nThe description of the object type.",
+            "title": "Description",
+            "type": "string"
+        },
+        "descriptionPropertyName": {
+            "description": "The name of the property in an instance that is used as the 'description' property in the meta for instances of this object type. If not specified, no description will be available.",
+            "markdownDescription": "**Description Property Name**\n\nThe name of the property in an instance that is used as the 'description' property in the meta for instances of this object type. If not specified, no description will be available.",
+            "title": "Description Property Name",
+            "type": "string"
+        },
+        "label": {
+            "description": "Label used to identify this instance.",
+            "markdownDescription": "**Label**\n\nLabel used to identify this instance.",
+            "title": "Label",
+            "type": "string"
+        },
+        "objectIdPropertyName": {
+            "description": "The name of the property in an instance that is used as the 'objectId' property in the meta for instances of this object type. If not specified, the internal adapter objectId for an object is used.",
+            "markdownDescription": "**Object Id Property Name**\n\nThe name of the property in an instance that is used as the 'objectId' property in the meta for instances of this object type. If not specified, the internal adapter objectId for an object is used.",
+            "title": "Object Id Property Name",
+            "type": "string"
+        },
+        "objectType": {
+            "description": "The object id of the object type.",
+            "markdownDescription": "**Object Type**\n\nThe object id of the object type.",
+            "title": "Object Type",
+            "type": "string"
+        },
+        "originURI": {
+            "description": "The origin URI of this object type. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
+            "format": "uri-reference",
+            "markdownDescription": "**Origin URI**\n\nThe origin URI of this object type. Descendant object types should be used for any deviations. This URI may be different from the URI within this instance of Adaptive Framework.",
+            "title": "Origin URI",
+            "type": "string"
+        },
+        "otherProperties": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveValueMeta_"
+                }
+            ],
+            "description": "If specified, this is the property type for properties that are not explicitly specified. If otherProperties is not specified, only explicitly specified properties are allowed.",
+            "markdownDescription": "**Other Properties**\n\nIf specified, this is the property type for properties that are not explicitly specified. If otherProperties is not specified, only explicitly specified properties are allowed.",
+            "title": "Other Properties",
+            "type": "object"
+        },
+        "propertyTypes": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptivePropertyTypes_"
+                }
+            ],
+            "description": "An object whose properties contain the _AdaptiveValueMeta_ for properties with corresponding name in instances of this _AdaptiveObjectType_.",
+            "markdownDescription": "**Property Types**\n\nAn object whose properties contain the _AdaptiveValueMeta_ for properties with corresponding name in instances of this _AdaptiveObjectType_.",
+            "title": "Property Types",
+            "type": "object"
+        },
+        "referenceURI": {
+            "description": "URI of more reference information about this object.",
+            "format": "uri-reference",
+            "markdownDescription": "**Reference URI**\n\nURI of more reference information about this object.",
+            "title": "Reference URI",
+            "type": "string"
+        },
+        "runtime": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveRuntimeObject_"
+                }
+            ],
+            "description": "This is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
+            "markdownDescription": "**Runtime**\n\nThis is only valid for runtime object types. These are objects that are accessed with adapterId afw. See afw_runtime.h for more information.",
+            "title": "Runtime",
+            "type": "object"
+        },
+        "tags": {
+            "description": "This is an array of keywords and terms associated with this object type. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+            "items": {
+                "description": "This is an array of keywords and terms associated with this object type. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                "markdownDescription": "This is an array of keywords and terms associated with this object type. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+                "title": "List of keywords associated with this object type",
+                "type": "string"
+            },
+            "markdownDescription": "**Tags**\n\nThis is an array of keywords and terms associated with this object type. An instance of _AdaptiveTag_ can be used to define and document the purpose of a tag. Adaptive Framework reserves the definition of all tags that begin with '_Adaptive'.",
+            "title": "Tags",
+            "type": "array"
         }
-    ]
+    },
+    "title": "_AdaptiveObjectType_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveObject_.json
+++ b/generated/schemas/afw/_AdaptiveObject_.json
@@ -1,8 +1,8 @@
 {
     "$defs": {
         "_AdaptiveObject_": {
-            "additionalProperties": {},
-            "anyOf": [
+            "additionalProperties": true,
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveObject_.propertyTypes"
                 }
@@ -15,7 +15,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveObject_"
         }

--- a/generated/schemas/afw/_AdaptiveObject_.json
+++ b/generated/schemas/afw/_AdaptiveObject_.json
@@ -1,12 +1,18 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveObject_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveObject_": {
             "additionalProperties": true,
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveObject_.propertyTypes"
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
                 }
-            ],
+            },
+            "title": "_AdaptiveObject_",
             "type": "object"
         },
         "_AdaptiveObject_.propertyTypes": {
@@ -15,9 +21,16 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveObject_"
+    "additionalProperties": true,
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
         }
-    ]
+    },
+    "title": "_AdaptiveObject_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptivePackage_.json
+++ b/generated/schemas/afw/_AdaptivePackage_.json
@@ -8,9 +8,10 @@
                     "title": "Compiler option",
                     "type": "string"
                 },
+                "title": "Compiler option",
                 "type": "array"
             },
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptivePackageCompileOptions_.propertyTypes"
                 }
@@ -24,7 +25,7 @@
             "type": "object"
         },
         "_AdaptivePackageSrcdirInfo_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptivePackageSrcdirInfo_.propertyTypes"
                 }
@@ -91,12 +92,15 @@
         },
         "_AdaptivePackageSrcdirs_": {
             "additionalProperties": {
-                "$ref": "#/$defs/_AdaptivePackageSrcdirInfo_",
+                "allOf": [
+                    {
+                        "$ref": "#/$defs/_AdaptivePackageSrcdirInfo_"
+                    }
+                ],
                 "description": "Property name is a srcdir and value is srcdir info.",
-                "title": "Srcdir Info",
-                "type": "object"
+                "title": "Srcdir Info"
             },
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptivePackageSrcdirs_.propertyTypes"
                 }
@@ -110,12 +114,16 @@
             "type": "object"
         },
         "_AdaptivePackage_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptivePackage_.propertyTypes"
                 }
             ],
             "description": "This is essential information that is needed for this AFW package by afwdev and related development tools.",
+            "required": [
+                "installPackageSubdir",
+                "version"
+            ],
             "type": "object",
             "unevaluatedProperties": false
         },
@@ -142,10 +150,13 @@
                     "type": "string"
                 },
                 "compileOptions": {
-                    "$ref": "#/$defs/_AdaptivePackageCompileOptions_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptivePackageCompileOptions_"
+                        }
+                    ],
                     "description": "This is an array of compile options to add during all compiles for a specific compiler id. The value of this property is an object with property names matching the <LANG> as defined under 'CMAKE_LANG_COMPILER_ID' in the CMake documentation and whose value is an array of compiler options for that <LANG>. This is useful for providing compiler specify options such as warning and error flags.",
-                    "title": "Compile Options",
-                    "type": "object"
+                    "title": "Compile Options"
                 },
                 "copyright": {
                     "description": "This is a text string that will be used as the copyright inserted into source files during the generate process.",
@@ -173,10 +184,13 @@
                     "type": "string"
                 },
                 "srcdirs": {
-                    "$ref": "#/$defs/_AdaptivePackageSrcdirs_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptivePackageSrcdirs_"
+                        }
+                    ],
                     "description": "This is information about subdirectories in this repository's src/ directory.",
-                    "title": "Package Srcdir Info",
-                    "type": "object"
+                    "title": "Package Srcdir Info"
                 },
                 "tarballName": {
                     "description": "This is the name of the tarball produced by make dist. It's used in the tarname parameter of AC_INIT in configure.ac.\n\nThis is the full package name. It defaults to package-name with \u2018GNU \u2019 stripped, lower-cased, and all characters other than alphanumerics and underscores are changed to \u2018-\u2019. ",
@@ -189,15 +203,11 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "installPackageSubdir",
-                "version"
-            ],
             "type": "object"
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptivePackage_"
         }

--- a/generated/schemas/afw/_AdaptivePackage_.json
+++ b/generated/schemas/afw/_AdaptivePackage_.json
@@ -1,22 +1,30 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptivePackage_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptivePackageCompileOptions_": {
             "additionalProperties": {
                 "description": "A LANG as defined under 'CMAKE_LANG_COMPILER_ID' in the CMake documentation.",
                 "items": {
                     "description": "A compiler option for the compiler id with this property name.",
+                    "markdownDescription": "A compiler option for the compiler id with this property name.",
                     "title": "Compiler option",
                     "type": "string"
                 },
+                "markdownDescription": "**Compiler option**\n\nA LANG as defined under 'CMAKE_LANG_COMPILER_ID' in the CMake documentation.",
                 "title": "Compiler option",
                 "type": "array"
             },
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptivePackageCompileOptions_.propertyTypes"
-                }
-            ],
             "description": "This is an array of compile options to add during all compiles for a specific compiler id. The value of this property is an object with property names matching the <LANG> as defined under 'CMAKE_LANG_COMPILER_ID' in the CMake documentation and whose value is an array of compiler options for that <LANG>. This is useful for providing compiler specify options such as warning and error flags.",
+            "markdownDescription": "This is an array of compile options to add during all compiles for a specific compiler id. The value of this property is an object with property names matching the <LANG> as defined under 'CMAKE_LANG_COMPILER_ID' in the CMake documentation and whose value is an array of compiler options for that <LANG>. This is useful for providing compiler specify options such as warning and error flags.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                }
+            },
             "title": "Compile Options",
             "type": "object"
         },
@@ -25,65 +33,140 @@
             "type": "object"
         },
         "_AdaptivePackageSrcdirInfo_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptivePackageSrcdirInfo_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "This is the srcdir info for the subdirectory of src/ that has the name of this property.",
-            "title": "Srcdir Info",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptivePackageSrcdirInfo_.propertyTypes": {
+            "markdownDescription": "This is the srcdir info for the subdirectory of src/ that has the name of this property.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "brief": {
                     "description": "This is a brief description of this source directory.",
+                    "markdownDescription": "This is a brief description of this source directory.",
                     "title": "Brief",
                     "type": "string"
                 },
                 "buildType": {
                     "description": "This is the type of build used for this source directory. Specify 'afwmake' for c source directories.",
+                    "markdownDescription": "This is the type of build used for this source directory. Specify 'afwmake' for c source directories.",
                     "title": "Build Type",
                     "type": "string"
                 },
                 "buildTypeParameters": {
                     "description": "Build type specific parameters.",
+                    "markdownDescription": "Build type specific parameters.",
                     "title": "buildType Parameters",
                     "type": "object"
                 },
                 "description": {
                     "description": "This describes this source directory.",
+                    "markdownDescription": "This describes this source directory.",
                     "title": "Description",
                     "type": "string"
                 },
                 "ignore": {
                     "description": "If true, afwdev will ignore this source directory.",
+                    "markdownDescription": "If true, afwdev will ignore this source directory.",
                     "title": "Ignore",
                     "type": "boolean"
                 },
                 "optionalChoiceDefault": {
                     "description": "If specified, processing this source directory is optional and the value of this property is the default. If this property is not specified, this source directory is always processed.\n\nIf this is buildType 'afwmake', either an --enable-<var> or --disable-<var> will be available on ./configure where <var> is the value of the 'id' property with 'afw_' removed if present and underscores ('_') replaced with dashes ('-').",
+                    "markdownDescription": "If specified, processing this source directory is optional and the value of this property is the default. If this property is not specified, this source directory is always processed.\n\nIf this is buildType 'afwmake', either an --enable-<var> or --disable-<var> will be available on ./configure where <var> is the value of the 'id' property with 'afw_' removed if present and underscores ('_') replaced with dashes ('-').",
                     "title": "Optional Choice",
                     "type": "boolean"
                 },
                 "prefix": {
                     "description": "This is the prefix that is commonly used for source files in this source directory. This is most commonly the corresponding 'srcdirs' property name followed by an underscore ('_'), which is also its default.",
+                    "markdownDescription": "This is the prefix that is commonly used for source files in this source directory. This is most commonly the corresponding 'srcdirs' property name followed by an underscore ('_'), which is also its default.",
                     "title": "Prefix",
                     "type": "string"
                 },
                 "produces": {
                     "description": "This is the name of what this source directory produces as known to the buildType.\n\nFor buildType 'afwmake', this starts with 'lib' for libraries.",
+                    "markdownDescription": "This is the name of what this source directory produces as known to the buildType.\n\nFor buildType 'afwmake', this starts with 'lib' for libraries.",
                     "title": "Produces",
                     "type": "string"
                 },
                 "srcdirPath": {
                     "description": "This is the relative path in the repository for this source directory. This defaults to the corresponding 'srcdirs' property name.",
+                    "markdownDescription": "This is the relative path in the repository for this source directory. This defaults to the corresponding 'srcdirs' property name.",
                     "title": "Srcdir Path",
                     "type": "string"
                 },
                 "version": {
                     "description": "This is the current version of this srcdir. The default is the package version. The form must be <MAJOR>.<MINOR>.<PATCH> as defined at http://semver.org.",
+                    "markdownDescription": "This is the current version of this srcdir. The default is the package version. The form must be <MAJOR>.<MINOR>.<PATCH> as defined at http://semver.org.",
+                    "title": "<MAJOR>.<MINOR>.<PATCH>",
+                    "type": "string"
+                }
+            },
+            "title": "Srcdir Info",
+            "type": "object"
+        },
+        "_AdaptivePackageSrcdirInfo_.propertyTypes": {
+            "properties": {
+                "brief": {
+                    "description": "This is a brief description of this source directory.",
+                    "markdownDescription": "This is a brief description of this source directory.",
+                    "title": "Brief",
+                    "type": "string"
+                },
+                "buildType": {
+                    "description": "This is the type of build used for this source directory. Specify 'afwmake' for c source directories.",
+                    "markdownDescription": "This is the type of build used for this source directory. Specify 'afwmake' for c source directories.",
+                    "title": "Build Type",
+                    "type": "string"
+                },
+                "buildTypeParameters": {
+                    "description": "Build type specific parameters.",
+                    "markdownDescription": "Build type specific parameters.",
+                    "title": "buildType Parameters",
+                    "type": "object"
+                },
+                "description": {
+                    "description": "This describes this source directory.",
+                    "markdownDescription": "This describes this source directory.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "ignore": {
+                    "description": "If true, afwdev will ignore this source directory.",
+                    "markdownDescription": "If true, afwdev will ignore this source directory.",
+                    "title": "Ignore",
+                    "type": "boolean"
+                },
+                "optionalChoiceDefault": {
+                    "description": "If specified, processing this source directory is optional and the value of this property is the default. If this property is not specified, this source directory is always processed.\n\nIf this is buildType 'afwmake', either an --enable-<var> or --disable-<var> will be available on ./configure where <var> is the value of the 'id' property with 'afw_' removed if present and underscores ('_') replaced with dashes ('-').",
+                    "markdownDescription": "If specified, processing this source directory is optional and the value of this property is the default. If this property is not specified, this source directory is always processed.\n\nIf this is buildType 'afwmake', either an --enable-<var> or --disable-<var> will be available on ./configure where <var> is the value of the 'id' property with 'afw_' removed if present and underscores ('_') replaced with dashes ('-').",
+                    "title": "Optional Choice",
+                    "type": "boolean"
+                },
+                "prefix": {
+                    "description": "This is the prefix that is commonly used for source files in this source directory. This is most commonly the corresponding 'srcdirs' property name followed by an underscore ('_'), which is also its default.",
+                    "markdownDescription": "This is the prefix that is commonly used for source files in this source directory. This is most commonly the corresponding 'srcdirs' property name followed by an underscore ('_'), which is also its default.",
+                    "title": "Prefix",
+                    "type": "string"
+                },
+                "produces": {
+                    "description": "This is the name of what this source directory produces as known to the buildType.\n\nFor buildType 'afwmake', this starts with 'lib' for libraries.",
+                    "markdownDescription": "This is the name of what this source directory produces as known to the buildType.\n\nFor buildType 'afwmake', this starts with 'lib' for libraries.",
+                    "title": "Produces",
+                    "type": "string"
+                },
+                "srcdirPath": {
+                    "description": "This is the relative path in the repository for this source directory. This defaults to the corresponding 'srcdirs' property name.",
+                    "markdownDescription": "This is the relative path in the repository for this source directory. This defaults to the corresponding 'srcdirs' property name.",
+                    "title": "Srcdir Path",
+                    "type": "string"
+                },
+                "version": {
+                    "description": "This is the current version of this srcdir. The default is the package version. The form must be <MAJOR>.<MINOR>.<PATCH> as defined at http://semver.org.",
+                    "markdownDescription": "This is the current version of this srcdir. The default is the package version. The form must be <MAJOR>.<MINOR>.<PATCH> as defined at http://semver.org.",
                     "title": "<MAJOR>.<MINOR>.<PATCH>",
                     "type": "string"
                 }
@@ -98,14 +181,21 @@
                     }
                 ],
                 "description": "Property name is a srcdir and value is srcdir info.",
-                "title": "Srcdir Info"
+                "markdownDescription": "Property name is a srcdir and value is srcdir info.",
+                "title": "Srcdir Info",
+                "type": "object"
             },
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptivePackageSrcdirs_.propertyTypes"
-                }
-            ],
             "description": "This is information about subdirectories in this repository's src/ directory.",
+            "markdownDescription": "This is information about subdirectories in this repository's src/ directory.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                }
+            },
             "title": "Package Srcdir Info",
             "type": "object"
         },
@@ -114,38 +204,38 @@
             "type": "object"
         },
         "_AdaptivePackage_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptivePackage_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "This is essential information that is needed for this AFW package by afwdev and related development tools.",
-            "required": [
-                "installPackageSubdir",
-                "version"
-            ],
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptivePackage_.propertyTypes": {
+            "markdownDescription": "This is essential information that is needed for this AFW package by afwdev and related development tools.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "afwPackageId": {
                     "description": "This is the AFW package id.",
+                    "markdownDescription": "This is the AFW package id.",
                     "title": "AFW Package Id",
                     "type": "string"
                 },
                 "afwPackageLabel": {
                     "description": "This is usually the AFW package id with dashes changed to underscores for use in places where dashes are not allowed.",
+                    "markdownDescription": "This is usually the AFW package id with dashes changed to underscores for use in places where dashes are not allowed.",
                     "title": "AFW Package Label",
                     "type": "string"
                 },
                 "brief": {
                     "description": "This is a brief description of this repository.",
+                    "markdownDescription": "This is a brief description of this repository.",
                     "title": "Brief",
                     "type": "string"
                 },
                 "bugReportEmail": {
                     "description": "This is the email to which users should send bug reports. It's used in the bug-report parameter of AC_INIT in configure.ac.",
+                    "markdownDescription": "This is the email to which users should send bug reports. It's used in the bug-report parameter of AC_INIT in configure.ac.",
                     "title": "Bug Report Email",
                     "type": "string"
                 },
@@ -156,30 +246,37 @@
                         }
                     ],
                     "description": "This is an array of compile options to add during all compiles for a specific compiler id. The value of this property is an object with property names matching the <LANG> as defined under 'CMAKE_LANG_COMPILER_ID' in the CMake documentation and whose value is an array of compiler options for that <LANG>. This is useful for providing compiler specify options such as warning and error flags.",
-                    "title": "Compile Options"
+                    "markdownDescription": "This is an array of compile options to add during all compiles for a specific compiler id. The value of this property is an object with property names matching the <LANG> as defined under 'CMAKE_LANG_COMPILER_ID' in the CMake documentation and whose value is an array of compiler options for that <LANG>. This is useful for providing compiler specify options such as warning and error flags.",
+                    "title": "Compile Options",
+                    "type": "object"
                 },
                 "copyright": {
                     "description": "This is a text string that will be used as the copyright inserted into source files during the generate process.",
+                    "markdownDescription": "This is a text string that will be used as the copyright inserted into source files during the generate process.",
                     "title": "Copyright",
                     "type": "string"
                 },
                 "description": {
                     "description": "This describes this repository.",
+                    "markdownDescription": "This describes this repository.",
                     "title": "Description",
                     "type": "string"
                 },
                 "homePageUrl": {
                     "description": "This is the home page for the package/repository. It's used in the url parameter of AC_INIT in configure.ac.",
+                    "markdownDescription": "This is the home page for the package/repository. It's used in the url parameter of AC_INIT in configure.ac.",
                     "title": "Home Page",
                     "type": "string"
                 },
                 "installPackageSubdir": {
                     "description": "This is the name of the package as known to make. It's used in the package parameter of AC_INIT in configure.ac. This name is used as the subdirectory within the target's include and lib directories. For the repositories in afw-org, this is usually afw<MAJOR> where <MAJOR> is the same as in the version keyword.",
+                    "markdownDescription": "This is the name of the package as known to make. It's used in the package parameter of AC_INIT in configure.ac. This name is used as the subdirectory within the target's include and lib directories. For the repositories in afw-org, this is usually afw<MAJOR> where <MAJOR> is the same as in the version keyword.",
                     "title": "Make Package Name",
                     "type": "string"
                 },
                 "srcdirManifest": {
                     "description": "This is the name of the property in the 'srcdirs' property of the AFW extension, that when loaded at runtime, will register the repository's manifest.",
+                    "markdownDescription": "This is the name of the property in the 'srcdirs' property of the AFW extension, that when loaded at runtime, will register the repository's manifest.",
                     "title": "Manifest Srcsubdir",
                     "type": "string"
                 },
@@ -190,15 +287,117 @@
                         }
                     ],
                     "description": "This is information about subdirectories in this repository's src/ directory.",
-                    "title": "Package Srcdir Info"
+                    "markdownDescription": "This is information about subdirectories in this repository's src/ directory.",
+                    "title": "Package Srcdir Info",
+                    "type": "object"
                 },
                 "tarballName": {
                     "description": "This is the name of the tarball produced by make dist. It's used in the tarname parameter of AC_INIT in configure.ac.\n\nThis is the full package name. It defaults to package-name with \u2018GNU \u2019 stripped, lower-cased, and all characters other than alphanumerics and underscores are changed to \u2018-\u2019. ",
+                    "markdownDescription": "This is the name of the tarball produced by make dist. It's used in the tarname parameter of AC_INIT in configure.ac.\n\nThis is the full package name. It defaults to package-name with \u2018GNU \u2019 stripped, lower-cased, and all characters other than alphanumerics and underscores are changed to \u2018-\u2019. ",
                     "title": "Tarball Name",
                     "type": "string"
                 },
                 "version": {
                     "description": "This is the current version of the package. The form must be <MAJOR>.<MINOR>.<PATCH> as defined at http://semver.org.",
+                    "markdownDescription": "This is the current version of the package. The form must be <MAJOR>.<MINOR>.<PATCH> as defined at http://semver.org.",
+                    "title": "<MAJOR>.<MINOR>.<PATCH>",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "installPackageSubdir",
+                "version"
+            ],
+            "title": "_AdaptivePackage_",
+            "type": "object"
+        },
+        "_AdaptivePackage_.propertyTypes": {
+            "properties": {
+                "afwPackageId": {
+                    "description": "This is the AFW package id.",
+                    "markdownDescription": "This is the AFW package id.",
+                    "title": "AFW Package Id",
+                    "type": "string"
+                },
+                "afwPackageLabel": {
+                    "description": "This is usually the AFW package id with dashes changed to underscores for use in places where dashes are not allowed.",
+                    "markdownDescription": "This is usually the AFW package id with dashes changed to underscores for use in places where dashes are not allowed.",
+                    "title": "AFW Package Label",
+                    "type": "string"
+                },
+                "brief": {
+                    "description": "This is a brief description of this repository.",
+                    "markdownDescription": "This is a brief description of this repository.",
+                    "title": "Brief",
+                    "type": "string"
+                },
+                "bugReportEmail": {
+                    "description": "This is the email to which users should send bug reports. It's used in the bug-report parameter of AC_INIT in configure.ac.",
+                    "markdownDescription": "This is the email to which users should send bug reports. It's used in the bug-report parameter of AC_INIT in configure.ac.",
+                    "title": "Bug Report Email",
+                    "type": "string"
+                },
+                "compileOptions": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptivePackageCompileOptions_"
+                        }
+                    ],
+                    "description": "This is an array of compile options to add during all compiles for a specific compiler id. The value of this property is an object with property names matching the <LANG> as defined under 'CMAKE_LANG_COMPILER_ID' in the CMake documentation and whose value is an array of compiler options for that <LANG>. This is useful for providing compiler specify options such as warning and error flags.",
+                    "markdownDescription": "This is an array of compile options to add during all compiles for a specific compiler id. The value of this property is an object with property names matching the <LANG> as defined under 'CMAKE_LANG_COMPILER_ID' in the CMake documentation and whose value is an array of compiler options for that <LANG>. This is useful for providing compiler specify options such as warning and error flags.",
+                    "title": "Compile Options",
+                    "type": "object"
+                },
+                "copyright": {
+                    "description": "This is a text string that will be used as the copyright inserted into source files during the generate process.",
+                    "markdownDescription": "This is a text string that will be used as the copyright inserted into source files during the generate process.",
+                    "title": "Copyright",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "This describes this repository.",
+                    "markdownDescription": "This describes this repository.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "homePageUrl": {
+                    "description": "This is the home page for the package/repository. It's used in the url parameter of AC_INIT in configure.ac.",
+                    "markdownDescription": "This is the home page for the package/repository. It's used in the url parameter of AC_INIT in configure.ac.",
+                    "title": "Home Page",
+                    "type": "string"
+                },
+                "installPackageSubdir": {
+                    "description": "This is the name of the package as known to make. It's used in the package parameter of AC_INIT in configure.ac. This name is used as the subdirectory within the target's include and lib directories. For the repositories in afw-org, this is usually afw<MAJOR> where <MAJOR> is the same as in the version keyword.",
+                    "markdownDescription": "This is the name of the package as known to make. It's used in the package parameter of AC_INIT in configure.ac. This name is used as the subdirectory within the target's include and lib directories. For the repositories in afw-org, this is usually afw<MAJOR> where <MAJOR> is the same as in the version keyword.",
+                    "title": "Make Package Name",
+                    "type": "string"
+                },
+                "srcdirManifest": {
+                    "description": "This is the name of the property in the 'srcdirs' property of the AFW extension, that when loaded at runtime, will register the repository's manifest.",
+                    "markdownDescription": "This is the name of the property in the 'srcdirs' property of the AFW extension, that when loaded at runtime, will register the repository's manifest.",
+                    "title": "Manifest Srcsubdir",
+                    "type": "string"
+                },
+                "srcdirs": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptivePackageSrcdirs_"
+                        }
+                    ],
+                    "description": "This is information about subdirectories in this repository's src/ directory.",
+                    "markdownDescription": "This is information about subdirectories in this repository's src/ directory.",
+                    "title": "Package Srcdir Info",
+                    "type": "object"
+                },
+                "tarballName": {
+                    "description": "This is the name of the tarball produced by make dist. It's used in the tarname parameter of AC_INIT in configure.ac.\n\nThis is the full package name. It defaults to package-name with \u2018GNU \u2019 stripped, lower-cased, and all characters other than alphanumerics and underscores are changed to \u2018-\u2019. ",
+                    "markdownDescription": "This is the name of the tarball produced by make dist. It's used in the tarname parameter of AC_INIT in configure.ac.\n\nThis is the full package name. It defaults to package-name with \u2018GNU \u2019 stripped, lower-cased, and all characters other than alphanumerics and underscores are changed to \u2018-\u2019. ",
+                    "title": "Tarball Name",
+                    "type": "string"
+                },
+                "version": {
+                    "description": "This is the current version of the package. The form must be <MAJOR>.<MINOR>.<PATCH> as defined at http://semver.org.",
+                    "markdownDescription": "This is the current version of the package. The form must be <MAJOR>.<MINOR>.<PATCH> as defined at http://semver.org.",
                     "title": "<MAJOR>.<MINOR>.<PATCH>",
                     "type": "string"
                 }
@@ -207,9 +406,110 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptivePackage_"
+    "additionalProperties": false,
+    "description": "This is essential information that is needed for this AFW package by afwdev and related development tools.",
+    "markdownDescription": "This is essential information that is needed for this AFW package by afwdev and related development tools.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "afwPackageId": {
+            "description": "This is the AFW package id.",
+            "markdownDescription": "This is the AFW package id.",
+            "title": "AFW Package Id",
+            "type": "string"
+        },
+        "afwPackageLabel": {
+            "description": "This is usually the AFW package id with dashes changed to underscores for use in places where dashes are not allowed.",
+            "markdownDescription": "This is usually the AFW package id with dashes changed to underscores for use in places where dashes are not allowed.",
+            "title": "AFW Package Label",
+            "type": "string"
+        },
+        "brief": {
+            "description": "This is a brief description of this repository.",
+            "markdownDescription": "This is a brief description of this repository.",
+            "title": "Brief",
+            "type": "string"
+        },
+        "bugReportEmail": {
+            "description": "This is the email to which users should send bug reports. It's used in the bug-report parameter of AC_INIT in configure.ac.",
+            "markdownDescription": "This is the email to which users should send bug reports. It's used in the bug-report parameter of AC_INIT in configure.ac.",
+            "title": "Bug Report Email",
+            "type": "string"
+        },
+        "compileOptions": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptivePackageCompileOptions_"
+                }
+            ],
+            "description": "This is an array of compile options to add during all compiles for a specific compiler id. The value of this property is an object with property names matching the <LANG> as defined under 'CMAKE_LANG_COMPILER_ID' in the CMake documentation and whose value is an array of compiler options for that <LANG>. This is useful for providing compiler specify options such as warning and error flags.",
+            "markdownDescription": "This is an array of compile options to add during all compiles for a specific compiler id. The value of this property is an object with property names matching the <LANG> as defined under 'CMAKE_LANG_COMPILER_ID' in the CMake documentation and whose value is an array of compiler options for that <LANG>. This is useful for providing compiler specify options such as warning and error flags.",
+            "title": "Compile Options",
+            "type": "object"
+        },
+        "copyright": {
+            "description": "This is a text string that will be used as the copyright inserted into source files during the generate process.",
+            "markdownDescription": "This is a text string that will be used as the copyright inserted into source files during the generate process.",
+            "title": "Copyright",
+            "type": "string"
+        },
+        "description": {
+            "description": "This describes this repository.",
+            "markdownDescription": "This describes this repository.",
+            "title": "Description",
+            "type": "string"
+        },
+        "homePageUrl": {
+            "description": "This is the home page for the package/repository. It's used in the url parameter of AC_INIT in configure.ac.",
+            "markdownDescription": "This is the home page for the package/repository. It's used in the url parameter of AC_INIT in configure.ac.",
+            "title": "Home Page",
+            "type": "string"
+        },
+        "installPackageSubdir": {
+            "description": "This is the name of the package as known to make. It's used in the package parameter of AC_INIT in configure.ac. This name is used as the subdirectory within the target's include and lib directories. For the repositories in afw-org, this is usually afw<MAJOR> where <MAJOR> is the same as in the version keyword.",
+            "markdownDescription": "This is the name of the package as known to make. It's used in the package parameter of AC_INIT in configure.ac. This name is used as the subdirectory within the target's include and lib directories. For the repositories in afw-org, this is usually afw<MAJOR> where <MAJOR> is the same as in the version keyword.",
+            "title": "Make Package Name",
+            "type": "string"
+        },
+        "srcdirManifest": {
+            "description": "This is the name of the property in the 'srcdirs' property of the AFW extension, that when loaded at runtime, will register the repository's manifest.",
+            "markdownDescription": "This is the name of the property in the 'srcdirs' property of the AFW extension, that when loaded at runtime, will register the repository's manifest.",
+            "title": "Manifest Srcsubdir",
+            "type": "string"
+        },
+        "srcdirs": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptivePackageSrcdirs_"
+                }
+            ],
+            "description": "This is information about subdirectories in this repository's src/ directory.",
+            "markdownDescription": "This is information about subdirectories in this repository's src/ directory.",
+            "title": "Package Srcdir Info",
+            "type": "object"
+        },
+        "tarballName": {
+            "description": "This is the name of the tarball produced by make dist. It's used in the tarname parameter of AC_INIT in configure.ac.\n\nThis is the full package name. It defaults to package-name with \u2018GNU \u2019 stripped, lower-cased, and all characters other than alphanumerics and underscores are changed to \u2018-\u2019. ",
+            "markdownDescription": "This is the name of the tarball produced by make dist. It's used in the tarname parameter of AC_INIT in configure.ac.\n\nThis is the full package name. It defaults to package-name with \u2018GNU \u2019 stripped, lower-cased, and all characters other than alphanumerics and underscores are changed to \u2018-\u2019. ",
+            "title": "Tarball Name",
+            "type": "string"
+        },
+        "version": {
+            "description": "This is the current version of the package. The form must be <MAJOR>.<MINOR>.<PATCH> as defined at http://semver.org.",
+            "markdownDescription": "This is the current version of the package. The form must be <MAJOR>.<MINOR>.<PATCH> as defined at http://semver.org.",
+            "title": "<MAJOR>.<MINOR>.<PATCH>",
+            "type": "string"
         }
-    ]
+    },
+    "required": [
+        "installPackageSubdir",
+        "version"
+    ],
+    "title": "_AdaptivePackage_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptivePolymorphicFunction_.json
+++ b/generated/schemas/afw/_AdaptivePolymorphicFunction_.json
@@ -1,28 +1,49 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptivePolymorphicFunction_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveFunctionErrorThrown_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveFunctionErrorThrown_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "An object entry of _AdaptiveFunction_ errorsThrown array.",
-            "required": [
-                "error",
-                "reason"
-            ],
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveFunctionErrorThrown_.propertyTypes": {
+            "markdownDescription": "An object entry of _AdaptiveFunction_ errorsThrown array.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "error": {
                     "description": "This is the error id of the error that can be thrown.",
+                    "markdownDescription": "**Error**\n\nThis is the error id of the error that can be thrown.",
                     "title": "Error",
                     "type": "string"
                 },
                 "reason": {
                     "description": "This is the reason the error can be thrown.",
+                    "markdownDescription": "**Reason**\n\nThis is the reason the error can be thrown.",
+                    "title": "Reason",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "error",
+                "reason"
+            ],
+            "title": "_AdaptiveFunctionErrorThrown_",
+            "type": "object"
+        },
+        "_AdaptiveFunctionErrorThrown_.propertyTypes": {
+            "properties": {
+                "error": {
+                    "description": "This is the error id of the error that can be thrown.",
+                    "markdownDescription": "**Error**\n\nThis is the error id of the error that can be thrown.",
+                    "title": "Error",
+                    "type": "string"
+                },
+                "reason": {
+                    "description": "This is the reason the error can be thrown.",
+                    "markdownDescription": "**Reason**\n\nThis is the reason the error can be thrown.",
                     "title": "Reason",
                     "type": "string"
                 }
@@ -30,67 +51,146 @@
             "type": "object"
         },
         "_AdaptiveFunctionParameter_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveFunctionParameter_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Adaptive function parameter meta.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveFunctionParameter_.propertyTypes": {
+            "markdownDescription": "Adaptive function parameter meta.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "brief": {
                     "description": "This is a predicate for the parameter with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for the parameter with the first letter capitalized and without a trailing period.",
                     "title": "Brief",
                     "type": "string"
                 },
                 "canBeUndefined": {
                     "default": false,
                     "description": "Indicates that parameter can be undefined (NULL) even if not optional.",
+                    "markdownDescription": "**Optional**\n\nIndicates that parameter can be undefined (NULL) even if not optional.",
                     "title": "Optional",
                     "type": "boolean"
                 },
                 "dataType": {
                     "description": "This is the data type id for this parameter's value.",
+                    "markdownDescription": "**Data Type**\n\nThis is the data type id for this parameter's value.",
                     "title": "Data Type",
                     "type": "string"
                 },
                 "dataTypeParameter": {
                     "description": "See the data type's dataTypeParameterType property to determine how to interpret this.",
+                    "markdownDescription": "**Data Type Parameter**\n\nSee the data type's dataTypeParameterType property to determine how to interpret this.",
                     "title": "Data Type Parameter",
                     "type": "string"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "This is the description of this parameter.",
+                    "markdownDescription": "**Description**\n\nThis is the description of this parameter.",
                     "title": "Description",
                     "type": "string"
                 },
                 "minArgs": {
                     "description": "This is the minimum number of values that can be specified for this parameter. If -1, the parameter can be specified exactly once. This can only have a value other than -1 on last parameter where it can have a value of -1 to 127.",
+                    "markdownDescription": "**Min Args**\n\nThis is the minimum number of values that can be specified for this parameter. If -1, the parameter can be specified exactly once. This can only have a value other than -1 on last parameter where it can have a value of -1 to 127.",
                     "title": "Min Args",
                     "type": "integer"
                 },
                 "name": {
                     "description": "This is the name of this parameter.",
+                    "markdownDescription": "**Name**\n\nThis is the name of this parameter.",
                     "title": "Name",
                     "type": "string"
                 },
                 "optional": {
                     "default": false,
                     "description": "This indicates that parameter is optional and can be undefined (NULL).",
+                    "markdownDescription": "**Optional**\n\nThis indicates that parameter is optional and can be undefined (NULL).",
                     "title": "Optional",
                     "type": "boolean"
                 },
                 "polymorphicDataType": {
                     "description": "The dataType for this parameter is <Type>.",
+                    "markdownDescription": "**Polymorphic Data Type**\n\nThe dataType for this parameter is <Type>.",
                     "title": "Polymorphic Data Type",
                     "type": "boolean"
                 },
                 "polymorphicDataTypeParameter": {
                     "description": "The dataTypeParameter for this parameter is <Type>.",
+                    "markdownDescription": "**Polymorphic Data Type Parameter**\n\nThe dataTypeParameter for this parameter is <Type>.",
+                    "title": "Polymorphic Data Type Parameter",
+                    "type": "boolean"
+                }
+            },
+            "title": "_AdaptiveFunctionParameter_",
+            "type": "object"
+        },
+        "_AdaptiveFunctionParameter_.propertyTypes": {
+            "properties": {
+                "brief": {
+                    "description": "This is a predicate for the parameter with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for the parameter with the first letter capitalized and without a trailing period.",
+                    "title": "Brief",
+                    "type": "string"
+                },
+                "canBeUndefined": {
+                    "default": false,
+                    "description": "Indicates that parameter can be undefined (NULL) even if not optional.",
+                    "markdownDescription": "**Optional**\n\nIndicates that parameter can be undefined (NULL) even if not optional.",
+                    "title": "Optional",
+                    "type": "boolean"
+                },
+                "dataType": {
+                    "description": "This is the data type id for this parameter's value.",
+                    "markdownDescription": "**Data Type**\n\nThis is the data type id for this parameter's value.",
+                    "title": "Data Type",
+                    "type": "string"
+                },
+                "dataTypeParameter": {
+                    "description": "See the data type's dataTypeParameterType property to determine how to interpret this.",
+                    "markdownDescription": "**Data Type Parameter**\n\nSee the data type's dataTypeParameterType property to determine how to interpret this.",
+                    "title": "Data Type Parameter",
+                    "type": "string"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "This is the description of this parameter.",
+                    "markdownDescription": "**Description**\n\nThis is the description of this parameter.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "minArgs": {
+                    "description": "This is the minimum number of values that can be specified for this parameter. If -1, the parameter can be specified exactly once. This can only have a value other than -1 on last parameter where it can have a value of -1 to 127.",
+                    "markdownDescription": "**Min Args**\n\nThis is the minimum number of values that can be specified for this parameter. If -1, the parameter can be specified exactly once. This can only have a value other than -1 on last parameter where it can have a value of -1 to 127.",
+                    "title": "Min Args",
+                    "type": "integer"
+                },
+                "name": {
+                    "description": "This is the name of this parameter.",
+                    "markdownDescription": "**Name**\n\nThis is the name of this parameter.",
+                    "title": "Name",
+                    "type": "string"
+                },
+                "optional": {
+                    "default": false,
+                    "description": "This indicates that parameter is optional and can be undefined (NULL).",
+                    "markdownDescription": "**Optional**\n\nThis indicates that parameter is optional and can be undefined (NULL).",
+                    "title": "Optional",
+                    "type": "boolean"
+                },
+                "polymorphicDataType": {
+                    "description": "The dataType for this parameter is <Type>.",
+                    "markdownDescription": "**Polymorphic Data Type**\n\nThe dataType for this parameter is <Type>.",
+                    "title": "Polymorphic Data Type",
+                    "type": "boolean"
+                },
+                "polymorphicDataTypeParameter": {
+                    "description": "The dataTypeParameter for this parameter is <Type>.",
+                    "markdownDescription": "**Polymorphic Data Type Parameter**\n\nThe dataTypeParameter for this parameter is <Type>.",
                     "title": "Polymorphic Data Type Parameter",
                     "type": "boolean"
                 }
@@ -101,43 +201,51 @@
             "properties": {
                 "afwCamelCaseFunctionLabel": {
                     "description": "This is the functionLabel prefixed with 'afw' and converted to camel case.",
+                    "markdownDescription": "**Prefixed Camel Case**\n\nThis is the functionLabel prefixed with 'afw' and converted to camel case.",
                     "title": "Prefixed Camel Case",
                     "type": "string"
                 },
                 "brief": {
                     "description": "This is a predicate for the function with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for the function with the first letter capitalized and without a trailing period.",
                     "title": "Brief",
                     "type": "string"
                 },
                 "camelCaseFunctionLabel": {
                     "description": "This is the functionLabel converted to camel case.",
+                    "markdownDescription": "**Camel Case**\n\nThis is the functionLabel converted to camel case.",
                     "title": "Camel Case",
                     "type": "string"
                 },
                 "category": {
                     "description": "Function category.",
+                    "markdownDescription": "**Category**\n\nFunction category.",
                     "title": "Category",
                     "type": "string"
                 },
                 "dataType": {
                     "description": "If present, this is a method for this data type.",
+                    "markdownDescription": "**Data Type**\n\nIf present, this is a method for this data type.",
                     "title": "Data Type",
                     "type": "string"
                 },
                 "dataTypeMethodNumber": {
                     "description": "This is an internal number that is unique to the method name (the part after :: in functionId) of a dataTypeMethod function.",
+                    "markdownDescription": "**Method Number**\n\nThis is an internal number that is unique to the method name (the part after :: in functionId) of a dataTypeMethod function.",
                     "title": "Method Number",
                     "type": "integer"
                 },
                 "deprecated": {
                     "default": false,
                     "description": "This indicates that the function is deprecated and may go away at some point.",
+                    "markdownDescription": "**Deprecated**\n\nThis indicates that the function is deprecated and may go away at some point.",
                     "title": "Deprecated",
                     "type": "boolean"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "This is the function's description, used for documentation purposes.",
+                    "markdownDescription": "**Description**\n\nThis is the function's description, used for documentation purposes.",
                     "title": "Description",
                     "type": "string"
                 },
@@ -150,49 +258,60 @@
                             }
                         ],
                         "description": "These are errors that can possibly be thrown by this function.",
-                        "title": "Errors thrown"
+                        "markdownDescription": "These are errors that can possibly be thrown by this function.",
+                        "title": "Errors thrown",
+                        "type": "object"
                     },
+                    "markdownDescription": "**Errors Thrown**\n\nThese are errors that can possibly be thrown by this function.",
                     "title": "Errors Thrown",
                     "type": "array"
                 },
                 "functionDeclaration": {
                     "contentMediaType": "text/plain",
                     "description": "This is the function's declaration with whitespace and brief comments.",
+                    "markdownDescription": "**Function Declaration**\n\nThis is the function's declaration with whitespace and brief comments.",
                     "title": "Function Declaration",
                     "type": "string"
                 },
                 "functionId": {
                     "description": "This is the function's id.",
+                    "markdownDescription": "**Function**\n\nThis is the function's id.",
                     "title": "Function",
                     "type": "string"
                 },
                 "functionLabel": {
                     "description": "This is the function's label.",
+                    "markdownDescription": "**Function Label**\n\nThis is the function's label.",
                     "title": "Function Label",
                     "type": "string"
                 },
                 "functionResourceId": {
                     "description": "This is the function's resource id.",
+                    "markdownDescription": "**Function Resource Id**\n\nThis is the function's resource id.",
                     "title": "Function Resource Id",
                     "type": "string"
                 },
                 "functionSignature": {
                     "description": "This is the function's signature.",
+                    "markdownDescription": "**Signature**\n\nThis is the function's signature.",
                     "title": "Signature",
                     "type": "string"
                 },
                 "maximumNumberOfParameters": {
                     "description": "This is the maximum number of parameters or -1 if there is no maximum.",
+                    "markdownDescription": "**Maximum Parameters**\n\nThis is the maximum number of parameters or -1 if there is no maximum.",
                     "title": "Maximum Parameters",
                     "type": "integer"
                 },
                 "numberOfRequiredParameters": {
                     "description": "This is the number of required parameters.",
+                    "markdownDescription": "**Required Parameters**\n\nThis is the number of required parameters.",
                     "title": "Required Parameters",
                     "type": "integer"
                 },
                 "op": {
                     "description": "This is the function's operator. This is not used at the moment, but may be used in a future expression syntax.",
+                    "markdownDescription": "**Op**\n\nThis is the function's operator. This is not used at the moment, but may be used in a future expression syntax.",
                     "title": "Op",
                     "type": "string"
                 },
@@ -205,14 +324,18 @@
                             }
                         ],
                         "description": "These are the function's parameters.",
-                        "title": "The function's parameters"
+                        "markdownDescription": "These are the function's parameters.",
+                        "title": "The function's parameters",
+                        "type": "object"
                     },
+                    "markdownDescription": "**Parameters**\n\nThese are the function's parameters.",
                     "title": "Parameters",
                     "type": "array"
                 },
                 "polymorphic": {
                     "default": false,
                     "description": "This indicates that this function can be called polymorphically without specifying the <Type>:: qualifier. The appropriate implementation of the function will be called based on the dataType and/or dataTypeParameter of the first function parameter value.",
+                    "markdownDescription": "**Polymorphic**\n\nThis indicates that this function can be called polymorphically without specifying the <Type>:: qualifier. The appropriate implementation of the function will be called based on the dataType and/or dataTypeParameter of the first function parameter value.",
                     "title": "Polymorphic",
                     "type": "boolean"
                 },
@@ -221,20 +344,24 @@
                     "description": "This function will call the appropriate function when the first parameter is one of these data types.",
                     "items": {
                         "description": "This function will call the appropriate function when the first parameter is one of these data types.",
+                        "markdownDescription": "This function will call the appropriate function when the first parameter is one of these data types.",
                         "title": "This function will call the appropriate function when the first parameter is one of these data types",
                         "type": "string"
                     },
+                    "markdownDescription": "**Polymorphic Data Types**\n\nThis function will call the appropriate function when the first parameter is one of these data types.",
                     "title": "Polymorphic Data Types",
                     "type": "array"
                 },
                 "pure": {
                     "default": false,
                     "description": "This indicates that, given exactly the same parameter values, this function will always return the same result and will not cause any side effects.",
+                    "markdownDescription": "**Pure**\n\nThis indicates that, given exactly the same parameter values, this function will always return the same result and will not cause any side effects.",
                     "title": "Pure",
                     "type": "boolean"
                 },
                 "requiresExecuteAccess": {
                     "description": "If true, this function requires 'execute' access to be called. The 'resourceId' for the authorization check is the function object path, the 'actionId' is 'execute', and the 'object' is object type '_AdaptiveFunctionArguments_' which contains the function object and the arguments to the called function.",
+                    "markdownDescription": "**Requires Execute Access**\n\nIf true, this function requires 'execute' access to be called. The 'resourceId' for the authorization check is the function object path, the 'actionId' is 'execute', and the 'object' is object type '_AdaptiveFunctionArguments_' which contains the function object and the arguments to the called function.",
                     "title": "Requires Execute Access",
                     "type": "boolean"
                 },
@@ -245,25 +372,31 @@
                         }
                     ],
                     "description": "The return parameter.",
-                    "title": "Returns"
+                    "markdownDescription": "**Returns**\n\nThe return parameter.",
+                    "title": "Returns",
+                    "type": "object"
                 },
                 "sideEffects": {
                     "description": "Any side effects that this function may produce as a result of execution.",
                     "items": {
                         "description": "Any side effects that this function may produce as a result of execution.",
+                        "markdownDescription": "Any side effects that this function may produce as a result of execution.",
                         "title": "Side effects for this function.",
                         "type": "string"
                     },
+                    "markdownDescription": "**Side Effects**\n\nAny side effects that this function may produce as a result of execution.",
                     "title": "Side Effects",
                     "type": "array"
                 },
                 "signatureOnly": {
                     "description": "This is a signature with an unimplemented execute function.",
+                    "markdownDescription": "**Signature Only**\n\nThis is a signature with an unimplemented execute function.",
                     "title": "Signature Only",
                     "type": "boolean"
                 },
                 "untypedFunctionId": {
                     "description": "This is the function's id without <dataType>. If this function is not polymorphic, this is the same as functionId.",
+                    "markdownDescription": "**Function**\n\nThis is the function's id without <dataType>. If this function is not polymorphic, this is the same as functionId.",
                     "title": "Function",
                     "type": "string"
                 }
@@ -271,22 +404,253 @@
             "type": "object"
         },
         "_AdaptivePolymorphicFunction_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptivePolymorphicFunction_.propertyTypes"
-                },
-                {
-                    "$ref": "#/$defs/_AdaptiveFunction_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "This is a development time only object type. Objects of this type in generate/objects are processed to produce one polymorphic _AdaptiveFunction_ plus one for each dataType in polymorphicDataTypes.",
+            "markdownDescription": "This is a development time only object type. Objects of this type in generate/objects are processed to produce one polymorphic _AdaptiveFunction_ plus one for each dataType in polymorphicDataTypes.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "afwCamelCaseFunctionLabel": {
+                    "description": "This is the functionLabel prefixed with 'afw' and converted to camel case.",
+                    "markdownDescription": "**Prefixed Camel Case**\n\nThis is the functionLabel prefixed with 'afw' and converted to camel case.",
+                    "title": "Prefixed Camel Case",
+                    "type": "string"
+                },
+                "brief": {
+                    "description": "This is a predicate for the function with the first letter capitalized and without a trailing period.",
+                    "markdownDescription": "**Brief**\n\nThis is a predicate for the function with the first letter capitalized and without a trailing period.",
+                    "title": "Brief",
+                    "type": "string"
+                },
+                "camelCaseFunctionLabel": {
+                    "description": "This is the functionLabel converted to camel case.",
+                    "markdownDescription": "**Camel Case**\n\nThis is the functionLabel converted to camel case.",
+                    "title": "Camel Case",
+                    "type": "string"
+                },
+                "category": {
+                    "description": "Function category.",
+                    "markdownDescription": "**Category**\n\nFunction category.",
+                    "title": "Category",
+                    "type": "string"
+                },
+                "dataType": {
+                    "description": "If present, this is a method for this data type.",
+                    "markdownDescription": "**Data Type**\n\nIf present, this is a method for this data type.",
+                    "title": "Data Type",
+                    "type": "string"
+                },
+                "dataTypeMethod": {
+                    "description": "If true, this is a data type method that can be called polymorphically or by prefixing the function with the data type followed by double colons ('::').",
+                    "markdownDescription": "**Data Type Method**\n\nIf true, this is a data type method that can be called polymorphically or by prefixing the function with the data type followed by double colons ('::').",
+                    "title": "Data Type Method",
+                    "type": "boolean"
+                },
+                "dataTypeMethodNumber": {
+                    "description": "This is an internal number that is unique to the method name (the part after :: in functionId) of a dataTypeMethod function.",
+                    "markdownDescription": "**Method Number**\n\nThis is an internal number that is unique to the method name (the part after :: in functionId) of a dataTypeMethod function.",
+                    "title": "Method Number",
+                    "type": "integer"
+                },
+                "deprecated": {
+                    "default": false,
+                    "description": "This indicates that the function is deprecated and may go away at some point.",
+                    "markdownDescription": "**Deprecated**\n\nThis indicates that the function is deprecated and may go away at some point.",
+                    "title": "Deprecated",
+                    "type": "boolean"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "This is the function's description, used for documentation purposes.",
+                    "markdownDescription": "**Description**\n\nThis is the function's description, used for documentation purposes.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "errorsThrown": {
+                    "description": "Errors that can be thrown by this function.",
+                    "items": {
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/_AdaptiveFunctionErrorThrown_"
+                            }
+                        ],
+                        "description": "Errors that can be thrown by this function.",
+                        "markdownDescription": "Errors that can be thrown by this function.",
+                        "title": "Errors thrown by this function",
+                        "type": "object"
+                    },
+                    "markdownDescription": "**Errors Thrown**\n\nErrors that can be thrown by this function.",
+                    "title": "Errors Thrown",
+                    "type": "array"
+                },
+                "functionDeclaration": {
+                    "contentMediaType": "text/plain",
+                    "description": "This is the function's declaration with whitespace and brief comments.",
+                    "markdownDescription": "**Function Declaration**\n\nThis is the function's declaration with whitespace and brief comments.",
+                    "title": "Function Declaration",
+                    "type": "string"
+                },
+                "functionId": {
+                    "description": "This is the function's id.",
+                    "markdownDescription": "**Function**\n\nThis is the function's id.",
+                    "title": "Function",
+                    "type": "string"
+                },
+                "functionLabel": {
+                    "description": "This is the function's label.",
+                    "markdownDescription": "**Function Label**\n\nThis is the function's label.",
+                    "title": "Function Label",
+                    "type": "string"
+                },
+                "functionResourceId": {
+                    "description": "This is the function's resource id.",
+                    "markdownDescription": "**Function Resource Id**\n\nThis is the function's resource id.",
+                    "title": "Function Resource Id",
+                    "type": "string"
+                },
+                "functionSignature": {
+                    "description": "This is the function's signature.",
+                    "markdownDescription": "**Signature**\n\nThis is the function's signature.",
+                    "title": "Signature",
+                    "type": "string"
+                },
+                "maximumNumberOfParameters": {
+                    "description": "This is the maximum number of parameters or -1 if there is no maximum.",
+                    "markdownDescription": "**Maximum Parameters**\n\nThis is the maximum number of parameters or -1 if there is no maximum.",
+                    "title": "Maximum Parameters",
+                    "type": "integer"
+                },
+                "numberOfRequiredParameters": {
+                    "description": "This is the number of required parameters.",
+                    "markdownDescription": "**Required Parameters**\n\nThis is the number of required parameters.",
+                    "title": "Required Parameters",
+                    "type": "integer"
+                },
+                "op": {
+                    "description": "This is the function's operator. This is not used at the moment, but may be used in a future expression syntax.",
+                    "markdownDescription": "**Op**\n\nThis is the function's operator. This is not used at the moment, but may be used in a future expression syntax.",
+                    "title": "Op",
+                    "type": "string"
+                },
+                "parameters": {
+                    "description": "These are the function's parameters.",
+                    "items": {
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/_AdaptiveFunctionParameter_"
+                            }
+                        ],
+                        "description": "These are the function's parameters.",
+                        "markdownDescription": "These are the function's parameters.",
+                        "title": "The function's parameters",
+                        "type": "object"
+                    },
+                    "markdownDescription": "**Parameters**\n\nThese are the function's parameters.",
+                    "title": "Parameters",
+                    "type": "array"
+                },
+                "polymorphic": {
+                    "default": false,
+                    "description": "This indicates that this function can be called polymorphically without specifying the <Type>:: qualifier. The appropriate implementation of the function will be called based on the dataType and/or dataTypeParameter of the first function parameter value.",
+                    "markdownDescription": "**Polymorphic**\n\nThis indicates that this function can be called polymorphically without specifying the <Type>:: qualifier. The appropriate implementation of the function will be called based on the dataType and/or dataTypeParameter of the first function parameter value.",
+                    "title": "Polymorphic",
+                    "type": "boolean"
+                },
+                "polymorphicDataTypes": {
+                    "default": false,
+                    "description": "This function will call the appropriate function when the first parameter is one of these data types.",
+                    "items": {
+                        "description": "This function will call the appropriate function when the first parameter is one of these data types.",
+                        "markdownDescription": "This function will call the appropriate function when the first parameter is one of these data types.",
+                        "title": "This function will call the appropriate function when the first parameter is one of these data types",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Polymorphic Data Types**\n\nThis function will call the appropriate function when the first parameter is one of these data types.",
+                    "title": "Polymorphic Data Types",
+                    "type": "array"
+                },
+                "polymorphicExecuteFunction": {
+                    "description": "Polymorphic Function.",
+                    "markdownDescription": "**Adapter**\n\nPolymorphic Function.",
+                    "title": "Adapter",
+                    "type": "string"
+                },
+                "polymorphicExecuteFunctionEvaluatesFirstParameter": {
+                    "default": false,
+                    "description": "If true, the first parameter evaluate is deferred to polymorphicExecuteFunction function. If false or not specified, standard polymorphic function processing evaluates the first parameter to determine the appropriate evaluate to call.",
+                    "markdownDescription": "**Defer Evaluate**\n\nIf true, the first parameter evaluate is deferred to polymorphicExecuteFunction function. If false or not specified, standard polymorphic function processing evaluates the first parameter to determine the appropriate evaluate to call.",
+                    "title": "Defer Evaluate",
+                    "type": "boolean"
+                },
+                "polymorphicOverrides": {
+                    "title": "Polymorphic Overrides",
+                    "type": "object"
+                },
+                "pure": {
+                    "default": false,
+                    "description": "This indicates that, given exactly the same parameter values, this function will always return the same result and will not cause any side effects.",
+                    "markdownDescription": "**Pure**\n\nThis indicates that, given exactly the same parameter values, this function will always return the same result and will not cause any side effects.",
+                    "title": "Pure",
+                    "type": "boolean"
+                },
+                "requiresExecuteAccess": {
+                    "description": "If true, this function requires 'execute' access to be called. The 'resourceId' for the authorization check is the function object path, the 'actionId' is 'execute', and the 'object' is object type '_AdaptiveFunctionArguments_' which contains the function object and the arguments to the called function.",
+                    "markdownDescription": "**Requires Execute Access**\n\nIf true, this function requires 'execute' access to be called. The 'resourceId' for the authorization check is the function object path, the 'actionId' is 'execute', and the 'object' is object type '_AdaptiveFunctionArguments_' which contains the function object and the arguments to the called function.",
+                    "title": "Requires Execute Access",
+                    "type": "boolean"
+                },
+                "returns": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveFunctionParameter_"
+                        }
+                    ],
+                    "description": "The return parameter.",
+                    "markdownDescription": "**Returns**\n\nThe return parameter.",
+                    "title": "Returns",
+                    "type": "object"
+                },
+                "sideEffects": {
+                    "description": "Any side effects that this function may produce as a result of execution.",
+                    "items": {
+                        "description": "Any side effects that this function may produce as a result of execution.",
+                        "markdownDescription": "Any side effects that this function may produce as a result of execution.",
+                        "title": "Side effects for this function.",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Side Effects**\n\nAny side effects that this function may produce as a result of execution.",
+                    "title": "Side Effects",
+                    "type": "array"
+                },
+                "signatureOnly": {
+                    "description": "This is a signature with an unimplemented execute function.",
+                    "markdownDescription": "**Signature Only**\n\nThis is a signature with an unimplemented execute function.",
+                    "title": "Signature Only",
+                    "type": "boolean"
+                },
+                "untypedFunctionId": {
+                    "description": "This is the function's id without <dataType>. If this function is not polymorphic, this is the same as functionId.",
+                    "markdownDescription": "**Function**\n\nThis is the function's id without <dataType>. If this function is not polymorphic, this is the same as functionId.",
+                    "title": "Function",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptivePolymorphicFunction_",
             "type": "object",
-            "unevaluatedProperties": false
+            "x-afw-inheritedObjectTypes": [
+                "_AdaptiveFunction_"
+            ]
         },
         "_AdaptivePolymorphicFunction_.propertyTypes": {
             "properties": {
                 "dataTypeMethod": {
                     "description": "If true, this is a data type method that can be called polymorphically or by prefixing the function with the data type followed by double colons ('::').",
+                    "markdownDescription": "**Data Type Method**\n\nIf true, this is a data type method that can be called polymorphically or by prefixing the function with the data type followed by double colons ('::').",
                     "title": "Data Type Method",
                     "type": "boolean"
                 },
@@ -299,19 +663,24 @@
                             }
                         ],
                         "description": "Errors that can be thrown by this function.",
-                        "title": "Errors thrown by this function"
+                        "markdownDescription": "Errors that can be thrown by this function.",
+                        "title": "Errors thrown by this function",
+                        "type": "object"
                     },
+                    "markdownDescription": "**Errors Thrown**\n\nErrors that can be thrown by this function.",
                     "title": "Errors Thrown",
                     "type": "array"
                 },
                 "polymorphicExecuteFunction": {
                     "description": "Polymorphic Function.",
+                    "markdownDescription": "**Adapter**\n\nPolymorphic Function.",
                     "title": "Adapter",
                     "type": "string"
                 },
                 "polymorphicExecuteFunctionEvaluatesFirstParameter": {
                     "default": false,
                     "description": "If true, the first parameter evaluate is deferred to polymorphicExecuteFunction function. If false or not specified, standard polymorphic function processing evaluates the first parameter to determine the appropriate evaluate to call.",
+                    "markdownDescription": "**Defer Evaluate**\n\nIf true, the first parameter evaluate is deferred to polymorphicExecuteFunction function. If false or not specified, standard polymorphic function processing evaluates the first parameter to determine the appropriate evaluate to call.",
                     "title": "Defer Evaluate",
                     "type": "boolean"
                 },
@@ -324,9 +693,245 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptivePolymorphicFunction_"
+    "additionalProperties": false,
+    "description": "This is a development time only object type. Objects of this type in generate/objects are processed to produce one polymorphic _AdaptiveFunction_ plus one for each dataType in polymorphicDataTypes.",
+    "markdownDescription": "This is a development time only object type. Objects of this type in generate/objects are processed to produce one polymorphic _AdaptiveFunction_ plus one for each dataType in polymorphicDataTypes.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "afwCamelCaseFunctionLabel": {
+            "description": "This is the functionLabel prefixed with 'afw' and converted to camel case.",
+            "markdownDescription": "**Prefixed Camel Case**\n\nThis is the functionLabel prefixed with 'afw' and converted to camel case.",
+            "title": "Prefixed Camel Case",
+            "type": "string"
+        },
+        "brief": {
+            "description": "This is a predicate for the function with the first letter capitalized and without a trailing period.",
+            "markdownDescription": "**Brief**\n\nThis is a predicate for the function with the first letter capitalized and without a trailing period.",
+            "title": "Brief",
+            "type": "string"
+        },
+        "camelCaseFunctionLabel": {
+            "description": "This is the functionLabel converted to camel case.",
+            "markdownDescription": "**Camel Case**\n\nThis is the functionLabel converted to camel case.",
+            "title": "Camel Case",
+            "type": "string"
+        },
+        "category": {
+            "description": "Function category.",
+            "markdownDescription": "**Category**\n\nFunction category.",
+            "title": "Category",
+            "type": "string"
+        },
+        "dataType": {
+            "description": "If present, this is a method for this data type.",
+            "markdownDescription": "**Data Type**\n\nIf present, this is a method for this data type.",
+            "title": "Data Type",
+            "type": "string"
+        },
+        "dataTypeMethod": {
+            "description": "If true, this is a data type method that can be called polymorphically or by prefixing the function with the data type followed by double colons ('::').",
+            "markdownDescription": "**Data Type Method**\n\nIf true, this is a data type method that can be called polymorphically or by prefixing the function with the data type followed by double colons ('::').",
+            "title": "Data Type Method",
+            "type": "boolean"
+        },
+        "dataTypeMethodNumber": {
+            "description": "This is an internal number that is unique to the method name (the part after :: in functionId) of a dataTypeMethod function.",
+            "markdownDescription": "**Method Number**\n\nThis is an internal number that is unique to the method name (the part after :: in functionId) of a dataTypeMethod function.",
+            "title": "Method Number",
+            "type": "integer"
+        },
+        "deprecated": {
+            "default": false,
+            "description": "This indicates that the function is deprecated and may go away at some point.",
+            "markdownDescription": "**Deprecated**\n\nThis indicates that the function is deprecated and may go away at some point.",
+            "title": "Deprecated",
+            "type": "boolean"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "This is the function's description, used for documentation purposes.",
+            "markdownDescription": "**Description**\n\nThis is the function's description, used for documentation purposes.",
+            "title": "Description",
+            "type": "string"
+        },
+        "errorsThrown": {
+            "description": "Errors that can be thrown by this function.",
+            "items": {
+                "allOf": [
+                    {
+                        "$ref": "#/$defs/_AdaptiveFunctionErrorThrown_"
+                    }
+                ],
+                "description": "Errors that can be thrown by this function.",
+                "markdownDescription": "Errors that can be thrown by this function.",
+                "title": "Errors thrown by this function",
+                "type": "object"
+            },
+            "markdownDescription": "**Errors Thrown**\n\nErrors that can be thrown by this function.",
+            "title": "Errors Thrown",
+            "type": "array"
+        },
+        "functionDeclaration": {
+            "contentMediaType": "text/plain",
+            "description": "This is the function's declaration with whitespace and brief comments.",
+            "markdownDescription": "**Function Declaration**\n\nThis is the function's declaration with whitespace and brief comments.",
+            "title": "Function Declaration",
+            "type": "string"
+        },
+        "functionId": {
+            "description": "This is the function's id.",
+            "markdownDescription": "**Function**\n\nThis is the function's id.",
+            "title": "Function",
+            "type": "string"
+        },
+        "functionLabel": {
+            "description": "This is the function's label.",
+            "markdownDescription": "**Function Label**\n\nThis is the function's label.",
+            "title": "Function Label",
+            "type": "string"
+        },
+        "functionResourceId": {
+            "description": "This is the function's resource id.",
+            "markdownDescription": "**Function Resource Id**\n\nThis is the function's resource id.",
+            "title": "Function Resource Id",
+            "type": "string"
+        },
+        "functionSignature": {
+            "description": "This is the function's signature.",
+            "markdownDescription": "**Signature**\n\nThis is the function's signature.",
+            "title": "Signature",
+            "type": "string"
+        },
+        "maximumNumberOfParameters": {
+            "description": "This is the maximum number of parameters or -1 if there is no maximum.",
+            "markdownDescription": "**Maximum Parameters**\n\nThis is the maximum number of parameters or -1 if there is no maximum.",
+            "title": "Maximum Parameters",
+            "type": "integer"
+        },
+        "numberOfRequiredParameters": {
+            "description": "This is the number of required parameters.",
+            "markdownDescription": "**Required Parameters**\n\nThis is the number of required parameters.",
+            "title": "Required Parameters",
+            "type": "integer"
+        },
+        "op": {
+            "description": "This is the function's operator. This is not used at the moment, but may be used in a future expression syntax.",
+            "markdownDescription": "**Op**\n\nThis is the function's operator. This is not used at the moment, but may be used in a future expression syntax.",
+            "title": "Op",
+            "type": "string"
+        },
+        "parameters": {
+            "description": "These are the function's parameters.",
+            "items": {
+                "allOf": [
+                    {
+                        "$ref": "#/$defs/_AdaptiveFunctionParameter_"
+                    }
+                ],
+                "description": "These are the function's parameters.",
+                "markdownDescription": "These are the function's parameters.",
+                "title": "The function's parameters",
+                "type": "object"
+            },
+            "markdownDescription": "**Parameters**\n\nThese are the function's parameters.",
+            "title": "Parameters",
+            "type": "array"
+        },
+        "polymorphic": {
+            "default": false,
+            "description": "This indicates that this function can be called polymorphically without specifying the <Type>:: qualifier. The appropriate implementation of the function will be called based on the dataType and/or dataTypeParameter of the first function parameter value.",
+            "markdownDescription": "**Polymorphic**\n\nThis indicates that this function can be called polymorphically without specifying the <Type>:: qualifier. The appropriate implementation of the function will be called based on the dataType and/or dataTypeParameter of the first function parameter value.",
+            "title": "Polymorphic",
+            "type": "boolean"
+        },
+        "polymorphicDataTypes": {
+            "default": false,
+            "description": "This function will call the appropriate function when the first parameter is one of these data types.",
+            "items": {
+                "description": "This function will call the appropriate function when the first parameter is one of these data types.",
+                "markdownDescription": "This function will call the appropriate function when the first parameter is one of these data types.",
+                "title": "This function will call the appropriate function when the first parameter is one of these data types",
+                "type": "string"
+            },
+            "markdownDescription": "**Polymorphic Data Types**\n\nThis function will call the appropriate function when the first parameter is one of these data types.",
+            "title": "Polymorphic Data Types",
+            "type": "array"
+        },
+        "polymorphicExecuteFunction": {
+            "description": "Polymorphic Function.",
+            "markdownDescription": "**Adapter**\n\nPolymorphic Function.",
+            "title": "Adapter",
+            "type": "string"
+        },
+        "polymorphicExecuteFunctionEvaluatesFirstParameter": {
+            "default": false,
+            "description": "If true, the first parameter evaluate is deferred to polymorphicExecuteFunction function. If false or not specified, standard polymorphic function processing evaluates the first parameter to determine the appropriate evaluate to call.",
+            "markdownDescription": "**Defer Evaluate**\n\nIf true, the first parameter evaluate is deferred to polymorphicExecuteFunction function. If false or not specified, standard polymorphic function processing evaluates the first parameter to determine the appropriate evaluate to call.",
+            "title": "Defer Evaluate",
+            "type": "boolean"
+        },
+        "polymorphicOverrides": {
+            "title": "Polymorphic Overrides",
+            "type": "object"
+        },
+        "pure": {
+            "default": false,
+            "description": "This indicates that, given exactly the same parameter values, this function will always return the same result and will not cause any side effects.",
+            "markdownDescription": "**Pure**\n\nThis indicates that, given exactly the same parameter values, this function will always return the same result and will not cause any side effects.",
+            "title": "Pure",
+            "type": "boolean"
+        },
+        "requiresExecuteAccess": {
+            "description": "If true, this function requires 'execute' access to be called. The 'resourceId' for the authorization check is the function object path, the 'actionId' is 'execute', and the 'object' is object type '_AdaptiveFunctionArguments_' which contains the function object and the arguments to the called function.",
+            "markdownDescription": "**Requires Execute Access**\n\nIf true, this function requires 'execute' access to be called. The 'resourceId' for the authorization check is the function object path, the 'actionId' is 'execute', and the 'object' is object type '_AdaptiveFunctionArguments_' which contains the function object and the arguments to the called function.",
+            "title": "Requires Execute Access",
+            "type": "boolean"
+        },
+        "returns": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveFunctionParameter_"
+                }
+            ],
+            "description": "The return parameter.",
+            "markdownDescription": "**Returns**\n\nThe return parameter.",
+            "title": "Returns",
+            "type": "object"
+        },
+        "sideEffects": {
+            "description": "Any side effects that this function may produce as a result of execution.",
+            "items": {
+                "description": "Any side effects that this function may produce as a result of execution.",
+                "markdownDescription": "Any side effects that this function may produce as a result of execution.",
+                "title": "Side effects for this function.",
+                "type": "string"
+            },
+            "markdownDescription": "**Side Effects**\n\nAny side effects that this function may produce as a result of execution.",
+            "title": "Side Effects",
+            "type": "array"
+        },
+        "signatureOnly": {
+            "description": "This is a signature with an unimplemented execute function.",
+            "markdownDescription": "**Signature Only**\n\nThis is a signature with an unimplemented execute function.",
+            "title": "Signature Only",
+            "type": "boolean"
+        },
+        "untypedFunctionId": {
+            "description": "This is the function's id without <dataType>. If this function is not polymorphic, this is the same as functionId.",
+            "markdownDescription": "**Function**\n\nThis is the function's id without <dataType>. If this function is not polymorphic, this is the same as functionId.",
+            "title": "Function",
+            "type": "string"
         }
+    },
+    "title": "_AdaptivePolymorphicFunction_",
+    "type": "object",
+    "x-afw-inheritedObjectTypes": [
+        "_AdaptiveFunction_"
     ]
 }

--- a/generated/schemas/afw/_AdaptivePolymorphicFunction_.json
+++ b/generated/schemas/afw/_AdaptivePolymorphicFunction_.json
@@ -1,12 +1,16 @@
 {
     "$defs": {
         "_AdaptiveFunctionErrorThrown_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveFunctionErrorThrown_.propertyTypes"
                 }
             ],
             "description": "An object entry of _AdaptiveFunction_ errorsThrown array.",
+            "required": [
+                "error",
+                "reason"
+            ],
             "type": "object",
             "unevaluatedProperties": false
         },
@@ -23,14 +27,10 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "error",
-                "reason"
-            ],
             "type": "object"
         },
         "_AdaptiveFunctionParameter_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveFunctionParameter_.propertyTypes"
                 }
@@ -47,6 +47,7 @@
                     "type": "string"
                 },
                 "canBeUndefined": {
+                    "default": false,
                     "description": "Indicates that parameter can be undefined (NULL) even if not optional.",
                     "title": "Optional",
                     "type": "boolean"
@@ -78,6 +79,7 @@
                     "type": "string"
                 },
                 "optional": {
+                    "default": false,
                     "description": "This indicates that parameter is optional and can be undefined (NULL).",
                     "title": "Optional",
                     "type": "boolean"
@@ -128,6 +130,7 @@
                     "type": "integer"
                 },
                 "deprecated": {
+                    "default": false,
                     "description": "This indicates that the function is deprecated and may go away at some point.",
                     "title": "Deprecated",
                     "type": "boolean"
@@ -141,10 +144,13 @@
                 "errorsThrown": {
                     "description": "These are errors that can possibly be thrown by this function.",
                     "items": {
-                        "$ref": "#/$defs/_AdaptiveFunctionErrorThrown_",
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/_AdaptiveFunctionErrorThrown_"
+                            }
+                        ],
                         "description": "These are errors that can possibly be thrown by this function.",
-                        "title": "Errors thrown",
-                        "type": "object"
+                        "title": "Errors thrown"
                     },
                     "title": "Errors Thrown",
                     "type": "array"
@@ -193,20 +199,25 @@
                 "parameters": {
                     "description": "These are the function's parameters.",
                     "items": {
-                        "$ref": "#/$defs/_AdaptiveFunctionParameter_",
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/_AdaptiveFunctionParameter_"
+                            }
+                        ],
                         "description": "These are the function's parameters.",
-                        "title": "The function's parameters",
-                        "type": "object"
+                        "title": "The function's parameters"
                     },
                     "title": "Parameters",
                     "type": "array"
                 },
                 "polymorphic": {
+                    "default": false,
                     "description": "This indicates that this function can be called polymorphically without specifying the <Type>:: qualifier. The appropriate implementation of the function will be called based on the dataType and/or dataTypeParameter of the first function parameter value.",
                     "title": "Polymorphic",
                     "type": "boolean"
                 },
                 "polymorphicDataTypes": {
+                    "default": false,
                     "description": "This function will call the appropriate function when the first parameter is one of these data types.",
                     "items": {
                         "description": "This function will call the appropriate function when the first parameter is one of these data types.",
@@ -217,6 +228,7 @@
                     "type": "array"
                 },
                 "pure": {
+                    "default": false,
                     "description": "This indicates that, given exactly the same parameter values, this function will always return the same result and will not cause any side effects.",
                     "title": "Pure",
                     "type": "boolean"
@@ -227,10 +239,13 @@
                     "type": "boolean"
                 },
                 "returns": {
-                    "$ref": "#/$defs/_AdaptiveFunctionParameter_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveFunctionParameter_"
+                        }
+                    ],
                     "description": "The return parameter.",
-                    "title": "Returns",
-                    "type": "object"
+                    "title": "Returns"
                 },
                 "sideEffects": {
                     "description": "Any side effects that this function may produce as a result of execution.",
@@ -253,17 +268,10 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "category",
-                "functionId",
-                "functionLabel",
-                "functionResourceId",
-                "returns"
-            ],
             "type": "object"
         },
         "_AdaptivePolymorphicFunction_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptivePolymorphicFunction_.propertyTypes"
                 },
@@ -277,9 +285,6 @@
         },
         "_AdaptivePolymorphicFunction_.propertyTypes": {
             "properties": {
-                "_meta_": {
-                    "title": " Meta "
-                },
                 "dataTypeMethod": {
                     "description": "If true, this is a data type method that can be called polymorphically or by prefixing the function with the data type followed by double colons ('::').",
                     "title": "Data Type Method",
@@ -288,10 +293,13 @@
                 "errorsThrown": {
                     "description": "Errors that can be thrown by this function.",
                     "items": {
-                        "$ref": "#/$defs/_AdaptiveFunctionErrorThrown_",
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/_AdaptiveFunctionErrorThrown_"
+                            }
+                        ],
                         "description": "Errors that can be thrown by this function.",
-                        "title": "Errors thrown by this function",
-                        "type": "object"
+                        "title": "Errors thrown by this function"
                     },
                     "title": "Errors Thrown",
                     "type": "array"
@@ -302,6 +310,7 @@
                     "type": "string"
                 },
                 "polymorphicExecuteFunctionEvaluatesFirstParameter": {
+                    "default": false,
                     "description": "If true, the first parameter evaluate is deferred to polymorphicExecuteFunction function. If false or not specified, standard polymorphic function processing evaluates the first parameter to determine the appropriate evaluate to call.",
                     "title": "Defer Evaluate",
                     "type": "boolean"
@@ -315,7 +324,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptivePolymorphicFunction_"
         }

--- a/generated/schemas/afw/_AdaptiveProvisioningPeer_.json
+++ b/generated/schemas/afw/_AdaptiveProvisioningPeer_.json
@@ -1,12 +1,15 @@
 {
     "$defs": {
         "_AdaptiveProvisioningPeer_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveProvisioningPeer_.propertyTypes"
                 }
             ],
             "description": "A provisioning peer consumes and/or produces adaptive journal entries.",
+            "required": [
+                "peerId"
+            ],
             "type": "object",
             "unevaluatedProperties": false
         },
@@ -23,6 +26,7 @@
                     "type": "string"
                 },
                 "consumeFilter": {
+                    "default": "true",
                     "description": "This is a boolean expression that determines if a journal entry is applicable to be consumed by this peer.",
                     "title": "Consume Filter",
                     "type": "string"
@@ -56,14 +60,11 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "peerId"
-            ],
             "type": "object"
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveProvisioningPeer_"
         }

--- a/generated/schemas/afw/_AdaptiveProvisioningPeer_.json
+++ b/generated/schemas/afw/_AdaptiveProvisioningPeer_.json
@@ -1,61 +1,128 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveProvisioningPeer_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveProvisioningPeer_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveProvisioningPeer_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "A provisioning peer consumes and/or produces adaptive journal entries.",
-            "required": [
-                "peerId"
-            ],
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveProvisioningPeer_.propertyTypes": {
+            "markdownDescription": "A provisioning peer consumes and/or produces adaptive journal entries.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "advanceCursor": {
                     "description": "This property set by get_entry() option advance_cursor_for_consumer. If set, get_entry() option next_for_consumer will removed it and use it as the cursor to begin looking for the next applicable entry. The intent of cursorNext is to be set by a background process/thread that examines journal entries from the cursorNext/cursorCurrent forward looking for a entry that passes the consumer filter. Once cursorNext is used by get_entry() next_for_consumer, the property is removed.",
+                    "markdownDescription": "**Advance Cursor**\n\nThis property set by get_entry() option advance_cursor_for_consumer. If set, get_entry() option next_for_consumer will removed it and use it as the cursor to begin looking for the next applicable entry. The intent of cursorNext is to be set by a background process/thread that examines journal entries from the cursorNext/cursorCurrent forward looking for a entry that passes the consumer filter. Once cursorNext is used by get_entry() next_for_consumer, the property is removed.",
                     "title": "Advance Cursor",
                     "type": "string"
                 },
                 "consumeCursor": {
                     "description": "This is the current cursor being consumed. This property only exists between a get_entry() option next_for_consumer and the corresponding mark_entry_consumed(). If this property exists, it should have exactly the same value as property cursorCurrent. Anything else is and error.",
+                    "markdownDescription": "**Consume Cursor**\n\nThis is the current cursor being consumed. This property only exists between a get_entry() option next_for_consumer and the corresponding mark_entry_consumed(). If this property exists, it should have exactly the same value as property cursorCurrent. Anything else is and error.",
                     "title": "Consume Cursor",
                     "type": "string"
                 },
                 "consumeFilter": {
                     "default": "true",
                     "description": "This is a boolean expression that determines if a journal entry is applicable to be consumed by this peer.",
+                    "markdownDescription": "**Consume Filter**\n\nThis is a boolean expression that determines if a journal entry is applicable to be consumed by this peer.",
                     "title": "Consume Filter",
                     "type": "string"
                 },
                 "consumeStartTime": {
                     "description": "The time that get_entry() next_for_consumer began. This property will only exist if cursorBeingConsumed property exists.",
                     "format": "date-time",
+                    "markdownDescription": "**Consume Start Time**\n\nThe time that get_entry() next_for_consumer began. This property will only exist if cursorBeingConsumed property exists.",
                     "title": "Consume Start Time",
                     "type": "string"
                 },
                 "currentCursor": {
                     "description": "This is the current cursor into the journal.",
+                    "markdownDescription": "**Current Cursor**\n\nThis is the current cursor into the journal.",
                     "title": "Current Cursor",
                     "type": "string"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "Description of provisioning peer.",
+                    "markdownDescription": "**Description**\n\nDescription of provisioning peer.",
                     "title": "Description",
                     "type": "string"
                 },
                 "lastContactTime": {
                     "description": "The last time the peer was successfully contacted.",
                     "format": "date-time",
+                    "markdownDescription": "**Last Contact Time**\n\nThe last time the peer was successfully contacted.",
                     "title": "Last Contact Time",
                     "type": "string"
                 },
                 "peerId": {
                     "description": "Id used to identify this peer. This may also be referred to as the consumerId or producerId, depending on the perspective.",
+                    "markdownDescription": "**Peer**\n\nId used to identify this peer. This may also be referred to as the consumerId or producerId, depending on the perspective.",
+                    "title": "Peer",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "peerId"
+            ],
+            "title": "_AdaptiveProvisioningPeer_",
+            "type": "object"
+        },
+        "_AdaptiveProvisioningPeer_.propertyTypes": {
+            "properties": {
+                "advanceCursor": {
+                    "description": "This property set by get_entry() option advance_cursor_for_consumer. If set, get_entry() option next_for_consumer will removed it and use it as the cursor to begin looking for the next applicable entry. The intent of cursorNext is to be set by a background process/thread that examines journal entries from the cursorNext/cursorCurrent forward looking for a entry that passes the consumer filter. Once cursorNext is used by get_entry() next_for_consumer, the property is removed.",
+                    "markdownDescription": "**Advance Cursor**\n\nThis property set by get_entry() option advance_cursor_for_consumer. If set, get_entry() option next_for_consumer will removed it and use it as the cursor to begin looking for the next applicable entry. The intent of cursorNext is to be set by a background process/thread that examines journal entries from the cursorNext/cursorCurrent forward looking for a entry that passes the consumer filter. Once cursorNext is used by get_entry() next_for_consumer, the property is removed.",
+                    "title": "Advance Cursor",
+                    "type": "string"
+                },
+                "consumeCursor": {
+                    "description": "This is the current cursor being consumed. This property only exists between a get_entry() option next_for_consumer and the corresponding mark_entry_consumed(). If this property exists, it should have exactly the same value as property cursorCurrent. Anything else is and error.",
+                    "markdownDescription": "**Consume Cursor**\n\nThis is the current cursor being consumed. This property only exists between a get_entry() option next_for_consumer and the corresponding mark_entry_consumed(). If this property exists, it should have exactly the same value as property cursorCurrent. Anything else is and error.",
+                    "title": "Consume Cursor",
+                    "type": "string"
+                },
+                "consumeFilter": {
+                    "default": "true",
+                    "description": "This is a boolean expression that determines if a journal entry is applicable to be consumed by this peer.",
+                    "markdownDescription": "**Consume Filter**\n\nThis is a boolean expression that determines if a journal entry is applicable to be consumed by this peer.",
+                    "title": "Consume Filter",
+                    "type": "string"
+                },
+                "consumeStartTime": {
+                    "description": "The time that get_entry() next_for_consumer began. This property will only exist if cursorBeingConsumed property exists.",
+                    "format": "date-time",
+                    "markdownDescription": "**Consume Start Time**\n\nThe time that get_entry() next_for_consumer began. This property will only exist if cursorBeingConsumed property exists.",
+                    "title": "Consume Start Time",
+                    "type": "string"
+                },
+                "currentCursor": {
+                    "description": "This is the current cursor into the journal.",
+                    "markdownDescription": "**Current Cursor**\n\nThis is the current cursor into the journal.",
+                    "title": "Current Cursor",
+                    "type": "string"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "Description of provisioning peer.",
+                    "markdownDescription": "**Description**\n\nDescription of provisioning peer.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "lastContactTime": {
+                    "description": "The last time the peer was successfully contacted.",
+                    "format": "date-time",
+                    "markdownDescription": "**Last Contact Time**\n\nThe last time the peer was successfully contacted.",
+                    "title": "Last Contact Time",
+                    "type": "string"
+                },
+                "peerId": {
+                    "description": "Id used to identify this peer. This may also be referred to as the consumerId or producerId, depending on the perspective.",
+                    "markdownDescription": "**Peer**\n\nId used to identify this peer. This may also be referred to as the consumerId or producerId, depending on the perspective.",
                     "title": "Peer",
                     "type": "string"
                 }
@@ -64,9 +131,73 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveProvisioningPeer_"
+    "additionalProperties": false,
+    "description": "A provisioning peer consumes and/or produces adaptive journal entries.",
+    "markdownDescription": "A provisioning peer consumes and/or produces adaptive journal entries.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "advanceCursor": {
+            "description": "This property set by get_entry() option advance_cursor_for_consumer. If set, get_entry() option next_for_consumer will removed it and use it as the cursor to begin looking for the next applicable entry. The intent of cursorNext is to be set by a background process/thread that examines journal entries from the cursorNext/cursorCurrent forward looking for a entry that passes the consumer filter. Once cursorNext is used by get_entry() next_for_consumer, the property is removed.",
+            "markdownDescription": "**Advance Cursor**\n\nThis property set by get_entry() option advance_cursor_for_consumer. If set, get_entry() option next_for_consumer will removed it and use it as the cursor to begin looking for the next applicable entry. The intent of cursorNext is to be set by a background process/thread that examines journal entries from the cursorNext/cursorCurrent forward looking for a entry that passes the consumer filter. Once cursorNext is used by get_entry() next_for_consumer, the property is removed.",
+            "title": "Advance Cursor",
+            "type": "string"
+        },
+        "consumeCursor": {
+            "description": "This is the current cursor being consumed. This property only exists between a get_entry() option next_for_consumer and the corresponding mark_entry_consumed(). If this property exists, it should have exactly the same value as property cursorCurrent. Anything else is and error.",
+            "markdownDescription": "**Consume Cursor**\n\nThis is the current cursor being consumed. This property only exists between a get_entry() option next_for_consumer and the corresponding mark_entry_consumed(). If this property exists, it should have exactly the same value as property cursorCurrent. Anything else is and error.",
+            "title": "Consume Cursor",
+            "type": "string"
+        },
+        "consumeFilter": {
+            "default": "true",
+            "description": "This is a boolean expression that determines if a journal entry is applicable to be consumed by this peer.",
+            "markdownDescription": "**Consume Filter**\n\nThis is a boolean expression that determines if a journal entry is applicable to be consumed by this peer.",
+            "title": "Consume Filter",
+            "type": "string"
+        },
+        "consumeStartTime": {
+            "description": "The time that get_entry() next_for_consumer began. This property will only exist if cursorBeingConsumed property exists.",
+            "format": "date-time",
+            "markdownDescription": "**Consume Start Time**\n\nThe time that get_entry() next_for_consumer began. This property will only exist if cursorBeingConsumed property exists.",
+            "title": "Consume Start Time",
+            "type": "string"
+        },
+        "currentCursor": {
+            "description": "This is the current cursor into the journal.",
+            "markdownDescription": "**Current Cursor**\n\nThis is the current cursor into the journal.",
+            "title": "Current Cursor",
+            "type": "string"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "Description of provisioning peer.",
+            "markdownDescription": "**Description**\n\nDescription of provisioning peer.",
+            "title": "Description",
+            "type": "string"
+        },
+        "lastContactTime": {
+            "description": "The last time the peer was successfully contacted.",
+            "format": "date-time",
+            "markdownDescription": "**Last Contact Time**\n\nThe last time the peer was successfully contacted.",
+            "title": "Last Contact Time",
+            "type": "string"
+        },
+        "peerId": {
+            "description": "Id used to identify this peer. This may also be referred to as the consumerId or producerId, depending on the perspective.",
+            "markdownDescription": "**Peer**\n\nId used to identify this peer. This may also be referred to as the consumerId or producerId, depending on the perspective.",
+            "title": "Peer",
+            "type": "string"
         }
-    ]
+    },
+    "required": [
+        "peerId"
+    ],
+    "title": "_AdaptiveProvisioningPeer_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveRequestContext_.json
+++ b/generated/schemas/afw/_AdaptiveRequestContext_.json
@@ -1,10 +1,8 @@
 {
     "$defs": {
         "_AdaptiveRequestContext_": {
-            "additionalProperties": {
-                "description": "Request subject."
-            },
-            "anyOf": [
+            "additionalProperties": true,
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveRequestContext_.propertyTypes"
                 }
@@ -24,7 +22,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveRequestContext_"
         }

--- a/generated/schemas/afw/_AdaptiveRequestContext_.json
+++ b/generated/schemas/afw/_AdaptiveRequestContext_.json
@@ -1,19 +1,33 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveRequestContext_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveRequestContext_": {
             "additionalProperties": true,
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveRequestContext_.propertyTypes"
-                }
-            ],
             "description": "Request subject.",
+            "markdownDescription": "Request subject.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "subjectCategories": {
+                    "description": "The initiator of the request.",
+                    "markdownDescription": "**Subject**\n\nThe initiator of the request.",
+                    "title": "Subject",
+                    "type": "array"
+                }
+            },
+            "title": "_AdaptiveRequestContext_",
             "type": "object"
         },
         "_AdaptiveRequestContext_.propertyTypes": {
             "properties": {
                 "subjectCategories": {
                     "description": "The initiator of the request.",
+                    "markdownDescription": "**Subject**\n\nThe initiator of the request.",
                     "title": "Subject",
                     "type": "array"
                 }
@@ -22,9 +36,24 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveRequestContext_"
+    "additionalProperties": true,
+    "description": "Request subject.",
+    "markdownDescription": "Request subject.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "subjectCategories": {
+            "description": "The initiator of the request.",
+            "markdownDescription": "**Subject**\n\nThe initiator of the request.",
+            "title": "Subject",
+            "type": "array"
         }
-    ]
+    },
+    "title": "_AdaptiveRequestContext_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveRequestHandlerType_.json
+++ b/generated/schemas/afw/_AdaptiveRequestHandlerType_.json
@@ -1,25 +1,47 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveRequestHandlerType_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveRequestHandlerType_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveRequestHandlerType_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "A registry type request_handler_factory entry.",
-            "type": "object",
-            "unevaluatedProperties": false
+            "markdownDescription": "A registry type request_handler_factory entry.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "Description of request handler type.",
+                    "markdownDescription": "**Description**\n\nDescription of request handler type.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "requestHandlerType": {
+                    "description": "Type of request handler.",
+                    "markdownDescription": "**Request Handler Type**\n\nType of request handler.",
+                    "title": "Request Handler Type",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveRequestHandlerType_",
+            "type": "object"
         },
         "_AdaptiveRequestHandlerType_.propertyTypes": {
             "properties": {
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "Description of request handler type.",
+                    "markdownDescription": "**Description**\n\nDescription of request handler type.",
                     "title": "Description",
                     "type": "string"
                 },
                 "requestHandlerType": {
                     "description": "Type of request handler.",
+                    "markdownDescription": "**Request Handler Type**\n\nType of request handler.",
                     "title": "Request Handler Type",
                     "type": "string"
                 }
@@ -28,9 +50,31 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveRequestHandlerType_"
+    "additionalProperties": false,
+    "description": "A registry type request_handler_factory entry.",
+    "markdownDescription": "A registry type request_handler_factory entry.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "Description of request handler type.",
+            "markdownDescription": "**Description**\n\nDescription of request handler type.",
+            "title": "Description",
+            "type": "string"
+        },
+        "requestHandlerType": {
+            "description": "Type of request handler.",
+            "markdownDescription": "**Request Handler Type**\n\nType of request handler.",
+            "title": "Request Handler Type",
+            "type": "string"
         }
-    ]
+    },
+    "title": "_AdaptiveRequestHandlerType_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveRequestHandlerType_.json
+++ b/generated/schemas/afw/_AdaptiveRequestHandlerType_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveRequestHandlerType_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveRequestHandlerType_.propertyTypes"
                 }
@@ -28,7 +28,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveRequestHandlerType_"
         }

--- a/generated/schemas/afw/_AdaptiveRequestHandler_.json
+++ b/generated/schemas/afw/_AdaptiveRequestHandler_.json
@@ -1,10 +1,33 @@
 {
     "$defs": {
+        "_AdaptiveConf_.propertyTypes": {
+            "properties": {
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "The description of this configuration component.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "sourceLocation": {
+                    "description": "This is a contextual string added when this configuration object is processed.",
+                    "title": "Source Location",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "The title for this configuration component.",
+                    "title": "Title",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Configuration type.",
+                    "title": "Type",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "_AdaptiveConf_requestHandler.propertyTypes": {
             "properties": {
-                "_meta_": {
-                    "title": " Meta "
-                },
                 "requestHandlerType": {
                     "description": "Type of request handler that will process requests directed to this handler.",
                     "title": "Handler Type",
@@ -19,31 +42,28 @@
             "type": "object"
         },
         "_AdaptiveRequestHandler_": {
-            "additionalProperties": {
-                "description": "Runtime request handler information."
-            },
-            "anyOf": [
+            "additionalProperties": true,
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveRequestHandler_.propertyTypes"
                 },
                 {
                     "$ref": "#/$defs/_AdaptiveConf_requestHandler.propertyTypes"
+                },
+                {
+                    "$ref": "#/$defs/_AdaptiveConf_.propertyTypes"
                 }
             ],
             "description": "Runtime request handler information.",
             "type": "object"
         },
         "_AdaptiveRequestHandler_.propertyTypes": {
-            "properties": {
-                "_meta_": {
-                    "title": " Meta "
-                }
-            },
+            "properties": {},
             "type": "object"
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveRequestHandler_"
         }

--- a/generated/schemas/afw/_AdaptiveRequestHandler_.json
+++ b/generated/schemas/afw/_AdaptiveRequestHandler_.json
@@ -1,25 +1,30 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveRequestHandler_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveConf_.propertyTypes": {
             "properties": {
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "The description of this configuration component.",
+                    "markdownDescription": "**Description**\n\nThe description of this configuration component.",
                     "title": "Description",
                     "type": "string"
                 },
                 "sourceLocation": {
                     "description": "This is a contextual string added when this configuration object is processed.",
+                    "markdownDescription": "**Source Location**\n\nThis is a contextual string added when this configuration object is processed.",
                     "title": "Source Location",
                     "type": "string"
                 },
                 "title": {
                     "description": "The title for this configuration component.",
+                    "markdownDescription": "**Title**\n\nThe title for this configuration component.",
                     "title": "Title",
                     "type": "string"
                 },
                 "type": {
                     "description": "Configuration type.",
+                    "markdownDescription": "**Type**\n\nConfiguration type.",
                     "title": "Type",
                     "type": "string"
                 }
@@ -30,11 +35,13 @@
             "properties": {
                 "requestHandlerType": {
                     "description": "Type of request handler that will process requests directed to this handler.",
+                    "markdownDescription": "**Handler Type**\n\nType of request handler that will process requests directed to this handler.",
                     "title": "Handler Type",
                     "type": "string"
                 },
                 "uriPrefix": {
                     "description": "Prefix of URIs that will be directed to this request handler.",
+                    "markdownDescription": "**URI Prefix**\n\nPrefix of URIs that will be directed to this request handler.",
                     "title": "URI Prefix",
                     "type": "string"
                 }
@@ -43,19 +50,60 @@
         },
         "_AdaptiveRequestHandler_": {
             "additionalProperties": true,
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveRequestHandler_.propertyTypes"
-                },
-                {
-                    "$ref": "#/$defs/_AdaptiveConf_requestHandler.propertyTypes"
-                },
-                {
-                    "$ref": "#/$defs/_AdaptiveConf_.propertyTypes"
-                }
-            ],
             "description": "Runtime request handler information.",
-            "type": "object"
+            "markdownDescription": "Runtime request handler information.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "The description of this configuration component.",
+                    "markdownDescription": "**Description**\n\nThe description of this configuration component.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "requestHandlerType": {
+                    "description": "Type of request handler that will process requests directed to this handler.",
+                    "markdownDescription": "**Handler Type**\n\nType of request handler that will process requests directed to this handler.",
+                    "title": "Handler Type",
+                    "type": "string"
+                },
+                "sourceLocation": {
+                    "description": "This is a contextual string added when this configuration object is processed.",
+                    "markdownDescription": "**Source Location**\n\nThis is a contextual string added when this configuration object is processed.",
+                    "title": "Source Location",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "The title for this configuration component.",
+                    "markdownDescription": "**Title**\n\nThe title for this configuration component.",
+                    "title": "Title",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Configuration type.",
+                    "markdownDescription": "**Type**\n\nConfiguration type.",
+                    "title": "Type",
+                    "type": "string"
+                },
+                "uriPrefix": {
+                    "description": "Prefix of URIs that will be directed to this request handler.",
+                    "markdownDescription": "**URI Prefix**\n\nPrefix of URIs that will be directed to this request handler.",
+                    "title": "URI Prefix",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveRequestHandler_",
+            "type": "object",
+            "x-afw-inheritedObjectTypes": [
+                "_AdaptiveConf_requestHandler",
+                "_AdaptiveConf_"
+            ]
         },
         "_AdaptiveRequestHandler_.propertyTypes": {
             "properties": {},
@@ -63,9 +111,59 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveRequestHandler_"
+    "additionalProperties": true,
+    "description": "Runtime request handler information.",
+    "markdownDescription": "Runtime request handler information.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "The description of this configuration component.",
+            "markdownDescription": "**Description**\n\nThe description of this configuration component.",
+            "title": "Description",
+            "type": "string"
+        },
+        "requestHandlerType": {
+            "description": "Type of request handler that will process requests directed to this handler.",
+            "markdownDescription": "**Handler Type**\n\nType of request handler that will process requests directed to this handler.",
+            "title": "Handler Type",
+            "type": "string"
+        },
+        "sourceLocation": {
+            "description": "This is a contextual string added when this configuration object is processed.",
+            "markdownDescription": "**Source Location**\n\nThis is a contextual string added when this configuration object is processed.",
+            "title": "Source Location",
+            "type": "string"
+        },
+        "title": {
+            "description": "The title for this configuration component.",
+            "markdownDescription": "**Title**\n\nThe title for this configuration component.",
+            "title": "Title",
+            "type": "string"
+        },
+        "type": {
+            "description": "Configuration type.",
+            "markdownDescription": "**Type**\n\nConfiguration type.",
+            "title": "Type",
+            "type": "string"
+        },
+        "uriPrefix": {
+            "description": "Prefix of URIs that will be directed to this request handler.",
+            "markdownDescription": "**URI Prefix**\n\nPrefix of URIs that will be directed to this request handler.",
+            "title": "URI Prefix",
+            "type": "string"
         }
+    },
+    "title": "_AdaptiveRequestHandler_",
+    "type": "object",
+    "x-afw-inheritedObjectTypes": [
+        "_AdaptiveConf_requestHandler",
+        "_AdaptiveConf_"
     ]
 }

--- a/generated/schemas/afw/_AdaptiveRequestProperties_.json
+++ b/generated/schemas/afw/_AdaptiveRequestProperties_.json
@@ -5,7 +5,7 @@
                 "description": "Object type for adaptive request properties. This includes most of the environment variables that are supplied by the associated server.",
                 "type": "string"
             },
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveRequestProperties_.propertyTypes"
                 }
@@ -17,182 +17,227 @@
             "properties": {
                 "ACCEPT": {
                     "description": "A list of the media types the client can accept.",
+                    "title": "A list of the media types the client can accept",
                     "type": "string"
                 },
                 "AUTH_TYPE": {
                     "description": "The authentication method used to validate a user. This is blank if the request did not require authentication.",
+                    "title": "The authentication method used to validate a user",
                     "type": "string"
                 },
                 "CONTENT_LENGTH": {
                     "description": "The length of the data (in bytes) passed to the CGI program via standard input.",
+                    "title": "The length of the data (in bytes) passed to the CGI program via standard input",
                     "type": "string"
                 },
                 "CONTENT_TYPE": {
                     "description": "The media type of the request body, such as 'application/x-www-form-urlencoded'.",
+                    "title": "The media type of the request body",
                     "type": "string"
                 },
                 "DOCUMENT_ROOT": {
                     "description": "The directory from which static documents are served.",
+                    "title": "The directory from which static documents are served",
                     "type": "string"
                 },
                 "FCGI_ROLE": {
                     "description": "The role component sets the role the Web server expects the application to play. The currently-defined roles are:  RESPONDER, AUTHORIZER, FILTER.",
+                    "title": "Sets the role the Web server expects the application to play",
                     "type": "string"
                 },
                 "GATEWAY_INTERFACE": {
                     "description": "The revision of the Common Gateway Interface that the server uses.",
+                    "title": "The revision of the Common Gateway Interface that the server uses",
                     "type": "string"
                 },
                 "HTTPS": {
                     "description": "This variable can be used as a flag to indicate whether the connection is secure; its values vary by server (e.g., 'ON' or 'on' when secure and blank or 'OFF' when not).",
+                    "title": "This variable can be used as a flag to indicate whether the connection is secure",
                     "type": "string"
                 },
                 "HTTP_ACCEPT": {
                     "description": "A list of the media types the client can accept.",
+                    "title": "A list of the media types the client can accept",
                     "type": "string"
                 },
                 "HTTP_ACCEPT_CHARSET": {
                     "description": "A list of the character sets the client can accept.",
+                    "title": "A list of the character sets the client can accept",
                     "type": "string"
                 },
                 "HTTP_ACCEPT_ENCODING": {
                     "description": "A list of the encodings the client can accept.",
+                    "title": "A list of the encodings the client can accept",
                     "type": "string"
                 },
                 "HTTP_ACCEPT_LANGUAGE": {
                     "description": "A list of the languages the client can accept.",
+                    "title": "A list of the languages the client can accept",
                     "type": "string"
                 },
                 "HTTP_COOKIE": {
                     "description": "A name-value pair previously set by the server.",
+                    "title": "A name-value pair previously set by the server",
                     "type": "string"
                 },
                 "HTTP_FROM": {
                     "description": "The email address of the user making the request; most browsers do not pass this information, since it is considered an invasion of the user's privacy.",
+                    "title": "The email address of the user making the request",
                     "type": "string"
                 },
                 "HTTP_HOST": {
                     "description": "The hostname of the server from the requested URL (this corresponds to the HTTP 1.1 Host field).",
+                    "title": "The hostname of the server from the requested URL",
                     "type": "string"
                 },
                 "HTTP_REFERER": {
                     "description": "The URL of the document that directed the user to this CGI program (e.g., via a hyperlink or via a form).",
+                    "title": "The URL of the document that directed the user to this CGI program",
                     "type": "string"
                 },
                 "HTTP_USER_AGENT": {
                     "description": "The name and version of the client's browser.",
+                    "title": "The name and version of the client's browser",
                     "type": "string"
                 },
                 "PATH_INFO": {
                     "description": "Extra path information passed to a CGI program.",
+                    "title": "Extra path information passed to a CGI program",
                     "type": "string"
                 },
                 "PATH_TRANSLATED": {
                     "description": "The translated version of the path given by the variable PATH_INFO.",
+                    "title": "The translated version of the path given by the variable PATH_INFO",
                     "type": "string"
                 },
                 "QUERY_STRING": {
                     "description": "The query information from requested URL (i.e., the data following '?').",
+                    "title": "The query information from requested URL",
                     "type": "string"
                 },
                 "REMOTE_ADDR": {
                     "description": "The remote IP address of the client making the request; this could be the address of an HTTP proxy between the server and the user.",
+                    "title": "The remote IP address of the client making the request",
                     "type": "string"
                 },
                 "REMOTE_HOST": {
                     "description": "The remote hostname of the client making the request; this could also be the name of an HTTP proxy between the server and the user.",
+                    "title": "The remote hostname of the client making the request",
                     "type": "string"
                 },
                 "REMOTE_IDENT": {
                     "description": "The user making the request, as reported by their ident daemon. Only some Unix and IRC users are likely to have this running.",
+                    "title": "The user making the request, as reported by their ident daemon",
                     "type": "string"
                 },
                 "REMOTE_PORT": {
                     "description": "The port number used by the client.",
+                    "title": "The port number used by the client",
                     "type": "string"
                 },
                 "REMOTE_USER": {
                     "description": "The user's login, authenticated by the web server.",
+                    "title": "The user's login, authenticated by the web server",
                     "type": "string"
                 },
                 "REQUEST_METHOD": {
                     "description": "The HTTP request method used for this request.",
+                    "title": "The HTTP request method used for this request",
                     "type": "string"
                 },
                 "REQUEST_SCHEME": {
                     "description": "The scheme of the request (usually 'http' or 'https').",
+                    "title": "The scheme of the request",
                     "type": "string"
                 },
                 "REQUEST_URI": {
                     "description": "The URI for this request relative to DOCUMENT_ROOT.",
+                    "title": "The URI for this request relative to DOCUMENT_ROOT",
                     "type": "string"
                 },
                 "SCHEME": {
                     "description": "The scheme of the request (usually 'http' or 'https').",
+                    "title": "The scheme of the request",
                     "type": "string"
                 },
                 "SCRIPT_NAME": {
                     "description": "The URL path (e.g., /cgi/program.cgi) of the script being executed.",
+                    "title": "The URL path (e.g., /cgi/program.cgi) of the script being executed",
                     "type": "string"
                 },
                 "SERVER_ADDR": {
                     "description": "The IP address of the computer running the web server.",
+                    "title": "The IP address of the computer running the web server",
                     "type": "string"
                 },
                 "SERVER_ADMIN": {
                     "description": "The email address for your server's webmaster.",
+                    "title": "The email address for your server's webmaster",
                     "type": "string"
                 },
                 "SERVER_NAME": {
                     "description": "The server's hostname or IP address.",
+                    "title": "The server's hostname or IP address",
                     "type": "string"
                 },
                 "SERVER_PORT": {
                     "description": "The port number of the host on which the server is listening.",
+                    "title": "The port number of the host on which the server is listening",
                     "type": "string"
                 },
                 "SERVER_PROTOCOL": {
                     "description": "The name and revision of the request protocol, e.g., 'HTTP/1.1'.",
+                    "title": "The name and revision of the request protocol",
                     "type": "string"
                 },
                 "SERVER_SIGNATURE": {
                     "description": "The HTML string that may be embedded in the page to identify this host.\nFor example, <ADDRESS>/Apache/1.3.14 Server at www.zytrax.com Port 80</ADDRESS>",
+                    "title": "The HTML string that may be embedded in the page to identify this host",
                     "type": "string"
                 },
                 "SERVER_SOFTWARE": {
                     "description": "The name and version of the server software that is answering the client request.",
+                    "title": "The name and version of the server software that is answering the client request",
                     "type": "string"
                 },
                 "SSL_CLIENT_M_SERIAL": {
                     "description": "The SSL client certificate serial number.",
+                    "title": "SSL client certificate serial number",
                     "type": "string"
                 },
                 "SSL_CLIENT_M_VERSION": {
                     "description": "The SSL client certificate version.",
+                    "title": "The SSL client certificate version",
                     "type": "string"
                 },
                 "SSL_CLIENT_S_DN": {
                     "description": "The SSL client certificate subject DN field.",
+                    "title": "SSL client certificate subject DN",
                     "type": "string"
                 },
                 "SSL_CLIENT_S_DN_CN": {
                     "description": "The SSL client certificate subject component of the DN field.",
+                    "title": "SSL client certificate subject CN",
                     "type": "string"
                 },
                 "SSL_CLIENT_VERIFY": {
                     "description": "The SSL client certificate verification result. May be NONE, SUCCESS, GENEROUS or FAILED:reason.",
+                    "title": "SSL client certificate verification result",
                     "type": "string"
                 },
                 "SSL_CLIENT_V_END": {
                     "description": "Validity of client's certificate (end time).",
+                    "title": "Validity of client's certificate (end time)",
                     "type": "string"
                 },
                 "SSL_CLIENT_V_REMAIN": {
                     "description": "Number of days until client's certificate expires.",
+                    "title": "Number of days until client's certificate expires",
                     "type": "string"
                 },
                 "SSL_CLIENT_V_START": {
                     "description": "Validity of client's certificate (start time).",
+                    "title": "Validity of client's certificate (start time)",
                     "type": "string"
                 }
             },
@@ -200,7 +245,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveRequestProperties_"
         }

--- a/generated/schemas/afw/_AdaptiveRequestProperties_.json
+++ b/generated/schemas/afw/_AdaptiveRequestProperties_.json
@@ -1,242 +1,565 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveRequestProperties_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveRequestProperties_": {
             "additionalProperties": {
                 "description": "Object type for adaptive request properties. This includes most of the environment variables that are supplied by the associated server.",
+                "markdownDescription": "Object type for adaptive request properties. This includes most of the environment variables that are supplied by the associated server.",
                 "type": "string"
             },
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveRequestProperties_.propertyTypes"
-                }
-            ],
             "description": "Object type for adaptive request properties. This includes most of the environment variables that are supplied by the associated server.",
+            "markdownDescription": "Object type for adaptive request properties. This includes most of the environment variables that are supplied by the associated server.",
+            "properties": {
+                "ACCEPT": {
+                    "description": "A list of the media types the client can accept.",
+                    "markdownDescription": "**A list of the media types the client can accept**\n\nA list of the media types the client can accept.",
+                    "title": "A list of the media types the client can accept",
+                    "type": "string"
+                },
+                "AUTH_TYPE": {
+                    "description": "The authentication method used to validate a user. This is blank if the request did not require authentication.",
+                    "markdownDescription": "**The authentication method used to validate a user**\n\nThe authentication method used to validate a user. This is blank if the request did not require authentication.",
+                    "title": "The authentication method used to validate a user",
+                    "type": "string"
+                },
+                "CONTENT_LENGTH": {
+                    "description": "The length of the data (in bytes) passed to the CGI program via standard input.",
+                    "markdownDescription": "**The length of the data (in bytes) passed to the CGI program via standard input**\n\nThe length of the data (in bytes) passed to the CGI program via standard input.",
+                    "title": "The length of the data (in bytes) passed to the CGI program via standard input",
+                    "type": "string"
+                },
+                "CONTENT_TYPE": {
+                    "description": "The media type of the request body, such as 'application/x-www-form-urlencoded'.",
+                    "markdownDescription": "**The media type of the request body**\n\nThe media type of the request body, such as 'application/x-www-form-urlencoded'.",
+                    "title": "The media type of the request body",
+                    "type": "string"
+                },
+                "DOCUMENT_ROOT": {
+                    "description": "The directory from which static documents are served.",
+                    "markdownDescription": "**The directory from which static documents are served**\n\nThe directory from which static documents are served.",
+                    "title": "The directory from which static documents are served",
+                    "type": "string"
+                },
+                "FCGI_ROLE": {
+                    "description": "The role component sets the role the Web server expects the application to play. The currently-defined roles are:  RESPONDER, AUTHORIZER, FILTER.",
+                    "markdownDescription": "**Sets the role the Web server expects the application to play**\n\nThe role component sets the role the Web server expects the application to play. The currently-defined roles are:  RESPONDER, AUTHORIZER, FILTER.",
+                    "title": "Sets the role the Web server expects the application to play",
+                    "type": "string"
+                },
+                "GATEWAY_INTERFACE": {
+                    "description": "The revision of the Common Gateway Interface that the server uses.",
+                    "markdownDescription": "**The revision of the Common Gateway Interface that the server uses**\n\nThe revision of the Common Gateway Interface that the server uses.",
+                    "title": "The revision of the Common Gateway Interface that the server uses",
+                    "type": "string"
+                },
+                "HTTPS": {
+                    "description": "This variable can be used as a flag to indicate whether the connection is secure; its values vary by server (e.g., 'ON' or 'on' when secure and blank or 'OFF' when not).",
+                    "markdownDescription": "**This variable can be used as a flag to indicate whether the connection is secure**\n\nThis variable can be used as a flag to indicate whether the connection is secure; its values vary by server (e.g., 'ON' or 'on' when secure and blank or 'OFF' when not).",
+                    "title": "This variable can be used as a flag to indicate whether the connection is secure",
+                    "type": "string"
+                },
+                "HTTP_ACCEPT": {
+                    "description": "A list of the media types the client can accept.",
+                    "markdownDescription": "**A list of the media types the client can accept**\n\nA list of the media types the client can accept.",
+                    "title": "A list of the media types the client can accept",
+                    "type": "string"
+                },
+                "HTTP_ACCEPT_CHARSET": {
+                    "description": "A list of the character sets the client can accept.",
+                    "markdownDescription": "**A list of the character sets the client can accept**\n\nA list of the character sets the client can accept.",
+                    "title": "A list of the character sets the client can accept",
+                    "type": "string"
+                },
+                "HTTP_ACCEPT_ENCODING": {
+                    "description": "A list of the encodings the client can accept.",
+                    "markdownDescription": "**A list of the encodings the client can accept**\n\nA list of the encodings the client can accept.",
+                    "title": "A list of the encodings the client can accept",
+                    "type": "string"
+                },
+                "HTTP_ACCEPT_LANGUAGE": {
+                    "description": "A list of the languages the client can accept.",
+                    "markdownDescription": "**A list of the languages the client can accept**\n\nA list of the languages the client can accept.",
+                    "title": "A list of the languages the client can accept",
+                    "type": "string"
+                },
+                "HTTP_COOKIE": {
+                    "description": "A name-value pair previously set by the server.",
+                    "markdownDescription": "**A name-value pair previously set by the server**\n\nA name-value pair previously set by the server.",
+                    "title": "A name-value pair previously set by the server",
+                    "type": "string"
+                },
+                "HTTP_FROM": {
+                    "description": "The email address of the user making the request; most browsers do not pass this information, since it is considered an invasion of the user's privacy.",
+                    "markdownDescription": "**The email address of the user making the request**\n\nThe email address of the user making the request; most browsers do not pass this information, since it is considered an invasion of the user's privacy.",
+                    "title": "The email address of the user making the request",
+                    "type": "string"
+                },
+                "HTTP_HOST": {
+                    "description": "The hostname of the server from the requested URL (this corresponds to the HTTP 1.1 Host field).",
+                    "markdownDescription": "**The hostname of the server from the requested URL**\n\nThe hostname of the server from the requested URL (this corresponds to the HTTP 1.1 Host field).",
+                    "title": "The hostname of the server from the requested URL",
+                    "type": "string"
+                },
+                "HTTP_REFERER": {
+                    "description": "The URL of the document that directed the user to this CGI program (e.g., via a hyperlink or via a form).",
+                    "markdownDescription": "**The URL of the document that directed the user to this CGI program**\n\nThe URL of the document that directed the user to this CGI program (e.g., via a hyperlink or via a form).",
+                    "title": "The URL of the document that directed the user to this CGI program",
+                    "type": "string"
+                },
+                "HTTP_USER_AGENT": {
+                    "description": "The name and version of the client's browser.",
+                    "markdownDescription": "**The name and version of the client's browser**\n\nThe name and version of the client's browser.",
+                    "title": "The name and version of the client's browser",
+                    "type": "string"
+                },
+                "PATH_INFO": {
+                    "description": "Extra path information passed to a CGI program.",
+                    "markdownDescription": "**Extra path information passed to a CGI program**\n\nExtra path information passed to a CGI program.",
+                    "title": "Extra path information passed to a CGI program",
+                    "type": "string"
+                },
+                "PATH_TRANSLATED": {
+                    "description": "The translated version of the path given by the variable PATH_INFO.",
+                    "markdownDescription": "**The translated version of the path given by the variable PATH_INFO**\n\nThe translated version of the path given by the variable PATH_INFO.",
+                    "title": "The translated version of the path given by the variable PATH_INFO",
+                    "type": "string"
+                },
+                "QUERY_STRING": {
+                    "description": "The query information from requested URL (i.e., the data following '?').",
+                    "markdownDescription": "**The query information from requested URL**\n\nThe query information from requested URL (i.e., the data following '?').",
+                    "title": "The query information from requested URL",
+                    "type": "string"
+                },
+                "REMOTE_ADDR": {
+                    "description": "The remote IP address of the client making the request; this could be the address of an HTTP proxy between the server and the user.",
+                    "markdownDescription": "**The remote IP address of the client making the request**\n\nThe remote IP address of the client making the request; this could be the address of an HTTP proxy between the server and the user.",
+                    "title": "The remote IP address of the client making the request",
+                    "type": "string"
+                },
+                "REMOTE_HOST": {
+                    "description": "The remote hostname of the client making the request; this could also be the name of an HTTP proxy between the server and the user.",
+                    "markdownDescription": "**The remote hostname of the client making the request**\n\nThe remote hostname of the client making the request; this could also be the name of an HTTP proxy between the server and the user.",
+                    "title": "The remote hostname of the client making the request",
+                    "type": "string"
+                },
+                "REMOTE_IDENT": {
+                    "description": "The user making the request, as reported by their ident daemon. Only some Unix and IRC users are likely to have this running.",
+                    "markdownDescription": "**The user making the request, as reported by their ident daemon**\n\nThe user making the request, as reported by their ident daemon. Only some Unix and IRC users are likely to have this running.",
+                    "title": "The user making the request, as reported by their ident daemon",
+                    "type": "string"
+                },
+                "REMOTE_PORT": {
+                    "description": "The port number used by the client.",
+                    "markdownDescription": "**The port number used by the client**\n\nThe port number used by the client.",
+                    "title": "The port number used by the client",
+                    "type": "string"
+                },
+                "REMOTE_USER": {
+                    "description": "The user's login, authenticated by the web server.",
+                    "markdownDescription": "**The user's login, authenticated by the web server**\n\nThe user's login, authenticated by the web server.",
+                    "title": "The user's login, authenticated by the web server",
+                    "type": "string"
+                },
+                "REQUEST_METHOD": {
+                    "description": "The HTTP request method used for this request.",
+                    "markdownDescription": "**The HTTP request method used for this request**\n\nThe HTTP request method used for this request.",
+                    "title": "The HTTP request method used for this request",
+                    "type": "string"
+                },
+                "REQUEST_SCHEME": {
+                    "description": "The scheme of the request (usually 'http' or 'https').",
+                    "markdownDescription": "**The scheme of the request**\n\nThe scheme of the request (usually 'http' or 'https').",
+                    "title": "The scheme of the request",
+                    "type": "string"
+                },
+                "REQUEST_URI": {
+                    "description": "The URI for this request relative to DOCUMENT_ROOT.",
+                    "markdownDescription": "**The URI for this request relative to DOCUMENT_ROOT**\n\nThe URI for this request relative to DOCUMENT_ROOT.",
+                    "title": "The URI for this request relative to DOCUMENT_ROOT",
+                    "type": "string"
+                },
+                "SCHEME": {
+                    "description": "The scheme of the request (usually 'http' or 'https').",
+                    "markdownDescription": "**The scheme of the request**\n\nThe scheme of the request (usually 'http' or 'https').",
+                    "title": "The scheme of the request",
+                    "type": "string"
+                },
+                "SCRIPT_NAME": {
+                    "description": "The URL path (e.g., /cgi/program.cgi) of the script being executed.",
+                    "markdownDescription": "**The URL path (e.g., /cgi/program.cgi) of the script being executed**\n\nThe URL path (e.g., /cgi/program.cgi) of the script being executed.",
+                    "title": "The URL path (e.g., /cgi/program.cgi) of the script being executed",
+                    "type": "string"
+                },
+                "SERVER_ADDR": {
+                    "description": "The IP address of the computer running the web server.",
+                    "markdownDescription": "**The IP address of the computer running the web server**\n\nThe IP address of the computer running the web server.",
+                    "title": "The IP address of the computer running the web server",
+                    "type": "string"
+                },
+                "SERVER_ADMIN": {
+                    "description": "The email address for your server's webmaster.",
+                    "markdownDescription": "**The email address for your server's webmaster**\n\nThe email address for your server's webmaster.",
+                    "title": "The email address for your server's webmaster",
+                    "type": "string"
+                },
+                "SERVER_NAME": {
+                    "description": "The server's hostname or IP address.",
+                    "markdownDescription": "**The server's hostname or IP address**\n\nThe server's hostname or IP address.",
+                    "title": "The server's hostname or IP address",
+                    "type": "string"
+                },
+                "SERVER_PORT": {
+                    "description": "The port number of the host on which the server is listening.",
+                    "markdownDescription": "**The port number of the host on which the server is listening**\n\nThe port number of the host on which the server is listening.",
+                    "title": "The port number of the host on which the server is listening",
+                    "type": "string"
+                },
+                "SERVER_PROTOCOL": {
+                    "description": "The name and revision of the request protocol, e.g., 'HTTP/1.1'.",
+                    "markdownDescription": "**The name and revision of the request protocol**\n\nThe name and revision of the request protocol, e.g., 'HTTP/1.1'.",
+                    "title": "The name and revision of the request protocol",
+                    "type": "string"
+                },
+                "SERVER_SIGNATURE": {
+                    "description": "The HTML string that may be embedded in the page to identify this host.\nFor example, <ADDRESS>/Apache/1.3.14 Server at www.zytrax.com Port 80</ADDRESS>",
+                    "markdownDescription": "**The HTML string that may be embedded in the page to identify this host**\n\nThe HTML string that may be embedded in the page to identify this host.\nFor example, <ADDRESS>/Apache/1.3.14 Server at www.zytrax.com Port 80</ADDRESS>",
+                    "title": "The HTML string that may be embedded in the page to identify this host",
+                    "type": "string"
+                },
+                "SERVER_SOFTWARE": {
+                    "description": "The name and version of the server software that is answering the client request.",
+                    "markdownDescription": "**The name and version of the server software that is answering the client request**\n\nThe name and version of the server software that is answering the client request.",
+                    "title": "The name and version of the server software that is answering the client request",
+                    "type": "string"
+                },
+                "SSL_CLIENT_M_SERIAL": {
+                    "description": "The SSL client certificate serial number.",
+                    "markdownDescription": "**SSL client certificate serial number**\n\nThe SSL client certificate serial number.",
+                    "title": "SSL client certificate serial number",
+                    "type": "string"
+                },
+                "SSL_CLIENT_M_VERSION": {
+                    "description": "The SSL client certificate version.",
+                    "markdownDescription": "**The SSL client certificate version**\n\nThe SSL client certificate version.",
+                    "title": "The SSL client certificate version",
+                    "type": "string"
+                },
+                "SSL_CLIENT_S_DN": {
+                    "description": "The SSL client certificate subject DN field.",
+                    "markdownDescription": "**SSL client certificate subject DN**\n\nThe SSL client certificate subject DN field.",
+                    "title": "SSL client certificate subject DN",
+                    "type": "string"
+                },
+                "SSL_CLIENT_S_DN_CN": {
+                    "description": "The SSL client certificate subject component of the DN field.",
+                    "markdownDescription": "**SSL client certificate subject CN**\n\nThe SSL client certificate subject component of the DN field.",
+                    "title": "SSL client certificate subject CN",
+                    "type": "string"
+                },
+                "SSL_CLIENT_VERIFY": {
+                    "description": "The SSL client certificate verification result. May be NONE, SUCCESS, GENEROUS or FAILED:reason.",
+                    "markdownDescription": "**SSL client certificate verification result**\n\nThe SSL client certificate verification result. May be NONE, SUCCESS, GENEROUS or FAILED:reason.",
+                    "title": "SSL client certificate verification result",
+                    "type": "string"
+                },
+                "SSL_CLIENT_V_END": {
+                    "description": "Validity of client's certificate (end time).",
+                    "markdownDescription": "**Validity of client's certificate (end time)**\n\nValidity of client's certificate (end time).",
+                    "title": "Validity of client's certificate (end time)",
+                    "type": "string"
+                },
+                "SSL_CLIENT_V_REMAIN": {
+                    "description": "Number of days until client's certificate expires.",
+                    "markdownDescription": "**Number of days until client's certificate expires**\n\nNumber of days until client's certificate expires.",
+                    "title": "Number of days until client's certificate expires",
+                    "type": "string"
+                },
+                "SSL_CLIENT_V_START": {
+                    "description": "Validity of client's certificate (start time).",
+                    "markdownDescription": "**Validity of client's certificate (start time)**\n\nValidity of client's certificate (start time).",
+                    "title": "Validity of client's certificate (start time)",
+                    "type": "string"
+                },
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                }
+            },
+            "title": "_AdaptiveRequestProperties_",
             "type": "object"
         },
         "_AdaptiveRequestProperties_.propertyTypes": {
             "properties": {
                 "ACCEPT": {
                     "description": "A list of the media types the client can accept.",
+                    "markdownDescription": "**A list of the media types the client can accept**\n\nA list of the media types the client can accept.",
                     "title": "A list of the media types the client can accept",
                     "type": "string"
                 },
                 "AUTH_TYPE": {
                     "description": "The authentication method used to validate a user. This is blank if the request did not require authentication.",
+                    "markdownDescription": "**The authentication method used to validate a user**\n\nThe authentication method used to validate a user. This is blank if the request did not require authentication.",
                     "title": "The authentication method used to validate a user",
                     "type": "string"
                 },
                 "CONTENT_LENGTH": {
                     "description": "The length of the data (in bytes) passed to the CGI program via standard input.",
+                    "markdownDescription": "**The length of the data (in bytes) passed to the CGI program via standard input**\n\nThe length of the data (in bytes) passed to the CGI program via standard input.",
                     "title": "The length of the data (in bytes) passed to the CGI program via standard input",
                     "type": "string"
                 },
                 "CONTENT_TYPE": {
                     "description": "The media type of the request body, such as 'application/x-www-form-urlencoded'.",
+                    "markdownDescription": "**The media type of the request body**\n\nThe media type of the request body, such as 'application/x-www-form-urlencoded'.",
                     "title": "The media type of the request body",
                     "type": "string"
                 },
                 "DOCUMENT_ROOT": {
                     "description": "The directory from which static documents are served.",
+                    "markdownDescription": "**The directory from which static documents are served**\n\nThe directory from which static documents are served.",
                     "title": "The directory from which static documents are served",
                     "type": "string"
                 },
                 "FCGI_ROLE": {
                     "description": "The role component sets the role the Web server expects the application to play. The currently-defined roles are:  RESPONDER, AUTHORIZER, FILTER.",
+                    "markdownDescription": "**Sets the role the Web server expects the application to play**\n\nThe role component sets the role the Web server expects the application to play. The currently-defined roles are:  RESPONDER, AUTHORIZER, FILTER.",
                     "title": "Sets the role the Web server expects the application to play",
                     "type": "string"
                 },
                 "GATEWAY_INTERFACE": {
                     "description": "The revision of the Common Gateway Interface that the server uses.",
+                    "markdownDescription": "**The revision of the Common Gateway Interface that the server uses**\n\nThe revision of the Common Gateway Interface that the server uses.",
                     "title": "The revision of the Common Gateway Interface that the server uses",
                     "type": "string"
                 },
                 "HTTPS": {
                     "description": "This variable can be used as a flag to indicate whether the connection is secure; its values vary by server (e.g., 'ON' or 'on' when secure and blank or 'OFF' when not).",
+                    "markdownDescription": "**This variable can be used as a flag to indicate whether the connection is secure**\n\nThis variable can be used as a flag to indicate whether the connection is secure; its values vary by server (e.g., 'ON' or 'on' when secure and blank or 'OFF' when not).",
                     "title": "This variable can be used as a flag to indicate whether the connection is secure",
                     "type": "string"
                 },
                 "HTTP_ACCEPT": {
                     "description": "A list of the media types the client can accept.",
+                    "markdownDescription": "**A list of the media types the client can accept**\n\nA list of the media types the client can accept.",
                     "title": "A list of the media types the client can accept",
                     "type": "string"
                 },
                 "HTTP_ACCEPT_CHARSET": {
                     "description": "A list of the character sets the client can accept.",
+                    "markdownDescription": "**A list of the character sets the client can accept**\n\nA list of the character sets the client can accept.",
                     "title": "A list of the character sets the client can accept",
                     "type": "string"
                 },
                 "HTTP_ACCEPT_ENCODING": {
                     "description": "A list of the encodings the client can accept.",
+                    "markdownDescription": "**A list of the encodings the client can accept**\n\nA list of the encodings the client can accept.",
                     "title": "A list of the encodings the client can accept",
                     "type": "string"
                 },
                 "HTTP_ACCEPT_LANGUAGE": {
                     "description": "A list of the languages the client can accept.",
+                    "markdownDescription": "**A list of the languages the client can accept**\n\nA list of the languages the client can accept.",
                     "title": "A list of the languages the client can accept",
                     "type": "string"
                 },
                 "HTTP_COOKIE": {
                     "description": "A name-value pair previously set by the server.",
+                    "markdownDescription": "**A name-value pair previously set by the server**\n\nA name-value pair previously set by the server.",
                     "title": "A name-value pair previously set by the server",
                     "type": "string"
                 },
                 "HTTP_FROM": {
                     "description": "The email address of the user making the request; most browsers do not pass this information, since it is considered an invasion of the user's privacy.",
+                    "markdownDescription": "**The email address of the user making the request**\n\nThe email address of the user making the request; most browsers do not pass this information, since it is considered an invasion of the user's privacy.",
                     "title": "The email address of the user making the request",
                     "type": "string"
                 },
                 "HTTP_HOST": {
                     "description": "The hostname of the server from the requested URL (this corresponds to the HTTP 1.1 Host field).",
+                    "markdownDescription": "**The hostname of the server from the requested URL**\n\nThe hostname of the server from the requested URL (this corresponds to the HTTP 1.1 Host field).",
                     "title": "The hostname of the server from the requested URL",
                     "type": "string"
                 },
                 "HTTP_REFERER": {
                     "description": "The URL of the document that directed the user to this CGI program (e.g., via a hyperlink or via a form).",
+                    "markdownDescription": "**The URL of the document that directed the user to this CGI program**\n\nThe URL of the document that directed the user to this CGI program (e.g., via a hyperlink or via a form).",
                     "title": "The URL of the document that directed the user to this CGI program",
                     "type": "string"
                 },
                 "HTTP_USER_AGENT": {
                     "description": "The name and version of the client's browser.",
+                    "markdownDescription": "**The name and version of the client's browser**\n\nThe name and version of the client's browser.",
                     "title": "The name and version of the client's browser",
                     "type": "string"
                 },
                 "PATH_INFO": {
                     "description": "Extra path information passed to a CGI program.",
+                    "markdownDescription": "**Extra path information passed to a CGI program**\n\nExtra path information passed to a CGI program.",
                     "title": "Extra path information passed to a CGI program",
                     "type": "string"
                 },
                 "PATH_TRANSLATED": {
                     "description": "The translated version of the path given by the variable PATH_INFO.",
+                    "markdownDescription": "**The translated version of the path given by the variable PATH_INFO**\n\nThe translated version of the path given by the variable PATH_INFO.",
                     "title": "The translated version of the path given by the variable PATH_INFO",
                     "type": "string"
                 },
                 "QUERY_STRING": {
                     "description": "The query information from requested URL (i.e., the data following '?').",
+                    "markdownDescription": "**The query information from requested URL**\n\nThe query information from requested URL (i.e., the data following '?').",
                     "title": "The query information from requested URL",
                     "type": "string"
                 },
                 "REMOTE_ADDR": {
                     "description": "The remote IP address of the client making the request; this could be the address of an HTTP proxy between the server and the user.",
+                    "markdownDescription": "**The remote IP address of the client making the request**\n\nThe remote IP address of the client making the request; this could be the address of an HTTP proxy between the server and the user.",
                     "title": "The remote IP address of the client making the request",
                     "type": "string"
                 },
                 "REMOTE_HOST": {
                     "description": "The remote hostname of the client making the request; this could also be the name of an HTTP proxy between the server and the user.",
+                    "markdownDescription": "**The remote hostname of the client making the request**\n\nThe remote hostname of the client making the request; this could also be the name of an HTTP proxy between the server and the user.",
                     "title": "The remote hostname of the client making the request",
                     "type": "string"
                 },
                 "REMOTE_IDENT": {
                     "description": "The user making the request, as reported by their ident daemon. Only some Unix and IRC users are likely to have this running.",
+                    "markdownDescription": "**The user making the request, as reported by their ident daemon**\n\nThe user making the request, as reported by their ident daemon. Only some Unix and IRC users are likely to have this running.",
                     "title": "The user making the request, as reported by their ident daemon",
                     "type": "string"
                 },
                 "REMOTE_PORT": {
                     "description": "The port number used by the client.",
+                    "markdownDescription": "**The port number used by the client**\n\nThe port number used by the client.",
                     "title": "The port number used by the client",
                     "type": "string"
                 },
                 "REMOTE_USER": {
                     "description": "The user's login, authenticated by the web server.",
+                    "markdownDescription": "**The user's login, authenticated by the web server**\n\nThe user's login, authenticated by the web server.",
                     "title": "The user's login, authenticated by the web server",
                     "type": "string"
                 },
                 "REQUEST_METHOD": {
                     "description": "The HTTP request method used for this request.",
+                    "markdownDescription": "**The HTTP request method used for this request**\n\nThe HTTP request method used for this request.",
                     "title": "The HTTP request method used for this request",
                     "type": "string"
                 },
                 "REQUEST_SCHEME": {
                     "description": "The scheme of the request (usually 'http' or 'https').",
+                    "markdownDescription": "**The scheme of the request**\n\nThe scheme of the request (usually 'http' or 'https').",
                     "title": "The scheme of the request",
                     "type": "string"
                 },
                 "REQUEST_URI": {
                     "description": "The URI for this request relative to DOCUMENT_ROOT.",
+                    "markdownDescription": "**The URI for this request relative to DOCUMENT_ROOT**\n\nThe URI for this request relative to DOCUMENT_ROOT.",
                     "title": "The URI for this request relative to DOCUMENT_ROOT",
                     "type": "string"
                 },
                 "SCHEME": {
                     "description": "The scheme of the request (usually 'http' or 'https').",
+                    "markdownDescription": "**The scheme of the request**\n\nThe scheme of the request (usually 'http' or 'https').",
                     "title": "The scheme of the request",
                     "type": "string"
                 },
                 "SCRIPT_NAME": {
                     "description": "The URL path (e.g., /cgi/program.cgi) of the script being executed.",
+                    "markdownDescription": "**The URL path (e.g., /cgi/program.cgi) of the script being executed**\n\nThe URL path (e.g., /cgi/program.cgi) of the script being executed.",
                     "title": "The URL path (e.g., /cgi/program.cgi) of the script being executed",
                     "type": "string"
                 },
                 "SERVER_ADDR": {
                     "description": "The IP address of the computer running the web server.",
+                    "markdownDescription": "**The IP address of the computer running the web server**\n\nThe IP address of the computer running the web server.",
                     "title": "The IP address of the computer running the web server",
                     "type": "string"
                 },
                 "SERVER_ADMIN": {
                     "description": "The email address for your server's webmaster.",
+                    "markdownDescription": "**The email address for your server's webmaster**\n\nThe email address for your server's webmaster.",
                     "title": "The email address for your server's webmaster",
                     "type": "string"
                 },
                 "SERVER_NAME": {
                     "description": "The server's hostname or IP address.",
+                    "markdownDescription": "**The server's hostname or IP address**\n\nThe server's hostname or IP address.",
                     "title": "The server's hostname or IP address",
                     "type": "string"
                 },
                 "SERVER_PORT": {
                     "description": "The port number of the host on which the server is listening.",
+                    "markdownDescription": "**The port number of the host on which the server is listening**\n\nThe port number of the host on which the server is listening.",
                     "title": "The port number of the host on which the server is listening",
                     "type": "string"
                 },
                 "SERVER_PROTOCOL": {
                     "description": "The name and revision of the request protocol, e.g., 'HTTP/1.1'.",
+                    "markdownDescription": "**The name and revision of the request protocol**\n\nThe name and revision of the request protocol, e.g., 'HTTP/1.1'.",
                     "title": "The name and revision of the request protocol",
                     "type": "string"
                 },
                 "SERVER_SIGNATURE": {
                     "description": "The HTML string that may be embedded in the page to identify this host.\nFor example, <ADDRESS>/Apache/1.3.14 Server at www.zytrax.com Port 80</ADDRESS>",
+                    "markdownDescription": "**The HTML string that may be embedded in the page to identify this host**\n\nThe HTML string that may be embedded in the page to identify this host.\nFor example, <ADDRESS>/Apache/1.3.14 Server at www.zytrax.com Port 80</ADDRESS>",
                     "title": "The HTML string that may be embedded in the page to identify this host",
                     "type": "string"
                 },
                 "SERVER_SOFTWARE": {
                     "description": "The name and version of the server software that is answering the client request.",
+                    "markdownDescription": "**The name and version of the server software that is answering the client request**\n\nThe name and version of the server software that is answering the client request.",
                     "title": "The name and version of the server software that is answering the client request",
                     "type": "string"
                 },
                 "SSL_CLIENT_M_SERIAL": {
                     "description": "The SSL client certificate serial number.",
+                    "markdownDescription": "**SSL client certificate serial number**\n\nThe SSL client certificate serial number.",
                     "title": "SSL client certificate serial number",
                     "type": "string"
                 },
                 "SSL_CLIENT_M_VERSION": {
                     "description": "The SSL client certificate version.",
+                    "markdownDescription": "**The SSL client certificate version**\n\nThe SSL client certificate version.",
                     "title": "The SSL client certificate version",
                     "type": "string"
                 },
                 "SSL_CLIENT_S_DN": {
                     "description": "The SSL client certificate subject DN field.",
+                    "markdownDescription": "**SSL client certificate subject DN**\n\nThe SSL client certificate subject DN field.",
                     "title": "SSL client certificate subject DN",
                     "type": "string"
                 },
                 "SSL_CLIENT_S_DN_CN": {
                     "description": "The SSL client certificate subject component of the DN field.",
+                    "markdownDescription": "**SSL client certificate subject CN**\n\nThe SSL client certificate subject component of the DN field.",
                     "title": "SSL client certificate subject CN",
                     "type": "string"
                 },
                 "SSL_CLIENT_VERIFY": {
                     "description": "The SSL client certificate verification result. May be NONE, SUCCESS, GENEROUS or FAILED:reason.",
+                    "markdownDescription": "**SSL client certificate verification result**\n\nThe SSL client certificate verification result. May be NONE, SUCCESS, GENEROUS or FAILED:reason.",
                     "title": "SSL client certificate verification result",
                     "type": "string"
                 },
                 "SSL_CLIENT_V_END": {
                     "description": "Validity of client's certificate (end time).",
+                    "markdownDescription": "**Validity of client's certificate (end time)**\n\nValidity of client's certificate (end time).",
                     "title": "Validity of client's certificate (end time)",
                     "type": "string"
                 },
                 "SSL_CLIENT_V_REMAIN": {
                     "description": "Number of days until client's certificate expires.",
+                    "markdownDescription": "**Number of days until client's certificate expires**\n\nNumber of days until client's certificate expires.",
                     "title": "Number of days until client's certificate expires",
                     "type": "string"
                 },
                 "SSL_CLIENT_V_START": {
                     "description": "Validity of client's certificate (start time).",
+                    "markdownDescription": "**Validity of client's certificate (start time)**\n\nValidity of client's certificate (start time).",
                     "title": "Validity of client's certificate (start time)",
                     "type": "string"
                 }
@@ -245,9 +568,292 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveRequestProperties_"
+    "additionalProperties": {
+        "description": "Object type for adaptive request properties. This includes most of the environment variables that are supplied by the associated server.",
+        "markdownDescription": "Object type for adaptive request properties. This includes most of the environment variables that are supplied by the associated server.",
+        "type": "string"
+    },
+    "description": "Object type for adaptive request properties. This includes most of the environment variables that are supplied by the associated server.",
+    "markdownDescription": "Object type for adaptive request properties. This includes most of the environment variables that are supplied by the associated server.",
+    "properties": {
+        "ACCEPT": {
+            "description": "A list of the media types the client can accept.",
+            "markdownDescription": "**A list of the media types the client can accept**\n\nA list of the media types the client can accept.",
+            "title": "A list of the media types the client can accept",
+            "type": "string"
+        },
+        "AUTH_TYPE": {
+            "description": "The authentication method used to validate a user. This is blank if the request did not require authentication.",
+            "markdownDescription": "**The authentication method used to validate a user**\n\nThe authentication method used to validate a user. This is blank if the request did not require authentication.",
+            "title": "The authentication method used to validate a user",
+            "type": "string"
+        },
+        "CONTENT_LENGTH": {
+            "description": "The length of the data (in bytes) passed to the CGI program via standard input.",
+            "markdownDescription": "**The length of the data (in bytes) passed to the CGI program via standard input**\n\nThe length of the data (in bytes) passed to the CGI program via standard input.",
+            "title": "The length of the data (in bytes) passed to the CGI program via standard input",
+            "type": "string"
+        },
+        "CONTENT_TYPE": {
+            "description": "The media type of the request body, such as 'application/x-www-form-urlencoded'.",
+            "markdownDescription": "**The media type of the request body**\n\nThe media type of the request body, such as 'application/x-www-form-urlencoded'.",
+            "title": "The media type of the request body",
+            "type": "string"
+        },
+        "DOCUMENT_ROOT": {
+            "description": "The directory from which static documents are served.",
+            "markdownDescription": "**The directory from which static documents are served**\n\nThe directory from which static documents are served.",
+            "title": "The directory from which static documents are served",
+            "type": "string"
+        },
+        "FCGI_ROLE": {
+            "description": "The role component sets the role the Web server expects the application to play. The currently-defined roles are:  RESPONDER, AUTHORIZER, FILTER.",
+            "markdownDescription": "**Sets the role the Web server expects the application to play**\n\nThe role component sets the role the Web server expects the application to play. The currently-defined roles are:  RESPONDER, AUTHORIZER, FILTER.",
+            "title": "Sets the role the Web server expects the application to play",
+            "type": "string"
+        },
+        "GATEWAY_INTERFACE": {
+            "description": "The revision of the Common Gateway Interface that the server uses.",
+            "markdownDescription": "**The revision of the Common Gateway Interface that the server uses**\n\nThe revision of the Common Gateway Interface that the server uses.",
+            "title": "The revision of the Common Gateway Interface that the server uses",
+            "type": "string"
+        },
+        "HTTPS": {
+            "description": "This variable can be used as a flag to indicate whether the connection is secure; its values vary by server (e.g., 'ON' or 'on' when secure and blank or 'OFF' when not).",
+            "markdownDescription": "**This variable can be used as a flag to indicate whether the connection is secure**\n\nThis variable can be used as a flag to indicate whether the connection is secure; its values vary by server (e.g., 'ON' or 'on' when secure and blank or 'OFF' when not).",
+            "title": "This variable can be used as a flag to indicate whether the connection is secure",
+            "type": "string"
+        },
+        "HTTP_ACCEPT": {
+            "description": "A list of the media types the client can accept.",
+            "markdownDescription": "**A list of the media types the client can accept**\n\nA list of the media types the client can accept.",
+            "title": "A list of the media types the client can accept",
+            "type": "string"
+        },
+        "HTTP_ACCEPT_CHARSET": {
+            "description": "A list of the character sets the client can accept.",
+            "markdownDescription": "**A list of the character sets the client can accept**\n\nA list of the character sets the client can accept.",
+            "title": "A list of the character sets the client can accept",
+            "type": "string"
+        },
+        "HTTP_ACCEPT_ENCODING": {
+            "description": "A list of the encodings the client can accept.",
+            "markdownDescription": "**A list of the encodings the client can accept**\n\nA list of the encodings the client can accept.",
+            "title": "A list of the encodings the client can accept",
+            "type": "string"
+        },
+        "HTTP_ACCEPT_LANGUAGE": {
+            "description": "A list of the languages the client can accept.",
+            "markdownDescription": "**A list of the languages the client can accept**\n\nA list of the languages the client can accept.",
+            "title": "A list of the languages the client can accept",
+            "type": "string"
+        },
+        "HTTP_COOKIE": {
+            "description": "A name-value pair previously set by the server.",
+            "markdownDescription": "**A name-value pair previously set by the server**\n\nA name-value pair previously set by the server.",
+            "title": "A name-value pair previously set by the server",
+            "type": "string"
+        },
+        "HTTP_FROM": {
+            "description": "The email address of the user making the request; most browsers do not pass this information, since it is considered an invasion of the user's privacy.",
+            "markdownDescription": "**The email address of the user making the request**\n\nThe email address of the user making the request; most browsers do not pass this information, since it is considered an invasion of the user's privacy.",
+            "title": "The email address of the user making the request",
+            "type": "string"
+        },
+        "HTTP_HOST": {
+            "description": "The hostname of the server from the requested URL (this corresponds to the HTTP 1.1 Host field).",
+            "markdownDescription": "**The hostname of the server from the requested URL**\n\nThe hostname of the server from the requested URL (this corresponds to the HTTP 1.1 Host field).",
+            "title": "The hostname of the server from the requested URL",
+            "type": "string"
+        },
+        "HTTP_REFERER": {
+            "description": "The URL of the document that directed the user to this CGI program (e.g., via a hyperlink or via a form).",
+            "markdownDescription": "**The URL of the document that directed the user to this CGI program**\n\nThe URL of the document that directed the user to this CGI program (e.g., via a hyperlink or via a form).",
+            "title": "The URL of the document that directed the user to this CGI program",
+            "type": "string"
+        },
+        "HTTP_USER_AGENT": {
+            "description": "The name and version of the client's browser.",
+            "markdownDescription": "**The name and version of the client's browser**\n\nThe name and version of the client's browser.",
+            "title": "The name and version of the client's browser",
+            "type": "string"
+        },
+        "PATH_INFO": {
+            "description": "Extra path information passed to a CGI program.",
+            "markdownDescription": "**Extra path information passed to a CGI program**\n\nExtra path information passed to a CGI program.",
+            "title": "Extra path information passed to a CGI program",
+            "type": "string"
+        },
+        "PATH_TRANSLATED": {
+            "description": "The translated version of the path given by the variable PATH_INFO.",
+            "markdownDescription": "**The translated version of the path given by the variable PATH_INFO**\n\nThe translated version of the path given by the variable PATH_INFO.",
+            "title": "The translated version of the path given by the variable PATH_INFO",
+            "type": "string"
+        },
+        "QUERY_STRING": {
+            "description": "The query information from requested URL (i.e., the data following '?').",
+            "markdownDescription": "**The query information from requested URL**\n\nThe query information from requested URL (i.e., the data following '?').",
+            "title": "The query information from requested URL",
+            "type": "string"
+        },
+        "REMOTE_ADDR": {
+            "description": "The remote IP address of the client making the request; this could be the address of an HTTP proxy between the server and the user.",
+            "markdownDescription": "**The remote IP address of the client making the request**\n\nThe remote IP address of the client making the request; this could be the address of an HTTP proxy between the server and the user.",
+            "title": "The remote IP address of the client making the request",
+            "type": "string"
+        },
+        "REMOTE_HOST": {
+            "description": "The remote hostname of the client making the request; this could also be the name of an HTTP proxy between the server and the user.",
+            "markdownDescription": "**The remote hostname of the client making the request**\n\nThe remote hostname of the client making the request; this could also be the name of an HTTP proxy between the server and the user.",
+            "title": "The remote hostname of the client making the request",
+            "type": "string"
+        },
+        "REMOTE_IDENT": {
+            "description": "The user making the request, as reported by their ident daemon. Only some Unix and IRC users are likely to have this running.",
+            "markdownDescription": "**The user making the request, as reported by their ident daemon**\n\nThe user making the request, as reported by their ident daemon. Only some Unix and IRC users are likely to have this running.",
+            "title": "The user making the request, as reported by their ident daemon",
+            "type": "string"
+        },
+        "REMOTE_PORT": {
+            "description": "The port number used by the client.",
+            "markdownDescription": "**The port number used by the client**\n\nThe port number used by the client.",
+            "title": "The port number used by the client",
+            "type": "string"
+        },
+        "REMOTE_USER": {
+            "description": "The user's login, authenticated by the web server.",
+            "markdownDescription": "**The user's login, authenticated by the web server**\n\nThe user's login, authenticated by the web server.",
+            "title": "The user's login, authenticated by the web server",
+            "type": "string"
+        },
+        "REQUEST_METHOD": {
+            "description": "The HTTP request method used for this request.",
+            "markdownDescription": "**The HTTP request method used for this request**\n\nThe HTTP request method used for this request.",
+            "title": "The HTTP request method used for this request",
+            "type": "string"
+        },
+        "REQUEST_SCHEME": {
+            "description": "The scheme of the request (usually 'http' or 'https').",
+            "markdownDescription": "**The scheme of the request**\n\nThe scheme of the request (usually 'http' or 'https').",
+            "title": "The scheme of the request",
+            "type": "string"
+        },
+        "REQUEST_URI": {
+            "description": "The URI for this request relative to DOCUMENT_ROOT.",
+            "markdownDescription": "**The URI for this request relative to DOCUMENT_ROOT**\n\nThe URI for this request relative to DOCUMENT_ROOT.",
+            "title": "The URI for this request relative to DOCUMENT_ROOT",
+            "type": "string"
+        },
+        "SCHEME": {
+            "description": "The scheme of the request (usually 'http' or 'https').",
+            "markdownDescription": "**The scheme of the request**\n\nThe scheme of the request (usually 'http' or 'https').",
+            "title": "The scheme of the request",
+            "type": "string"
+        },
+        "SCRIPT_NAME": {
+            "description": "The URL path (e.g., /cgi/program.cgi) of the script being executed.",
+            "markdownDescription": "**The URL path (e.g., /cgi/program.cgi) of the script being executed**\n\nThe URL path (e.g., /cgi/program.cgi) of the script being executed.",
+            "title": "The URL path (e.g., /cgi/program.cgi) of the script being executed",
+            "type": "string"
+        },
+        "SERVER_ADDR": {
+            "description": "The IP address of the computer running the web server.",
+            "markdownDescription": "**The IP address of the computer running the web server**\n\nThe IP address of the computer running the web server.",
+            "title": "The IP address of the computer running the web server",
+            "type": "string"
+        },
+        "SERVER_ADMIN": {
+            "description": "The email address for your server's webmaster.",
+            "markdownDescription": "**The email address for your server's webmaster**\n\nThe email address for your server's webmaster.",
+            "title": "The email address for your server's webmaster",
+            "type": "string"
+        },
+        "SERVER_NAME": {
+            "description": "The server's hostname or IP address.",
+            "markdownDescription": "**The server's hostname or IP address**\n\nThe server's hostname or IP address.",
+            "title": "The server's hostname or IP address",
+            "type": "string"
+        },
+        "SERVER_PORT": {
+            "description": "The port number of the host on which the server is listening.",
+            "markdownDescription": "**The port number of the host on which the server is listening**\n\nThe port number of the host on which the server is listening.",
+            "title": "The port number of the host on which the server is listening",
+            "type": "string"
+        },
+        "SERVER_PROTOCOL": {
+            "description": "The name and revision of the request protocol, e.g., 'HTTP/1.1'.",
+            "markdownDescription": "**The name and revision of the request protocol**\n\nThe name and revision of the request protocol, e.g., 'HTTP/1.1'.",
+            "title": "The name and revision of the request protocol",
+            "type": "string"
+        },
+        "SERVER_SIGNATURE": {
+            "description": "The HTML string that may be embedded in the page to identify this host.\nFor example, <ADDRESS>/Apache/1.3.14 Server at www.zytrax.com Port 80</ADDRESS>",
+            "markdownDescription": "**The HTML string that may be embedded in the page to identify this host**\n\nThe HTML string that may be embedded in the page to identify this host.\nFor example, <ADDRESS>/Apache/1.3.14 Server at www.zytrax.com Port 80</ADDRESS>",
+            "title": "The HTML string that may be embedded in the page to identify this host",
+            "type": "string"
+        },
+        "SERVER_SOFTWARE": {
+            "description": "The name and version of the server software that is answering the client request.",
+            "markdownDescription": "**The name and version of the server software that is answering the client request**\n\nThe name and version of the server software that is answering the client request.",
+            "title": "The name and version of the server software that is answering the client request",
+            "type": "string"
+        },
+        "SSL_CLIENT_M_SERIAL": {
+            "description": "The SSL client certificate serial number.",
+            "markdownDescription": "**SSL client certificate serial number**\n\nThe SSL client certificate serial number.",
+            "title": "SSL client certificate serial number",
+            "type": "string"
+        },
+        "SSL_CLIENT_M_VERSION": {
+            "description": "The SSL client certificate version.",
+            "markdownDescription": "**The SSL client certificate version**\n\nThe SSL client certificate version.",
+            "title": "The SSL client certificate version",
+            "type": "string"
+        },
+        "SSL_CLIENT_S_DN": {
+            "description": "The SSL client certificate subject DN field.",
+            "markdownDescription": "**SSL client certificate subject DN**\n\nThe SSL client certificate subject DN field.",
+            "title": "SSL client certificate subject DN",
+            "type": "string"
+        },
+        "SSL_CLIENT_S_DN_CN": {
+            "description": "The SSL client certificate subject component of the DN field.",
+            "markdownDescription": "**SSL client certificate subject CN**\n\nThe SSL client certificate subject component of the DN field.",
+            "title": "SSL client certificate subject CN",
+            "type": "string"
+        },
+        "SSL_CLIENT_VERIFY": {
+            "description": "The SSL client certificate verification result. May be NONE, SUCCESS, GENEROUS or FAILED:reason.",
+            "markdownDescription": "**SSL client certificate verification result**\n\nThe SSL client certificate verification result. May be NONE, SUCCESS, GENEROUS or FAILED:reason.",
+            "title": "SSL client certificate verification result",
+            "type": "string"
+        },
+        "SSL_CLIENT_V_END": {
+            "description": "Validity of client's certificate (end time).",
+            "markdownDescription": "**Validity of client's certificate (end time)**\n\nValidity of client's certificate (end time).",
+            "title": "Validity of client's certificate (end time)",
+            "type": "string"
+        },
+        "SSL_CLIENT_V_REMAIN": {
+            "description": "Number of days until client's certificate expires.",
+            "markdownDescription": "**Number of days until client's certificate expires**\n\nNumber of days until client's certificate expires.",
+            "title": "Number of days until client's certificate expires",
+            "type": "string"
+        },
+        "SSL_CLIENT_V_START": {
+            "description": "Validity of client's certificate (start time).",
+            "markdownDescription": "**Validity of client's certificate (start time)**\n\nValidity of client's certificate (start time).",
+            "title": "Validity of client's certificate (start time)",
+            "type": "string"
+        },
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
         }
-    ]
+    },
+    "title": "_AdaptiveRequestProperties_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveResponse_.json
+++ b/generated/schemas/afw/_AdaptiveResponse_.json
@@ -1,13 +1,146 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveResponse_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveError_": {
             "additionalProperties": true,
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveError_.propertyTypes"
-                }
-            ],
             "description": "This is error detail if status is error. This property will not exist for intermediate response objects.",
+            "markdownDescription": "This is error detail if status is error. This property will not exist for intermediate response objects.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "actionNumber": {
+                    "description": "If the request has multiple actions, this is the number, starting with 1, of the action that caused the error.",
+                    "markdownDescription": "**Action Index**\n\nIf the request has multiple actions, this is the number, starting with 1, of the action that caused the error.",
+                    "title": "Action Index",
+                    "type": "integer"
+                },
+                "backtrace": {
+                    "contentMediaType": "text/plain",
+                    "description": "The backtrace from where the error occurred.",
+                    "markdownDescription": "**Backtrace**\n\nThe backtrace from where the error occurred.",
+                    "title": "Backtrace",
+                    "type": "string"
+                },
+                "backtraceEvaluation": {
+                    "contentMediaType": "text/plain",
+                    "description": "The evaluation backtrace from where the error occurred.",
+                    "markdownDescription": "**Backtrace Expression**\n\nThe evaluation backtrace from where the error occurred.",
+                    "title": "Backtrace Expression",
+                    "type": "string"
+                },
+                "column": {
+                    "description": "The column in line of the error. This is only available if source contains line breaks.",
+                    "markdownDescription": "**Column**\n\nThe column in line of the error. This is only available if source contains line breaks.",
+                    "title": "Column",
+                    "type": "integer"
+                },
+                "data": {
+                    "description": "Optional data supplied on the throw.",
+                    "markdownDescription": "**Additional**\n\nOptional data supplied on the throw.",
+                    "title": "Additional"
+                },
+                "errorCode": {
+                    "description": "The numeric error code.",
+                    "markdownDescription": "**Error Code**\n\nThe numeric error code.",
+                    "title": "Error Code",
+                    "type": "integer"
+                },
+                "errorSource": {
+                    "description": "The internal source filename:line where the error occurred.",
+                    "markdownDescription": "**Error Source**\n\nThe internal source filename:line where the error occurred.",
+                    "title": "Error Source",
+                    "type": "string"
+                },
+                "id": {
+                    "description": "The mnemonic for the numeric error code (errorCode).",
+                    "markdownDescription": "**Error Code Id**\n\nThe mnemonic for the numeric error code (errorCode).",
+                    "title": "Error Code Id",
+                    "type": "string"
+                },
+                "line": {
+                    "description": "The line number in the adaptive value source of the error. This is only available if source contains line breaks.",
+                    "markdownDescription": "**Line**\n\nThe line number in the adaptive value source of the error. This is only available if source contains line breaks.",
+                    "title": "Line",
+                    "type": "integer"
+                },
+                "message": {
+                    "description": "The error message.",
+                    "markdownDescription": "**Message**\n\nThe error message.",
+                    "title": "Message",
+                    "type": "string"
+                },
+                "offset": {
+                    "description": "The offset in the adaptive value source of the error.",
+                    "markdownDescription": "**Offset**\n\nThe offset in the adaptive value source of the error.",
+                    "title": "Offset",
+                    "type": "integer"
+                },
+                "parserColumnNumber": {
+                    "description": "The column number where the error occurred.",
+                    "markdownDescription": "**Parser Column Number**\n\nThe column number where the error occurred.",
+                    "title": "Parser Column Number",
+                    "type": "integer"
+                },
+                "parserCursor": {
+                    "description": "The UTF-8 octet source cursor that the parser at the time the syntax error occurred. This can be used as an offset into parserSource if it is available.",
+                    "markdownDescription": "**Parser Cursor**\n\nThe UTF-8 octet source cursor that the parser at the time the syntax error occurred. This can be used as an offset into parserSource if it is available.",
+                    "title": "Parser Cursor",
+                    "type": "integer"
+                },
+                "parserLineNumber": {
+                    "description": "The parser cursor's line number where the syntax error occurred.",
+                    "markdownDescription": "**Parser Line Number**\n\nThe parser cursor's line number where the syntax error occurred.",
+                    "title": "Parser Line Number",
+                    "type": "integer"
+                },
+                "parserSource": {
+                    "description": "This is the source being compiled that was available at the time of the syntax error. This may be the partial source since the compiler sometimes reads source as it is needed.",
+                    "markdownDescription": "**Parser Source**\n\nThis is the source being compiled that was available at the time of the syntax error. This may be the partial source since the compiler sometimes reads source as it is needed.",
+                    "title": "Parser Source",
+                    "type": "integer"
+                },
+                "rv": {
+                    "description": "The return value.",
+                    "markdownDescription": "**Rv**\n\nThe return value.",
+                    "title": "Rv",
+                    "type": "string"
+                },
+                "rvDecoded": {
+                    "description": "The decoded rv.",
+                    "markdownDescription": "**Rv Decoded**\n\nThe decoded rv.",
+                    "title": "Rv Decoded",
+                    "type": "string"
+                },
+                "rvSourceId": {
+                    "description": "The source id of rv.",
+                    "markdownDescription": "**Rv Source**\n\nThe source id of rv.",
+                    "title": "Rv Source",
+                    "type": "string"
+                },
+                "sourceFile": {
+                    "description": "The c source file where the error was thrown.",
+                    "markdownDescription": "**Source File**\n\nThe c source file where the error was thrown.",
+                    "title": "Source File",
+                    "type": "string"
+                },
+                "sourceLocation": {
+                    "description": "This is the source location of the error. This is usually a reference to the adaptive value source location.",
+                    "markdownDescription": "**Source Location**\n\nThis is the source location of the error. This is usually a reference to the adaptive value source location.",
+                    "title": "Source Location",
+                    "type": "string"
+                },
+                "xctxUUID": {
+                    "description": "This is the UUID of the execution context (xctx) when the error occurred. There is normally one xctx per request. This UUID is included by default in log message, which can be useful for finding messages related to a request.",
+                    "markdownDescription": "**XCTX UUID**\n\nThis is the UUID of the execution context (xctx) when the error occurred. There is normally one xctx per request. This UUID is included by default in log message, which can be useful for finding messages related to a request.",
+                    "title": "XCTX UUID",
+                    "type": "string"
+                }
+            },
             "title": "Error",
             "type": "object"
         },
@@ -15,107 +148,128 @@
             "properties": {
                 "actionNumber": {
                     "description": "If the request has multiple actions, this is the number, starting with 1, of the action that caused the error.",
+                    "markdownDescription": "**Action Index**\n\nIf the request has multiple actions, this is the number, starting with 1, of the action that caused the error.",
                     "title": "Action Index",
                     "type": "integer"
                 },
                 "backtrace": {
                     "contentMediaType": "text/plain",
                     "description": "The backtrace from where the error occurred.",
+                    "markdownDescription": "**Backtrace**\n\nThe backtrace from where the error occurred.",
                     "title": "Backtrace",
                     "type": "string"
                 },
                 "backtraceEvaluation": {
                     "contentMediaType": "text/plain",
                     "description": "The evaluation backtrace from where the error occurred.",
+                    "markdownDescription": "**Backtrace Expression**\n\nThe evaluation backtrace from where the error occurred.",
                     "title": "Backtrace Expression",
                     "type": "string"
                 },
                 "column": {
                     "description": "The column in line of the error. This is only available if source contains line breaks.",
+                    "markdownDescription": "**Column**\n\nThe column in line of the error. This is only available if source contains line breaks.",
                     "title": "Column",
                     "type": "integer"
                 },
                 "data": {
                     "description": "Optional data supplied on the throw.",
+                    "markdownDescription": "**Additional**\n\nOptional data supplied on the throw.",
                     "title": "Additional"
                 },
                 "errorCode": {
                     "description": "The numeric error code.",
+                    "markdownDescription": "**Error Code**\n\nThe numeric error code.",
                     "title": "Error Code",
                     "type": "integer"
                 },
                 "errorSource": {
                     "description": "The internal source filename:line where the error occurred.",
+                    "markdownDescription": "**Error Source**\n\nThe internal source filename:line where the error occurred.",
                     "title": "Error Source",
                     "type": "string"
                 },
                 "id": {
                     "description": "The mnemonic for the numeric error code (errorCode).",
+                    "markdownDescription": "**Error Code Id**\n\nThe mnemonic for the numeric error code (errorCode).",
                     "title": "Error Code Id",
                     "type": "string"
                 },
                 "line": {
                     "description": "The line number in the adaptive value source of the error. This is only available if source contains line breaks.",
+                    "markdownDescription": "**Line**\n\nThe line number in the adaptive value source of the error. This is only available if source contains line breaks.",
                     "title": "Line",
                     "type": "integer"
                 },
                 "message": {
                     "description": "The error message.",
+                    "markdownDescription": "**Message**\n\nThe error message.",
                     "title": "Message",
                     "type": "string"
                 },
                 "offset": {
                     "description": "The offset in the adaptive value source of the error.",
+                    "markdownDescription": "**Offset**\n\nThe offset in the adaptive value source of the error.",
                     "title": "Offset",
                     "type": "integer"
                 },
                 "parserColumnNumber": {
                     "description": "The column number where the error occurred.",
+                    "markdownDescription": "**Parser Column Number**\n\nThe column number where the error occurred.",
                     "title": "Parser Column Number",
                     "type": "integer"
                 },
                 "parserCursor": {
                     "description": "The UTF-8 octet source cursor that the parser at the time the syntax error occurred. This can be used as an offset into parserSource if it is available.",
+                    "markdownDescription": "**Parser Cursor**\n\nThe UTF-8 octet source cursor that the parser at the time the syntax error occurred. This can be used as an offset into parserSource if it is available.",
                     "title": "Parser Cursor",
                     "type": "integer"
                 },
                 "parserLineNumber": {
                     "description": "The parser cursor's line number where the syntax error occurred.",
+                    "markdownDescription": "**Parser Line Number**\n\nThe parser cursor's line number where the syntax error occurred.",
                     "title": "Parser Line Number",
                     "type": "integer"
                 },
                 "parserSource": {
                     "description": "This is the source being compiled that was available at the time of the syntax error. This may be the partial source since the compiler sometimes reads source as it is needed.",
+                    "markdownDescription": "**Parser Source**\n\nThis is the source being compiled that was available at the time of the syntax error. This may be the partial source since the compiler sometimes reads source as it is needed.",
                     "title": "Parser Source",
                     "type": "integer"
                 },
                 "rv": {
                     "description": "The return value.",
+                    "markdownDescription": "**Rv**\n\nThe return value.",
                     "title": "Rv",
                     "type": "string"
                 },
                 "rvDecoded": {
                     "description": "The decoded rv.",
+                    "markdownDescription": "**Rv Decoded**\n\nThe decoded rv.",
                     "title": "Rv Decoded",
                     "type": "string"
                 },
                 "rvSourceId": {
                     "description": "The source id of rv.",
+                    "markdownDescription": "**Rv Source**\n\nThe source id of rv.",
                     "title": "Rv Source",
                     "type": "string"
                 },
                 "sourceFile": {
                     "description": "The c source file where the error was thrown.",
+                    "markdownDescription": "**Source File**\n\nThe c source file where the error was thrown.",
                     "title": "Source File",
                     "type": "string"
                 },
                 "sourceLocation": {
                     "description": "This is the source location of the error. This is usually a reference to the adaptive value source location.",
+                    "markdownDescription": "**Source Location**\n\nThis is the source location of the error. This is usually a reference to the adaptive value source location.",
                     "title": "Source Location",
                     "type": "string"
                 },
                 "xctxUUID": {
                     "description": "This is the UUID of the execution context (xctx) when the error occurred. There is normally one xctx per request. This UUID is included by default in log message, which can be useful for finding messages related to a request.",
+                    "markdownDescription": "**XCTX UUID**\n\nThis is the UUID of the execution context (xctx) when the error occurred. There is normally one xctx per request. This UUID is included by default in log message, which can be useful for finding messages related to a request.",
                     "title": "XCTX UUID",
                     "type": "string"
                 }
@@ -124,32 +278,65 @@
         },
         "_AdaptiveResponseAction_": {
             "additionalProperties": true,
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveResponseAction_.propertyTypes"
-                }
-            ],
             "description": "The result of an action.",
+            "markdownDescription": "The result of an action.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "console": {
+                    "description": "If response:console flag is set and response:console:stream is not set, this will have any output written to console.",
+                    "markdownDescription": "**Console**\n\nIf response:console flag is set and response:console:stream is not set, this will have any output written to console.",
+                    "title": "Console",
+                    "type": "string"
+                },
+                "result": {
+                    "description": "Result of action.",
+                    "markdownDescription": "**Result**\n\nResult of action.",
+                    "title": "Result"
+                },
+                "stderr": {
+                    "description": "If response:stderr flag is set and response:stderr:stream is not set, this will have any output written to stderr.",
+                    "markdownDescription": "**Stderr**\n\nIf response:stderr flag is set and response:stderr:stream is not set, this will have any output written to stderr.",
+                    "title": "Stderr",
+                    "type": "string"
+                },
+                "stdout": {
+                    "description": "If response:stdout flag is set and response:stdout:stream is not set, this will have any output written to stdout.",
+                    "markdownDescription": "**Stdout**\n\nIf response:stdout flag is set and response:stdout:stream is not set, this will have any output written to stdout.",
+                    "title": "Stdout",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveResponseAction_",
             "type": "object"
         },
         "_AdaptiveResponseAction_.propertyTypes": {
             "properties": {
                 "console": {
                     "description": "If response:console flag is set and response:console:stream is not set, this will have any output written to console.",
+                    "markdownDescription": "**Console**\n\nIf response:console flag is set and response:console:stream is not set, this will have any output written to console.",
                     "title": "Console",
                     "type": "string"
                 },
                 "result": {
                     "description": "Result of action.",
+                    "markdownDescription": "**Result**\n\nResult of action.",
                     "title": "Result"
                 },
                 "stderr": {
                     "description": "If response:stderr flag is set and response:stderr:stream is not set, this will have any output written to stderr.",
+                    "markdownDescription": "**Stderr**\n\nIf response:stderr flag is set and response:stderr:stream is not set, this will have any output written to stderr.",
                     "title": "Stderr",
                     "type": "string"
                 },
                 "stdout": {
                     "description": "If response:stdout flag is set and response:stdout:stream is not set, this will have any output written to stdout.",
+                    "markdownDescription": "**Stdout**\n\nIf response:stdout flag is set and response:stdout:stream is not set, this will have any output written to stdout.",
                     "title": "Stdout",
                     "type": "string"
                 }
@@ -158,11 +345,90 @@
         },
         "_AdaptiveResponse_": {
             "additionalProperties": true,
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveResponse_.propertyTypes"
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "actions": {
+                    "description": "If the request has multiple actions, this property is an array of _AdaptiveResponseAction_ objects.",
+                    "items": {
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/_AdaptiveResponseAction_"
+                            }
+                        ],
+                        "description": "If the request has multiple actions, this property is an array of _AdaptiveResponseAction_ objects.",
+                        "markdownDescription": "If the request has multiple actions, this property is an array of _AdaptiveResponseAction_ objects.",
+                        "title": "List of _AdaptiveResponseAction_ objects",
+                        "type": "object"
+                    },
+                    "markdownDescription": "**Actions**\n\nIf the request has multiple actions, this property is an array of _AdaptiveResponseAction_ objects.",
+                    "title": "Actions",
+                    "type": "array"
+                },
+                "console": {
+                    "description": "If response:console flag is set and response:console:stream is not set, this will have any output written to console.",
+                    "markdownDescription": "**Console**\n\nIf response:console flag is set and response:console:stream is not set, this will have any output written to console.",
+                    "title": "Console",
+                    "type": "string"
+                },
+                "error": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveError_"
+                        }
+                    ],
+                    "description": "This is error detail if status is error. This property will not exist for intermediate response objects.",
+                    "markdownDescription": "**Error**\n\nThis is error detail if status is error. This property will not exist for intermediate response objects.",
+                    "title": "Error",
+                    "type": "object"
+                },
+                "intermediate": {
+                    "description": "If true, this is an intermediate response object containing a single result that will be followed by at least one more response object. If intermediate is missing or false, this is the final response object.",
+                    "markdownDescription": "**Intermediate**\n\nIf true, this is an intermediate response object containing a single result that will be followed by at least one more response object. If intermediate is missing or false, this is the final response object.",
+                    "title": "Intermediate",
+                    "type": "boolean"
+                },
+                "result": {
+                    "description": "The result if this is a single action request or intermediate response when no error occurred. If the 'actions' property is present, see that list of objects for results.",
+                    "markdownDescription": "**Result**\n\nThe result if this is a single action request or intermediate response when no error occurred. If the 'actions' property is present, see that list of objects for results.",
+                    "title": "Result"
+                },
+                "resultDataType": {
+                    "description": "Data type of result.",
+                    "markdownDescription": "**Result Data Type**\n\nData type of result.",
+                    "title": "Result Data Type",
+                    "type": "string"
+                },
+                "status": {
+                    "description": "Result status. If this value is 'error', see property 'error' for more detail. This property will not exist for intermediate response objects.",
+                    "enum": [
+                        "success",
+                        "error",
+                        "fatal"
+                    ],
+                    "markdownDescription": "**Status**\n\nResult status. If this value is 'error', see property 'error' for more detail. This property will not exist for intermediate response objects.",
+                    "title": "Status",
+                    "type": "string"
+                },
+                "stderr": {
+                    "description": "If response:stderr flag is set and response:stderr:stream is not set, this will have any output written to stderr.",
+                    "markdownDescription": "**Stderr**\n\nIf response:stderr flag is set and response:stderr:stream is not set, this will have any output written to stderr.",
+                    "title": "Stderr",
+                    "type": "string"
+                },
+                "stdout": {
+                    "description": "If response:stdout flag is set and response:stdout:stream is not set, this will have any output written to stdout.",
+                    "markdownDescription": "**Stdout**\n\nIf response:stdout flag is set and response:stdout:stream is not set, this will have any output written to stdout.",
+                    "title": "Stdout",
+                    "type": "string"
                 }
-            ],
+            },
+            "title": "_AdaptiveResponse_",
             "type": "object"
         },
         "_AdaptiveResponse_.propertyTypes": {
@@ -176,13 +442,17 @@
                             }
                         ],
                         "description": "If the request has multiple actions, this property is an array of _AdaptiveResponseAction_ objects.",
-                        "title": "List of _AdaptiveResponseAction_ objects"
+                        "markdownDescription": "If the request has multiple actions, this property is an array of _AdaptiveResponseAction_ objects.",
+                        "title": "List of _AdaptiveResponseAction_ objects",
+                        "type": "object"
                     },
+                    "markdownDescription": "**Actions**\n\nIf the request has multiple actions, this property is an array of _AdaptiveResponseAction_ objects.",
                     "title": "Actions",
                     "type": "array"
                 },
                 "console": {
                     "description": "If response:console flag is set and response:console:stream is not set, this will have any output written to console.",
+                    "markdownDescription": "**Console**\n\nIf response:console flag is set and response:console:stream is not set, this will have any output written to console.",
                     "title": "Console",
                     "type": "string"
                 },
@@ -193,19 +463,24 @@
                         }
                     ],
                     "description": "This is error detail if status is error. This property will not exist for intermediate response objects.",
-                    "title": "Error"
+                    "markdownDescription": "**Error**\n\nThis is error detail if status is error. This property will not exist for intermediate response objects.",
+                    "title": "Error",
+                    "type": "object"
                 },
                 "intermediate": {
                     "description": "If true, this is an intermediate response object containing a single result that will be followed by at least one more response object. If intermediate is missing or false, this is the final response object.",
+                    "markdownDescription": "**Intermediate**\n\nIf true, this is an intermediate response object containing a single result that will be followed by at least one more response object. If intermediate is missing or false, this is the final response object.",
                     "title": "Intermediate",
                     "type": "boolean"
                 },
                 "result": {
                     "description": "The result if this is a single action request or intermediate response when no error occurred. If the 'actions' property is present, see that list of objects for results.",
+                    "markdownDescription": "**Result**\n\nThe result if this is a single action request or intermediate response when no error occurred. If the 'actions' property is present, see that list of objects for results.",
                     "title": "Result"
                 },
                 "resultDataType": {
                     "description": "Data type of result.",
+                    "markdownDescription": "**Result Data Type**\n\nData type of result.",
                     "title": "Result Data Type",
                     "type": "string"
                 },
@@ -216,16 +491,19 @@
                         "error",
                         "fatal"
                     ],
+                    "markdownDescription": "**Status**\n\nResult status. If this value is 'error', see property 'error' for more detail. This property will not exist for intermediate response objects.",
                     "title": "Status",
                     "type": "string"
                 },
                 "stderr": {
                     "description": "If response:stderr flag is set and response:stderr:stream is not set, this will have any output written to stderr.",
+                    "markdownDescription": "**Stderr**\n\nIf response:stderr flag is set and response:stderr:stream is not set, this will have any output written to stderr.",
                     "title": "Stderr",
                     "type": "string"
                 },
                 "stdout": {
                     "description": "If response:stdout flag is set and response:stdout:stream is not set, this will have any output written to stdout.",
+                    "markdownDescription": "**Stdout**\n\nIf response:stdout flag is set and response:stdout:stream is not set, this will have any output written to stdout.",
                     "title": "Stdout",
                     "type": "string"
                 }
@@ -234,9 +512,90 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveResponse_"
+    "additionalProperties": true,
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "actions": {
+            "description": "If the request has multiple actions, this property is an array of _AdaptiveResponseAction_ objects.",
+            "items": {
+                "allOf": [
+                    {
+                        "$ref": "#/$defs/_AdaptiveResponseAction_"
+                    }
+                ],
+                "description": "If the request has multiple actions, this property is an array of _AdaptiveResponseAction_ objects.",
+                "markdownDescription": "If the request has multiple actions, this property is an array of _AdaptiveResponseAction_ objects.",
+                "title": "List of _AdaptiveResponseAction_ objects",
+                "type": "object"
+            },
+            "markdownDescription": "**Actions**\n\nIf the request has multiple actions, this property is an array of _AdaptiveResponseAction_ objects.",
+            "title": "Actions",
+            "type": "array"
+        },
+        "console": {
+            "description": "If response:console flag is set and response:console:stream is not set, this will have any output written to console.",
+            "markdownDescription": "**Console**\n\nIf response:console flag is set and response:console:stream is not set, this will have any output written to console.",
+            "title": "Console",
+            "type": "string"
+        },
+        "error": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveError_"
+                }
+            ],
+            "description": "This is error detail if status is error. This property will not exist for intermediate response objects.",
+            "markdownDescription": "**Error**\n\nThis is error detail if status is error. This property will not exist for intermediate response objects.",
+            "title": "Error",
+            "type": "object"
+        },
+        "intermediate": {
+            "description": "If true, this is an intermediate response object containing a single result that will be followed by at least one more response object. If intermediate is missing or false, this is the final response object.",
+            "markdownDescription": "**Intermediate**\n\nIf true, this is an intermediate response object containing a single result that will be followed by at least one more response object. If intermediate is missing or false, this is the final response object.",
+            "title": "Intermediate",
+            "type": "boolean"
+        },
+        "result": {
+            "description": "The result if this is a single action request or intermediate response when no error occurred. If the 'actions' property is present, see that list of objects for results.",
+            "markdownDescription": "**Result**\n\nThe result if this is a single action request or intermediate response when no error occurred. If the 'actions' property is present, see that list of objects for results.",
+            "title": "Result"
+        },
+        "resultDataType": {
+            "description": "Data type of result.",
+            "markdownDescription": "**Result Data Type**\n\nData type of result.",
+            "title": "Result Data Type",
+            "type": "string"
+        },
+        "status": {
+            "description": "Result status. If this value is 'error', see property 'error' for more detail. This property will not exist for intermediate response objects.",
+            "enum": [
+                "success",
+                "error",
+                "fatal"
+            ],
+            "markdownDescription": "**Status**\n\nResult status. If this value is 'error', see property 'error' for more detail. This property will not exist for intermediate response objects.",
+            "title": "Status",
+            "type": "string"
+        },
+        "stderr": {
+            "description": "If response:stderr flag is set and response:stderr:stream is not set, this will have any output written to stderr.",
+            "markdownDescription": "**Stderr**\n\nIf response:stderr flag is set and response:stderr:stream is not set, this will have any output written to stderr.",
+            "title": "Stderr",
+            "type": "string"
+        },
+        "stdout": {
+            "description": "If response:stdout flag is set and response:stdout:stream is not set, this will have any output written to stdout.",
+            "markdownDescription": "**Stdout**\n\nIf response:stdout flag is set and response:stdout:stream is not set, this will have any output written to stdout.",
+            "title": "Stdout",
+            "type": "string"
         }
-    ]
+    },
+    "title": "_AdaptiveResponse_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveResponse_.json
+++ b/generated/schemas/afw/_AdaptiveResponse_.json
@@ -1,10 +1,8 @@
 {
     "$defs": {
         "_AdaptiveError_": {
-            "additionalProperties": {
-                "description": "The _AdaptiveObjectType_ for _AdaptiveError_ objects."
-            },
-            "anyOf": [
+            "additionalProperties": true,
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveError_.propertyTypes"
                 }
@@ -125,10 +123,8 @@
             "type": "object"
         },
         "_AdaptiveResponseAction_": {
-            "additionalProperties": {
-                "description": "The result of an action."
-            },
-            "anyOf": [
+            "additionalProperties": true,
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveResponseAction_.propertyTypes"
                 }
@@ -161,8 +157,8 @@
             "type": "object"
         },
         "_AdaptiveResponse_": {
-            "additionalProperties": {},
-            "anyOf": [
+            "additionalProperties": true,
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveResponse_.propertyTypes"
                 }
@@ -174,10 +170,13 @@
                 "actions": {
                     "description": "If the request has multiple actions, this property is an array of _AdaptiveResponseAction_ objects.",
                     "items": {
-                        "$ref": "#/$defs/_AdaptiveResponseAction_",
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/_AdaptiveResponseAction_"
+                            }
+                        ],
                         "description": "If the request has multiple actions, this property is an array of _AdaptiveResponseAction_ objects.",
-                        "title": "List of _AdaptiveResponseAction_ objects",
-                        "type": "object"
+                        "title": "List of _AdaptiveResponseAction_ objects"
                     },
                     "title": "Actions",
                     "type": "array"
@@ -188,10 +187,13 @@
                     "type": "string"
                 },
                 "error": {
-                    "$ref": "#/$defs/_AdaptiveError_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveError_"
+                        }
+                    ],
                     "description": "This is error detail if status is error. This property will not exist for intermediate response objects.",
-                    "title": "Error",
-                    "type": "object"
+                    "title": "Error"
                 },
                 "intermediate": {
                     "description": "If true, this is an intermediate response object containing a single result that will be followed by at least one more response object. If intermediate is missing or false, this is the final response object.",
@@ -209,6 +211,11 @@
                 },
                 "status": {
                     "description": "Result status. If this value is 'error', see property 'error' for more detail. This property will not exist for intermediate response objects.",
+                    "enum": [
+                        "success",
+                        "error",
+                        "fatal"
+                    ],
                     "title": "Status",
                     "type": "string"
                 },
@@ -227,7 +234,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveResponse_"
         }

--- a/generated/schemas/afw/_AdaptiveRuntimeCustom_.json
+++ b/generated/schemas/afw/_AdaptiveRuntimeCustom_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveRuntimeCustom_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveRuntimeCustom_.propertyTypes"
                 }
@@ -22,7 +22,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveRuntimeCustom_"
         }

--- a/generated/schemas/afw/_AdaptiveRuntimeCustom_.json
+++ b/generated/schemas/afw/_AdaptiveRuntimeCustom_.json
@@ -1,19 +1,33 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveRuntimeCustom_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveRuntimeCustom_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveRuntimeCustom_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "A registry type runtime_custom entry.",
-            "type": "object",
-            "unevaluatedProperties": false
+            "markdownDescription": "A registry type runtime_custom entry.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "key": {
+                    "description": "Key of entry.",
+                    "markdownDescription": "**Key**\n\nKey of entry.",
+                    "title": "Key",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveRuntimeCustom_",
+            "type": "object"
         },
         "_AdaptiveRuntimeCustom_.propertyTypes": {
             "properties": {
                 "key": {
                     "description": "Key of entry.",
+                    "markdownDescription": "**Key**\n\nKey of entry.",
                     "title": "Key",
                     "type": "string"
                 }
@@ -22,9 +36,24 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveRuntimeCustom_"
+    "additionalProperties": false,
+    "description": "A registry type runtime_custom entry.",
+    "markdownDescription": "A registry type runtime_custom entry.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "key": {
+            "description": "Key of entry.",
+            "markdownDescription": "**Key**\n\nKey of entry.",
+            "title": "Key",
+            "type": "string"
         }
-    ]
+    },
+    "title": "_AdaptiveRuntimeCustom_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveRuntimeValueAccessor_.json
+++ b/generated/schemas/afw/_AdaptiveRuntimeValueAccessor_.json
@@ -1,19 +1,33 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveRuntimeValueAccessor_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveRuntimeValueAccessor_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveRuntimeValueAccessor_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "A registry type runtime_value_accessor entry.",
-            "type": "object",
-            "unevaluatedProperties": false
+            "markdownDescription": "A registry type runtime_value_accessor entry.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "key": {
+                    "description": "Key of entry.",
+                    "markdownDescription": "**Key**\n\nKey of entry.",
+                    "title": "Key",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveRuntimeValueAccessor_",
+            "type": "object"
         },
         "_AdaptiveRuntimeValueAccessor_.propertyTypes": {
             "properties": {
                 "key": {
                     "description": "Key of entry.",
+                    "markdownDescription": "**Key**\n\nKey of entry.",
                     "title": "Key",
                     "type": "string"
                 }
@@ -22,9 +36,24 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveRuntimeValueAccessor_"
+    "additionalProperties": false,
+    "description": "A registry type runtime_value_accessor entry.",
+    "markdownDescription": "A registry type runtime_value_accessor entry.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "key": {
+            "description": "Key of entry.",
+            "markdownDescription": "**Key**\n\nKey of entry.",
+            "title": "Key",
+            "type": "string"
         }
-    ]
+    },
+    "title": "_AdaptiveRuntimeValueAccessor_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveRuntimeValueAccessor_.json
+++ b/generated/schemas/afw/_AdaptiveRuntimeValueAccessor_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveRuntimeValueAccessor_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveRuntimeValueAccessor_.propertyTypes"
                 }
@@ -22,7 +22,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveRuntimeValueAccessor_"
         }

--- a/generated/schemas/afw/_AdaptiveServer_.json
+++ b/generated/schemas/afw/_AdaptiveServer_.json
@@ -1,12 +1,19 @@
 {
     "$defs": {
         "_AdaptiveServer_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveServer_.propertyTypes"
                 }
             ],
             "description": "Object type for afw_server_fcgi server info.",
+            "required": [
+                "concurrent",
+                "maxConcurrent",
+                "requestCount",
+                "threadCount",
+                "unhandledErrors"
+            ],
             "type": "object",
             "unevaluatedProperties": false
         },
@@ -64,18 +71,11 @@
                     "type": "integer"
                 }
             },
-            "required": [
-                "concurrent",
-                "maxConcurrent",
-                "requestCount",
-                "threadCount",
-                "unhandledErrors"
-            ],
             "type": "object"
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveServer_"
         }

--- a/generated/schemas/afw/_AdaptiveServer_.json
+++ b/generated/schemas/afw/_AdaptiveServer_.json
@@ -1,12 +1,80 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveServer_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveServer_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveServer_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Object type for afw_server_fcgi server info.",
+            "markdownDescription": "Object type for afw_server_fcgi server info.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "afwCompiledVersion": {
+                    "description": "The server is an application, which is dynamically linked to libafw, containing Adaptive Framework Core. In many cases, these two versions would be the same, but may differ if the server binary has been updated and the libafw has not (or vice versa). This is the version of Adaptive Framework core (libafw) the server was compiled against, not what is currently active.",
+                    "markdownDescription": "**Compiled AFW Version**\n\nThe server is an application, which is dynamically linked to libafw, containing Adaptive Framework Core. In many cases, these two versions would be the same, but may differ if the server binary has been updated and the libafw has not (or vice versa). This is the version of Adaptive Framework core (libafw) the server was compiled against, not what is currently active.",
+                    "title": "Compiled AFW Version",
+                    "type": "string"
+                },
+                "afwVersion": {
+                    "description": "When the Adaptive Framework server is run, it executes Adaptive Framework core code out of libafw. This is the version of the actively available libafw.",
+                    "markdownDescription": "**AFW Version**\n\nWhen the Adaptive Framework server is run, it executes Adaptive Framework core code out of libafw. This is the version of the actively available libafw.",
+                    "title": "AFW Version",
+                    "type": "string"
+                },
+                "concurrent": {
+                    "description": "This is the number of threads that are currently being processed at the time of this request. It may change over time, and will not exceed the the number of threads that are available.",
+                    "markdownDescription": "**Concurrent**\n\nThis is the number of threads that are currently being processed at the time of this request. It may change over time, and will not exceed the the number of threads that are available.",
+                    "title": "Concurrent",
+                    "type": "integer"
+                },
+                "maxConcurrent": {
+                    "description": "This is the maximum water-level number of threads that have been observed to have been currently being processed by the server at any given time.",
+                    "markdownDescription": "**Max Concurrent**\n\nThis is the maximum water-level number of threads that have been observed to have been currently being processed by the server at any given time.",
+                    "title": "Max Concurrent",
+                    "type": "integer"
+                },
+                "requestCount": {
+                    "description": "This is the total number of requests that have been processed since the server was started.",
+                    "markdownDescription": "**Request Count**\n\nThis is the total number of requests that have been processed since the server was started.",
+                    "title": "Request Count",
+                    "type": "integer"
+                },
+                "serverType": {
+                    "description": "An Adaptive Framework server can be implemented in a variety of ways. This field describes the type of this server.",
+                    "markdownDescription": "**Server Type**\n\nAn Adaptive Framework server can be implemented in a variety of ways. This field describes the type of this server.",
+                    "title": "Server Type",
+                    "type": "string"
+                },
+                "serverVersion": {
+                    "description": "This version represents the compiled version of the Adaptive Framework server code.",
+                    "markdownDescription": "**Server Version**\n\nThis version represents the compiled version of the Adaptive Framework server code.",
+                    "title": "Server Version",
+                    "type": "string"
+                },
+                "startTime": {
+                    "description": "This timestamp represents when the server was started.",
+                    "format": "date-time",
+                    "markdownDescription": "**Start Time**\n\nThis timestamp represents when the server was started.",
+                    "title": "Start Time",
+                    "type": "string"
+                },
+                "threadCount": {
+                    "description": "The number of threads to create at startup to process client requests.",
+                    "markdownDescription": "**Thread Count**\n\nThe number of threads to create at startup to process client requests.",
+                    "title": "Thread Count",
+                    "type": "integer"
+                },
+                "unhandledErrors": {
+                    "description": "The number of errors that remained unreported. This usually happens when an error occurs while trying to respond to an error.",
+                    "markdownDescription": "**Unhandled Errors**\n\nThe number of errors that remained unreported. This usually happens when an error occurs while trying to respond to an error.",
+                    "title": "Unhandled Errors",
+                    "type": "integer"
+                }
+            },
             "required": [
                 "concurrent",
                 "maxConcurrent",
@@ -14,59 +82,69 @@
                 "threadCount",
                 "unhandledErrors"
             ],
-            "type": "object",
-            "unevaluatedProperties": false
+            "title": "_AdaptiveServer_",
+            "type": "object"
         },
         "_AdaptiveServer_.propertyTypes": {
             "properties": {
                 "afwCompiledVersion": {
                     "description": "The server is an application, which is dynamically linked to libafw, containing Adaptive Framework Core. In many cases, these two versions would be the same, but may differ if the server binary has been updated and the libafw has not (or vice versa). This is the version of Adaptive Framework core (libafw) the server was compiled against, not what is currently active.",
+                    "markdownDescription": "**Compiled AFW Version**\n\nThe server is an application, which is dynamically linked to libafw, containing Adaptive Framework Core. In many cases, these two versions would be the same, but may differ if the server binary has been updated and the libafw has not (or vice versa). This is the version of Adaptive Framework core (libafw) the server was compiled against, not what is currently active.",
                     "title": "Compiled AFW Version",
                     "type": "string"
                 },
                 "afwVersion": {
                     "description": "When the Adaptive Framework server is run, it executes Adaptive Framework core code out of libafw. This is the version of the actively available libafw.",
+                    "markdownDescription": "**AFW Version**\n\nWhen the Adaptive Framework server is run, it executes Adaptive Framework core code out of libafw. This is the version of the actively available libafw.",
                     "title": "AFW Version",
                     "type": "string"
                 },
                 "concurrent": {
                     "description": "This is the number of threads that are currently being processed at the time of this request. It may change over time, and will not exceed the the number of threads that are available.",
+                    "markdownDescription": "**Concurrent**\n\nThis is the number of threads that are currently being processed at the time of this request. It may change over time, and will not exceed the the number of threads that are available.",
                     "title": "Concurrent",
                     "type": "integer"
                 },
                 "maxConcurrent": {
                     "description": "This is the maximum water-level number of threads that have been observed to have been currently being processed by the server at any given time.",
+                    "markdownDescription": "**Max Concurrent**\n\nThis is the maximum water-level number of threads that have been observed to have been currently being processed by the server at any given time.",
                     "title": "Max Concurrent",
                     "type": "integer"
                 },
                 "requestCount": {
                     "description": "This is the total number of requests that have been processed since the server was started.",
+                    "markdownDescription": "**Request Count**\n\nThis is the total number of requests that have been processed since the server was started.",
                     "title": "Request Count",
                     "type": "integer"
                 },
                 "serverType": {
                     "description": "An Adaptive Framework server can be implemented in a variety of ways. This field describes the type of this server.",
+                    "markdownDescription": "**Server Type**\n\nAn Adaptive Framework server can be implemented in a variety of ways. This field describes the type of this server.",
                     "title": "Server Type",
                     "type": "string"
                 },
                 "serverVersion": {
                     "description": "This version represents the compiled version of the Adaptive Framework server code.",
+                    "markdownDescription": "**Server Version**\n\nThis version represents the compiled version of the Adaptive Framework server code.",
                     "title": "Server Version",
                     "type": "string"
                 },
                 "startTime": {
                     "description": "This timestamp represents when the server was started.",
                     "format": "date-time",
+                    "markdownDescription": "**Start Time**\n\nThis timestamp represents when the server was started.",
                     "title": "Start Time",
                     "type": "string"
                 },
                 "threadCount": {
                     "description": "The number of threads to create at startup to process client requests.",
+                    "markdownDescription": "**Thread Count**\n\nThe number of threads to create at startup to process client requests.",
                     "title": "Thread Count",
                     "type": "integer"
                 },
                 "unhandledErrors": {
                     "description": "The number of errors that remained unreported. This usually happens when an error occurs while trying to respond to an error.",
+                    "markdownDescription": "**Unhandled Errors**\n\nThe number of errors that remained unreported. This usually happens when an error occurs while trying to respond to an error.",
                     "title": "Unhandled Errors",
                     "type": "integer"
                 }
@@ -75,9 +153,86 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveServer_"
+    "additionalProperties": false,
+    "description": "Object type for afw_server_fcgi server info.",
+    "markdownDescription": "Object type for afw_server_fcgi server info.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "afwCompiledVersion": {
+            "description": "The server is an application, which is dynamically linked to libafw, containing Adaptive Framework Core. In many cases, these two versions would be the same, but may differ if the server binary has been updated and the libafw has not (or vice versa). This is the version of Adaptive Framework core (libafw) the server was compiled against, not what is currently active.",
+            "markdownDescription": "**Compiled AFW Version**\n\nThe server is an application, which is dynamically linked to libafw, containing Adaptive Framework Core. In many cases, these two versions would be the same, but may differ if the server binary has been updated and the libafw has not (or vice versa). This is the version of Adaptive Framework core (libafw) the server was compiled against, not what is currently active.",
+            "title": "Compiled AFW Version",
+            "type": "string"
+        },
+        "afwVersion": {
+            "description": "When the Adaptive Framework server is run, it executes Adaptive Framework core code out of libafw. This is the version of the actively available libafw.",
+            "markdownDescription": "**AFW Version**\n\nWhen the Adaptive Framework server is run, it executes Adaptive Framework core code out of libafw. This is the version of the actively available libafw.",
+            "title": "AFW Version",
+            "type": "string"
+        },
+        "concurrent": {
+            "description": "This is the number of threads that are currently being processed at the time of this request. It may change over time, and will not exceed the the number of threads that are available.",
+            "markdownDescription": "**Concurrent**\n\nThis is the number of threads that are currently being processed at the time of this request. It may change over time, and will not exceed the the number of threads that are available.",
+            "title": "Concurrent",
+            "type": "integer"
+        },
+        "maxConcurrent": {
+            "description": "This is the maximum water-level number of threads that have been observed to have been currently being processed by the server at any given time.",
+            "markdownDescription": "**Max Concurrent**\n\nThis is the maximum water-level number of threads that have been observed to have been currently being processed by the server at any given time.",
+            "title": "Max Concurrent",
+            "type": "integer"
+        },
+        "requestCount": {
+            "description": "This is the total number of requests that have been processed since the server was started.",
+            "markdownDescription": "**Request Count**\n\nThis is the total number of requests that have been processed since the server was started.",
+            "title": "Request Count",
+            "type": "integer"
+        },
+        "serverType": {
+            "description": "An Adaptive Framework server can be implemented in a variety of ways. This field describes the type of this server.",
+            "markdownDescription": "**Server Type**\n\nAn Adaptive Framework server can be implemented in a variety of ways. This field describes the type of this server.",
+            "title": "Server Type",
+            "type": "string"
+        },
+        "serverVersion": {
+            "description": "This version represents the compiled version of the Adaptive Framework server code.",
+            "markdownDescription": "**Server Version**\n\nThis version represents the compiled version of the Adaptive Framework server code.",
+            "title": "Server Version",
+            "type": "string"
+        },
+        "startTime": {
+            "description": "This timestamp represents when the server was started.",
+            "format": "date-time",
+            "markdownDescription": "**Start Time**\n\nThis timestamp represents when the server was started.",
+            "title": "Start Time",
+            "type": "string"
+        },
+        "threadCount": {
+            "description": "The number of threads to create at startup to process client requests.",
+            "markdownDescription": "**Thread Count**\n\nThe number of threads to create at startup to process client requests.",
+            "title": "Thread Count",
+            "type": "integer"
+        },
+        "unhandledErrors": {
+            "description": "The number of errors that remained unreported. This usually happens when an error occurs while trying to respond to an error.",
+            "markdownDescription": "**Unhandled Errors**\n\nThe number of errors that remained unreported. This usually happens when an error occurs while trying to respond to an error.",
+            "title": "Unhandled Errors",
+            "type": "integer"
         }
-    ]
+    },
+    "required": [
+        "concurrent",
+        "maxConcurrent",
+        "requestCount",
+        "threadCount",
+        "unhandledErrors"
+    ],
+    "title": "_AdaptiveServer_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveServiceConf_.json
+++ b/generated/schemas/afw/_AdaptiveServiceConf_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveServiceConf_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveServiceConf_.propertyTypes"
                 }
@@ -23,6 +23,7 @@
                     "type": "string"
                 },
                 "startup": {
+                    "default": "manual",
                     "description": "Service startup condition specifies how the service should be started. Choose 'manual', if you intend to start the service by hand. Choose 'immediate' if the service should be started as soon as it as loaded. Services defined in the main configuration file are 'permanent', which are started immediately and cannot be stopped.",
                     "title": "Startup",
                     "type": "string"
@@ -32,7 +33,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveServiceConf_"
         }

--- a/generated/schemas/afw/_AdaptiveServiceConf_.json
+++ b/generated/schemas/afw/_AdaptiveServiceConf_.json
@@ -1,30 +1,59 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveServiceConf_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveServiceConf_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveServiceConf_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "An adaptive service.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveServiceConf_.propertyTypes": {
+            "markdownDescription": "An adaptive service.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "conf": {
                     "description": "Configuration object. The object must have type and id property where type is a supported value.",
+                    "markdownDescription": "**Conf**\n\nConfiguration object. The object must have type and id property where type is a supported value.",
                     "title": "Conf",
                     "type": "object"
                 },
                 "serviceId": {
                     "description": "Service id. This is the type and type specific id property separated with a '-'. For example, for conf type=adapter, adapterId=x, the serviceId must be 'adapter-x'.",
+                    "markdownDescription": "**Service Id**\n\nService id. This is the type and type specific id property separated with a '-'. For example, for conf type=adapter, adapterId=x, the serviceId must be 'adapter-x'.",
                     "title": "Service Id",
                     "type": "string"
                 },
                 "startup": {
                     "default": "manual",
                     "description": "Service startup condition specifies how the service should be started. Choose 'manual', if you intend to start the service by hand. Choose 'immediate' if the service should be started as soon as it as loaded. Services defined in the main configuration file are 'permanent', which are started immediately and cannot be stopped.",
+                    "markdownDescription": "**Startup**\n\nService startup condition specifies how the service should be started. Choose 'manual', if you intend to start the service by hand. Choose 'immediate' if the service should be started as soon as it as loaded. Services defined in the main configuration file are 'permanent', which are started immediately and cannot be stopped.",
+                    "title": "Startup",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveServiceConf_",
+            "type": "object"
+        },
+        "_AdaptiveServiceConf_.propertyTypes": {
+            "properties": {
+                "conf": {
+                    "description": "Configuration object. The object must have type and id property where type is a supported value.",
+                    "markdownDescription": "**Conf**\n\nConfiguration object. The object must have type and id property where type is a supported value.",
+                    "title": "Conf",
+                    "type": "object"
+                },
+                "serviceId": {
+                    "description": "Service id. This is the type and type specific id property separated with a '-'. For example, for conf type=adapter, adapterId=x, the serviceId must be 'adapter-x'.",
+                    "markdownDescription": "**Service Id**\n\nService id. This is the type and type specific id property separated with a '-'. For example, for conf type=adapter, adapterId=x, the serviceId must be 'adapter-x'.",
+                    "title": "Service Id",
+                    "type": "string"
+                },
+                "startup": {
+                    "default": "manual",
+                    "description": "Service startup condition specifies how the service should be started. Choose 'manual', if you intend to start the service by hand. Choose 'immediate' if the service should be started as soon as it as loaded. Services defined in the main configuration file are 'permanent', which are started immediately and cannot be stopped.",
+                    "markdownDescription": "**Startup**\n\nService startup condition specifies how the service should be started. Choose 'manual', if you intend to start the service by hand. Choose 'immediate' if the service should be started as soon as it as loaded. Services defined in the main configuration file are 'permanent', which are started immediately and cannot be stopped.",
                     "title": "Startup",
                     "type": "string"
                 }
@@ -33,9 +62,37 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveServiceConf_"
+    "additionalProperties": false,
+    "description": "An adaptive service.",
+    "markdownDescription": "An adaptive service.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "conf": {
+            "description": "Configuration object. The object must have type and id property where type is a supported value.",
+            "markdownDescription": "**Conf**\n\nConfiguration object. The object must have type and id property where type is a supported value.",
+            "title": "Conf",
+            "type": "object"
+        },
+        "serviceId": {
+            "description": "Service id. This is the type and type specific id property separated with a '-'. For example, for conf type=adapter, adapterId=x, the serviceId must be 'adapter-x'.",
+            "markdownDescription": "**Service Id**\n\nService id. This is the type and type specific id property separated with a '-'. For example, for conf type=adapter, adapterId=x, the serviceId must be 'adapter-x'.",
+            "title": "Service Id",
+            "type": "string"
+        },
+        "startup": {
+            "default": "manual",
+            "description": "Service startup condition specifies how the service should be started. Choose 'manual', if you intend to start the service by hand. Choose 'immediate' if the service should be started as soon as it as loaded. Services defined in the main configuration file are 'permanent', which are started immediately and cannot be stopped.",
+            "markdownDescription": "**Startup**\n\nService startup condition specifies how the service should be started. Choose 'manual', if you intend to start the service by hand. Choose 'immediate' if the service should be started as soon as it as loaded. Services defined in the main configuration file are 'permanent', which are started immediately and cannot be stopped.",
+            "title": "Startup",
+            "type": "string"
         }
-    ]
+    },
+    "title": "_AdaptiveServiceConf_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveServiceType_.json
+++ b/generated/schemas/afw/_AdaptiveServiceType_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveConfType_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveConfType_.propertyTypes"
                 }
@@ -68,7 +68,7 @@
             "type": "object"
         },
         "_AdaptiveServiceType_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveServiceType_.propertyTypes"
                 }
@@ -80,10 +80,13 @@
         "_AdaptiveServiceType_.propertyTypes": {
             "properties": {
                 "confType": {
-                    "$ref": "#/$defs/_AdaptiveConfType_",
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveConfType_"
+                        }
+                    ],
                     "description": "Conf type for this service type.",
-                    "title": "Conf Type",
-                    "type": "object"
+                    "title": "Conf Type"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
@@ -106,7 +109,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveServiceType_"
         }

--- a/generated/schemas/afw/_AdaptiveServiceType_.json
+++ b/generated/schemas/afw/_AdaptiveServiceType_.json
@@ -1,66 +1,143 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveServiceType_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveConfType_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveConfType_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "Conf type for this service type.",
+            "markdownDescription": "Conf type for this service type.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "Description of this configuration type.",
+                    "markdownDescription": "**Description**\n\nDescription of this configuration type.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "idPropertyName": {
+                    "description": "This is the id property name for instances of this conf type. For adapter, this is 'adapterId'.",
+                    "markdownDescription": "**Id Property Name**\n\nThis is the id property name for instances of this conf type. For adapter, this is 'adapterId'.",
+                    "title": "Id Property Name",
+                    "type": "string"
+                },
+                "idRegistryType": {
+                    "description": "This is the registry type for instances of this conf type. For adapter, this is 'adapter_id'.",
+                    "markdownDescription": "**Id Registry Type**\n\nThis is the registry type for instances of this conf type. For adapter, this is 'adapter_id'.",
+                    "title": "Id Registry Type",
+                    "type": "string"
+                },
+                "idRuntimeObjectType": {
+                    "description": "This is the runtime object type for instances of this conf type. For adapter, this is '_AdaptiveAdapter_'.",
+                    "markdownDescription": "**Id Runtime Object Type**\n\nThis is the runtime object type for instances of this conf type. For adapter, this is '_AdaptiveAdapter_'.",
+                    "title": "Id Runtime Object Type",
+                    "type": "string"
+                },
+                "isUnique": {
+                    "description": "This configuration type can only be specified once.",
+                    "markdownDescription": "**Is Unique**\n\nThis configuration type can only be specified once.",
+                    "title": "Is Unique",
+                    "type": "boolean"
+                },
+                "subtypePropertyName": {
+                    "description": "This is the subtype property name for instances of this conf type.  For adapter, this is 'adapterType'.",
+                    "markdownDescription": "**Subtype Property Name**\n\nThis is the subtype property name for instances of this conf type.  For adapter, this is 'adapterType'.",
+                    "title": "Subtype Property Name",
+                    "type": "string"
+                },
+                "subtypeRegistryType": {
+                    "description": "This is the subtype registry type for instances of this conf type. For adapter, this is 'adapter_type'.",
+                    "markdownDescription": "**Subtype Registry Type**\n\nThis is the subtype registry type for instances of this conf type. For adapter, this is 'adapter_type'.",
+                    "title": "Subtype Registry Type",
+                    "type": "string"
+                },
+                "subtypeRuntimeObjectType": {
+                    "description": "This is the subtype runtime object type for instances of this conf type. For adapter, this is '_AdaptiveAdapterType_'.",
+                    "markdownDescription": "**Subtype Runtime Object Type**\n\nThis is the subtype runtime object type for instances of this conf type. For adapter, this is '_AdaptiveAdapterType_'.",
+                    "title": "Subtype Runtime Object Type",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Title for this configuration type.",
+                    "markdownDescription": "**Title**\n\nTitle for this configuration type.",
+                    "title": "Title",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Configuration type id.",
+                    "markdownDescription": "**Type**\n\nConfiguration type id.",
+                    "title": "Type",
+                    "type": "string"
+                }
+            },
             "title": "Conf Type",
-            "type": "object",
-            "unevaluatedProperties": false
+            "type": "object"
         },
         "_AdaptiveConfType_.propertyTypes": {
             "properties": {
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "Description of this configuration type.",
+                    "markdownDescription": "**Description**\n\nDescription of this configuration type.",
                     "title": "Description",
                     "type": "string"
                 },
                 "idPropertyName": {
                     "description": "This is the id property name for instances of this conf type. For adapter, this is 'adapterId'.",
+                    "markdownDescription": "**Id Property Name**\n\nThis is the id property name for instances of this conf type. For adapter, this is 'adapterId'.",
                     "title": "Id Property Name",
                     "type": "string"
                 },
                 "idRegistryType": {
                     "description": "This is the registry type for instances of this conf type. For adapter, this is 'adapter_id'.",
+                    "markdownDescription": "**Id Registry Type**\n\nThis is the registry type for instances of this conf type. For adapter, this is 'adapter_id'.",
                     "title": "Id Registry Type",
                     "type": "string"
                 },
                 "idRuntimeObjectType": {
                     "description": "This is the runtime object type for instances of this conf type. For adapter, this is '_AdaptiveAdapter_'.",
+                    "markdownDescription": "**Id Runtime Object Type**\n\nThis is the runtime object type for instances of this conf type. For adapter, this is '_AdaptiveAdapter_'.",
                     "title": "Id Runtime Object Type",
                     "type": "string"
                 },
                 "isUnique": {
                     "description": "This configuration type can only be specified once.",
+                    "markdownDescription": "**Is Unique**\n\nThis configuration type can only be specified once.",
                     "title": "Is Unique",
                     "type": "boolean"
                 },
                 "subtypePropertyName": {
                     "description": "This is the subtype property name for instances of this conf type.  For adapter, this is 'adapterType'.",
+                    "markdownDescription": "**Subtype Property Name**\n\nThis is the subtype property name for instances of this conf type.  For adapter, this is 'adapterType'.",
                     "title": "Subtype Property Name",
                     "type": "string"
                 },
                 "subtypeRegistryType": {
                     "description": "This is the subtype registry type for instances of this conf type. For adapter, this is 'adapter_type'.",
+                    "markdownDescription": "**Subtype Registry Type**\n\nThis is the subtype registry type for instances of this conf type. For adapter, this is 'adapter_type'.",
                     "title": "Subtype Registry Type",
                     "type": "string"
                 },
                 "subtypeRuntimeObjectType": {
                     "description": "This is the subtype runtime object type for instances of this conf type. For adapter, this is '_AdaptiveAdapterType_'.",
+                    "markdownDescription": "**Subtype Runtime Object Type**\n\nThis is the subtype runtime object type for instances of this conf type. For adapter, this is '_AdaptiveAdapterType_'.",
                     "title": "Subtype Runtime Object Type",
                     "type": "string"
                 },
                 "title": {
                     "description": "Title for this configuration type.",
+                    "markdownDescription": "**Title**\n\nTitle for this configuration type.",
                     "title": "Title",
                     "type": "string"
                 },
                 "type": {
                     "description": "Configuration type id.",
+                    "markdownDescription": "**Type**\n\nConfiguration type id.",
                     "title": "Type",
                     "type": "string"
                 }
@@ -68,14 +145,50 @@
             "type": "object"
         },
         "_AdaptiveServiceType_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveServiceType_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "An adaptive service type.",
-            "type": "object",
-            "unevaluatedProperties": false
+            "markdownDescription": "An adaptive service type.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "confType": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/_AdaptiveConfType_"
+                        }
+                    ],
+                    "description": "Conf type for this service type.",
+                    "markdownDescription": "**Conf Type**\n\nConf type for this service type.",
+                    "title": "Conf Type",
+                    "type": "object"
+                },
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "'Service type' description.",
+                    "markdownDescription": "**Description**\n\n'Service type' description.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "serviceType": {
+                    "description": "Configuration type id.",
+                    "markdownDescription": "**Service Type**\n\nConfiguration type id.",
+                    "title": "Service Type",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "'Service type' title.",
+                    "markdownDescription": "**Title**\n\n'Service type' title.",
+                    "title": "Title",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveServiceType_",
+            "type": "object"
         },
         "_AdaptiveServiceType_.propertyTypes": {
             "properties": {
@@ -86,21 +199,26 @@
                         }
                     ],
                     "description": "Conf type for this service type.",
-                    "title": "Conf Type"
+                    "markdownDescription": "**Conf Type**\n\nConf type for this service type.",
+                    "title": "Conf Type",
+                    "type": "object"
                 },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "'Service type' description.",
+                    "markdownDescription": "**Description**\n\n'Service type' description.",
                     "title": "Description",
                     "type": "string"
                 },
                 "serviceType": {
                     "description": "Configuration type id.",
+                    "markdownDescription": "**Service Type**\n\nConfiguration type id.",
                     "title": "Service Type",
                     "type": "string"
                 },
                 "title": {
                     "description": "'Service type' title.",
+                    "markdownDescription": "**Title**\n\n'Service type' title.",
                     "title": "Title",
                     "type": "string"
                 }
@@ -109,9 +227,48 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveServiceType_"
+    "additionalProperties": false,
+    "description": "An adaptive service type.",
+    "markdownDescription": "An adaptive service type.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "confType": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/_AdaptiveConfType_"
+                }
+            ],
+            "description": "Conf type for this service type.",
+            "markdownDescription": "**Conf Type**\n\nConf type for this service type.",
+            "title": "Conf Type",
+            "type": "object"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "'Service type' description.",
+            "markdownDescription": "**Description**\n\n'Service type' description.",
+            "title": "Description",
+            "type": "string"
+        },
+        "serviceType": {
+            "description": "Configuration type id.",
+            "markdownDescription": "**Service Type**\n\nConfiguration type id.",
+            "title": "Service Type",
+            "type": "string"
+        },
+        "title": {
+            "description": "'Service type' title.",
+            "markdownDescription": "**Title**\n\n'Service type' title.",
+            "title": "Title",
+            "type": "string"
         }
-    ]
+    },
+    "title": "_AdaptiveServiceType_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveService_.json
+++ b/generated/schemas/afw/_AdaptiveService_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveService_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveService_.propertyTypes"
                 }
@@ -64,6 +64,7 @@
                     "type": "string"
                 },
                 "startup": {
+                    "default": "manual",
                     "description": "Service startup condition.",
                     "title": "Startup",
                     "type": "string"
@@ -111,7 +112,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveService_"
         }

--- a/generated/schemas/afw/_AdaptiveService_.json
+++ b/generated/schemas/afw/_AdaptiveService_.json
@@ -1,109 +1,247 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveService_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveService_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveService_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "An adaptive service.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveService_.propertyTypes": {
+            "markdownDescription": "An adaptive service.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "canRestart": {
                     "description": "Can attempt to restart this service.",
+                    "markdownDescription": "Can attempt to restart this service.",
                     "title": "Can Restart",
                     "type": "boolean"
                 },
                 "canStart": {
                     "description": "Can attempt to start this service.",
+                    "markdownDescription": "Can attempt to start this service.",
                     "title": "Can Start",
                     "type": "boolean"
                 },
                 "canStop": {
                     "description": "Can attempt to stop this service.",
+                    "markdownDescription": "Can attempt to stop this service.",
                     "title": "Can Stop",
                     "type": "boolean"
                 },
                 "confId": {
                     "description": "The 'id' part of serviceId. This is the value of appropriate conf id property based on the conf type.",
+                    "markdownDescription": "The 'id' part of serviceId. This is the value of appropriate conf id property based on the conf type.",
                     "title": "Conf Id",
                     "type": "string"
                 },
                 "confPropertyObjectType": {
                     "description": "Object type for 'conf' property object.",
+                    "markdownDescription": "Object type for 'conf' property object.",
                     "title": "Conf Property Object Type",
                     "type": "string"
                 },
                 "confSubtype": {
                     "description": "This is the value of appropriate conf subtype property based on the conf type.",
+                    "markdownDescription": "This is the value of appropriate conf subtype property based on the conf type.",
                     "title": "Conf Subtype",
                     "type": "string"
                 },
                 "serviceId": {
                     "description": "Service id.",
+                    "markdownDescription": "Service id.",
                     "title": "Service",
                     "type": "string"
                 },
                 "serviceType": {
                     "description": "The 'type' part of serviceId.",
+                    "markdownDescription": "The 'type' part of serviceId.",
                     "title": "Service Type",
                     "type": "string"
                 },
                 "sourceLocation": {
                     "description": "Related to where service was defined.",
+                    "markdownDescription": "Related to where service was defined.",
                     "title": "Source Location",
                     "type": "string"
                 },
                 "startTime": {
                     "description": "Start time.",
                     "format": "date-time",
+                    "markdownDescription": "Start time.",
                     "title": "Start Time",
                     "type": "string"
                 },
                 "startup": {
                     "default": "manual",
                     "description": "Service startup condition.",
+                    "markdownDescription": "Service startup condition.",
                     "title": "Startup",
                     "type": "string"
                 },
                 "startupDescription": {
                     "description": "Service startup condition description.",
+                    "markdownDescription": "Service startup condition description.",
                     "title": "Startup Description",
                     "type": "string"
                 },
                 "status": {
                     "description": "Service status.",
+                    "markdownDescription": "Service status.",
                     "title": "Status",
                     "type": "string"
                 },
                 "statusDebug": {
                     "contentMediaType": "text/plain",
                     "description": "This is statusMessage with additional debug information.",
+                    "markdownDescription": "This is statusMessage with additional debug information.",
                     "title": "Status Debug",
                     "type": "string"
                 },
                 "statusDescription": {
                     "description": "Service status description.",
+                    "markdownDescription": "Service status description.",
                     "title": "Status Description",
                     "type": "string"
                 },
                 "statusMessage": {
                     "description": "Optional message associated with status. In the case of status=error, this is the error message.",
+                    "markdownDescription": "Optional message associated with status. In the case of status=error, this is the error message.",
                     "title": "Status Message",
                     "type": "string"
                 },
                 "uriRelated": {
                     "description": "URI of related object.",
                     "format": "uri-reference",
+                    "markdownDescription": "URI of related object.",
                     "title": "URI Related",
                     "type": "string"
                 },
                 "uriServiceConf": {
                     "description": "URI of service conf object.",
                     "format": "uri-reference",
+                    "markdownDescription": "URI of service conf object.",
+                    "title": "URI Service Conf",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveService_",
+            "type": "object"
+        },
+        "_AdaptiveService_.propertyTypes": {
+            "properties": {
+                "canRestart": {
+                    "description": "Can attempt to restart this service.",
+                    "markdownDescription": "Can attempt to restart this service.",
+                    "title": "Can Restart",
+                    "type": "boolean"
+                },
+                "canStart": {
+                    "description": "Can attempt to start this service.",
+                    "markdownDescription": "Can attempt to start this service.",
+                    "title": "Can Start",
+                    "type": "boolean"
+                },
+                "canStop": {
+                    "description": "Can attempt to stop this service.",
+                    "markdownDescription": "Can attempt to stop this service.",
+                    "title": "Can Stop",
+                    "type": "boolean"
+                },
+                "confId": {
+                    "description": "The 'id' part of serviceId. This is the value of appropriate conf id property based on the conf type.",
+                    "markdownDescription": "The 'id' part of serviceId. This is the value of appropriate conf id property based on the conf type.",
+                    "title": "Conf Id",
+                    "type": "string"
+                },
+                "confPropertyObjectType": {
+                    "description": "Object type for 'conf' property object.",
+                    "markdownDescription": "Object type for 'conf' property object.",
+                    "title": "Conf Property Object Type",
+                    "type": "string"
+                },
+                "confSubtype": {
+                    "description": "This is the value of appropriate conf subtype property based on the conf type.",
+                    "markdownDescription": "This is the value of appropriate conf subtype property based on the conf type.",
+                    "title": "Conf Subtype",
+                    "type": "string"
+                },
+                "serviceId": {
+                    "description": "Service id.",
+                    "markdownDescription": "Service id.",
+                    "title": "Service",
+                    "type": "string"
+                },
+                "serviceType": {
+                    "description": "The 'type' part of serviceId.",
+                    "markdownDescription": "The 'type' part of serviceId.",
+                    "title": "Service Type",
+                    "type": "string"
+                },
+                "sourceLocation": {
+                    "description": "Related to where service was defined.",
+                    "markdownDescription": "Related to where service was defined.",
+                    "title": "Source Location",
+                    "type": "string"
+                },
+                "startTime": {
+                    "description": "Start time.",
+                    "format": "date-time",
+                    "markdownDescription": "Start time.",
+                    "title": "Start Time",
+                    "type": "string"
+                },
+                "startup": {
+                    "default": "manual",
+                    "description": "Service startup condition.",
+                    "markdownDescription": "Service startup condition.",
+                    "title": "Startup",
+                    "type": "string"
+                },
+                "startupDescription": {
+                    "description": "Service startup condition description.",
+                    "markdownDescription": "Service startup condition description.",
+                    "title": "Startup Description",
+                    "type": "string"
+                },
+                "status": {
+                    "description": "Service status.",
+                    "markdownDescription": "Service status.",
+                    "title": "Status",
+                    "type": "string"
+                },
+                "statusDebug": {
+                    "contentMediaType": "text/plain",
+                    "description": "This is statusMessage with additional debug information.",
+                    "markdownDescription": "This is statusMessage with additional debug information.",
+                    "title": "Status Debug",
+                    "type": "string"
+                },
+                "statusDescription": {
+                    "description": "Service status description.",
+                    "markdownDescription": "Service status description.",
+                    "title": "Status Description",
+                    "type": "string"
+                },
+                "statusMessage": {
+                    "description": "Optional message associated with status. In the case of status=error, this is the error message.",
+                    "markdownDescription": "Optional message associated with status. In the case of status=error, this is the error message.",
+                    "title": "Status Message",
+                    "type": "string"
+                },
+                "uriRelated": {
+                    "description": "URI of related object.",
+                    "format": "uri-reference",
+                    "markdownDescription": "URI of related object.",
+                    "title": "URI Related",
+                    "type": "string"
+                },
+                "uriServiceConf": {
+                    "description": "URI of service conf object.",
+                    "format": "uri-reference",
+                    "markdownDescription": "URI of service conf object.",
                     "title": "URI Service Conf",
                     "type": "string"
                 }
@@ -112,9 +250,131 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveService_"
+    "additionalProperties": false,
+    "description": "An adaptive service.",
+    "markdownDescription": "An adaptive service.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "canRestart": {
+            "description": "Can attempt to restart this service.",
+            "markdownDescription": "Can attempt to restart this service.",
+            "title": "Can Restart",
+            "type": "boolean"
+        },
+        "canStart": {
+            "description": "Can attempt to start this service.",
+            "markdownDescription": "Can attempt to start this service.",
+            "title": "Can Start",
+            "type": "boolean"
+        },
+        "canStop": {
+            "description": "Can attempt to stop this service.",
+            "markdownDescription": "Can attempt to stop this service.",
+            "title": "Can Stop",
+            "type": "boolean"
+        },
+        "confId": {
+            "description": "The 'id' part of serviceId. This is the value of appropriate conf id property based on the conf type.",
+            "markdownDescription": "The 'id' part of serviceId. This is the value of appropriate conf id property based on the conf type.",
+            "title": "Conf Id",
+            "type": "string"
+        },
+        "confPropertyObjectType": {
+            "description": "Object type for 'conf' property object.",
+            "markdownDescription": "Object type for 'conf' property object.",
+            "title": "Conf Property Object Type",
+            "type": "string"
+        },
+        "confSubtype": {
+            "description": "This is the value of appropriate conf subtype property based on the conf type.",
+            "markdownDescription": "This is the value of appropriate conf subtype property based on the conf type.",
+            "title": "Conf Subtype",
+            "type": "string"
+        },
+        "serviceId": {
+            "description": "Service id.",
+            "markdownDescription": "Service id.",
+            "title": "Service",
+            "type": "string"
+        },
+        "serviceType": {
+            "description": "The 'type' part of serviceId.",
+            "markdownDescription": "The 'type' part of serviceId.",
+            "title": "Service Type",
+            "type": "string"
+        },
+        "sourceLocation": {
+            "description": "Related to where service was defined.",
+            "markdownDescription": "Related to where service was defined.",
+            "title": "Source Location",
+            "type": "string"
+        },
+        "startTime": {
+            "description": "Start time.",
+            "format": "date-time",
+            "markdownDescription": "Start time.",
+            "title": "Start Time",
+            "type": "string"
+        },
+        "startup": {
+            "default": "manual",
+            "description": "Service startup condition.",
+            "markdownDescription": "Service startup condition.",
+            "title": "Startup",
+            "type": "string"
+        },
+        "startupDescription": {
+            "description": "Service startup condition description.",
+            "markdownDescription": "Service startup condition description.",
+            "title": "Startup Description",
+            "type": "string"
+        },
+        "status": {
+            "description": "Service status.",
+            "markdownDescription": "Service status.",
+            "title": "Status",
+            "type": "string"
+        },
+        "statusDebug": {
+            "contentMediaType": "text/plain",
+            "description": "This is statusMessage with additional debug information.",
+            "markdownDescription": "This is statusMessage with additional debug information.",
+            "title": "Status Debug",
+            "type": "string"
+        },
+        "statusDescription": {
+            "description": "Service status description.",
+            "markdownDescription": "Service status description.",
+            "title": "Status Description",
+            "type": "string"
+        },
+        "statusMessage": {
+            "description": "Optional message associated with status. In the case of status=error, this is the error message.",
+            "markdownDescription": "Optional message associated with status. In the case of status=error, this is the error message.",
+            "title": "Status Message",
+            "type": "string"
+        },
+        "uriRelated": {
+            "description": "URI of related object.",
+            "format": "uri-reference",
+            "markdownDescription": "URI of related object.",
+            "title": "URI Related",
+            "type": "string"
+        },
+        "uriServiceConf": {
+            "description": "URI of service conf object.",
+            "format": "uri-reference",
+            "markdownDescription": "URI of service conf object.",
+            "title": "URI Service Conf",
+            "type": "string"
         }
-    ]
+    },
+    "title": "_AdaptiveService_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveSingleton_.json
+++ b/generated/schemas/afw/_AdaptiveSingleton_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveSingleton_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveSingleton_.propertyTypes"
                 }
@@ -22,7 +22,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveSingleton_"
         }

--- a/generated/schemas/afw/_AdaptiveSingleton_.json
+++ b/generated/schemas/afw/_AdaptiveSingleton_.json
@@ -1,19 +1,33 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveSingleton_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveSingleton_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveSingleton_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "A registry type singleton entry.",
-            "type": "object",
-            "unevaluatedProperties": false
+            "markdownDescription": "A registry type singleton entry.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "key": {
+                    "description": "Key of entry.",
+                    "markdownDescription": "**Key**\n\nKey of entry.",
+                    "title": "Key",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveSingleton_",
+            "type": "object"
         },
         "_AdaptiveSingleton_.propertyTypes": {
             "properties": {
                 "key": {
                     "description": "Key of entry.",
+                    "markdownDescription": "**Key**\n\nKey of entry.",
                     "title": "Key",
                     "type": "string"
                 }
@@ -22,9 +36,24 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveSingleton_"
+    "additionalProperties": false,
+    "description": "A registry type singleton entry.",
+    "markdownDescription": "A registry type singleton entry.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "key": {
+            "description": "Key of entry.",
+            "markdownDescription": "**Key**\n\nKey of entry.",
+            "title": "Key",
+            "type": "string"
         }
-    ]
+    },
+    "title": "_AdaptiveSingleton_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveSystemInfo_.json
+++ b/generated/schemas/afw/_AdaptiveSystemInfo_.json
@@ -1,10 +1,8 @@
 {
     "$defs": {
         "_AdaptiveSystemInfo_": {
-            "additionalProperties": {
-                "description": "Objects of this type represent runtime information about the system Adaptive Framework is running on. The meta of instances of _AdaptiveSystemInfo_ should contain the description of the instance plus supplemental property type information."
-            },
-            "anyOf": [
+            "additionalProperties": true,
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveSystemInfo_.propertyTypes"
                 }
@@ -18,7 +16,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveSystemInfo_"
         }

--- a/generated/schemas/afw/_AdaptiveSystemInfo_.json
+++ b/generated/schemas/afw/_AdaptiveSystemInfo_.json
@@ -1,13 +1,20 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveSystemInfo_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveSystemInfo_": {
             "additionalProperties": true,
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveSystemInfo_.propertyTypes"
-                }
-            ],
             "description": "Objects of this type represent runtime information about the system Adaptive Framework is running on. The meta of instances of _AdaptiveSystemInfo_ should contain the description of the instance plus supplemental property type information.",
+            "markdownDescription": "Objects of this type represent runtime information about the system Adaptive Framework is running on. The meta of instances of _AdaptiveSystemInfo_ should contain the description of the instance plus supplemental property type information.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                }
+            },
+            "title": "_AdaptiveSystemInfo_",
             "type": "object"
         },
         "_AdaptiveSystemInfo_.propertyTypes": {
@@ -16,9 +23,18 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveSystemInfo_"
+    "additionalProperties": true,
+    "description": "Objects of this type represent runtime information about the system Adaptive Framework is running on. The meta of instances of _AdaptiveSystemInfo_ should contain the description of the instance plus supplemental property type information.",
+    "markdownDescription": "Objects of this type represent runtime information about the system Adaptive Framework is running on. The meta of instances of _AdaptiveSystemInfo_ should contain the description of the instance plus supplemental property type information.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
         }
-    ]
+    },
+    "title": "_AdaptiveSystemInfo_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveTag_.json
+++ b/generated/schemas/afw/_AdaptiveTag_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveTag_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveTag_.propertyTypes"
                 }
@@ -38,7 +38,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveTag_"
         }

--- a/generated/schemas/afw/_AdaptiveTag_.json
+++ b/generated/schemas/afw/_AdaptiveTag_.json
@@ -1,25 +1,28 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveTag_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveTag_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveTag_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "This defines the purpose of a tag id. Among other places, tags can be specified in object types and property types. All tags that begin with '_Adaptive' are reserved by Adaptive Framework. The requirement that other tags be defined is up to the application.",
-            "type": "object",
-            "unevaluatedProperties": false
-        },
-        "_AdaptiveTag_.propertyTypes": {
+            "markdownDescription": "This defines the purpose of a tag id. Among other places, tags can be specified in object types and property types. All tags that begin with '_Adaptive' are reserved by Adaptive Framework. The requirement that other tags be defined is up to the application.",
             "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
                 "description": {
                     "contentMediaType": "text/plain",
                     "description": "Description of this tag.",
+                    "markdownDescription": "**Description**\n\nDescription of this tag.",
                     "title": "Description",
                     "type": "string"
                 },
                 "tagId": {
                     "description": "The id of this tag.",
+                    "markdownDescription": "**Tag Id**\n\nThe id of this tag.",
                     "title": "Tag Id",
                     "type": "string"
                 },
@@ -27,9 +30,42 @@
                     "description": "Tags that can be used to query for this tag. One possible purpose is to use a tag to define a category of tags.",
                     "items": {
                         "description": "Tags that can be used to query for this tag. One possible purpose is to use a tag to define a category of tags.",
+                        "markdownDescription": "Tags that can be used to query for this tag. One possible purpose is to use a tag to define a category of tags.",
                         "title": "Tags that can be used to query for this tag",
                         "type": "string"
                     },
+                    "markdownDescription": "**Tags**\n\nTags that can be used to query for this tag. One possible purpose is to use a tag to define a category of tags.",
+                    "title": "Tags",
+                    "type": "array"
+                }
+            },
+            "title": "_AdaptiveTag_",
+            "type": "object"
+        },
+        "_AdaptiveTag_.propertyTypes": {
+            "properties": {
+                "description": {
+                    "contentMediaType": "text/plain",
+                    "description": "Description of this tag.",
+                    "markdownDescription": "**Description**\n\nDescription of this tag.",
+                    "title": "Description",
+                    "type": "string"
+                },
+                "tagId": {
+                    "description": "The id of this tag.",
+                    "markdownDescription": "**Tag Id**\n\nThe id of this tag.",
+                    "title": "Tag Id",
+                    "type": "string"
+                },
+                "tags": {
+                    "description": "Tags that can be used to query for this tag. One possible purpose is to use a tag to define a category of tags.",
+                    "items": {
+                        "description": "Tags that can be used to query for this tag. One possible purpose is to use a tag to define a category of tags.",
+                        "markdownDescription": "Tags that can be used to query for this tag. One possible purpose is to use a tag to define a category of tags.",
+                        "title": "Tags that can be used to query for this tag",
+                        "type": "string"
+                    },
+                    "markdownDescription": "**Tags**\n\nTags that can be used to query for this tag. One possible purpose is to use a tag to define a category of tags.",
                     "title": "Tags",
                     "type": "array"
                 }
@@ -38,9 +74,43 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveTag_"
+    "additionalProperties": false,
+    "description": "This defines the purpose of a tag id. Among other places, tags can be specified in object types and property types. All tags that begin with '_Adaptive' are reserved by Adaptive Framework. The requirement that other tags be defined is up to the application.",
+    "markdownDescription": "This defines the purpose of a tag id. Among other places, tags can be specified in object types and property types. All tags that begin with '_Adaptive' are reserved by Adaptive Framework. The requirement that other tags be defined is up to the application.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "description": {
+            "contentMediaType": "text/plain",
+            "description": "Description of this tag.",
+            "markdownDescription": "**Description**\n\nDescription of this tag.",
+            "title": "Description",
+            "type": "string"
+        },
+        "tagId": {
+            "description": "The id of this tag.",
+            "markdownDescription": "**Tag Id**\n\nThe id of this tag.",
+            "title": "Tag Id",
+            "type": "string"
+        },
+        "tags": {
+            "description": "Tags that can be used to query for this tag. One possible purpose is to use a tag to define a category of tags.",
+            "items": {
+                "description": "Tags that can be used to query for this tag. One possible purpose is to use a tag to define a category of tags.",
+                "markdownDescription": "Tags that can be used to query for this tag. One possible purpose is to use a tag to define a category of tags.",
+                "title": "Tags that can be used to query for this tag",
+                "type": "string"
+            },
+            "markdownDescription": "**Tags**\n\nTags that can be used to query for this tag. One possible purpose is to use a tag to define a category of tags.",
+            "title": "Tags",
+            "type": "array"
         }
-    ]
+    },
+    "title": "_AdaptiveTag_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveValueInf_.json
+++ b/generated/schemas/afw/_AdaptiveValueInf_.json
@@ -1,7 +1,7 @@
 {
     "$defs": {
         "_AdaptiveValueInf_": {
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveValueInf_.propertyTypes"
                 }
@@ -22,7 +22,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveValueInf_"
         }

--- a/generated/schemas/afw/_AdaptiveValueInf_.json
+++ b/generated/schemas/afw/_AdaptiveValueInf_.json
@@ -1,19 +1,33 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveValueInf_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveValueInf_": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveValueInf_.propertyTypes"
-                }
-            ],
+            "additionalProperties": false,
             "description": "A registry type value_inf entry.",
-            "type": "object",
-            "unevaluatedProperties": false
+            "markdownDescription": "A registry type value_inf entry.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "key": {
+                    "description": "Key of entry.",
+                    "markdownDescription": "**Key**\n\nKey of entry.",
+                    "title": "Key",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveValueInf_",
+            "type": "object"
         },
         "_AdaptiveValueInf_.propertyTypes": {
             "properties": {
                 "key": {
                     "description": "Key of entry.",
+                    "markdownDescription": "**Key**\n\nKey of entry.",
                     "title": "Key",
                     "type": "string"
                 }
@@ -22,9 +36,24 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveValueInf_"
+    "additionalProperties": false,
+    "description": "A registry type value_inf entry.",
+    "markdownDescription": "A registry type value_inf entry.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "key": {
+            "description": "Key of entry.",
+            "markdownDescription": "**Key**\n\nKey of entry.",
+            "title": "Key",
+            "type": "string"
         }
-    ]
+    },
+    "title": "_AdaptiveValueInf_",
+    "type": "object"
 }

--- a/generated/schemas/afw/_AdaptiveVersionInfo_.json
+++ b/generated/schemas/afw/_AdaptiveVersionInfo_.json
@@ -5,7 +5,7 @@
                 "description": "The version information associated with an id.",
                 "type": "string"
             },
-            "anyOf": [
+            "allOf": [
                 {
                     "$ref": "#/$defs/_AdaptiveVersionInfo_.propertyTypes"
                 }
@@ -70,7 +70,7 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "#/$defs/_AdaptiveVersionInfo_"
         }

--- a/generated/schemas/afw/_AdaptiveVersionInfo_.json
+++ b/generated/schemas/afw/_AdaptiveVersionInfo_.json
@@ -1,67 +1,145 @@
 {
+    "$comment": "Generated from adaptive object type _AdaptiveVersionInfo_. Primary use: editor completion/validation for generate/objects JSON. Do not hand-edit.",
     "$defs": {
         "_AdaptiveVersionInfo_": {
             "additionalProperties": {
                 "description": "The version information associated with an id.",
+                "markdownDescription": "The version information associated with an id.",
                 "type": "string"
             },
-            "allOf": [
-                {
-                    "$ref": "#/$defs/_AdaptiveVersionInfo_.propertyTypes"
-                }
-            ],
             "description": "The version information associated with an id.",
+            "markdownDescription": "The version information associated with an id.",
+            "properties": {
+                "_meta_": {
+                    "additionalProperties": true,
+                    "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+                    "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+                    "title": "Meta",
+                    "type": "object"
+                },
+                "compileDate": {
+                    "description": "This uses the C preprocessor macro __DATE__ at time of compile.",
+                    "markdownDescription": "**Compile Date**\n\nThis uses the C preprocessor macro __DATE__ at time of compile.",
+                    "title": "Compile Date",
+                    "type": "string"
+                },
+                "compileTime": {
+                    "description": "This uses the C preprocessor macro __TIME__ at time of compile.",
+                    "markdownDescription": "**Compile Time**\n\nThis uses the C preprocessor macro __TIME__ at time of compile.",
+                    "title": "Compile Time",
+                    "type": "string"
+                },
+                "gitBranch": {
+                    "description": "The current Git branch used for this build. It's calculated with the command, 'git rev-parse --abbrev-ref HEAD'",
+                    "markdownDescription": "**Git Branch**\n\nThe current Git branch used for this build. It's calculated with the command, 'git rev-parse --abbrev-ref HEAD'",
+                    "title": "Git Branch",
+                    "type": "string"
+                },
+                "gitDescribe": {
+                    "description": "The most recent tag that is reachable from the current Git commit. If the tag points to the commit, then only the tag is shown. Otherwise, it suffixes the tag name with the number of additional commits on top of the tagged object and the abbreviated object name of the most recent commit. The result is a human-readable object name which can also be used to identify the commit to other git commands. This is calculated with the command 'git describe --dirty --always --tags'",
+                    "markdownDescription": "**Git Describe**\n\nThe most recent tag that is reachable from the current Git commit. If the tag points to the commit, then only the tag is shown. Otherwise, it suffixes the tag name with the number of additional commits on top of the tagged object and the abbreviated object name of the most recent commit. The result is a human-readable object name which can also be used to identify the commit to other git commands. This is calculated with the command 'git describe --dirty --always --tags'",
+                    "title": "Git Describe",
+                    "type": "string"
+                },
+                "gitSha": {
+                    "description": "The full SHA-1 object name (40-byte hexadecimal string), that is unique within the repository, used to identify the source for this build. It's calculated with the command 'git rev-parse HEAD'",
+                    "markdownDescription": "**Git SHA**\n\nThe full SHA-1 object name (40-byte hexadecimal string), that is unique within the repository, used to identify the source for this build. It's calculated with the command 'git rev-parse HEAD'",
+                    "title": "Git SHA",
+                    "type": "string"
+                },
+                "id": {
+                    "description": "This is the id associated with the version information. This is usually the name of the subdirectory containing the source for the command or extension.",
+                    "markdownDescription": "**ID**\n\nThis is the id associated with the version information. This is usually the name of the subdirectory containing the source for the command or extension.",
+                    "title": "ID",
+                    "type": "string"
+                },
+                "libafwVersion": {
+                    "description": "AFW_VERSION_STRING at time of compile.",
+                    "markdownDescription": "**libafw Version**\n\nAFW_VERSION_STRING at time of compile.",
+                    "title": "libafw Version",
+                    "type": "string"
+                },
+                "libafwVersionWithGitInfo": {
+                    "description": "AFW_VERSION_WITH_GIT_INFO at time of compile.",
+                    "markdownDescription": "**libafw Version+Git**\n\nAFW_VERSION_WITH_GIT_INFO at time of compile.",
+                    "title": "libafw Version+Git",
+                    "type": "string"
+                },
+                "version": {
+                    "description": "<srcdir>_VERSION_STRING at time of compile.",
+                    "markdownDescription": "**<srcdir> Version**\n\n<srcdir>_VERSION_STRING at time of compile.",
+                    "title": "<srcdir> Version",
+                    "type": "string"
+                },
+                "versionWithGitInfo": {
+                    "description": "<srcdir>_VERSION_WITH_GIT_INFO at time of compile.",
+                    "markdownDescription": "**<srcdir> Version+Git**\n\n<srcdir>_VERSION_WITH_GIT_INFO at time of compile.",
+                    "title": "<srcdir> Version+Git",
+                    "type": "string"
+                }
+            },
+            "title": "_AdaptiveVersionInfo_",
             "type": "object"
         },
         "_AdaptiveVersionInfo_.propertyTypes": {
             "properties": {
                 "compileDate": {
                     "description": "This uses the C preprocessor macro __DATE__ at time of compile.",
+                    "markdownDescription": "**Compile Date**\n\nThis uses the C preprocessor macro __DATE__ at time of compile.",
                     "title": "Compile Date",
                     "type": "string"
                 },
                 "compileTime": {
                     "description": "This uses the C preprocessor macro __TIME__ at time of compile.",
+                    "markdownDescription": "**Compile Time**\n\nThis uses the C preprocessor macro __TIME__ at time of compile.",
                     "title": "Compile Time",
                     "type": "string"
                 },
                 "gitBranch": {
                     "description": "The current Git branch used for this build. It's calculated with the command, 'git rev-parse --abbrev-ref HEAD'",
+                    "markdownDescription": "**Git Branch**\n\nThe current Git branch used for this build. It's calculated with the command, 'git rev-parse --abbrev-ref HEAD'",
                     "title": "Git Branch",
                     "type": "string"
                 },
                 "gitDescribe": {
                     "description": "The most recent tag that is reachable from the current Git commit. If the tag points to the commit, then only the tag is shown. Otherwise, it suffixes the tag name with the number of additional commits on top of the tagged object and the abbreviated object name of the most recent commit. The result is a human-readable object name which can also be used to identify the commit to other git commands. This is calculated with the command 'git describe --dirty --always --tags'",
+                    "markdownDescription": "**Git Describe**\n\nThe most recent tag that is reachable from the current Git commit. If the tag points to the commit, then only the tag is shown. Otherwise, it suffixes the tag name with the number of additional commits on top of the tagged object and the abbreviated object name of the most recent commit. The result is a human-readable object name which can also be used to identify the commit to other git commands. This is calculated with the command 'git describe --dirty --always --tags'",
                     "title": "Git Describe",
                     "type": "string"
                 },
                 "gitSha": {
                     "description": "The full SHA-1 object name (40-byte hexadecimal string), that is unique within the repository, used to identify the source for this build. It's calculated with the command 'git rev-parse HEAD'",
+                    "markdownDescription": "**Git SHA**\n\nThe full SHA-1 object name (40-byte hexadecimal string), that is unique within the repository, used to identify the source for this build. It's calculated with the command 'git rev-parse HEAD'",
                     "title": "Git SHA",
                     "type": "string"
                 },
                 "id": {
                     "description": "This is the id associated with the version information. This is usually the name of the subdirectory containing the source for the command or extension.",
+                    "markdownDescription": "**ID**\n\nThis is the id associated with the version information. This is usually the name of the subdirectory containing the source for the command or extension.",
                     "title": "ID",
                     "type": "string"
                 },
                 "libafwVersion": {
                     "description": "AFW_VERSION_STRING at time of compile.",
+                    "markdownDescription": "**libafw Version**\n\nAFW_VERSION_STRING at time of compile.",
                     "title": "libafw Version",
                     "type": "string"
                 },
                 "libafwVersionWithGitInfo": {
                     "description": "AFW_VERSION_WITH_GIT_INFO at time of compile.",
+                    "markdownDescription": "**libafw Version+Git**\n\nAFW_VERSION_WITH_GIT_INFO at time of compile.",
                     "title": "libafw Version+Git",
                     "type": "string"
                 },
                 "version": {
                     "description": "<srcdir>_VERSION_STRING at time of compile.",
+                    "markdownDescription": "**<srcdir> Version**\n\n<srcdir>_VERSION_STRING at time of compile.",
                     "title": "<srcdir> Version",
                     "type": "string"
                 },
                 "versionWithGitInfo": {
                     "description": "<srcdir>_VERSION_WITH_GIT_INFO at time of compile.",
+                    "markdownDescription": "**<srcdir> Version+Git**\n\n<srcdir>_VERSION_WITH_GIT_INFO at time of compile.",
                     "title": "<srcdir> Version+Git",
                     "type": "string"
                 }
@@ -70,9 +148,82 @@
         }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "allOf": [
-        {
-            "$ref": "#/$defs/_AdaptiveVersionInfo_"
+    "additionalProperties": {
+        "description": "The version information associated with an id.",
+        "markdownDescription": "The version information associated with an id.",
+        "type": "string"
+    },
+    "description": "The version information associated with an id.",
+    "markdownDescription": "The version information associated with an id.",
+    "properties": {
+        "_meta_": {
+            "additionalProperties": true,
+            "description": "Adaptive instance meta (objectId, path, objectType, ...).",
+            "markdownDescription": "Adaptive instance meta (`objectId`, `path`, `objectType`, \u2026).",
+            "title": "Meta",
+            "type": "object"
+        },
+        "compileDate": {
+            "description": "This uses the C preprocessor macro __DATE__ at time of compile.",
+            "markdownDescription": "**Compile Date**\n\nThis uses the C preprocessor macro __DATE__ at time of compile.",
+            "title": "Compile Date",
+            "type": "string"
+        },
+        "compileTime": {
+            "description": "This uses the C preprocessor macro __TIME__ at time of compile.",
+            "markdownDescription": "**Compile Time**\n\nThis uses the C preprocessor macro __TIME__ at time of compile.",
+            "title": "Compile Time",
+            "type": "string"
+        },
+        "gitBranch": {
+            "description": "The current Git branch used for this build. It's calculated with the command, 'git rev-parse --abbrev-ref HEAD'",
+            "markdownDescription": "**Git Branch**\n\nThe current Git branch used for this build. It's calculated with the command, 'git rev-parse --abbrev-ref HEAD'",
+            "title": "Git Branch",
+            "type": "string"
+        },
+        "gitDescribe": {
+            "description": "The most recent tag that is reachable from the current Git commit. If the tag points to the commit, then only the tag is shown. Otherwise, it suffixes the tag name with the number of additional commits on top of the tagged object and the abbreviated object name of the most recent commit. The result is a human-readable object name which can also be used to identify the commit to other git commands. This is calculated with the command 'git describe --dirty --always --tags'",
+            "markdownDescription": "**Git Describe**\n\nThe most recent tag that is reachable from the current Git commit. If the tag points to the commit, then only the tag is shown. Otherwise, it suffixes the tag name with the number of additional commits on top of the tagged object and the abbreviated object name of the most recent commit. The result is a human-readable object name which can also be used to identify the commit to other git commands. This is calculated with the command 'git describe --dirty --always --tags'",
+            "title": "Git Describe",
+            "type": "string"
+        },
+        "gitSha": {
+            "description": "The full SHA-1 object name (40-byte hexadecimal string), that is unique within the repository, used to identify the source for this build. It's calculated with the command 'git rev-parse HEAD'",
+            "markdownDescription": "**Git SHA**\n\nThe full SHA-1 object name (40-byte hexadecimal string), that is unique within the repository, used to identify the source for this build. It's calculated with the command 'git rev-parse HEAD'",
+            "title": "Git SHA",
+            "type": "string"
+        },
+        "id": {
+            "description": "This is the id associated with the version information. This is usually the name of the subdirectory containing the source for the command or extension.",
+            "markdownDescription": "**ID**\n\nThis is the id associated with the version information. This is usually the name of the subdirectory containing the source for the command or extension.",
+            "title": "ID",
+            "type": "string"
+        },
+        "libafwVersion": {
+            "description": "AFW_VERSION_STRING at time of compile.",
+            "markdownDescription": "**libafw Version**\n\nAFW_VERSION_STRING at time of compile.",
+            "title": "libafw Version",
+            "type": "string"
+        },
+        "libafwVersionWithGitInfo": {
+            "description": "AFW_VERSION_WITH_GIT_INFO at time of compile.",
+            "markdownDescription": "**libafw Version+Git**\n\nAFW_VERSION_WITH_GIT_INFO at time of compile.",
+            "title": "libafw Version+Git",
+            "type": "string"
+        },
+        "version": {
+            "description": "<srcdir>_VERSION_STRING at time of compile.",
+            "markdownDescription": "**<srcdir> Version**\n\n<srcdir>_VERSION_STRING at time of compile.",
+            "title": "<srcdir> Version",
+            "type": "string"
+        },
+        "versionWithGitInfo": {
+            "description": "<srcdir>_VERSION_WITH_GIT_INFO at time of compile.",
+            "markdownDescription": "**<srcdir> Version+Git**\n\n<srcdir>_VERSION_WITH_GIT_INFO at time of compile.",
+            "title": "<srcdir> Version+Git",
+            "type": "string"
         }
-    ]
+    },
+    "title": "_AdaptiveVersionInfo_",
+    "type": "object"
 }

--- a/src/afw_dev/_afwdev/generate/json_schema.py
+++ b/src/afw_dev/_afwdev/generate/json_schema.py
@@ -3,446 +3,611 @@
 ##
 # @file json_schema.py
 # @ingroup afwdev_generate
-# @brief This file contains the functions used to generate JSON schema files
+# @brief Generate package-root JSON Schema files from adaptive object types.
+# @details
+# Adaptive object types under src/**/generated/objects/_AdaptiveObjectType_/
+# are the source of truth. This module emits a best-effort JSON Schema
+# (draft 2020-12) projection into generated/schemas/afw/ for editors and
+# `afwdev validate`. It is not a complete model of adaptive meta (runtime,
+# allowQuery, etc. are intentionally omitted).
+#
+# Important mapping choices:
+# - Object-typed properties use pure $ref or annotations + allOf/[{$ref}]
+#   (never $ref mixed with siblings; see issue #3).
+# - Inheritance (parentPaths) is composite allOf of .propertyTypes defs.
+# - required applies only to the leaf object type, not inherited property maps.
 #
 
-import os
 import glob
+import os
+
 from _afwdev.common import msg, package, resources, nfc
 
-_data_types = None
+# Adaptive dataTypeParameterType values with no JSON Schema projection yet.
+_UNMAPPED_PARAMETER_TYPES = frozenset({
+    'SourceParameter',
+    'FunctionSignature',
+    'Type',
+    'xpathExpression',
+})
 
-# Look for pattern in setting.json json.schema.
-def _fileMatch_exists(json_schema, pattern):
-    for entry in json_schema:
-        if entry.get('fileMatch'):
-            for fileMatch in entry['fileMatch']:
-                if fileMatch == pattern:
-                    return True
+
+##
+# @brief Per-generate build state (object types, data types, emitted schemas).
+#
+class _SchemaBuildContext:
+
+    def __init__(self, options):
+        self.options = options
+        self.data_types = {}
+        self.object_types = {}
+        self.schemas = {}
+        self.ref_prefix = '#/$defs/'
+        self.ref_suffix = ''
+        self.json_schema_uri = 'https://json-schema.org/draft/2020-12/schema'
+
+    def ref(self, name):
+        return self.ref_prefix + name + self.ref_suffix
+
+
+# ---------------------------------------------------------------------------
+# VS Code settings (optional side effect of generate)
+# ---------------------------------------------------------------------------
+
+def _fileMatch_exists(json_schema_entries, pattern):
+    for entry in json_schema_entries:
+        for fileMatch in entry.get('fileMatch') or []:
+            if fileMatch == pattern:
+                return True
     return False
 
-# Update setting.json json.schema with unmatched object type schemas patterns.
+
 def _update_vscode_settings_json_schema(options):
+    """Ensure .vscode/settings.json maps generate object paths to schemas."""
     filename = '.vscode/settings.json'
     fullpath = options['afw_package_dir_path'] + filename
     was_updated = False
+
     if os.path.exists(fullpath):
         with nfc.open(fullpath, 'r') as fd:
             settings = nfc.json_load(fd)
     else:
         settings = {}
 
-    json_schema = settings.get('json.schemas')
-    if json_schema is None:
-        json_schema = []
+    json_schema_entries = settings.get('json.schemas')
+    if json_schema_entries is None:
+        json_schema_entries = []
 
-    # Make sure entry for afw-package.json exists.
-    if not _fileMatch_exists(json_schema, '/afw-package.json'):
-        fileMatch = "/afw-package.json"
-        json_schema.append({
-            "fileMatch": [ fileMatch ],
-            "url": "./generated/schemas/afw/_AdaptivePackage_.json"
+    if not _fileMatch_exists(json_schema_entries, '/afw-package.json'):
+        json_schema_entries.append({
+            'fileMatch': ['/afw-package.json'],
+            'url': './generated/schemas/afw/_AdaptivePackage_.json',
         })
-        msg.info('Added fileMatch ' + fileMatch + ' to ' + filename + ' json.schemas')
+        msg.info('Added fileMatch /afw-package.json to ' + filename +
+                 ' json.schemas')
         was_updated = True
 
-    # Make sure entries exist for all schemas in generated/schemas/afw/.
     relative_schema_path = 'generated/schemas/afw/'
-    for full_schema_path in glob.glob(options['afw_package_dir_path'] + relative_schema_path + '*.json'):
-        objectType = full_schema_path[len(options['afw_package_dir_path'] + relative_schema_path):-5]
+    schema_glob = options['afw_package_dir_path'] + relative_schema_path + '*.json'
+    prefix_len = len(options['afw_package_dir_path'] + relative_schema_path)
+    for full_schema_path in glob.glob(schema_glob):
+        objectType = full_schema_path[prefix_len:-5]
         fileMatch = '/src/*/generate*/objects/' + objectType + '/*.json'
-        if not _fileMatch_exists(json_schema, fileMatch):
-            json_schema.append({
-                "fileMatch": [ fileMatch ],
-                "url": "./generated/schemas/afw/" + objectType + ".json"
+        if not _fileMatch_exists(json_schema_entries, fileMatch):
+            json_schema_entries.append({
+                'fileMatch': [fileMatch],
+                'url': './generated/schemas/afw/' + objectType + '.json',
             })
-            msg.info('Added fileMatch ' + fileMatch + ' to ' + filename + ' json.schemas')
+            msg.info('Added fileMatch ' + fileMatch + ' to ' + filename +
+                     ' json.schemas')
             was_updated = True
 
     if was_updated:
-        settings['json.schemas'] = json_schema
+        settings['json.schemas'] = json_schema_entries
         os.makedirs(options['afw_package_dir_path'] + '.vscode', exist_ok=True)
         with nfc.open(fullpath, 'w') as fd:
             nfc.json_dump(settings, fd, indent=4, sort_keys=True)
-        msg.success('Update to settings.json json.schemas property for new object types successful (restart vscode required to take effect)')
+        msg.success(
+            'Updated settings.json json.schemas for new object types '
+            '(restart vscode required to take effect)')
 
 
-# Add objectType's needs and make sure they're in global _all_schemas.
-def _add_definition(mutable_objectTypes_needed,
-    options, objectType, ref_prefix, ref_suffix,
-    propertyTypesOnly=False, description=None, title=None):
+# ---------------------------------------------------------------------------
+# $ref helpers (issue #3)
+# ---------------------------------------------------------------------------
 
-    global _all_schemas
-    global _all_object_type_objects
+def _ref_schema(ref, base=None):
+    """
+    Build a schema that references another without mixing $ref and siblings.
 
-    # If the objectType is already in definitions, return.
-    if objectType in mutable_objectTypes_needed:
+    With annotations: { title, description, ..., allOf: [ { $ref } ] }
+    Without:          { $ref }
+    """
+    annotations = {}
+    if base:
+        for key, value in base.items():
+            # type/format come from the target; never re-emit $ref/allOf here.
+            if key in ('$ref', 'type', 'format', 'allOf'):
+                continue
+            annotations[key] = value
+    if not annotations:
+        return {'$ref': ref}
+    result = dict(annotations)
+    result['allOf'] = [{'$ref': ref}]
+    return result
+
+
+def _apply_annotations(schema, annotations):
+    """Attach title/description/etc. without putting them beside a bare $ref."""
+    if not annotations:
+        return schema
+    if list(schema.keys()) == ['$ref']:
+        return _ref_schema(schema['$ref'], annotations)
+    all_of = schema.get('allOf')
+    if (isinstance(all_of, list) and len(all_of) == 1 and
+            isinstance(all_of[0], dict) and
+            list(all_of[0].keys()) == ['$ref']):
+        base = {k: v for k, v in schema.items() if k != 'allOf'}
+        base.update(annotations)
+        return _ref_schema(all_of[0]['$ref'], base)
+    result = dict(schema)
+    result.update(annotations)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Data type / property conversion
+# ---------------------------------------------------------------------------
+
+def _set_type(ctx, schema_node, data_type_id):
+    """Map adaptive dataType id onto JSON Schema type/format. Returns DT object."""
+    data_type = ctx.data_types.get(data_type_id)
+    if data_type is None:
+        msg.error('Unknown data type ' + data_type_id)
+        return None
+    if data_type.get('jsonPrimitive') is None:
+        msg.warn('Missing jsonPrimitive for data type ' + data_type_id)
+        return None
+
+    # Adaptive "integer" uses JSON Schema integer (not number).
+    if data_type_id == 'integer':
+        schema_node['type'] = 'integer'
+    else:
+        schema_node['type'] = data_type['jsonPrimitive']
+
+    if 'jsonSchemaStringFormat' in data_type:
+        schema_node['format'] = data_type['jsonSchemaStringFormat']
+    return data_type
+
+
+def _apply_property_annotations(schema_node, property_type,
+                                description=None, title=None):
+    """Copy title, description, default, readOnly, enum from adaptive value meta."""
+    if title is not None:
+        schema_node['title'] = title
+    elif 'label' in property_type:
+        schema_node['title'] = property_type['label']
+    elif 'brief' in property_type:
+        schema_node['title'] = property_type['brief']
+
+    if description is not None:
+        schema_node['description'] = description
+    elif 'description' in property_type:
+        schema_node['description'] = property_type['description']
+
+    if 'defaultValue' in property_type:
+        schema_node['default'] = property_type['defaultValue']
+    elif 'default' in property_type:
+        schema_node['default'] = property_type['default']
+
+    if 'allowWrite' in property_type:
+        schema_node['readOnly'] = not property_type['allowWrite']
+
+    if 'allowedValues' in property_type:
+        schema_node['enum'] = property_type['allowedValues']
+    elif 'possibleValues' in property_type:
+        schema_node['enum'] = property_type['possibleValues']
+
+
+def _apply_type_constraints(schema_node, property_type):
+    """Map min/max/length/unique onto JSON Schema keywords by JSON type."""
+    json_type = schema_node.get('type')
+    if json_type in ('integer', 'number'):
+        if 'minValue' in property_type:
+            schema_node['minimum'] = property_type['minValue']
+        if 'maxValue' in property_type:
+            schema_node['maximum'] = property_type['maxValue']
+    elif json_type == 'string':
+        if 'minLength' in property_type:
+            schema_node['minLength'] = property_type['minLength']
+        if 'maxLength' in property_type:
+            schema_node['maxLength'] = property_type['maxLength']
+    elif json_type == 'array' and property_type.get('unique') is True:
+        schema_node['uniqueItems'] = True
+
+
+def _array_items_for_object_type(ctx, needed, object_type_id):
+    _add_definition(ctx, needed, object_type_id, propertyTypesOnly=False)
+    return _ref_schema(ctx.ref(object_type_id))
+
+
+def _parse_array_data_type_parameter(ctx, needed, dataTypeParameter):
+    """
+    Parse adaptive ArrayOf dataTypeParameter into an items subschema.
+
+    Accepts primitives (string, integer, ...), object types
+    (object _AdaptiveX_ or bare _AdaptiveX_), and nested array of ...
+    """
+    if not dataTypeParameter or not str(dataTypeParameter).strip():
+        return None
+
+    tokens = dataTypeParameter.strip().split(' ', 1)
+    head = tokens[0]
+    rest = tokens[1] if len(tokens) > 1 else None
+
+    # Nested arrays: "array of <element>"
+    if head == 'array':
+        if rest is None:
+            return {'type': 'array'}
+        rest_tokens = rest.split(' ', 1)
+        if rest_tokens[0] != 'of' or len(rest_tokens) < 2:
+            return None
+        nested = _parse_array_data_type_parameter(ctx, needed, rest_tokens[1])
+        if nested is None:
+            return None
+        return {'type': 'array', 'items': nested}
+
+    # Bare object type id (layout components often omit the "object " prefix).
+    if (head not in ctx.data_types and rest is None and
+            (head in ctx.object_types or head.startswith('_Adaptive'))):
+        return _array_items_for_object_type(ctx, needed, head)
+
+    items = {}
+    data_type = _set_type(ctx, items, head)
+    if not data_type:
+        return None
+
+    ptype = data_type.get('dataTypeParameterType')
+    if ptype is not None and rest is not None:
+        if ptype == 'ObjectType':
+            return _array_items_for_object_type(ctx, needed, rest)
+        if ptype == 'MediaType':
+            items['contentMediaType'] = rest
+
+    return items
+
+
+def _convert_property_type(ctx, needed, property_type, property_id_for_msg,
+                           description=None, title=None):
+    """Convert one adaptive propertyTypes entry to a JSON Schema property."""
+    schema_node = {}
+    data_type = None
+
+    if property_type.get('dataType'):
+        data_type = _set_type(ctx, schema_node, property_type['dataType'])
+
+    _apply_property_annotations(
+        schema_node, property_type, description=description, title=title)
+    _apply_type_constraints(schema_node, property_type)
+
+    if (data_type and
+            'dataTypeParameter' in property_type and
+            'dataTypeParameterType' in data_type):
+        ptype = data_type['dataTypeParameterType'].strip()
+        param = property_type['dataTypeParameter']
+
+        if ptype == 'ObjectType':
+            _add_definition(
+                ctx, needed, param, propertyTypesOnly=False,
+                description=property_type.get('description'),
+                title=property_type.get('label'))
+            schema_node = _ref_schema(ctx.ref(param), schema_node)
+
+        elif ptype == 'ArrayOf':
+            items = _parse_array_data_type_parameter(ctx, needed, param)
+            if items:
+                item_annotations = {}
+                if 'description' in property_type:
+                    item_annotations['description'] = property_type['description']
+                if 'brief' in property_type:
+                    item_annotations['title'] = property_type['brief']
+                schema_node['items'] = _apply_annotations(
+                    items, item_annotations)
+            else:
+                msg.warn('Invalid ' + property_id_for_msg +
+                         ' dataTypeParameter')
+
+        elif ptype == 'MediaType':
+            schema_node['contentMediaType'] = param
+
+        elif ptype in _UNMAPPED_PARAMETER_TYPES:
+            pass
+
+        else:
+            msg.warn(
+                'Unknown dataTypeParameterType ' + ptype +
+                ' in dataType ' + property_type['dataType'])
+
+    return schema_node
+
+
+# ---------------------------------------------------------------------------
+# Object type conversion and inheritance
+# ---------------------------------------------------------------------------
+
+def _parent_object_type_from_path(parent_path):
+    """
+    Extract object type id from propertyTypes._meta_.parentPaths entry.
+
+    Supports:
+      /afw/_AdaptiveObjectType_/_AdaptiveConf_/propertyTypes
+      /*/*/_AdaptiveLayoutComponentType_Common/propertyTypes
+    """
+    if not parent_path or not isinstance(parent_path, str):
+        return None
+    parts = [p for p in parent_path.split('/') if p and p != '*']
+    if not parts:
+        return None
+    if parts[-1] == 'propertyTypes':
+        if len(parts) < 2:
+            return None
+        return parts[-2]
+    return parts[-1]
+
+
+def _process_parents(ctx, needed, object_type, meta, visited=None):
+    """
+    Build allOf $refs for ancestor .propertyTypes (composite inheritance).
+
+    Walks parentPaths recursively with cycle detection. Required is not
+    inherited here — only property shape maps.
+    """
+    if not meta or 'parentPaths' not in meta:
+        return []
+
+    if visited is None:
+        visited = set()
+
+    parent_refs = []
+    for parent_path in meta['parentPaths']:
+        parent_id = _parent_object_type_from_path(parent_path)
+        if not parent_id:
+            msg.warn(object_type + ' parentPath could not be parsed: ' +
+                     str(parent_path))
+            continue
+        if not str(parent_path).rstrip('/').endswith('propertyTypes'):
+            msg.warn(object_type +
+                     ' parentPath does not end with /propertyTypes: ' +
+                     str(parent_path))
+
+        if parent_id in visited:
+            continue
+        visited.add(parent_id)
+
+        parent_refs.append({'$ref': ctx.ref(parent_id + '.propertyTypes')})
+        _add_definition(ctx, needed, parent_id, propertyTypesOnly=True)
+
+        parent_ot = ctx.object_types.get(parent_id)
+        if parent_ot and isinstance(parent_ot.get('propertyTypes'), dict):
+            parent_meta = parent_ot['propertyTypes'].get('_meta_')
+            if parent_meta:
+                parent_refs.extend(
+                    _process_parents(
+                        ctx, needed, parent_id, parent_meta, visited=visited))
+
+    return parent_refs
+
+
+def _ensure_property_types_schema(ctx, needed, object_type, object_type_object):
+    """
+    Build ObjectType.propertyTypes def: property map only (no required).
+
+    Shared via allOf into descendants; leaf required lives on the entity def.
+    """
+    key = object_type + '.propertyTypes'
+    if key in needed or object_type == '_AdaptivePropertyTypes_':
         return
-    
-    # Load the objectTypeObject, convert it to a JSON schema, and add it to the
-    # definitions.
-    objectTypeObject = _all_object_type_objects.get(objectType)
-    if objectTypeObject is None:
-        msg.warn('Unable to load object type ' + objectType)
+    needed.append(key)
 
-    # Set objectType property in definitions even if objectTypeObject wasn't
-    # found so it wont be tried again.
-    _convert_objectType(mutable_objectTypes_needed,
-        options, objectType, objectTypeObject, ref_prefix, ref_suffix,
+    properties = {}
+    for name, prop in (object_type_object.get('propertyTypes') or {}).items():
+        # _meta_ is inheritance metadata, not an instance property.
+        if name == '_meta_' or not isinstance(prop, dict):
+            continue
+        properties[name] = _convert_property_type(
+            ctx, needed, prop,
+            'objectType ' + object_type + ' property ' + name)
+
+    ctx.schemas[key] = {
+        'type': 'object',
+        'properties': properties,
+    }
+
+
+def _property_types_meta_schema():
+    """Synthetic schema for _AdaptivePropertyTypes_._meta_ (core-implied)."""
+    return {
+        'properties': {
+            'parentPaths': {
+                'title': 'Parent Paths',
+                'description':
+                    'This is a list of paths to the parent object type.',
+                'type': 'array',
+                'items': {
+                    'type': 'string',
+                    'title': 'Parent Path',
+                    'description':
+                        'This is a path to a parent object type.',
+                },
+            }
+        },
+        'description':
+            'This is the special Meta object that has deltas between this '
+            'instance and its Adaptive Object Type.',
+        'title': 'Meta',
+    }
+
+
+def _convert_object_type(ctx, needed, object_type, object_type_object,
+                         propertyTypesOnly=False, description=None, title=None):
+    """Convert one adaptive object type into ctx.schemas entries."""
+    if object_type_object is None:
+        object_type_object = {}
+
+    _ensure_property_types_schema(ctx, needed, object_type, object_type_object)
+
+    if propertyTypesOnly or object_type in needed:
+        return
+
+    needed.append(object_type)
+    schema = {'type': 'object'}
+    all_of = []
+
+    # Required only for instances of this object type (not ancestors).
+    local_required = []
+    for name, prop in (object_type_object.get('propertyTypes') or {}).items():
+        if name == '_meta_' or not isinstance(prop, dict):
+            continue
+        if prop.get('required', False):
+            local_required.append(name)
+
+    if object_type == '_AdaptivePropertyTypes_':
+        schema['properties'] = {'_meta_': _property_types_meta_schema()}
+    else:
+        all_of = [{'$ref': ctx.ref(object_type + '.propertyTypes')}]
+
+    property_types = object_type_object.get('propertyTypes')
+    if isinstance(property_types, dict) and '_meta_' in property_types:
+        parent_refs = _process_parents(
+            ctx, needed, object_type, property_types['_meta_'])
+        if parent_refs:
+            all_of.extend(parent_refs)
+
+    # otherProperties → additionalProperties; missing → closed object.
+    if 'otherProperties' in object_type_object:
+        other = object_type_object['otherProperties']
+        if other is None or other == {}:
+            schema['additionalProperties'] = True
+        else:
+            schema['additionalProperties'] = _convert_property_type(
+                ctx, needed, other,
+                object_type + ' additionalProperties',
+                description=object_type_object.get('description'),
+                title=object_type_object.get('label'))
+    else:
+        schema['unevaluatedProperties'] = False
+
+    if all_of:
+        schema['allOf'] = all_of
+    if local_required:
+        schema['required'] = local_required
+
+    if description is not None:
+        schema['description'] = description
+    elif 'description' in object_type_object:
+        schema['description'] = object_type_object['description']
+
+    if title is not None:
+        schema['title'] = title
+    elif 'title' in object_type_object:
+        schema['title'] = object_type_object['title']
+
+    ctx.schemas[object_type] = schema
+
+
+def _add_definition(ctx, needed, object_type, propertyTypesOnly=False,
+                    description=None, title=None):
+    """Ensure object_type (and deps) are converted into ctx.schemas."""
+    if object_type in needed:
+        return
+
+    object_type_object = ctx.object_types.get(object_type)
+    if object_type_object is None:
+        msg.warn('Unable to load object type ' + object_type)
+
+    _convert_object_type(
+        ctx, needed, object_type, object_type_object,
         propertyTypesOnly=propertyTypesOnly,
         description=description, title=title)
 
 
-# Parse dataTypeParameter for list. Return None if invalid or items for
-# subschema if good.
-def _parse_dataTypeParameter_for_list(mutable_objectTypes_needed,
-        options, dataTypeParameter, ref_prefix, ref_suffix) :
+# ---------------------------------------------------------------------------
+# Public entry
+# ---------------------------------------------------------------------------
 
-    t = dataTypeParameter.split(" ", 1)
-    if len(t) == 0:
-        return None
-    if t[0] == 'array':
-        items = {'type':'array'}
-        if len(t) > 1:
-            t = t[0].split(" ", 1)
-            if t[0] != 'of' or len(t) < 2:
-                return None
-            r = _parse_dataTypeParameter_for_list(mutable_objectTypes_needed,
-                options, t[1], ref_prefix, ref_suffix)
-            if r is None:
-                return None
-            items['items'] = r
-    else:
-        items = {}
-        data_type = _set_type(items, t[0])
-        if not data_type:
-            return None
-        ptype = data_type.get('dataTypeParameterType')
-        if ptype is not None and len(t) > 1:
-            if ptype == 'ObjectType':
-                _add_definition(mutable_objectTypes_needed,
-                    options, t[1], ref_prefix, ref_suffix,
-                    propertyTypesOnly=False)
-                items['$ref'] = ref_prefix + t[1] + ref_suffix
-            elif ptype == 'MediaType':
-                property['contentMediaType'] = t[1]
-    
-    return items
+def _load_data_types(ctx):
+    entries = resources.copy_resources(
+        ctx.options, 'objects/_AdaptiveDataTypeGenerate_/')
+    for entry in entries:
+        data_type_object = nfc.json_loads(entry['resource'])
+        ctx.data_types[data_type_object['dataType']] = data_type_object
 
 
-# Set type and optional format for data type.
-def _set_type(mutable_property, data_type_id):
-    data_type = _data_types.get(data_type_id)
-    if data_type is None:
-        msg.error('Unknown data type ' + data_type_id)
-        return None
-    if data_type.get('jsonPrimitive') is not None:          
-        mutable_property['type'] = data_type['jsonPrimitive']
-        # Override for integer since JSON Schema supports integer.
-        if data_type_id == "integer":
-            mutable_property['type'] = 'integer'
-    else:
-        msg.warn('Missing jsonPrimitive for data type ' + data_type_id)
-        return None
-    
-    if 'jsonSchemaStringFormat' in data_type:
-        mutable_property['format'] = data_type['jsonSchemaStringFormat']
-        
-    return data_type
+def _load_object_types(ctx):
+    options = ctx.options
+    if not options['is_core_afw_package']:
+        for object_type_object in resources.get_core_object_types(options):
+            object_type = object_type_object['_meta_']['objectId']
+            ctx.object_types[object_type] = object_type_object
+
+    src_dir_path = options['afw_package_dir_path'] + 'src/'
+    pattern = src_dir_path + '**/generated/objects/_AdaptiveObjectType_/*.json'
+    for object_type_file in glob.glob(pattern, recursive=True):
+        object_type = os.path.basename(object_type_file)[:-len('.json')]
+        msg.info('Generating JSON schema for ' + object_type)
+        with nfc.open(object_type_file, 'r') as fd:
+            ctx.object_types[object_type] = nfc.json_load(fd)
 
 
-# Convert propertyType.
-def _convert_propertyType(
-        mutable_objectTypes_needed, options, propertyType, property_id_for_msg,
-        ref_prefix, ref_suffix, description=None, title=None):
+def _write_entity_schemas(ctx):
+    """
+    Write one schema file per allowEntity object type.
 
-    property = {}
+    allowEntity defaults to true when omitted (matches adaptive OT meta).
+    """
+    schemas_dir = ctx.options['afw_package_dir_path'] + 'generated/schemas/afw/'
+    os.makedirs(schemas_dir, exist_ok=True)
 
-    # Convert dataType to type
-    data_type = None
-    if propertyType.get('dataType'):
-        _set_type(property, propertyType['dataType'])
-        data_type = _data_types.get(propertyType['dataType'])
-    
-    # If the propertyType has a label or title passed, use it as the title.
-    if title:
-        property['title'] = title
-    elif 'label' in propertyType:
-        property['title'] = propertyType['label']
+    for object_type, object_type_object in ctx.object_types.items():
+        if object_type_object.get('allowEntity', True) is False:
+            continue
 
-    # If the propertyType has a default, use it as the default.
-    if 'default' in propertyType:
-        property['default'] = propertyType['default']
+        filename = object_type + '.json'
+        msg.info('Writing ' + schemas_dir + filename)
 
-    # If propertyType has a description or one passed, use it as the description.
-    if description:
-        property['description'] = description
-    elif 'description' in propertyType:
-        property['description'] = propertyType['description']
+        needed = []
+        _convert_object_type(
+            ctx, needed, object_type, object_type_object,
+            propertyTypesOnly=False)
 
-    # If the propertyType has allowWrite, use it to determine readOnly.
-    if 'allowWrite' in propertyType:
-        property['readOnly'] = not propertyType['allowWrite']   
+        defs = {}
+        for need in sorted(set(needed)):
+            if need not in ctx.schemas:
+                msg.warn(
+                    'Missing schema definition for ' + need +
+                    ' while writing ' + object_type)
+                continue
+            defs[need] = ctx.schemas[need]
 
-    # Any type
-    if 'allowedValues' in propertyType:
-        property['enum'] = propertyType['allowedValues']
-
-    # JSON Schema extra type integer
-    if property.get('type') == 'integer':
-        if 'minValue' in propertyType:
-            property['minimum'] = propertyType['minValue']
-        if 'maxValue' in propertyType:
-            property['maximum'] = propertyType['maxValue']
-
-    # jsonPrimitive number
-    elif property.get('type') == 'number':
-        if 'minValue' in propertyType:
-            property['minimum'] = propertyType['minValue']
-        if 'maxValue' in propertyType:
-            property['maximum'] = propertyType['maxValue']
-
-    # jsonPrimitive string
-    elif property.get('type') == 'string':
-        if 'minLength' in propertyType:
-            property['minLength'] = propertyType['minLength']
-        if 'maxLength' in propertyType:
-            property['maxLength'] = propertyType['maxLength']
-
-    # jsonPrimitive array
-    elif property.get('type') == 'array':
-        pass
-
-    # jsonPrimitive object
-    elif property.get('type') == 'object':
-        pass
- 
-    # jsonPrimitive boolean
-    elif property.get('dataType') == 'boolean':
-        pass
-
-    # jsonPrimitive null
-    elif property.get('dataType') == 'null':
-        pass
-
-    # Handle dataTypeParameter
-    if (data_type and 
-        'dataTypeParameter' in propertyType and
-        'dataTypeParameterType' in data_type):
-        ptype = data_type['dataTypeParameterType'].strip()
-        param = propertyType['dataTypeParameter']
-        if ptype == 'ObjectType':
-            _add_definition(mutable_objectTypes_needed,
-                options, param, ref_prefix, ref_suffix,
-                propertyTypesOnly=False,
-                description=propertyType.get('description'),
-                title=propertyType.get('label'))
-            property['$ref'] = ref_prefix + param + ref_suffix
-        elif ptype == 'ArrayOf':
-            items = _parse_dataTypeParameter_for_list(mutable_objectTypes_needed,
-                options, param, ref_prefix, ref_suffix)           
-            if "description" in propertyType:
-                items["description"] = propertyType["description"]
-            if "brief" in propertyType:
-                items["title"] = propertyType["brief"]     
-            if items:
-                property['items'] = items
-            else:
-                msg.warn('Invalid ' + property_id_for_msg + ' dataTypeParameter')
-        elif ptype == 'MediaType':
-            property['contentMediaType'] = param 
-        elif ptype == 'SourceParameter':
-            pass
-        elif ptype == 'FunctionSignature':
-            pass
-        elif ptype == 'Type':
-            pass
-        elif ptype == 'xpathExpression':
-            pass
-        else:
-            msg.warn('Unknown dataTypeParameterType ' + ptype + ' in dataType ' + propertyType['dataType'])
-
-    return property
-
-# Process _meta_ for parent.
-def _process_parents(mutable_objectTypes_needed, options, objectType, meta,
-    ref_prefix='./',
-    ref_suffix='.json'):
-
-    if not 'parentPaths' in meta:
-        return None
-    
-    anyOf = []
-    for parentPath in meta['parentPaths']:
-        if parentPath.startswith('/afw/_AdaptiveObjectType_/'):
-            parentObjectType = parentPath[26:]
-            if parentObjectType.endswith('/propertyTypes'):
-                parentObjectType = parentObjectType[:-14]
-            else:
-                msg.warn(objectType + 'parentPath does not end with /propertyTypes')
-            anyOf.append({'$ref': ref_prefix + parentObjectType + '.propertyTypes' + ref_suffix})
-            _add_definition(mutable_objectTypes_needed,
-                options, parentObjectType, ref_prefix, ref_suffix,
-                propertyTypesOnly=True)
-            # parentsAnyOf = _process_parents(mutable_objectTypes_needed,
-            #     options, parentObjectType, meta,
-            #     ref_prefix=ref_prefix,
-            #     ref_suffix=ref_suffix)
-            # if parentsAnyOf:
-            #     anyOf += parentsAnyOf
-        else:
-            msg.warn(objectType + ' parentPath does not begin with /afw/_AdaptiveObjectType_/')
-
-    return anyOf
-
-
-# Conversion based on:
-#   http://json-schema.org/draft/2020-12/json-schema-validation.html#name-default
-
-# Convert objectType.
-def _convert_objectType(mutable_objectTypes_needed,
-        options, objectType, objectTypeObject, ref_prefix, ref_suffix,
-        propertyTypesOnly=False, description=None, title=None):
-    
-    global _all_schemas
-
-    # If objectType propertyTypes is not already in _all_schemas, make it.
-    # Skip if objectType is _AdaptivePropertyTypes_ since it has to be handled
-    # specially because of _meta_.
-    objectTypePropertyTypes = objectType + '.propertyTypes'
-    if (objectTypePropertyTypes not in mutable_objectTypes_needed and
-        objectType != '_AdaptivePropertyTypes_'):
-
-        # Will need self and everything added to mutable_objectTypes_needed.
-        mutable_objectTypes_needed.append(objectTypePropertyTypes)
-    
-        # Start schema object for propertyTypes and initialize some variables..
-        schema = {
-            "type": "object"
-        } 
-        properties = {}
-        required = []
-
-        # Process all of the propertyTypes.
-        for propertyTypeName, propertyType in objectTypeObject.get('propertyTypes',{}).items():
-            property =  _convert_propertyType(mutable_objectTypes_needed,
-                options, propertyType,
-                'objectType ' + objectType + ' property ' + propertyTypeName,
-                ref_prefix, ref_suffix)     
-            properties[propertyTypeName] = property
-            # If the propertyType is required, add it to the required list.
-            if propertyType.get('required', False):
-                required.append(propertyTypeName)
-        schema['properties'] = properties
-        
-        # If objectType has required properties, list them in schema required.
-        if len(required) > 0:
-            schema['required'] = required
-
-        # Keep objectType in _all_schemas
-        _all_schemas[objectTypePropertyTypes] = schema
-
-    # If propertyTypesOnly or objectType already being handled, return.
-    if propertyTypesOnly or objectType in mutable_objectTypes_needed:
-        return
- 
-    # Start schema object and initialize some variables..
-    mutable_objectTypes_needed.append(objectType)
-    schema = {
-        "type": "object"
-    } 
-
-    anyOf = []
-
-    # Special handling for _meta_ in _AdaptivePropertyTypes_ because it's not
-    # defined in Adaptive Object type but implied by core code.
-    if objectType == '_AdaptivePropertyTypes_':
-        schema['properties'] = {
-            "_meta_": {
-                "properties": {
-                    "parentPaths":{
-                        "title": "Parent Paths",
-                        "description": "This is a list of paths to the parent object type.",
-                        "items": {
-                            "type": "string",
-                            "title": "Parent Path",
-                            "description": "This is a path to a parent object type."
-                        },
-                        "type": "array"
-                    }
-                },
-                "description":"This is the special Meta object that has deltas between this instance and its Adaptive Object Type.",
-                "title":"Meta"
-            }
+        document = {
+            '$schema': ctx.json_schema_uri,
+            '$defs': defs,
+            'allOf': [{'$ref': ctx.ref(object_type)}],
         }
-    else:
-        # Have _process_parents return anyOf.
-        anyOf = [
-            {'$ref': ref_prefix + objectTypePropertyTypes + ref_suffix}
-        ]
-
-    if 'propertyTypes' in objectTypeObject:
-        propertyTypes = objectTypeObject['propertyTypes']
-        if '_meta_' in propertyTypes:
-            parentAnyOf = _process_parents(mutable_objectTypes_needed,
-                options, objectType, propertyTypes['_meta_'],
-                ref_prefix=ref_prefix, ref_suffix=ref_suffix)
-            if parentAnyOf:
-                anyOf += parentAnyOf
+        with nfc.open(schemas_dir + filename, 'w') as fd:
+            nfc.json_dump(document, fd, indent=4, sort_keys=True)
 
 
-    # If objectType has otherProperties, use it for additionalProperties in
-    # schema.
-    if 'otherProperties' in objectTypeObject:
-        additionalProperties = _convert_propertyType(
-            mutable_objectTypes_needed, options,
-            objectTypeObject['otherProperties'],
-            objectType + ' additionalProperties',
-            ref_prefix, ref_suffix,
-            description=objectTypeObject.get('description'),
-            title=objectTypeObject.get('label'),)
-        schema['additionalProperties'] = additionalProperties
-        
-    # If objectType does not have otherProperties, set unevaluatedProperties to
-    # false in outermost schema only to prevent additional properties.
-    else:
-        schema['unevaluatedProperties'] = False
-
-    # Add anyOf to schema.
-    if len(anyOf) > 0:
-        schema['anyOf'] = anyOf
-
-    # If objectType has a description or one passed, use it as the description.
-    if description:
-        schema['description'] = description
-    elif 'description' in objectTypeObject:
-        schema['description'] = objectTypeObject['description']
-
-    # If objectType has a title or one passed, use it as the title.
-    if title:
-        schema['title'] = title
-    elif 'title' in objectTypeObject:
-        schema['title'] = objectTypeObject['title']
-
-    # Keep objectType in _all_schemas
-    _all_schemas[objectType] = schema
-
-
-# Generate generated/schemas/afw and generated/schema.json.
 def generate(options):
+    """Generate generated/schemas/afw/*.json and update VS Code schema map."""
+    msg.info(
+        'Generating JSON schema files for generated _AdaptiveObjectType_ '
+        'objects')
 
-    global _data_types
-    global _all_schemas
-    global _all_object_type_objects
-
-    _all_schemas = {}
-    _all_object_type_objects = {}
-
-
-    msg.info('Generating JSON schema files for generated _AdaptiveObjectType_ objects')
-
-    # Get afw package
+    ctx = _SchemaBuildContext(options)
     afw_package = package.get_afw_package(options)
+
+    # Reserved for possible future $id emission.
     options['json_schema_id_base_uri'] = (
         'https://adaptiveframework.org/' +
         afw_package['afwPackageId'] + '-' + afw_package['version'] +
@@ -451,78 +616,10 @@ def generate(options):
         'https://adaptiveframework.org/' +
         afw_package['afwPackageId'] + '-' + afw_package['version'] +
         '/schema')
-    options['json_schema_uri'] = 'https://json-schema.org/draft/2020-12/schema'
+    options['json_schema_uri'] = ctx.json_schema_uri
 
-    # Copy afwdev's resources to generated/afwdev/_resources
-    if _data_types is None:
-        list = resources.copy_resources(
-            options, 'objects/_AdaptiveDataTypeGenerate_/')
-        _data_types = {}
-        for entry in list:
-            object = nfc.json_loads(entry['resource'])
-            _data_types[object['dataType']] = object
-
-    # JSON schema files for all subdirs go in package's generated/schemas directory.
-    schemasDir = options['afw_package_dir_path'] + 'generated/schemas/afw/'
-    os.makedirs(schemasDir, exist_ok=True)
-
-    ref_prefix = '#/$defs/'
-    ref_suffix = ''
-
-    # If not core afw package, get the core _AdaptiveObjectType_ objects and add
-    # them to _all_object_type_objects.
-    if not options['is_core_afw_package']:
-        for objectTypeObject in resources.get_core_object_types(options):
-            objectType = objectTypeObject['_meta_']['objectId']
-            _all_object_type_objects[objectType] = objectTypeObject
-
-    # Get all the generated _AdaptiveObjectType_ objects and add them to
-    # _all_object_type_objects.
-    srcDirPath = options['afw_package_dir_path'] + 'src/'  
-    for objectTypeFile in glob.glob(
-        srcDirPath + '**/generated/objects/_AdaptiveObjectType_/*.json',
-        recursive=True):
-        objectType = os.path.basename(objectTypeFile)[: -len('.json')]
-        msg.info('Generating JSON schema for ' +  objectType)
-
-        with nfc.open(objectTypeFile, 'r') as fd:
-            objectTypeObject = nfc.json_load(fd)
-            _all_object_type_objects[objectType] = objectTypeObject
-
-    # Process all of the _AdaptiveObjectType_ objects.    
-    for objectType, objectTypeObject in _all_object_type_objects.items():
-
-        if not objectTypeObject.get('allowEntity', False):
-            continue
-
-        filename = objectType + '.json'
-        msg.info('Writing ' + schemasDir + filename)
-        with nfc.open(schemasDir + filename, 'w') as fd:
-            definitions = {}
-
-            mutable_objectTypes_needed = []
-            _convert_objectType(mutable_objectTypes_needed,
-                options, objectType, objectTypeObject, ref_prefix, ref_suffix,
-                propertyTypesOnly=False)
-            
-            # Add definitions for all object types needed by this objectType.
-            defs = {}
-            for need in sorted(set(mutable_objectTypes_needed)):
-                defs[need] = _all_schemas[need]
-
-            schema = {
-                # Removed> '$id': options['json_schema_id_base_uri'] + objectType,
-                '$schema': options['json_schema_uri'],
-                '$defs': defs,
-                'anyOf': [
-                    {'$ref': ref_prefix + objectType + ref_suffix}
-                ]
-            }
-
-            nfc.json_dump(schema, fd, indent=4, sort_keys=True)         
-
-    # Update vscode settings.json with schema.json if needed.
+    _load_data_types(ctx)
+    _load_object_types(ctx)
+    _write_entity_schemas(ctx)
     _update_vscode_settings_json_schema(options)
-
-    # Indicate success
     msg.success('Generate JSON schema files successful')

--- a/src/afw_dev/_afwdev/generate/json_schema.py
+++ b/src/afw_dev/_afwdev/generate/json_schema.py
@@ -6,16 +6,25 @@
 # @brief Generate package-root JSON Schema files from adaptive object types.
 # @details
 # Adaptive object types under src/**/generated/objects/_AdaptiveObjectType_/
-# are the source of truth. This module emits a best-effort JSON Schema
-# (draft 2020-12) projection into generated/schemas/afw/ for editors and
-# `afwdev validate`. It is not a complete model of adaptive meta (runtime,
-# allowQuery, etc. are intentionally omitted).
+# are the source of truth. This module emits a JSON Schema (draft 2020-12)
+# projection into generated/schemas/afw/.
 #
-# Important mapping choices:
-# - Object-typed properties use pure $ref or annotations + allOf/[{$ref}]
-#   (never $ref mixed with siblings; see issue #3).
-# - Inheritance (parentPaths) is composite allOf of .propertyTypes defs.
-# - required applies only to the leaf object type, not inherited property maps.
+# Primary purpose: help editors (VS Code json.schemas, etc.) when authoring
+# adaptive object JSON under generate/objects/ — completion, hovers, and light
+# validation. Schemas are generated and read-only, so verbosity is fine; prefer
+# structures editors resolve well (flat property maps, explicit type object,
+# $defs + $ref) over compact or validator-only forms.
+#
+# Secondary: afwdev validate / tests. Not a full adaptive meta model (runtime,
+# allowQuery, etc. are omitted). Client-side UI validation should stay simple;
+# these files are not optimized as a minimal runtime payload.
+#
+# Mapping choices:
+# - Object-typed properties: pure $ref, or annotations + type object +
+#   allOf:[{$ref}] (never $ref mixed with siblings; issue #3).
+# - Inheritance: merge property maps with child override (not stacked allOf of
+#   parent maps, which breaks overrides and confuses editors).
+# - required applies only to the leaf object type.
 #
 
 import glob
@@ -113,27 +122,46 @@ def _update_vscode_settings_json_schema(options):
 
 
 # ---------------------------------------------------------------------------
-# $ref helpers (issue #3)
+# $ref helpers (issue #3 + editor-friendly object refs)
 # ---------------------------------------------------------------------------
+
+def _editor_docs(schema_node):
+    """
+    Duplicate description into markdownDescription for VS Code hovers.
+
+    vscode.json-language-features recognizes markdownDescription on schemas.
+    """
+    if schema_node.get('description') and 'markdownDescription' not in schema_node:
+        schema_node['markdownDescription'] = schema_node['description']
+
 
 def _ref_schema(ref, base=None):
     """
     Build a schema that references another without mixing $ref and siblings.
 
-    With annotations: { title, description, ..., allOf: [ { $ref } ] }
-    Without:          { $ref }
+    Editor-oriented forms (verbose is fine; schemas are generated):
+    - No annotations: { "$ref": "..." }  (VS Code follows $ref cleanly)
+    - With annotations: {
+        "type": "object",
+        "title", "description", "markdownDescription", ...
+        "allOf": [ { "$ref": "..." } ]
+      }
+      type sits beside allOf, never beside $ref (issue #3).
     """
     annotations = {}
     if base:
         for key, value in base.items():
-            # type/format come from the target; never re-emit $ref/allOf here.
+            # Target supplies structural type; never re-emit $ref/allOf here.
             if key in ('$ref', 'type', 'format', 'allOf'):
                 continue
             annotations[key] = value
     if not annotations:
         return {'$ref': ref}
     result = dict(annotations)
+    # Explicit object type helps completion before $ref is fully resolved.
+    result['type'] = 'object'
     result['allOf'] = [{'$ref': ref}]
+    _editor_docs(result)
     return result
 
 
@@ -147,11 +175,12 @@ def _apply_annotations(schema, annotations):
     if (isinstance(all_of, list) and len(all_of) == 1 and
             isinstance(all_of[0], dict) and
             list(all_of[0].keys()) == ['$ref']):
-        base = {k: v for k, v in schema.items() if k != 'allOf'}
+        base = {k: v for k, v in schema.items() if k not in ('allOf', 'type')}
         base.update(annotations)
         return _ref_schema(all_of[0]['$ref'], base)
     result = dict(schema)
     result.update(annotations)
+    _editor_docs(result)
     return result
 
 
@@ -194,6 +223,19 @@ def _apply_property_annotations(schema_node, property_type,
         schema_node['description'] = description
     elif 'description' in property_type:
         schema_node['description'] = property_type['description']
+
+    # Prefer label as completion text; brief as secondary hover when both exist.
+    if ('brief' in property_type and
+            property_type.get('brief') and
+            schema_node.get('description') and
+            property_type.get('brief') != schema_node.get('description') and
+            'markdownDescription' not in schema_node):
+        schema_node['markdownDescription'] = (
+            '**' + str(property_type.get('label') or
+                       property_type.get('brief')) + '**\n\n' +
+            str(schema_node['description']))
+    else:
+        _editor_docs(schema_node)
 
     if 'defaultValue' in property_type:
         schema_node['default'] = property_type['defaultValue']
@@ -400,9 +442,11 @@ def _process_parents(ctx, needed, object_type, meta, visited=None):
 
 def _ensure_property_types_schema(ctx, needed, object_type, object_type_object):
     """
-    Build ObjectType.propertyTypes def: property map only (no required).
+    Build ObjectType.propertyTypes def: local property map only (no required).
 
-    Shared via allOf into descendants; leaf required lives on the entity def.
+    Kept for tooling/docs and as a building block. Entity schemas use a
+    merged composite map so child property definitions override parents
+    (adaptive composite), which plain allOf of parent maps cannot express.
     """
     key = object_type + '.propertyTypes'
     if key in needed or object_type == '_AdaptivePropertyTypes_':
@@ -422,6 +466,60 @@ def _ensure_property_types_schema(ctx, needed, object_type, object_type_object):
         'type': 'object',
         'properties': properties,
     }
+
+
+def _ancestor_object_type_ids(ctx, object_type_object):
+    """Return ancestor object type ids from parentPaths (nearest parent first)."""
+    ordered = []
+    seen = set()
+
+    def walk(meta):
+        if not meta or 'parentPaths' not in meta:
+            return
+        for parent_path in meta['parentPaths']:
+            parent_id = _parent_object_type_from_path(parent_path)
+            if not parent_id or parent_id in seen:
+                continue
+            seen.add(parent_id)
+            ordered.append(parent_id)
+            parent_ot = ctx.object_types.get(parent_id)
+            if parent_ot and isinstance(parent_ot.get('propertyTypes'), dict):
+                walk(parent_ot['propertyTypes'].get('_meta_'))
+
+    pts = object_type_object.get('propertyTypes')
+    if isinstance(pts, dict):
+        walk(pts.get('_meta_'))
+    return ordered
+
+
+def _merged_instance_properties(ctx, needed, object_type, object_type_object):
+    """
+    Merge propertyTypes along the inheritance chain with child override.
+
+    Ancestors first, then this object type. Same-named properties from the
+    child replace the parent (e.g. ModelObjectType.propertyTypes overrides
+    ObjectType.propertyTypes). Returns a properties dict for the entity.
+    """
+    merged = {}
+    # Farthest ancestor first so nearer ancestors and self overwrite.
+    ancestor_ids = _ancestor_object_type_ids(ctx, object_type_object)
+    chain = []
+    for ancestor_id in reversed(ancestor_ids):
+        ancestor_ot = ctx.object_types.get(ancestor_id)
+        if ancestor_ot is not None:
+            chain.append((ancestor_id, ancestor_ot))
+        _ensure_property_types_schema(
+            ctx, needed, ancestor_id, ancestor_ot or {})
+    chain.append((object_type, object_type_object))
+
+    for ot_id, ot_obj in chain:
+        for name, prop in (ot_obj.get('propertyTypes') or {}).items():
+            if name == '_meta_' or not isinstance(prop, dict):
+                continue
+            merged[name] = _convert_property_type(
+                ctx, needed, prop,
+                'objectType ' + ot_id + ' property ' + name)
+    return merged
 
 
 def _property_types_meta_schema():
@@ -461,7 +559,6 @@ def _convert_object_type(ctx, needed, object_type, object_type_object,
 
     needed.append(object_type)
     schema = {'type': 'object'}
-    all_of = []
 
     # Required only for instances of this object type (not ancestors).
     local_required = []
@@ -474,16 +571,35 @@ def _convert_object_type(ctx, needed, object_type, object_type_object,
     if object_type == '_AdaptivePropertyTypes_':
         schema['properties'] = {'_meta_': _property_types_meta_schema()}
     else:
-        all_of = [{'$ref': ctx.ref(object_type + '.propertyTypes')}]
+        # Composite map: inherited + local with child property override.
+        # Also keep allOf refs to each .propertyTypes for documentation of
+        # the inheritance chain (validators use properties= merged map).
+        merged = _merged_instance_properties(
+            ctx, needed, object_type, object_type_object)
+        # Optional adaptive instance meta bag (common on real objects).
+        merged.setdefault('_meta_', {
+            'type': 'object',
+            'additionalProperties': True,
+            'title': 'Meta',
+            'description':
+                'Adaptive instance meta (objectId, path, objectType, ...).',
+            'markdownDescription':
+                'Adaptive instance meta (`objectId`, `path`, `objectType`, …).',
+        })
+        schema['properties'] = merged
 
-    property_types = object_type_object.get('propertyTypes')
-    if isinstance(property_types, dict) and '_meta_' in property_types:
-        parent_refs = _process_parents(
-            ctx, needed, object_type, property_types['_meta_'])
-        if parent_refs:
-            all_of.extend(parent_refs)
+        # Inheritance chain for tests/tooling only (not applied as allOf).
+        inherited = _ancestor_object_type_ids(ctx, object_type_object)
+        if inherited:
+            schema['x-afw-inheritedObjectTypes'] = inherited
+            _process_parents(
+                ctx, needed, object_type,
+                (object_type_object.get('propertyTypes') or {}).get('_meta_')
+                or {})
 
     # otherProperties → additionalProperties; missing → closed object.
+    # Prefer additionalProperties (widely understood by editors) over
+    # unevaluatedProperties.
     if 'otherProperties' in object_type_object:
         other = object_type_object['otherProperties']
         if other is None or other == {}:
@@ -495,10 +611,8 @@ def _convert_object_type(ctx, needed, object_type, object_type_object,
                 description=object_type_object.get('description'),
                 title=object_type_object.get('label'))
     else:
-        schema['unevaluatedProperties'] = False
+        schema['additionalProperties'] = False
 
-    if all_of:
-        schema['allOf'] = all_of
     if local_required:
         schema['required'] = local_required
 
@@ -506,11 +620,15 @@ def _convert_object_type(ctx, needed, object_type, object_type_object,
         schema['description'] = description
     elif 'description' in object_type_object:
         schema['description'] = object_type_object['description']
+    _editor_docs(schema)
 
     if title is not None:
         schema['title'] = title
     elif 'title' in object_type_object:
         schema['title'] = object_type_object['title']
+    elif 'objectType' in object_type_object:
+        # Editors show title in schema pickers / hovers.
+        schema['title'] = object_type_object['objectType']
 
     ctx.schemas[object_type] = schema
 
@@ -564,6 +682,10 @@ def _write_entity_schemas(ctx):
     Write one schema file per allowEntity object type.
 
     allowEntity defaults to true when omitted (matches adaptive OT meta).
+
+    Document shape is editor-first: the entity schema is at the document root
+    (type/properties/required/...) so VS Code applies it directly to matched
+    files. $defs holds the entity and nested types for $ref resolution.
     """
     schemas_dir = ctx.options['afw_package_dir_path'] + 'generated/schemas/afw/'
     os.makedirs(schemas_dir, exist_ok=True)
@@ -589,11 +711,24 @@ def _write_entity_schemas(ctx):
                 continue
             defs[need] = ctx.schemas[need]
 
+        entity = ctx.schemas.get(object_type)
+        if entity is None:
+            msg.warn('No entity schema for ' + object_type)
+            continue
+
+        # Root = entity keywords (editor applies this to the open file).
+        # $defs keeps the same entity plus dependencies for internal $refs.
         document = {
             '$schema': ctx.json_schema_uri,
+            '$comment':
+                'Generated from adaptive object type ' + object_type +
+                '. Primary use: editor completion/validation for '
+                'generate/objects JSON. Do not hand-edit.',
             '$defs': defs,
-            'allOf': [{'$ref': ctx.ref(object_type)}],
         }
+        for key, value in entity.items():
+            document[key] = value
+
         with nfc.open(schemas_dir + filename, 'w') as fd:
             nfc.json_dump(document, fd, indent=4, sort_keys=True)
 

--- a/src/afw_dev/tests/json_schema/_common.py
+++ b/src/afw_dev/tests/json_schema/_common.py
@@ -73,7 +73,11 @@ def iter_schema_files(root=None):
 
 
 def entity_def(schema_doc, object_type_id):
-    return schema_doc.get('$defs', {}).get(object_type_id)
+    """Entity body from $defs, or root when the document is the entity."""
+    defs = schema_doc.get('$defs') or {}
+    if object_type_id in defs:
+        return defs[object_type_id]
+    return entity_from_document(schema_doc, object_type_id)
 
 
 def property_types_def(schema_doc, object_type_id):
@@ -103,7 +107,13 @@ def find_mixed_refs(obj, path='$'):
 
 
 def is_clean_ref_form(node):
-    """True if node is pure $ref or annotations + allOf:[{$ref}]."""
+    """
+    True if node is pure $ref or editor-friendly allOf ref form.
+
+    Allowed with allOf:[{$ref}]: type (object), title, description,
+    markdownDescription, defaults, enums, etc. Never $ref as a sibling
+    of those keywords (issue #3).
+    """
     if not isinstance(node, dict):
         return False
     if list(node.keys()) == ['$ref']:
@@ -113,31 +123,56 @@ def is_clean_ref_form(node):
         return False
     if not isinstance(all_of[0], dict) or list(all_of[0].keys()) != ['$ref']:
         return False
-    # siblings of allOf must not include $ref or type (type comes from target)
     for key in node:
-        if key in ('allOf', 'title', 'description', 'default', 'readOnly',
-                   'enum', 'minimum', 'maximum', 'minLength', 'maxLength',
-                   'uniqueItems', 'contentMediaType'):
+        if key in (
+                'allOf', 'type', 'title', 'description', 'markdownDescription',
+                'default', 'readOnly', 'enum', 'minimum', 'maximum',
+                'minLength', 'maxLength', 'uniqueItems', 'contentMediaType'):
             continue
         if key == '$ref':
             return False
-        # allow nothing else that would re-mix $ref semantics
-        if key in ('type', 'format', 'properties', 'items', 'required'):
+        if key in ('format', 'properties', 'items', 'required',
+                   'additionalProperties', 'unevaluatedProperties'):
             return False
     return True
 
 
+def entity_from_document(schema_doc, object_type_id):
+    """Entity schema: $defs copy, or root document if promoted for editors."""
+    defs = schema_doc.get('$defs') or {}
+    if object_type_id in defs:
+        return defs[object_type_id]
+    if schema_doc.get('type') == 'object' or 'properties' in schema_doc:
+        skip = {'$schema', '$defs', '$comment', '$id'}
+        return {k: v for k, v in schema_doc.items() if k not in skip}
+    return None
+
+
 def allof_property_types_refs(entity):
-    """Set of object-type ids referenced as .propertyTypes in entity allOf."""
-    refs = set()
+    """
+    Set of inherited object-type ids for an entity schema.
+
+    Prefers x-afw-inheritedObjectTypes (composite merge). Falls back to
+    legacy allOf .propertyTypes $refs if present.
+    """
     if not entity:
-        return refs
+        return set()
+    inherited = entity.get('x-afw-inheritedObjectTypes')
+    if isinstance(inherited, list):
+        return set(inherited)
+    refs = set()
     for entry in entity.get('allOf') or []:
         ref = entry.get('$ref', '')
-        # #/$defs/Foo.propertyTypes
         if ref.startswith('#/$defs/') and ref.endswith('.propertyTypes'):
             refs.add(ref[len('#/$defs/'):-len('.propertyTypes')])
     return refs
+
+
+def entity_property_names(entity):
+    """Instance property names on an entity def (merged composite map)."""
+    if not entity:
+        return set()
+    return set((entity.get('properties') or {}).keys())
 
 
 def parent_ot_ids_from_adaptive(ot_json):

--- a/src/afw_dev/tests/json_schema/_common.py
+++ b/src/afw_dev/tests/json_schema/_common.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Shared helpers for JSON Schema projection tests."""
+
+import json
+import os
+from pathlib import Path
+
+try:
+    import jsonschema
+    from jsonschema import Draft202012Validator
+except ImportError:  # pragma: no cover
+    jsonschema = None
+    Draft202012Validator = None
+
+
+def package_root():
+    """Locate the AFW package root (directory containing afw-package.json)."""
+    here = Path(__file__).resolve()
+    for parent in [here] + list(here.parents):
+        if (parent / 'afw-package.json').is_file():
+            return parent
+    raise RuntimeError(
+        'Could not find afw-package.json above ' + str(here))
+
+
+def schemas_dir(root=None):
+    root = root or package_root()
+    return root / 'generated' / 'schemas' / 'afw'
+
+
+def schemas_available(root=None):
+    d = schemas_dir(root)
+    return d.is_dir() and any(d.glob('*.json'))
+
+
+def load_schema(object_type_id, root=None):
+    path = schemas_dir(root) / (object_type_id + '.json')
+    if not path.is_file():
+        raise FileNotFoundError('Schema not found: ' + str(path))
+    with open(path, encoding='utf-8') as fd:
+        return json.load(fd)
+
+
+def load_ot(object_type_id, root=None):
+    """Load adaptive object type JSON from src/**/generated/objects."""
+    root = root or package_root()
+    pattern = '**/generated/objects/_AdaptiveObjectType_/' + object_type_id + '.json'
+    matches = list(root.glob('src/' + pattern))
+    if not matches:
+        # also accept without src/ prefix for safety
+        matches = list(root.glob(pattern))
+    if not matches:
+        raise FileNotFoundError(
+            'Object type not found: ' + object_type_id)
+    with open(matches[0], encoding='utf-8') as fd:
+        return json.load(fd)
+
+
+def load_json(path, root=None):
+    root = root or package_root()
+    p = Path(path)
+    if not p.is_absolute():
+        p = root / p
+    with open(p, encoding='utf-8') as fd:
+        return json.load(fd)
+
+
+def iter_schema_files(root=None):
+    d = schemas_dir(root)
+    if not d.is_dir():
+        return []
+    return sorted(d.glob('*.json'))
+
+
+def entity_def(schema_doc, object_type_id):
+    return schema_doc.get('$defs', {}).get(object_type_id)
+
+
+def property_types_def(schema_doc, object_type_id):
+    return schema_doc.get('$defs', {}).get(object_type_id + '.propertyTypes')
+
+
+def property_map(schema_doc, object_type_id):
+    ptd = property_types_def(schema_doc, object_type_id)
+    if not ptd:
+        return {}
+    return ptd.get('properties') or {}
+
+
+def find_mixed_refs(obj, path='$'):
+    """Return paths where a dict has $ref plus other keys."""
+    issues = []
+    if isinstance(obj, dict):
+        if '$ref' in obj and len(obj) > 1:
+            others = sorted(k for k in obj if k != '$ref')
+            issues.append((path, others))
+        for key, value in obj.items():
+            issues.extend(find_mixed_refs(value, path + '.' + key))
+    elif isinstance(obj, list):
+        for i, value in enumerate(obj):
+            issues.extend(find_mixed_refs(value, path + '[' + str(i) + ']'))
+    return issues
+
+
+def is_clean_ref_form(node):
+    """True if node is pure $ref or annotations + allOf:[{$ref}]."""
+    if not isinstance(node, dict):
+        return False
+    if list(node.keys()) == ['$ref']:
+        return True
+    all_of = node.get('allOf')
+    if not (isinstance(all_of, list) and len(all_of) == 1):
+        return False
+    if not isinstance(all_of[0], dict) or list(all_of[0].keys()) != ['$ref']:
+        return False
+    # siblings of allOf must not include $ref or type (type comes from target)
+    for key in node:
+        if key in ('allOf', 'title', 'description', 'default', 'readOnly',
+                   'enum', 'minimum', 'maximum', 'minLength', 'maxLength',
+                   'uniqueItems', 'contentMediaType'):
+            continue
+        if key == '$ref':
+            return False
+        # allow nothing else that would re-mix $ref semantics
+        if key in ('type', 'format', 'properties', 'items', 'required'):
+            return False
+    return True
+
+
+def allof_property_types_refs(entity):
+    """Set of object-type ids referenced as .propertyTypes in entity allOf."""
+    refs = set()
+    if not entity:
+        return refs
+    for entry in entity.get('allOf') or []:
+        ref = entry.get('$ref', '')
+        # #/$defs/Foo.propertyTypes
+        if ref.startswith('#/$defs/') and ref.endswith('.propertyTypes'):
+            refs.add(ref[len('#/$defs/'):-len('.propertyTypes')])
+    return refs
+
+
+def parent_ot_ids_from_adaptive(ot_json):
+    """Object type ids from propertyTypes._meta_.parentPaths (recursive one-level list)."""
+    parents = []
+    pts = ot_json.get('propertyTypes') or {}
+    meta = pts.get('_meta_') or {}
+    for parent_path in meta.get('parentPaths') or []:
+        parts = [p for p in str(parent_path).split('/') if p and p != '*']
+        if not parts:
+            continue
+        if parts[-1] == 'propertyTypes' and len(parts) >= 2:
+            parents.append(parts[-2])
+        else:
+            parents.append(parts[-1])
+    return parents
+
+
+def ancestor_ot_ids(object_type_id, root=None, visited=None):
+    """All ancestor OT ids via parentPaths, depth-first, no cycles."""
+    if visited is None:
+        visited = set()
+    if object_type_id in visited:
+        return []
+    visited.add(object_type_id)
+    ot = load_ot(object_type_id, root)
+    result = []
+    for parent_id in parent_ot_ids_from_adaptive(ot):
+        if parent_id in visited:
+            continue
+        result.append(parent_id)
+        result.extend(ancestor_ot_ids(parent_id, root, visited))
+    return result
+
+
+def ot_local_property_names(ot_json):
+    pts = ot_json.get('propertyTypes') or {}
+    return sorted(k for k in pts if k != '_meta_' and isinstance(pts[k], dict))
+
+
+def ot_local_required(ot_json):
+    pts = ot_json.get('propertyTypes') or {}
+    return sorted(
+        k for k, v in pts.items()
+        if k != '_meta_' and isinstance(v, dict) and v.get('required') is True)
+
+
+def validate_instance(instance, schema_doc):
+    """Return (ok: bool, error_message: str|None)."""
+    if Draft202012Validator is None:
+        return False, 'jsonschema package not available'
+    try:
+        Draft202012Validator(schema_doc).validate(instance)
+        return True, None
+    except Exception as exc:
+        return False, str(exc)
+
+
+def make_test(test_id, description, passed, detail=None, skip=False):
+    item = {
+        'test': test_id,
+        'description': description,
+        'passed': bool(passed),
+    }
+    if skip:
+        item['skip'] = True
+        item['passed'] = True
+    if detail and not passed and not skip:
+        item['description'] = description + ' — ' + detail
+    return item
+
+
+def skip_if_no_schemas(tests_list):
+    """Append a single skip/fail and return True if schemas are missing."""
+    if schemas_available():
+        return False
+    tests_list.append(make_test(
+        'schemas-dir-missing',
+        'generated/schemas/afw not found or empty '
+        '(run generate / build so schemas exist before tests)',
+        passed=False,
+        detail=str(schemas_dir()),
+    ))
+    return True

--- a/src/afw_dev/tests/json_schema/adaptive_compare.py
+++ b/src/afw_dev/tests/json_schema/adaptive_compare.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Compare adaptive object type JSON to generated JSON Schema projection."""
+
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+from _common import (
+    entity_def,
+    is_clean_ref_form,
+    load_ot,
+    load_schema,
+    make_test,
+    ot_local_property_names,
+    ot_local_required,
+    package_root,
+    property_map,
+    property_types_def,
+    skip_if_no_schemas,
+)
+
+# Golden object types for property-level comparison.
+GOLDEN_OTS = [
+    '_AdaptiveObject_',
+    '_AdaptiveObjectType_',
+    '_AdaptiveFunction_',
+    '_AdaptiveFunctionGenerate_',
+    '_AdaptivePolymorphicFunction_',
+    '_AdaptiveResponse_',
+    '_AdaptiveApplication_',
+]
+
+
+def _check_property_names(ot_id, ot_json, schema_doc, tests):
+    expected = set(ot_local_property_names(ot_json))
+    actual = set(property_map(schema_doc, ot_id).keys())
+    missing = sorted(expected - actual)
+    extra = sorted(actual - expected)
+    ok = not missing and not extra
+    detail = None
+    if missing:
+        detail = 'missing in schema: ' + ','.join(missing[:10])
+    elif extra:
+        detail = 'extra in schema: ' + ','.join(extra[:10])
+    tests.append(make_test(
+        'props-' + ot_id,
+        ot_id + ' property names match adaptive propertyTypes (minus _meta_)',
+        ok,
+        detail=detail,
+    ))
+
+
+def _check_object_refs(ot_id, ot_json, schema_doc, tests):
+    props = property_map(schema_doc, ot_id)
+    pts = ot_json.get('propertyTypes') or {}
+    for name, prop in pts.items():
+        if name == '_meta_' or not isinstance(prop, dict):
+            continue
+        if prop.get('dataType') != 'object' or not prop.get('dataTypeParameter'):
+            continue
+        node = props.get(name)
+        ok = node is not None and is_clean_ref_form(node)
+        # referenced type should appear in $defs
+        target = prop['dataTypeParameter']
+        has_def = target in (schema_doc.get('$defs') or {})
+        tests.append(make_test(
+            'object-ref-' + ot_id + '-' + name,
+            ot_id + '.' + name + ' projects to clean $ref of ' + target,
+            ok and has_def,
+            detail=None if (ok and has_def) else repr(node)[:160],
+        ))
+
+
+def _check_array_object_items(ot_id, ot_json, schema_doc, tests):
+    props = property_map(schema_doc, ot_id)
+    pts = ot_json.get('propertyTypes') or {}
+    for name, prop in pts.items():
+        if name == '_meta_' or not isinstance(prop, dict):
+            continue
+        if prop.get('dataType') != 'array':
+            continue
+        param = prop.get('dataTypeParameter') or ''
+        # object-typed elements: "object _AdaptiveX_" or bare _Adaptive*
+        is_object_items = (
+            param.startswith('object ') or
+            (param.startswith('_Adaptive') and ' ' not in param.strip()))
+        if not is_object_items:
+            continue
+        node = props.get(name) or {}
+        items = node.get('items')
+        ok = (
+            node.get('type') == 'array' and
+            items is not None and
+            is_clean_ref_form(items))
+        tests.append(make_test(
+            'array-items-ref-' + ot_id + '-' + name,
+            ot_id + '.' + name + ' is array with clean object $ref items',
+            ok,
+            detail=None if ok else repr(node)[:160],
+        ))
+
+
+def _check_defaults_and_enums(ot_id, ot_json, schema_doc, tests):
+    props = property_map(schema_doc, ot_id)
+    pts = ot_json.get('propertyTypes') or {}
+    for name, prop in pts.items():
+        if name == '_meta_' or not isinstance(prop, dict):
+            continue
+        node = props.get(name) or {}
+        if 'defaultValue' in prop:
+            ok = node.get('default') == prop['defaultValue']
+            tests.append(make_test(
+                'default-' + ot_id + '-' + name,
+                ot_id + '.' + name + ' defaultValue → schema default',
+                ok,
+                detail=None if ok else repr(node.get('default')),
+            ))
+        if 'allowedValues' in prop or 'possibleValues' in prop:
+            expected = prop.get('allowedValues', prop.get('possibleValues'))
+            ok = node.get('enum') == expected
+            tests.append(make_test(
+                'enum-' + ot_id + '-' + name,
+                ot_id + '.' + name + ' allowed/possibleValues → enum',
+                ok,
+                detail=None if ok else repr(node.get('enum')),
+            ))
+
+
+def _check_open_closed(ot_id, ot_json, schema_doc, tests):
+    entity = entity_def(schema_doc, ot_id)
+    if not entity:
+        tests.append(make_test(
+            'open-closed-' + ot_id,
+            ot_id + ' open/closed matches otherProperties',
+            False,
+            detail='entity def missing',
+        ))
+        return
+    if 'otherProperties' in ot_json:
+        other = ot_json['otherProperties']
+        if other is None or other == {}:
+            ok = entity.get('additionalProperties') is True
+            tests.append(make_test(
+                'open-' + ot_id,
+                ot_id + ' otherProperties {} → additionalProperties true',
+                ok,
+            ))
+        else:
+            ok = 'additionalProperties' in entity
+            tests.append(make_test(
+                'additional-' + ot_id,
+                ot_id + ' typed otherProperties → additionalProperties present',
+                ok,
+            ))
+    else:
+        ok = entity.get('unevaluatedProperties') is False
+        tests.append(make_test(
+            'closed-' + ot_id,
+            ot_id + ' no otherProperties → unevaluatedProperties false',
+            ok,
+        ))
+
+
+def _check_required(ot_id, ot_json, schema_doc, tests):
+    entity = entity_def(schema_doc, ot_id)
+    ptd = property_types_def(schema_doc, ot_id)
+    expected = ot_local_required(ot_json)
+    actual = sorted(entity.get('required') or []) if entity else []
+    ok = actual == expected
+    tests.append(make_test(
+        'required-leaf-' + ot_id,
+        ot_id + ' entity required matches local adaptive required only',
+        ok,
+        detail=None if ok else 'expected ' + str(expected) + ' got ' + str(actual),
+    ))
+    # shared propertyTypes map must not carry required
+    if ptd is not None:
+        tests.append(make_test(
+            'required-not-on-propertyTypes-' + ot_id,
+            ot_id + '.propertyTypes def has no required array',
+            'required' not in ptd,
+        ))
+
+
+def run():
+    response = {
+        'description':
+            'Adaptive object type JSON compared to generated JSON Schema',
+        'tests': [],
+    }
+    tests = response['tests']
+    if skip_if_no_schemas(tests):
+        return response
+
+    root = package_root()
+    for ot_id in GOLDEN_OTS:
+        try:
+            ot_json = load_ot(ot_id, root)
+            schema_doc = load_schema(ot_id, root)
+        except FileNotFoundError as exc:
+            tests.append(make_test(
+                'load-' + ot_id,
+                'load adaptive OT and schema for ' + ot_id,
+                False,
+                detail=str(exc),
+            ))
+            continue
+
+        tests.append(make_test(
+            'load-' + ot_id,
+            'load adaptive OT and schema for ' + ot_id,
+            True,
+        ))
+        _check_property_names(ot_id, ot_json, schema_doc, tests)
+        _check_object_refs(ot_id, ot_json, schema_doc, tests)
+        _check_array_object_items(ot_id, ot_json, schema_doc, tests)
+        _check_defaults_and_enums(ot_id, ot_json, schema_doc, tests)
+        _check_open_closed(ot_id, ot_json, schema_doc, tests)
+        _check_required(ot_id, ot_json, schema_doc, tests)
+
+    return response

--- a/src/afw_dev/tests/json_schema/adaptive_compare.py
+++ b/src/afw_dev/tests/json_schema/adaptive_compare.py
@@ -156,10 +156,12 @@ def _check_open_closed(ot_id, ot_json, schema_doc, tests):
                 ok,
             ))
     else:
-        ok = entity.get('unevaluatedProperties') is False
+        ok = (
+            entity.get('additionalProperties') is False or
+            entity.get('unevaluatedProperties') is False)
         tests.append(make_test(
             'closed-' + ot_id,
-            ot_id + ' no otherProperties → unevaluatedProperties false',
+            ot_id + ' no otherProperties → closed additional/unevaluatedProperties',
             ok,
         ))
 

--- a/src/afw_dev/tests/json_schema/complex.py
+++ b/src/afw_dev/tests/json_schema/complex.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Complex adaptive cases: inheritance chains and nested object graphs."""
+
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+from _common import (
+    allof_property_types_refs,
+    ancestor_ot_ids,
+    entity_def,
+    is_clean_ref_form,
+    load_json,
+    load_ot,
+    load_schema,
+    make_test,
+    package_root,
+    property_map,
+    skip_if_no_schemas,
+    validate_instance,
+)
+
+# (object type id, description)
+INHERITANCE_CASES = [
+    (
+        '_AdaptivePolymorphicFunction_',
+        'PolymorphicFunction inherits Function propertyTypes',
+    ),
+    (
+        '_AdaptiveApplication_',
+        'Application inherits Conf_application and Conf_ propertyTypes',
+    ),
+    (
+        '_AdaptiveDataTypeGenerate_',
+        'DataTypeGenerate inherits DataType propertyTypes',
+    ),
+    (
+        '_AdaptiveRequestHandler_',
+        'RequestHandler inherits Conf_requestHandler (and ancestors)',
+    ),
+]
+
+NESTED_OBJECT_PROPS = [
+    ('_AdaptiveFunction_', 'returns', '_AdaptiveFunctionParameter_'),
+    ('_AdaptiveFunction_', 'parameters', None),  # array; check items
+    ('_AdaptiveObjectType_', 'propertyTypes', '_AdaptivePropertyTypes_'),
+    ('_AdaptiveObjectType_', 'otherProperties', '_AdaptiveValueMeta_'),
+    ('_AdaptiveConf_application', 'authorizationControl',
+     '_AdaptiveAuthorizationControl_'),
+]
+
+COMPLEX_INSTANCES = [
+    (
+        'src/afw/generate/objects/_AdaptivePolymorphicFunction_/abs.json',
+        '_AdaptivePolymorphicFunction_',
+        'complex-instance-poly-abs',
+    ),
+    (
+        'src/afw/generate/objects/_AdaptivePolymorphicFunction_/eq.json',
+        '_AdaptivePolymorphicFunction_',
+        'complex-instance-poly-eq',
+    ),
+    (
+        'src/afw/generate/objects/_AdaptiveFunctionGenerate_/and.json',
+        '_AdaptiveFunctionGenerate_',
+        'complex-instance-function-generate-and',
+    ),
+    (
+        'src/afw/generate/objects/_AdaptiveObjectType_/_AdaptiveConf_application.json',
+        '_AdaptiveObjectType_',
+        'complex-instance-ot-conf-application',
+    ),
+]
+
+
+def run():
+    response = {
+        'description':
+            'Complex adaptive object types: inheritance and nested graphs',
+        'tests': [],
+    }
+    tests = response['tests']
+    if skip_if_no_schemas(tests):
+        return response
+
+    root = package_root()
+
+    # --- inheritance: adaptive parentPaths vs schema allOf ---
+    for ot_id, description in INHERITANCE_CASES:
+        try:
+            schema_doc = load_schema(ot_id, root)
+            entity = entity_def(schema_doc, ot_id)
+            expected_ancestors = set(ancestor_ot_ids(ot_id, root))
+            actual_refs = allof_property_types_refs(entity)
+        except FileNotFoundError as exc:
+            tests.append(make_test(
+                'inherit-' + ot_id,
+                description,
+                False,
+                detail=str(exc),
+            ))
+            continue
+
+        # allOf must include self.propertyTypes and every ancestor
+        expected_refs = set(expected_ancestors)
+        expected_refs.add(ot_id)
+        missing = sorted(expected_refs - actual_refs)
+        # actual may only list direct path; ancestor_ot_ids is full chain —
+        # require full chain in schema (generator walks recursively)
+        ok = not missing and ot_id in actual_refs
+        tests.append(make_test(
+            'inherit-' + ot_id,
+            description,
+            ok,
+            detail=None if ok else (
+                'missing allOf propertyTypes refs: ' + ','.join(missing) +
+                '; have ' + ','.join(sorted(actual_refs))),
+        ))
+
+        # Polymorphic must not require Function's functionResourceId
+        if ot_id == '_AdaptivePolymorphicFunction_':
+            req = entity.get('required') or []
+            tests.append(make_test(
+                'inherit-poly-no-functionResourceId-required',
+                'PolymorphicFunction does not require functionResourceId',
+                'functionResourceId' not in req,
+            ))
+
+    # --- nested object / array-of-object projections ---
+    for ot_id, prop_name, target_ot in NESTED_OBJECT_PROPS:
+        try:
+            # Conf_application may only live inside Application schema file
+            try:
+                schema_doc = load_schema(ot_id, root)
+            except FileNotFoundError:
+                if ot_id == '_AdaptiveConf_application':
+                    schema_doc = load_schema('_AdaptiveApplication_', root)
+                else:
+                    raise
+            props = property_map(schema_doc, ot_id)
+            if prop_name not in props:
+                ptd = schema_doc.get('$defs', {}).get(
+                    ot_id + '.propertyTypes', {})
+                props = ptd.get('properties') or {}
+            node = props.get(prop_name)
+        except FileNotFoundError as exc:
+            tests.append(make_test(
+                'nested-' + ot_id + '-' + prop_name,
+                ot_id + '.' + prop_name + ' nested projection',
+                False,
+                detail=str(exc),
+            ))
+            continue
+
+        if target_ot is None:
+            # parameters: array with object items
+            ok = (
+                isinstance(node, dict) and
+                node.get('type') == 'array' and
+                is_clean_ref_form(node.get('items') or {}))
+            items = (node or {}).get('items') or {}
+            has_param_def = '_AdaptiveFunctionParameter_' in (
+                schema_doc.get('$defs') or {})
+            tests.append(make_test(
+                'nested-' + ot_id + '-' + prop_name,
+                ot_id + '.' + prop_name +
+                ' is array of FunctionParameter refs',
+                ok and has_param_def,
+                detail=None if (ok and has_param_def) else repr(node)[:160],
+            ))
+        else:
+            ok = node is not None and is_clean_ref_form(node)
+            has_def = target_ot in (schema_doc.get('$defs') or {})
+            tests.append(make_test(
+                'nested-' + ot_id + '-' + prop_name,
+                ot_id + '.' + prop_name + ' refs ' + target_ot,
+                ok and has_def,
+                detail=None if (ok and has_def) else repr(node)[:160],
+            ))
+
+    # errorsThrown items on Function
+    try:
+        doc = load_schema('_AdaptiveFunction_', root)
+        thrown = property_map(doc, '_AdaptiveFunction_').get('errorsThrown') or {}
+        items = thrown.get('items')
+        ok = (
+            thrown.get('type') == 'array' and
+            is_clean_ref_form(items or {}) and
+            '_AdaptiveFunctionErrorThrown_' in (doc.get('$defs') or {}))
+        tests.append(make_test(
+            'nested-Function-errorsThrown-items',
+            'Function.errorsThrown items ref FunctionErrorThrown',
+            ok,
+            detail=None if ok else repr(thrown)[:160],
+        ))
+    except FileNotFoundError as exc:
+        tests.append(make_test(
+            'nested-Function-errorsThrown-items',
+            'Function.errorsThrown items ref FunctionErrorThrown',
+            False,
+            detail=str(exc),
+        ))
+
+    # --- complex instances ---
+    for rel_path, schema_id, test_id in COMPLEX_INSTANCES:
+        try:
+            instance = load_json(rel_path, root)
+            schema_doc = load_schema(schema_id, root)
+        except FileNotFoundError as exc:
+            tests.append(make_test(
+                test_id,
+                'complex instance ' + rel_path,
+                False,
+                detail=str(exc),
+            ))
+            continue
+        ok, err = validate_instance(instance, schema_doc)
+        tests.append(make_test(
+            test_id,
+            'complex instance validates: ' + rel_path,
+            ok,
+            detail=err[:300] if err else None,
+        ))
+
+    # Poly abs uses inherited Function fields (category, functionId, returns)
+    try:
+        abs_inst = load_json(
+            'src/afw/generate/objects/_AdaptivePolymorphicFunction_/abs.json',
+            root)
+        poly_ot = load_ot('_AdaptivePolymorphicFunction_', root)
+        local = set(
+            k for k in (poly_ot.get('propertyTypes') or {})
+            if k != '_meta_')
+        # category/functionId/returns are on Function, not local poly props
+        inherited_used = [
+            k for k in ('category', 'functionId', 'returns', 'parameters')
+            if k in abs_inst and k not in local]
+        tests.append(make_test(
+            'complex-poly-uses-inherited-props',
+            'poly abs instance uses inherited Function properties',
+            len(inherited_used) >= 3,
+            detail='inherited present: ' + ','.join(inherited_used),
+        ))
+    except FileNotFoundError as exc:
+        tests.append(make_test(
+            'complex-poly-uses-inherited-props',
+            'poly abs instance uses inherited Function properties',
+            False,
+            detail=str(exc),
+        ))
+
+    return response

--- a/src/afw_dev/tests/json_schema/complex.py
+++ b/src/afw_dev/tests/json_schema/complex.py
@@ -12,11 +12,13 @@ from _common import (
     allof_property_types_refs,
     ancestor_ot_ids,
     entity_def,
+    entity_property_names,
     is_clean_ref_form,
     load_json,
     load_ot,
     load_schema,
     make_test,
+    ot_local_property_names,
     package_root,
     property_map,
     skip_if_no_schemas,
@@ -88,13 +90,14 @@ def run():
 
     root = package_root()
 
-    # --- inheritance: adaptive parentPaths vs schema allOf ---
+    # --- inheritance: parentPaths recorded + composite property merge ---
     for ot_id, description in INHERITANCE_CASES:
         try:
             schema_doc = load_schema(ot_id, root)
             entity = entity_def(schema_doc, ot_id)
             expected_ancestors = set(ancestor_ot_ids(ot_id, root))
-            actual_refs = allof_property_types_refs(entity)
+            actual_inherited = allof_property_types_refs(entity)
+            prop_names = entity_property_names(entity)
         except FileNotFoundError as exc:
             tests.append(make_test(
                 'inherit-' + ot_id,
@@ -104,20 +107,34 @@ def run():
             ))
             continue
 
-        # allOf must include self.propertyTypes and every ancestor
-        expected_refs = set(expected_ancestors)
-        expected_refs.add(ot_id)
-        missing = sorted(expected_refs - actual_refs)
-        # actual may only list direct path; ancestor_ot_ids is full chain —
-        # require full chain in schema (generator walks recursively)
-        ok = not missing and ot_id in actual_refs
+        missing_inherited = sorted(expected_ancestors - actual_inherited)
+        ok_chain = not missing_inherited
         tests.append(make_test(
             'inherit-' + ot_id,
-            description,
-            ok,
-            detail=None if ok else (
-                'missing allOf propertyTypes refs: ' + ','.join(missing) +
-                '; have ' + ','.join(sorted(actual_refs))),
+            description + ' (x-afw-inheritedObjectTypes)',
+            ok_chain,
+            detail=None if ok_chain else (
+                'missing inherited OTs: ' + ','.join(missing_inherited) +
+                '; have ' + ','.join(sorted(actual_inherited))),
+        ))
+
+        # Composite entity properties include local + ancestor property names
+        # (child overrides share names but still appear once).
+        expected_props = set()
+        try:
+            for aid in list(expected_ancestors) + [ot_id]:
+                expected_props.update(ot_local_property_names(load_ot(aid, root)))
+        except FileNotFoundError:
+            expected_props = set()
+        # _meta_ is added as optional instance bag on closed composites
+        expected_props.add('_meta_')
+        missing_props = sorted(expected_props - prop_names)
+        tests.append(make_test(
+            'inherit-merged-props-' + ot_id,
+            ot_id + ' entity properties include inherited + local names',
+            not missing_props,
+            detail=None if not missing_props else (
+                'missing props: ' + ','.join(missing_props[:15])),
         ))
 
         # Polymorphic must not require Function's functionResourceId
@@ -128,7 +145,6 @@ def run():
                 'PolymorphicFunction does not require functionResourceId',
                 'functionResourceId' not in req,
             ))
-
     # --- nested object / array-of-object projections ---
     for ot_id, prop_name, target_ot in NESTED_OBJECT_PROPS:
         try:

--- a/src/afw_dev/tests/json_schema/config.py
+++ b/src/afw_dev/tests/json_schema/config.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+
+# JSON Schema projection tests (generated/schemas/afw vs adaptive object types).
+Tags = ["json_schema", "generate"]

--- a/src/afw_dev/tests/json_schema/data/invalid_function_id_type.json
+++ b/src/afw_dev/tests/json_schema/data/invalid_function_id_type.json
@@ -1,0 +1,9 @@
+{
+    "category": "logical",
+    "functionId": 12345,
+    "functionLabel": "broken",
+    "returns": {
+        "dataType": "boolean"
+    },
+    "brief": "Invalid: functionId must be string"
+}

--- a/src/afw_dev/tests/json_schema/data/invalid_function_missing_id.json
+++ b/src/afw_dev/tests/json_schema/data/invalid_function_missing_id.json
@@ -1,0 +1,8 @@
+{
+    "category": "logical",
+    "functionLabel": "broken",
+    "returns": {
+        "dataType": "boolean"
+    },
+    "brief": "Invalid: missing functionId"
+}

--- a/src/afw_dev/tests/json_schema/data/invalid_poly_extra_property.json
+++ b/src/afw_dev/tests/json_schema/data/invalid_poly_extra_property.json
@@ -1,0 +1,24 @@
+{
+    "brief": "Absolute value",
+    "category": "polymorphic",
+    "dataTypeMethod": true,
+    "description": "Compute the absolute value.",
+    "functionId": "abs",
+    "functionLabel": "abs",
+    "pure": true,
+    "parameters": [
+        {
+            "name": "value",
+            "polymorphicDataType": true
+        }
+    ],
+    "polymorphic": true,
+    "polymorphicDataTypes": [
+        "double",
+        "integer"
+    ],
+    "returns": {
+        "polymorphicDataType": true
+    },
+    "notARealFunctionProperty": true
+}

--- a/src/afw_dev/tests/json_schema/gnarly_models.py
+++ b/src/afw_dev/tests/json_schema/gnarly_models.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""
+Gnarly inheritance cases centered on _AdaptiveModel_ and related types.
+
+Real model instances use nested objectTypes maps whose values inherit
+ModelObjectType → ObjectType, and propertyTypes maps whose values inherit
+ModelPropertyType → ValueMeta. Child property definitions must override
+parents (e.g. model propertyTypes is ModelPropertyTypes, not PropertyTypes).
+"""
+
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+from _common import (
+    allof_property_types_refs,
+    ancestor_ot_ids,
+    entity_def,
+    entity_property_names,
+    is_clean_ref_form,
+    load_json,
+    load_ot,
+    load_schema,
+    make_test,
+    package_root,
+    property_map,
+    skip_if_no_schemas,
+    validate_instance,
+)
+
+# Real model instances scattered in the tree (prefer source over build/).
+# Each entry: path, test id suffix, description, optional unwrap key for envelopes.
+MODEL_INSTANCES = [
+    (
+        'src/afw/tests/environments/models/objects/_AdaptiveModel_/TestModel1.json',
+        'test-model-1-environments',
+        'TestModel1 from models test environment',
+        None,
+    ),
+    (
+        'src/afw/tests/authorization/application/models/objects/_AdaptiveModel_/TestModel1.json',
+        'test-model-1-authorization',
+        'TestModel1 from authorization application models',
+        None,
+    ),
+    (
+        'docker/images/afw/afw/models/_AdaptiveModel_/TIER Core Schema.json',
+        'tier-core-schema',
+        'TIER Core Schema docker model (large nested objectTypes)',
+        None,
+    ),
+    (
+        # URL-encoded filename; body is a get_object mock envelope {status, result}.
+        'src/afw_test/javascript/src/__mocks__/get_object/models/_AdaptiveModel_/TIER%20Core%20Schema.json',
+        'tier-core-schema-js-mock',
+        'TIER Core Schema from JS get_object mock (unwrap result)',
+        'result',
+    ),
+]
+
+
+def run():
+    response = {
+        'description':
+            'Gnarly _AdaptiveModel_ inheritance and nested model object graphs',
+        'tests': [],
+    }
+    tests = response['tests']
+    if skip_if_no_schemas(tests):
+        return response
+
+    root = package_root()
+
+    # --- Model schema graph structure ---
+    try:
+        model_schema = load_schema('_AdaptiveModel_', root)
+        model_entity = entity_def(model_schema, '_AdaptiveModel_')
+        model_props = property_map(model_schema, '_AdaptiveModel_')
+        defs = model_schema.get('$defs') or {}
+    except FileNotFoundError as exc:
+        tests.append(make_test(
+            'model-schema-load',
+            'load _AdaptiveModel_ schema',
+            False,
+            detail=str(exc),
+        ))
+        return response
+
+    tests.append(make_test(
+        'model-schema-load',
+        'load _AdaptiveModel_ schema',
+        True,
+    ))
+
+    # Nested $defs required for a useful model projection
+    for need in (
+            '_AdaptiveModelObjectTypes_',
+            '_AdaptiveModelObjectType_',
+            '_AdaptiveModelPropertyTypes_',
+            '_AdaptiveModelPropertyType_',
+            '_AdaptiveObjectType_.propertyTypes',
+            '_AdaptiveValueMeta_.propertyTypes',
+            '_AdaptiveValueMeta_',
+    ):
+        tests.append(make_test(
+            'model-def-' + need.replace('.', '_'),
+            'Model schema $defs includes ' + need,
+            need in defs,
+        ))
+
+    # objectTypes / propertyTypes on Model are clean object refs
+    for prop_name, target in (
+            ('objectTypes', '_AdaptiveModelObjectTypes_'),
+            ('propertyTypes', '_AdaptiveModelPropertyTypes_'),
+            ('custom', '_AdaptiveTemplateProperties_'),
+    ):
+        node = model_props.get(prop_name)
+        ok = node is not None and is_clean_ref_form(node) and target in defs
+        tests.append(make_test(
+            'model-prop-ref-' + prop_name,
+            'Model.' + prop_name + ' refs ' + target,
+            ok,
+            detail=None if ok else repr(node)[:160],
+        ))
+
+    # ModelObjectType inherits ObjectType (override-capable composite)
+    try:
+        mot = entity_def(model_schema, '_AdaptiveModelObjectType_')
+        inherited = allof_property_types_refs(mot) if mot else set()
+        # if MOT only appears as nested def, x-afw-inheritedObjectTypes should list ObjectType
+        has_object_type = (
+            '_AdaptiveObjectType_' in inherited or
+            (mot and 'allowAdd' in (mot.get('properties') or {})) or
+            (mot and 'mappedObjectType' in (mot.get('properties') or {})))
+        # prefer: inherited list or merged props contain both sides
+        props = (mot or {}).get('properties') or {}
+        has_mapped = 'mappedObjectType' in props
+        has_allow = 'allowAdd' in props  # from ObjectType
+        has_model_hooks = 'onGetObject' in props or 'onRetrieveObjects' in props
+        tests.append(make_test(
+            'model-object-type-composite',
+            'ModelObjectType composite has model hooks + ObjectType props '
+            '(override-safe merge)',
+            has_mapped and has_allow and has_model_hooks,
+            detail='props sample: ' + ','.join(sorted(props)[:20]),
+        ))
+        tests.append(make_test(
+            'model-object-type-inherits-ObjectType',
+            'ModelObjectType records or merges ObjectType inheritance',
+            '_AdaptiveObjectType_' in inherited or has_allow,
+            detail='inherited=' + ','.join(sorted(inherited)),
+        ))
+    except Exception as exc:
+        tests.append(make_test(
+            'model-object-type-composite',
+            'ModelObjectType composite has model hooks + ObjectType props',
+            False,
+            detail=str(exc),
+        ))
+
+    # ModelPropertyType inherits ValueMeta + mappedPropertyName
+    try:
+        mpt = entity_def(model_schema, '_AdaptiveModelPropertyType_')
+        props = (mpt or {}).get('properties') or {}
+        tests.append(make_test(
+            'model-property-type-composite',
+            'ModelPropertyType has mappedPropertyName and ValueMeta dataType',
+            'mappedPropertyName' in props and 'dataType' in props,
+            detail='props: ' + ','.join(sorted(props)[:25]),
+        ))
+        inherited = allof_property_types_refs(mpt) if mpt else set()
+        tests.append(make_test(
+            'model-property-type-inherits-ValueMeta',
+            'ModelPropertyType inherits _AdaptiveValueMeta_',
+            '_AdaptiveValueMeta_' in inherited or 'dataType' in props,
+            detail='inherited=' + ','.join(sorted(inherited)),
+        ))
+    except Exception as exc:
+        tests.append(make_test(
+            'model-property-type-composite',
+            'ModelPropertyType composite',
+            False,
+            detail=str(exc),
+        ))
+
+    # ModelObjectTypes / ModelPropertyTypes are open maps of nested types
+    for map_id, value_id in (
+            ('_AdaptiveModelObjectTypes_', '_AdaptiveModelObjectType_'),
+            ('_AdaptiveModelPropertyTypes_', '_AdaptiveModelPropertyType_'),
+    ):
+        node = defs.get(map_id) or {}
+        add = node.get('additionalProperties')
+        ok = False
+        if isinstance(add, dict):
+            # allOf [ $ref value ] or pure $ref
+            if is_clean_ref_form(add):
+                ref = add.get('$ref') or (
+                    add.get('allOf') or [{}])[0].get('$ref', '')
+                ok = value_id in ref
+            elif '$ref' in str(add):
+                ok = value_id in str(add)
+        tests.append(make_test(
+            'model-map-' + map_id,
+            map_id + ' additionalProperties refs ' + value_id,
+            ok,
+            detail=None if ok else repr(add)[:200],
+        ))
+
+    # propertyTypes on ModelObjectType must be ModelPropertyTypes, not
+    # the parent ObjectType PropertyTypes (override check)
+    mot = entity_def(model_schema, '_AdaptiveModelObjectType_') or {}
+    pt_node = (mot.get('properties') or {}).get('propertyTypes')
+    override_ok = False
+    if isinstance(pt_node, dict):
+        blob = json_dumps_safe(pt_node)
+        override_ok = (
+            '_AdaptiveModelPropertyTypes_' in blob and
+            # should not solely be AdaptivePropertyTypes without Model
+            ('_AdaptiveModelPropertyTypes_' in blob))
+    tests.append(make_test(
+        'model-object-type-propertyTypes-override',
+        'ModelObjectType.propertyTypes overrides ObjectType with '
+        'ModelPropertyTypes (not plain PropertyTypes only)',
+        override_ok,
+        detail=None if override_ok else repr(pt_node)[:200],
+    ))
+
+    # --- Real model instances ---
+    for entry in MODEL_INSTANCES:
+        rel_path, suffix, description, unwrap = entry
+        path = root / rel_path
+        if not path.is_file():
+            tests.append(make_test(
+                'instance-' + suffix,
+                description,
+                False,
+                detail='file not found: ' + rel_path,
+            ))
+            continue
+        try:
+            instance = load_json(rel_path, root)
+            if unwrap:
+                if not isinstance(instance, dict) or unwrap not in instance:
+                    tests.append(make_test(
+                        'instance-' + suffix,
+                        description,
+                        False,
+                        detail='missing envelope key ' + unwrap,
+                    ))
+                    continue
+                instance = instance[unwrap]
+        except Exception as exc:
+            tests.append(make_test(
+                'instance-' + suffix,
+                description,
+                False,
+                detail=str(exc),
+            ))
+            continue
+        ok, err = validate_instance(instance, model_schema)
+        tests.append(make_test(
+            'instance-' + suffix,
+            description,
+            ok,
+            detail=err[:400] if err else None,
+        ))
+    # Structural gnarl: TestModel1 has hooks + mapped props + scripts
+    try:
+        test_model = load_json(
+            'src/afw/tests/environments/models/objects/_AdaptiveModel_/'
+            'TestModel1.json',
+            root)
+        ots = test_model.get('objectTypes') or {}
+        tests.append(make_test(
+            'test-model-1-has-multiple-object-types',
+            'TestModel1 defines multiple model object types',
+            len(ots) >= 5,
+            detail='count=' + str(len(ots)),
+        ))
+        # at least one type with model hooks and one with mappedPropertyName
+        has_hooks = any(
+            isinstance(v, dict) and (
+                'onGetObject' in v or 'onRetrieveObjects' in v)
+            for v in ots.values())
+        has_mapped_prop = any(
+            isinstance(v, dict) and isinstance(v.get('propertyTypes'), dict) and
+            any(
+                isinstance(p, dict) and 'mappedPropertyName' in p
+                for p in v['propertyTypes'].values())
+            for v in ots.values())
+        tests.append(make_test(
+            'test-model-1-has-hooks-and-mapped-props',
+            'TestModel1 uses on* hooks and mappedPropertyName',
+            has_hooks and has_mapped_prop,
+        ))
+    except FileNotFoundError as exc:
+        tests.append(make_test(
+            'test-model-1-has-multiple-object-types',
+            'TestModel1 defines multiple model object types',
+            False,
+            detail=str(exc),
+        ))
+
+    # TIER model scale
+    tier_path = (
+        'docker/images/afw/afw/models/_AdaptiveModel_/TIER Core Schema.json')
+    try:
+        tier = load_json(tier_path, root)
+        n = len(tier.get('objectTypes') or {})
+        tests.append(make_test(
+            'tier-model-object-type-count',
+            'TIER Core Schema has a substantial objectTypes map',
+            n >= 10,
+            detail='objectTypes count=' + str(n),
+        ))
+    except FileNotFoundError as exc:
+        tests.append(make_test(
+            'tier-model-object-type-count',
+            'TIER Core Schema has a substantial objectTypes map',
+            False,
+            detail=str(exc),
+        ))
+
+    # Negative: model object type property with unknown field under closed MOT
+    bad_model = {
+        'modelId': 'bad',
+        'objectTypes': {
+            'T': {
+                'mappedObjectType': 'X',
+                'notAValidModelOrObjectTypeProperty': True,
+            }
+        },
+    }
+    ok, _ = validate_instance(bad_model, model_schema)
+    tests.append(make_test(
+        'neg-model-unknown-object-type-property',
+        'Model rejects unknown properties on nested model object types',
+        not ok,
+        detail=None if not ok else 'unexpectedly valid',
+    ))
+
+    # Negative: model property type with unknown field
+    bad_model2 = {
+        'modelId': 'bad2',
+        'objectTypes': {
+            'T': {
+                'propertyTypes': {
+                    'p': {
+                        'dataType': 'string',
+                        'notAValidValueMetaOrModelProp': 1,
+                    }
+                }
+            }
+        },
+    }
+    ok, _ = validate_instance(bad_model2, model_schema)
+    tests.append(make_test(
+        'neg-model-unknown-property-type-field',
+        'Model rejects unknown fields on nested model property types',
+        not ok,
+        detail=None if not ok else 'unexpectedly valid',
+    ))
+
+    return response
+
+
+def json_dumps_safe(obj):
+    import json
+    return json.dumps(obj)

--- a/src/afw_dev/tests/json_schema/instances.py
+++ b/src/afw_dev/tests/json_schema/instances.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Validate real adaptive object instances against generated schemas."""
+
+import copy
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+from _common import (
+    load_json,
+    load_schema,
+    make_test,
+    package_root,
+    skip_if_no_schemas,
+    validate_instance,
+)
+
+# (relative path under package root, schema entity id, test id suffix)
+POSITIVE_INSTANCES = [
+    (
+        'src/afw/generate/objects/_AdaptiveFunctionGenerate_/and.json',
+        '_AdaptiveFunctionGenerate_',
+        'function-generate-and',
+    ),
+    (
+        'src/afw/generate/objects/_AdaptiveFunctionGenerate_/if.json',
+        '_AdaptiveFunctionGenerate_',
+        'function-generate-if',
+    ),
+    (
+        'src/afw/generate/objects/_AdaptivePolymorphicFunction_/abs.json',
+        '_AdaptivePolymorphicFunction_',
+        'poly-abs',
+    ),
+    (
+        'src/afw/generate/objects/_AdaptivePolymorphicFunction_/eq.json',
+        '_AdaptivePolymorphicFunction_',
+        'poly-eq',
+    ),
+    (
+        'src/afw/generate/objects/_AdaptiveObjectType_/_AdaptiveFunction_.json',
+        '_AdaptiveObjectType_',
+        'ot-function',
+    ),
+    (
+        'src/afw/generate/objects/_AdaptiveObjectType_/_AdaptiveObject_.json',
+        '_AdaptiveObjectType_',
+        'ot-object',
+    ),
+    (
+        'src/afw/generate/objects/_AdaptiveDataTypeGenerate_/object.json',
+        '_AdaptiveDataTypeGenerate_',
+        'datatype-object',
+    ),
+    (
+        'afw-package.json',
+        '_AdaptivePackage_',
+        'afw-package',
+    ),
+]
+
+NEGATIVE_FIXTURES = [
+    (
+        'data/invalid_function_missing_id.json',
+        '_AdaptiveFunctionGenerate_',
+        'neg-missing-functionId',
+        'FunctionGenerate missing functionId is rejected',
+    ),
+    (
+        'data/invalid_function_id_type.json',
+        '_AdaptiveFunctionGenerate_',
+        'neg-functionId-type',
+        'FunctionGenerate with non-string functionId is rejected',
+    ),
+    (
+        'data/invalid_poly_extra_property.json',
+        '_AdaptivePolymorphicFunction_',
+        'neg-poly-extra-property',
+        'Polymorphic function with unknown property is rejected',
+    ),
+]
+
+
+def run():
+    response = {
+        'description':
+            'Adaptive object instances validated against generated JSON Schema',
+        'tests': [],
+    }
+    tests = response['tests']
+    if skip_if_no_schemas(tests):
+        return response
+
+    root = package_root()
+    data_dir = os.path.join(_HERE)
+
+    for rel_path, schema_id, suffix in POSITIVE_INSTANCES:
+        try:
+            instance = load_json(rel_path, root)
+            schema_doc = load_schema(schema_id, root)
+        except FileNotFoundError as exc:
+            tests.append(make_test(
+                'instance-' + suffix,
+                'validate ' + rel_path + ' as ' + schema_id,
+                False,
+                detail=str(exc),
+            ))
+            continue
+        ok, err = validate_instance(instance, schema_doc)
+        tests.append(make_test(
+            'instance-' + suffix,
+            'validate ' + rel_path + ' as ' + schema_id,
+            ok,
+            detail=err[:300] if err else None,
+        ))
+
+    for rel_path, schema_id, suffix, description in NEGATIVE_FIXTURES:
+        path = os.path.join(data_dir, rel_path)
+        try:
+            instance = load_json(path, root)
+            schema_doc = load_schema(schema_id, root)
+        except FileNotFoundError as exc:
+            tests.append(make_test(
+                suffix,
+                description,
+                False,
+                detail=str(exc),
+            ))
+            continue
+        ok, err = validate_instance(instance, schema_doc)
+        # negative: validation must fail
+        tests.append(make_test(
+            suffix,
+            description,
+            not ok,
+            detail=None if not ok else 'unexpectedly valid',
+        ))
+
+    # Inline negative: strip functionId from a known-good FunctionGenerate
+    try:
+        good = load_json(
+            'src/afw/generate/objects/_AdaptiveFunctionGenerate_/and.json',
+            root)
+        schema_doc = load_schema('_AdaptiveFunctionGenerate_', root)
+        broken = copy.deepcopy(good)
+        broken.pop('functionId', None)
+        ok, _ = validate_instance(broken, schema_doc)
+        tests.append(make_test(
+            'neg-strip-functionId-from-and',
+            'and.json without functionId is rejected',
+            not ok,
+            detail=None if not ok else 'unexpectedly valid',
+        ))
+    except FileNotFoundError as exc:
+        tests.append(make_test(
+            'neg-strip-functionId-from-and',
+            'and.json without functionId is rejected',
+            False,
+            detail=str(exc),
+        ))
+
+    return response

--- a/src/afw_dev/tests/json_schema/structural.py
+++ b/src/afw_dev/tests/json_schema/structural.py
@@ -68,18 +68,19 @@ def run():
                 detail=str(exc),
             ))
             continue
+        # Editor-first: entity keywords live at document root; $defs holds
+        # the entity and nested types for $ref.
         ok = (
             doc.get('$schema') is not None and
             isinstance(doc.get('$defs'), dict) and
             ot_id in doc['$defs'] and
-            isinstance(doc.get('allOf'), list) and
-            len(doc['allOf']) >= 1 and
-            doc['allOf'][0].get('$ref') == '#/$defs/' + ot_id
+            doc.get('type') == 'object' and
+            isinstance(doc.get('properties'), dict)
         )
         tests.append(make_test(
             'entity-document-shape-' + ot_id,
             'schema document for ' + ot_id +
-            ' has $schema, $defs, allOf->$ref entity',
+            ' has $schema, $defs, and entity properties at root (editor)',
             ok,
         ))
 

--- a/src/afw_dev/tests/json_schema/structural.py
+++ b/src/afw_dev/tests/json_schema/structural.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Structural contracts on package-root generated/schemas/afw."""
+
+import json
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+from _common import (
+    find_mixed_refs,
+    is_clean_ref_form,
+    iter_schema_files,
+    load_schema,
+    make_test,
+    package_root,
+    property_map,
+    schemas_dir,
+    skip_if_no_schemas,
+)
+
+
+def run():
+    response = {
+        'description': 'JSON Schema structural contracts (generated/schemas/afw)',
+        'tests': [],
+    }
+    tests = response['tests']
+    if skip_if_no_schemas(tests):
+        return response
+
+    root = package_root()
+    files = list(iter_schema_files(root))
+    tests.append(make_test(
+        'schemas-dir-exists',
+        'generated/schemas/afw exists and contains schema files',
+        len(files) > 0,
+        detail=str(schemas_dir(root)),
+    ))
+
+    mixed = []
+    for path in files:
+        with open(path, encoding='utf-8') as fd:
+            doc = json.load(fd)
+        for issue_path, others in find_mixed_refs(doc):
+            mixed.append(
+                path.name + ' ' + issue_path + ' extras=' + str(others))
+    tests.append(make_test(
+        'no-mixed-ref',
+        'no schema node combines $ref with sibling keywords (issue #3)',
+        len(mixed) == 0,
+        detail='; '.join(mixed[:5]) if mixed else None,
+    ))
+
+    for ot_id in (
+            '_AdaptiveObject_',
+            '_AdaptiveFunction_',
+            '_AdaptivePolymorphicFunction_'):
+        try:
+            doc = load_schema(ot_id, root)
+        except FileNotFoundError as exc:
+            tests.append(make_test(
+                'entity-document-shape-' + ot_id,
+                'schema document shape for ' + ot_id,
+                False,
+                detail=str(exc),
+            ))
+            continue
+        ok = (
+            doc.get('$schema') is not None and
+            isinstance(doc.get('$defs'), dict) and
+            ot_id in doc['$defs'] and
+            isinstance(doc.get('allOf'), list) and
+            len(doc['allOf']) >= 1 and
+            doc['allOf'][0].get('$ref') == '#/$defs/' + ot_id
+        )
+        tests.append(make_test(
+            'entity-document-shape-' + ot_id,
+            'schema document for ' + ot_id +
+            ' has $schema, $defs, allOf->$ref entity',
+            ok,
+        ))
+
+    ref_checks = [
+        ('_AdaptiveFunction_', 'returns'),
+        ('_AdaptiveObjectType_', 'otherProperties'),
+        ('_AdaptiveObjectType_', 'propertyTypes'),
+        ('_AdaptiveObjectType_', 'runtime'),
+        ('_AdaptiveConf_application', 'authorizationControl'),
+    ]
+    for ot_id, prop_name in ref_checks:
+        doc = None
+        try:
+            doc = load_schema(ot_id, root)
+        except FileNotFoundError:
+            if ot_id == '_AdaptiveConf_application':
+                try:
+                    doc = load_schema('_AdaptiveApplication_', root)
+                except FileNotFoundError as exc:
+                    tests.append(make_test(
+                        'ref-form-' + ot_id + '-' + prop_name,
+                        'object property ' + ot_id + '.' + prop_name +
+                        ' uses clean $ref form',
+                        False,
+                        detail=str(exc),
+                    ))
+                    continue
+            else:
+                tests.append(make_test(
+                    'ref-form-' + ot_id + '-' + prop_name,
+                    'object property ' + ot_id + '.' + prop_name +
+                    ' uses clean $ref form',
+                    False,
+                    detail='schema missing',
+                ))
+                continue
+
+        props = property_map(doc, ot_id)
+        if prop_name not in props:
+            ptd = doc.get('$defs', {}).get(ot_id + '.propertyTypes', {})
+            props = ptd.get('properties') or {}
+        node = props.get(prop_name)
+        ok = node is not None and is_clean_ref_form(node)
+        tests.append(make_test(
+            'ref-form-' + ot_id + '-' + prop_name,
+            'object property ' + ot_id + '.' + prop_name +
+            ' uses pure $ref or allOf+annotations',
+            ok,
+            detail=None if ok else repr(node)[:200],
+        ))
+
+    try:
+        doc = load_schema('_AdaptiveFunction_', root)
+        params = property_map(doc, '_AdaptiveFunction_').get('parameters') or {}
+        items = params.get('items')
+        ok = items is not None and is_clean_ref_form(items)
+        tests.append(make_test(
+            'ref-form-Function-parameters-items',
+            'Function.parameters.items uses clean $ref form',
+            ok,
+            detail=None if ok else repr(items)[:200],
+        ))
+    except FileNotFoundError as exc:
+        tests.append(make_test(
+            'ref-form-Function-parameters-items',
+            'Function.parameters.items uses clean $ref form',
+            False,
+            detail=str(exc),
+        ))
+
+    param_schema = schemas_dir(root) / '_AdaptiveFunctionParameter_.json'
+    tests.append(make_test(
+        'allowEntity-false-no-top-level-file',
+        '_AdaptiveFunctionParameter_ (allowEntity false) has no top-level schema file',
+        not param_schema.is_file(),
+    ))
+
+    tests.append(make_test(
+        'allowEntity-entity-file-exists',
+        '_AdaptiveFunction_ entity schema file exists',
+        (schemas_dir(root) / '_AdaptiveFunction_.json').is_file(),
+    ))
+
+    try:
+        doc = load_schema('_AdaptiveFunction_', root)
+        props = property_map(doc, '_AdaptiveFunction_')
+        tests.append(make_test(
+            'meta-not-instance-property',
+            '_meta_ is not listed as a Function instance property',
+            '_meta_' not in props,
+        ))
+    except FileNotFoundError as exc:
+        tests.append(make_test(
+            'meta-not-instance-property',
+            '_meta_ is not listed as a Function instance property',
+            False,
+            detail=str(exc),
+        ))
+
+    return response


### PR DESCRIPTION
## Summary

Fixes **issue #3** (JSON Schema generation mixes `$ref` with other properties) and improves the adaptive object type JSON Schema projection for the main use case: **editor support** (VS Code `json.schemas`) when authoring adaptive object JSON.

- Stop emitting `$ref` as a sibling of `type` / `title` / `description` (use pure `$ref` or annotations + `allOf: [{ $ref }]`).
- Merge inherited `propertyTypes` with **child override** so nested models (e.g. `ModelObjectType`  `ObjectType`) validate correctly.
- Promote entity schemas to the document root for better editor application of fileMatch schemas.
- Map `defaultValue` / `possibleValues`, optional `_meta_`, `markdownDescription`, and recursive `parentPaths` (including `/*/*/` layout paths).
- Regenerate `generated/schemas/afw/*`.
- Add `afwdev` Python tests under `src/afw_dev/tests/json_schema/` (structural, OT comparison, instances, complex inheritance, gnarly `_AdaptiveModel_` cases including TestModel1 and TIER Core Schema).

## Issue

Closes / addresses: **#3**  *JSON Schema generation mixes `$ref` and other properties*.