### PR TITLE
Add optional libedit line editing and history for interactive afw

### DIFF
--- a/.cursor/rules/afw-command.mdc
+++ b/.cursor/rules/afw-command.mdc
@@ -26,11 +26,32 @@ Includes **`afw.h`** (consumer pattern), never `afw_internal.h`. See `afw-enviro
 |------|-----|--------|
 | One-shot expression | `-x '…'` | Eval first; exits if no `[IN]` |
 | Script / test file | `[IN]` + `-s script` / default / `test_script` | Whole file; script result → shell exit `0–255` or null |
-| Interactive | stdin, no `[IN]`/`-l` | Line-oriented; type `exit` |
+| Interactive | stdin, no `[IN]`/`-l` | Line-oriented; type `exit`; optional TTY line editing (below) |
 | Check only | `-k` / `--check` | Compile only, no evaluate |
 | Local server | `-l` / `--local <fd\|path>` | Chunked stdin→fd protocol; see `afw_command_local.md` |
 
 `impl_evaluate` uses a **child xctx**, `afw_compile_to_value_with_callback` → `afw_value_evaluate` (unless `-k`), then content-type serialize (`-a`, default json). Commits/releases adapter session cache after each eval.
+
+## Interactive input and libedit
+
+Issue context: GitHub **#30** (line editing / history for interactive `afw`).
+
+| Piece | Detail |
+|-------|--------|
+| Library | **libedit** (NetBSD Editline) — BSD, MIT-compatible. **Do not** use GNU readline (GPL). |
+| Build | Optional: `find_package(LibEdit …)` in `CMakeLists.txt`; `AFW_COMMAND_HAVE_LIBEDIT` when found. Build must still succeed without it. |
+| Find module | Hand `cmake/LibEditConfig.cmake` → `LibEdit::LibEdit` INTERFACE target. Wire with **`target_link_libraries` only** — never `target_include_directories(... LibEdit::LibEdit)` (CMake treats that name as a path). |
+| Runtime gate | Only when `interactive_mode && isatty(stdin)` and libedit was linked. |
+| Non-TTY / file / `-l` | Keep the plain **`fgetc` / `impl_get_input`** path. Never run libedit on pipes, `[IN]`, or `--local` chunks. |
+| History | `~/.afw_history` when `HOME` is set; size via `AFW_COMMAND_HISTORY_SIZE`. |
+| I/O split | libedit prompts/editing on **stderr**; evaluated results stay on **stdout** (`fd_output`). |
+| Line join | Trailing `\` + newline continues the logical line (same as non-edit path); continuation prompt `> `. |
+| Teardown | Save history → **`el_end` before `history_end`** (EditLine holds `EL_HIST`). |
+| Help text | Build-time `#ifdef AFW_COMMAND_HAVE_LIBEDIT` in `impl_additional_help_text`: with libedit describe history; without, say history is unavailable because the build was not linked with libedit. Prefer user-facing wording about *history/editing*, not the library name, when present. |
+| Static docs | `doc/reference/usage.xml` is **not** build-aware; document the common (with history) case and a short note when not linked. |
+| Packages | Ubuntu `libedit-dev`; Alpine `libedit-dev`; Rocky/OpenSUSE `libedit-devel`. Runtime: `libedit`. Keep **docker/images/afw-dev-base/** and runtime base images in sync. |
+
+Spot-check interactive: real TTY or `python`/`pty`; pipes alone do not exercise libedit.
 
 ## `-s` syntax mapping (code truth)
 
@@ -62,6 +83,7 @@ Production HTTP uses **`afwfcgi`** instead (`afw-server-fcgi`); `http-like` loca
 | Hand-edit | Never hand-edit |
 |-----------|-----------------|
 | `afw_command.c`, `afw_command_internal.h`, `afw_command_local*.{c,h,md}` | `generated/**` |
+| `CMakeLists.txt`, `cmake/*Config.cmake` (e.g. LibEdit) | |
 | `generate/strings/strings.txt` only (no objects/interfaces/manifest) | |
 | `doc/**`, `tests/local_test*` | |
 
@@ -75,8 +97,9 @@ Production HTTP uses **`afwfcgi`** instead (`afw-server-fcgi`); `http-like` loca
 
 | Path | Role |
 |------|------|
-| `afw_command.c` | `main`, flags, `impl_evaluate` |
-| `afw_command_internal.h` | `afw_command_self_t` |
+| `afw_command.c` | `main`, flags, `impl_evaluate`, interactive libedit |
+| `afw_command_internal.h` | `afw_command_self_t` (incl. editline / history fields) |
+| `CMakeLists.txt`, `cmake/LibEditConfig.cmake` | Optional libedit link |
 | `afw_command_local_server.c` | `--local` loop / modes |
 | `afw_command_local.md` | Local protocol |
 | `generate/strings/strings.txt` | Source-location / directive strings |
@@ -87,6 +110,7 @@ Production HTTP uses **`afwfcgi`** instead (`afw-server-fcgi`); `http-like` loca
 2. Confirm `-s` → `compile_option` in code (not help text alone).
 3. Need adapters/types from conf? `-f` present? Extension before conf? `-e`.
 4. Local: validate segment framing; stderr is unstructured.
-5. After string changes: `./afwdev build --cdev -j`.
+5. Interactive editing missing? Check `AFW_COMMAND_HAVE_LIBEDIT` at build, `ldd $(which afw) \| grep edit`, and that stdin is a TTY.
+6. After string / CMake / C changes: `./afwdev build --cdev -j`.
 
 Related: `afw-environment`, `afw-script-eval`, `afw-tests`, `afw-headers`.

--- a/.cursor/rules/afw-project.mdc
+++ b/.cursor/rules/afw-project.mdc
@@ -12,6 +12,7 @@ Metadata-driven **C** runtime (`libafw`) plus Python **`afwdev`**. Define functi
 - After metadata/C/afwdev changes, use the C-dev build below before trusting tests.
 - Prefer existing patterns; match naming in `src/afw/doc/guide/developer/contributing.xml`.
 - Primary agent focus: **C + Python (afwdev)**. JS/admin app only when explicitly asked.
+- **Third-party deps must stay MIT-compatible** (AFW is MIT — see `LICENSE` / `COPYING`). Prefer BSD/MIT/Apache-2.0 libraries (e.g. **libedit** for line editing). Avoid GPL-only linkage such as **GNU readline**. If a package is on all supported distros (Ubuntu, Alpine, Rocky, OpenSUSE — see `docker/images/afw-dev-base/` and CI), it may be required; otherwise make it optional at CMake time and degrade gracefully. Keep Dockerfiles and build docs in sync with new packages.
 
 ## Layout
 - `src/afw` — `libafw` (values, pools, xctx, compile/evaluate)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ AFW is **metadata-driven**: define object types, functions, data types, and C **
 |------|------|
 | `src/afw` | `libafw` — pools, values, xctx, compiler, objects/adapters, environment (module map: [`.cursor/rules/afw-core-layout.mdc`](.cursor/rules/afw-core-layout.mdc)) |
 | `src/afw_dev` | `afwdev` (generate, build, test, docs, validate, …) |
-| `src/afw_command` | `afw` CLI — compile/eval Adaptive syntaxes, conf/extensions, `--local` ([`.cursor/rules/afw-command.mdc`](.cursor/rules/afw-command.mdc)) |
+| `src/afw_command` | `afw` CLI — compile/eval Adaptive syntaxes, conf/extensions, `--local`, optional interactive libedit ([`.cursor/rules/afw-command.mdc`](.cursor/rules/afw-command.mdc)) |
 | `src/afw_*` | Loadable extension DSOs — same env registries as core ([`.cursor/rules/afw-extensions.mdc`](.cursor/rules/afw-extensions.mdc): curl, ldap, lmdb, ubjson, vfs, yaml) |
 | `src/afw_server_fcgi` | `afwfcgi` FastCGI server — HTTP transport over libafw request handlers ([`.cursor/rules/afw-server-fcgi.mdc`](.cursor/rules/afw-server-fcgi.mdc)) |
 | `src/afw_app` | Admin React app (defer unless asked) |

--- a/docker/images/afw-base/Dockerfile.alpine
+++ b/docker/images/afw-base/Dockerfile.alpine
@@ -4,4 +4,4 @@ LABEL org.opencontainers.image.source=https://github.com/afw-org/afw
 
 RUN apk add --no-cache apr apr-util apr-util-ldap \
     apr-util-dbd_mysql apr-util-dbd_pgsql icu-libs fcgi \
-    libxml2 libunwind elfutils curl db lmdb yaml libldap nginx
+    libxml2 libunwind elfutils curl db lmdb yaml libldap libedit nginx

--- a/docker/images/afw-dev-base/Dockerfile.alpine
+++ b/docker/images/afw-dev-base/Dockerfile.alpine
@@ -6,7 +6,7 @@ RUN apk add --no-cache build-base libtool clang-analyzer py3-clang \
     apr-dev fcgi-dev libxml2-dev libxslt-dev apache2-dev cmake nginx \
     python3 python3-dev py3-pip openjdk8 valgrind libunwind-dev \
     elfutils-dev yaml-dev curl-dev icu-libs icu-dev doxygen bash \
-    db-dev lmdb-dev git alpine-sdk sudo libexecinfo-dev nodejs npm
+    db-dev lmdb-dev libedit-dev git alpine-sdk sudo libexecinfo-dev nodejs npm
 
 COPY python-requirements.txt /tmp/python-requirements.txt
 RUN pip3 install -r /tmp/python-requirements.txt

--- a/docker/images/afw-dev-base/Dockerfile.opensuse
+++ b/docker/images/afw-dev-base/Dockerfile.opensuse
@@ -11,7 +11,7 @@ RUN zypper ref -s && \
     elfutils libdw1 libdw-devel libyaml-devel \
     FastCGI FastCGI-devel libmysqlclient-devel \
     libdb-4_8 libdb-4_8-devel libcurl-devel git \
-    lmdb lmdb-devel doxygen rpm-build valgrind lato-fonts \
+    lmdb lmdb-devel libedit-devel doxygen rpm-build valgrind lato-fonts \
     python3 python3-pip java-9-openjdk nodejs18 npm18 && \
     zypper cc -a
 

--- a/docker/images/afw-dev-base/Dockerfile.rockylinux
+++ b/docker/images/afw-dev-base/Dockerfile.rockylinux
@@ -15,7 +15,7 @@ RUN dnf install -y epel-release && \
     libxml2-devel libxslt-devel libicu-devel \
     elfutils elfutils-devel libunwind-devel \
     httpd-devel mariadb mariadb-devel libdb-devel lmdb lmdb-devel \
-    libcurl-devel libyaml libyaml-devel \
+    libcurl-devel libyaml libyaml-devel libedit-devel \
     python3-pip python3-devel \
     fcgi fcgi-devel wget git \
     rpm-build npm \

--- a/docker/images/afw-dev-base/Dockerfile.ubuntu
+++ b/docker/images/afw-dev-base/Dockerfile.ubuntu
@@ -12,7 +12,7 @@ RUN apt-get update && \
     libmysqlclient-dev libdb-dev liblmdb-dev libcurl4-openssl-dev libssl-dev \
     libaprutil1-dbd-mysql libaprutil1-dbd-sqlite3 libaprutil1-dbd-odbc \
     libaprutil1-ldap libaprutil1-dbd-pgsql \
-    libyaml-dev libfcgi-dev nginx gdb valgrind lsof default-jre doxygen \
+    libyaml-dev libfcgi-dev libedit-dev nginx gdb valgrind lsof default-jre doxygen \
     nodejs npm tmux vim locales bash-completion docker.io && \
     apt-get clean
 

--- a/src/afw/doc/building_on_linux.md
+++ b/src/afw/doc/building_on_linux.md
@@ -54,6 +54,14 @@ Eventually, these adapters will not be required, but rather enabled/disabled via
     # YAML
     sudo apt-get install libyaml-dev
 
+## afw command interactive line editing (optional)
+
+    # NetBSD Editline (BSD-licensed). Enables line editing and history when
+    # running `afw` interactively on a terminal. History is stored in
+    # ~/.afw_history. Build succeeds without this package; editing is disabled.
+    sudo apt-get install libedit-dev
+    # Other distros: apk add libedit-dev  |  dnf install libedit-devel  |  zypper in libedit-devel
+
 ## HTTP stack, used by AdaptiveFramework 
 
     # FastCGI library

--- a/src/afw/doc/building_on_mac.md
+++ b/src/afw/doc/building_on_mac.md
@@ -17,6 +17,8 @@ This build process relies on CLang for MacOS, provided by XCode, along with Home
     brew install berkeley-db
     brew install openldap
     brew install lmdb
+    # Optional: interactive line editing for the `afw` command (often already present on macOS)
+    brew install libedit
 
 ## Download and Build apr and apr-util
 

--- a/src/afw_command/CMakeLists.txt
+++ b/src/afw_command/CMakeLists.txt
@@ -1,5 +1,29 @@
 # Adaptive Framework afw command
 
-# Include basic afwdev generated build. See this file for documentation and
-# customization options.
-include(generated/basic_afw_build.cmake)
+# Include afwdev generated variables.
+include(generated/afwdev_generated_variables.cmake)
+
+# Include basic afw project.
+include(generated/basic_afw_project.cmake)
+
+# libedit (NetBSD Editline) for interactive line editing and history.
+# BSD-licensed and MIT-compatible. Available on all supported distros
+# (Ubuntu: libedit-dev, Alpine: libedit-dev, Rocky/OpenSUSE: libedit-devel).
+# Optional so builds still succeed if the package is not installed; when found,
+# interactive TTY sessions get line editing and ~/.afw_history.
+find_package(LibEdit NO_MODULE PATHS cmake QUIET)
+if(LibEdit_FOUND)
+    message(STATUS "afw_command: libedit found — interactive line editing enabled")
+    # Link only: INTERFACE includes/libs come from LibEdit::LibEdit.
+    # Do not pass LibEdit::LibEdit to target_include_directories — CMake would
+    # treat the name as a filesystem path (e.g. .../LibEdit::LibEdit).
+    target_link_libraries(${PROJECT_NAME} PRIVATE LibEdit::LibEdit)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE AFW_COMMAND_HAVE_LIBEDIT=1)
+else()
+    message(STATUS
+        "afw_command: libedit not found — interactive line editing disabled "
+        "(install libedit-dev / libedit-devel to enable)")
+endif()
+
+# Include basic afw install.
+include(generated/basic_afw_install.cmake)

--- a/src/afw_command/afw_command.c
+++ b/src/afw_command/afw_command.c
@@ -12,6 +12,12 @@
 #include <apr_file_io.h>
 #include <apr_getopt.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#ifdef AFW_COMMAND_HAVE_LIBEDIT
+#include <histedit.h>
+#endif
 
 /**
  * @addtogroup afw_command_internal
@@ -26,6 +32,11 @@
  * can change between releases and even between patches, so do not use outside
  * of the source for this command.
  */
+
+#ifdef AFW_COMMAND_HAVE_LIBEDIT
+/* Default number of history entries kept for interactive sessions. */
+#define AFW_COMMAND_HISTORY_SIZE 500
+#endif
 
 static void
 impl_print_result(afw_command_self_t *self, const char *format, ...);
@@ -42,6 +53,12 @@ impl_print_end(afw_command_self_t *self);
 
 static int
 impl_octet_get_cb(afw_utf8_octet_t *octet, void *data, afw_xctx_t *xctx);
+
+static void
+impl_line_editing_init(afw_command_self_t *self, afw_xctx_t *xctx);
+
+static void
+impl_line_editing_cleanup(afw_command_self_t *self);
 
 
 /* Command line options. */
@@ -103,6 +120,13 @@ static const char * impl_additional_help_text =
     "Each line read from stdin is evaluated as an adaptive expressions\n"
     "until either a line containing only \"exit\" or end of file is\n"
     "encountered.\n"
+#ifdef AFW_COMMAND_HAVE_LIBEDIT
+    "When stdin is a terminal, line editing and command history are\n"
+    "available; history is stored in ~/.afw_history when HOME is set.\n"
+#else
+    "Line editing and command history are not available in this build\n"
+    "because it was not linked with libedit.\n"
+#endif
     "\n"
     "If [IN] is specified but -s is not, the file is evaluated as an\n"
     "adaptive script.\n"
@@ -153,6 +177,225 @@ impl_octet_get_cb(afw_utf8_octet_t *octet, void *data, afw_xctx_t *xctx)
 }
 
 
+#ifdef AFW_COMMAND_HAVE_LIBEDIT
+
+/* Prompt callback for libedit (primary or continuation). */
+static char *
+impl_editline_prompt(EditLine *el)
+{
+    afw_command_self_t *self;
+
+    self = NULL;
+    (void)el_get(el, EL_CLIENTDATA, &self);
+    if (self && self->prompt_continuation) {
+        return (char *)"> ";
+    }
+    return (char *)"afw> ";
+}
+
+
+/* Append octets to the input buffer. */
+static void
+impl_input_buffer_append(
+    afw_command_self_t *self,
+    const char *s,
+    size_t len)
+{
+    size_t i;
+
+    for (i = 0; i < len; i++) {
+        APR_ARRAY_PUSH(self->input_buffer, unsigned char) = (unsigned char)s[i];
+    }
+}
+
+
+/* Initialize libedit for interactive TTY sessions. */
+static void
+impl_line_editing_init(afw_command_self_t *self, afw_xctx_t *xctx)
+{
+    EditLine *el;
+    History *hist;
+    HistEvent ev;
+    const char *home;
+    size_t home_len;
+    size_t path_len;
+
+    AFW_ASSERT(self);
+    AFW_ASSERT(xctx);
+
+    /* Only for interactive mode with a terminal stdin. */
+    if (!self->interactive_mode) {
+        return;
+    }
+    if (!isatty(fileno(self->fd_input))) {
+        return;
+    }
+
+    /*
+     * Prompts and editing go to stderr so evaluated results on stdout stay
+     * clean when stdout is redirected.
+     */
+    el = el_init("afw", self->fd_input, stderr, stderr);
+    if (!el) {
+        return;
+    }
+
+    hist = history_init();
+    if (!hist) {
+        el_end(el);
+        return;
+    }
+
+    memset(&ev, 0, sizeof(ev));
+    history(hist, &ev, H_SETSIZE, AFW_COMMAND_HISTORY_SIZE);
+
+    home = getenv("HOME");
+    if (home && home[0]) {
+        home_len = strlen(home);
+        path_len = home_len + sizeof("/.afw_history");
+        self->history_path = afw_pool_malloc(xctx->p, path_len, xctx);
+        memcpy(self->history_path, home, home_len);
+        memcpy(self->history_path + home_len, "/.afw_history",
+            sizeof("/.afw_history"));
+        history(hist, &ev, H_LOAD, self->history_path);
+    }
+
+    el_set(el, EL_CLIENTDATA, self);
+    el_set(el, EL_PROMPT, impl_editline_prompt);
+    el_set(el, EL_EDITOR, "emacs");
+    el_set(el, EL_SIGNAL, 1);
+    el_set(el, EL_HIST, history, hist);
+
+    self->editline = el;
+    self->editline_history = hist;
+    self->use_line_editing = true;
+}
+
+
+/* Save history and tear down libedit. */
+static void
+impl_line_editing_cleanup(afw_command_self_t *self)
+{
+    HistEvent ev;
+    History *hist;
+
+    if (!self) {
+        return;
+    }
+
+    hist = (History *)self->editline_history;
+
+    /* Persist history before releasing EditLine (it may still reference hist). */
+    if (hist && self->history_path) {
+        memset(&ev, 0, sizeof(ev));
+        history(hist, &ev, H_SAVE, self->history_path);
+    }
+
+    /* End EditLine before History; EditLine holds the EL_HIST pointer. */
+    if (self->editline) {
+        el_end((EditLine *)self->editline);
+        self->editline = NULL;
+    }
+
+    if (hist) {
+        history_end(hist);
+        self->editline_history = NULL;
+    }
+
+    self->use_line_editing = false;
+}
+
+
+/* Get one logical line via libedit (including \ continuation). */
+static afw_utf8_t *
+impl_get_input_libedit(afw_command_self_t *self, afw_xctx_t *xctx)
+{
+    const char *line;
+    int count;
+    size_t len;
+    afw_boolean_t continued;
+    afw_boolean_t had_continuation;
+    HistEvent ev;
+
+    self->prompt_continuation = false;
+    had_continuation = false;
+
+    for (;;) {
+        line = el_gets((EditLine *)self->editline, &count);
+        if (!line || count <= 0) {
+            self->eof = true;
+            break;
+        }
+
+        len = (size_t)count;
+
+        /*
+         * Line ending with '\' followed by newline continues onto the
+         * next physical line (same rule as the fgetc path).
+         */
+        continued = false;
+        if (len >= 2 &&
+            line[len - 1] == '\n' &&
+            line[len - 2] == '\\')
+        {
+            continued = true;
+            len -= 2; /* drop backslash and newline */
+        }
+
+        impl_input_buffer_append(self, line, len);
+
+        if (continued) {
+            had_continuation = true;
+            self->prompt_continuation = true;
+            continue;
+        }
+
+        /* Enter complete logical line into history. */
+        if (self->editline_history && self->input_buffer->nelts > 0) {
+            memset(&ev, 0, sizeof(ev));
+            /*
+             * history() expects a NUL-terminated C string. Use the just-read
+             * line when it is a single physical line; otherwise terminate a
+             * copy of the assembled buffer.
+             */
+            if (!had_continuation && count > 0) {
+                history((History *)self->editline_history, &ev, H_ENTER, line);
+            }
+            else {
+                APR_ARRAY_PUSH(self->input_buffer, unsigned char) = 0;
+                history((History *)self->editline_history, &ev, H_ENTER,
+                    self->input_buffer->elts);
+                apr_array_pop(self->input_buffer);
+            }
+        }
+        break;
+    }
+
+    self->prompt_continuation = false;
+
+    return (self->input_buffer->nelts == 0)
+        ? NULL
+        : (afw_utf8_t *)afw_utf8_create(self->input_buffer->elts,
+            self->input_buffer->nelts, xctx->p, xctx);
+}
+
+#else /* !AFW_COMMAND_HAVE_LIBEDIT */
+
+static void
+impl_line_editing_init(afw_command_self_t *self, afw_xctx_t *xctx)
+{
+    (void)self;
+    (void)xctx;
+}
+
+static void
+impl_line_editing_cleanup(afw_command_self_t *self)
+{
+    (void)self;
+}
+
+#endif /* AFW_COMMAND_HAVE_LIBEDIT */
+
 
 /* Get input. */
 static afw_utf8_t *
@@ -171,8 +414,16 @@ impl_get_input(afw_command_self_t *self, afw_xctx_t *xctx)
             2000, 1);
     }
 
-    /* Read input up to a \n that is not preceded by a \ */
     apr_array_clear(self->input_buffer);
+
+#ifdef AFW_COMMAND_HAVE_LIBEDIT
+    /* Interactive TTY: line editing and history via libedit. */
+    if (self->use_line_editing && self->editline) {
+        return impl_get_input_libedit(self, xctx);
+    }
+#endif
+
+    /* Read input up to a \n that is not preceded by a \ */
     for (prev_c = 0; ; prev_c = c) {
         c = fgetc(self->fd_input);
         if (c == EOF) {
@@ -787,6 +1038,7 @@ main(int argc, const char * const *argv) {
 
         if (self->interactive_mode) {
             self->source_location = afw_command_s_afw_command_interactive;
+            impl_line_editing_init(self, xctx);
         }
 
         /* If script, only evaluate once. */
@@ -832,6 +1084,10 @@ main(int argc, const char * const *argv) {
                     "afw " AFW_VERSION_STRING "\n\n"
                     "Input will be evaluated as entered.  "
                     "Type exit to end.\n");
+                if (self->use_line_editing) {
+                    impl_print_result(self,
+                        "Line editing and command history are enabled.\n");
+                }
             }
             impl_print_end(self);
 
@@ -848,6 +1104,11 @@ main(int argc, const char * const *argv) {
 
     /* Make sure things are cleaned up. */
     AFW_FINALLY{
+
+        /* Tear down interactive line editing / history. */
+        if (self) {
+            impl_line_editing_cleanup(self);
+        }
 
         /* If [IN] specified and file open, close it. */
         if (self && self->fd_input && self->in_z) {

--- a/src/afw_command/afw_command_internal.h
+++ b/src/afw_command/afw_command_internal.h
@@ -94,6 +94,13 @@ typedef struct afw_command_self_s {
 
     void *callback_data;
 
+    /* Opaque libedit handles (EditLine *, History *); set only in interactive TTY. */
+    void *editline;
+
+    void *editline_history;
+
+    char *history_path;
+
     afw_compile_type_t compile_option;
 
     afw_compile_residual_check_t residual_check;
@@ -101,6 +108,8 @@ typedef struct afw_command_self_s {
     afw_boolean_t help_option;
 
     afw_boolean_t interactive_mode;
+
+    afw_boolean_t use_line_editing;
 
     afw_boolean_t check_mode;
 
@@ -111,6 +120,8 @@ typedef struct afw_command_self_s {
     afw_boolean_t terminal_error;
 
     afw_boolean_t eof;
+
+    afw_boolean_t prompt_continuation;
 
     int local_model_fd_num;
 

--- a/src/afw_command/cmake/LibEditConfig.cmake
+++ b/src/afw_command/cmake/LibEditConfig.cmake
@@ -1,0 +1,63 @@
+# See the 'COPYING' file in the project root for licensing information.
+#
+# Find NetBSD Editline (libedit). BSD-licensed and MIT-compatible.
+# Provides LibEdit::LibEdit imported interface target.
+#
+
+if(LibEdit_FOUND)
+  return()
+endif()
+
+# Allow maintainers to override paths.
+if(NOT LibEdit_INCLUDE_DIRS)
+    set(LibEdit_INCLUDE_DIRS "")
+endif()
+if(NOT LibEdit_LIBRARIES)
+    set(LibEdit_LIBRARIES "")
+endif()
+
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND AND (LibEdit_INCLUDE_DIRS STREQUAL "" OR LibEdit_LIBRARIES STREQUAL ""))
+    pkg_check_modules(LibEdit_PKG QUIET libedit)
+    if(LibEdit_PKG_FOUND)
+        if(LibEdit_INCLUDE_DIRS STREQUAL "" AND LibEdit_PKG_INCLUDE_DIRS)
+            set(LibEdit_INCLUDE_DIRS ${LibEdit_PKG_INCLUDE_DIRS})
+        endif()
+        if(LibEdit_LIBRARIES STREQUAL "" AND LibEdit_PKG_LIBRARIES)
+            set(LibEdit_LIBRARIES ${LibEdit_PKG_LIBRARIES})
+        endif()
+    endif()
+endif()
+
+if(LibEdit_INCLUDE_DIRS STREQUAL "")
+    find_path(LibEdit_FIND_INCLUDE_DIR
+        NAMES histedit.h
+        DOC "libedit histedit.h include directory")
+    if(LibEdit_FIND_INCLUDE_DIR)
+        set(LibEdit_INCLUDE_DIRS ${LibEdit_FIND_INCLUDE_DIR})
+    endif()
+endif()
+
+if(LibEdit_LIBRARIES STREQUAL "")
+    find_library(LibEdit_FIND_LIBRARY
+        NAMES edit
+        DOC "libedit library")
+    if(LibEdit_FIND_LIBRARY)
+        set(LibEdit_LIBRARIES ${LibEdit_FIND_LIBRARY})
+    endif()
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LibEdit
+    REQUIRED_VARS LibEdit_LIBRARIES LibEdit_INCLUDE_DIRS)
+
+if(LibEdit_FOUND AND NOT TARGET LibEdit::LibEdit)
+    add_library(LibEdit::LibEdit INTERFACE IMPORTED)
+    set_property(TARGET LibEdit::LibEdit PROPERTY
+        INTERFACE_INCLUDE_DIRECTORIES "${LibEdit_INCLUDE_DIRS}")
+    set_property(TARGET LibEdit::LibEdit PROPERTY
+        INTERFACE_LINK_LIBRARIES "${LibEdit_LIBRARIES}")
+endif()
+
+mark_as_advanced(LibEdit_INCLUDE_DIRS LibEdit_LIBRARIES
+    LibEdit_FIND_INCLUDE_DIR LibEdit_FIND_LIBRARY)

--- a/src/afw_command/doc/reference/usage.xml
+++ b/src/afw_command/doc/reference/usage.xml
@@ -58,7 +58,10 @@ afw will end after evaluating the expression.
 If neither -x or [IN] is specified, input is read from stdin.
 Each line read from stdin is evaluated as an adaptive expressions
 until either a line containing only "exit" or end of file is
-encountered.
+encountered. When stdin is a terminal, line editing and command
+history are available; history is stored in ~/.afw_history when
+HOME is set. (If this build was not linked with libedit, line
+editing and history are not available.)
 
 If [IN] is specified but -s is not, the file is evaluated as an
 adaptive script.


### PR DESCRIPTION
## Summary

- Implements interactive **line editing** and **command history** for the `afw` CLI when stdin is a TTY (fixes #30).
- Uses **libedit** (BSD / MIT-compatible); GNU readline is not used.
- Optional at build time: if libedit is not found, the command still builds and uses plain stdin input; help text reflects whether history is available.
- History is stored in `~/.afw_history` when `HOME` is set. Pipes, `[IN]` files, and `--local` mode are unchanged.
- Docker dev-base images (Ubuntu, Alpine, Rocky, OpenSUSE) and Alpine runtime base install libedit packages; Linux/Mac build docs updated.
- Cursor agent rules document libedit usage and third-party MIT-compatible dependency guidance.

## Test plan

- [ ] `./afwdev build --cdev -j` with libedit installed — confirm cmake reports libedit enabled and `ldd $(which afw)` shows libedit
- [ ] Interactive TTY: `afw` — arrow keys, backspace, history up/down, `exit`; confirm `~/.afw_history`
- [ ] Backslash continuation: multi-line input with trailing `\`
- [ ] Piped input: `printf 'add(2,2)\nexit\n' | afw` still works without requiring a TTY
- [ ] `afwdev test --srcdir-pattern afw_command -j`
- [ ] Build without libedit still succeeds (optional/degraded path)

Closes #30
