### PR TITLE
Add #110 regression tests and Cursor rules for default cloning

### DIFF
--- a/.cursor/rules/afw-adaptive-script.mdc
+++ b/.cursor/rules/afw-adaptive-script.mdc
@@ -1,0 +1,53 @@
+---
+description: Adaptive Script language quirks — equality, nullish, defaults, asserts, CLI probes
+globs: "**/*.as,**/generate/objects/_AdaptiveModel_/**,src/afw/tests/environments/**/includes/**"
+alwaysApply: false
+---
+
+# Adaptive Script (authoring)
+
+Use when writing or reviewing `.as` tests, model `on*` handlers, Fiddle snippets, or script-shaped conf.
+
+## Equality and identity
+
+- **`===` / `!==` on objects and arrays is structural** (deep equality), not pointer identity.
+- Two independently created `{}` values compare equal until one is mutated.
+- To prove **clone independence** (separate instances), mutate one side and assert the other did not change — do not rely on `a !== b` alone for fresh empties.
+
+Example (clone regression):
+
+```adaptive
+const a = property_get({}, "y", {});
+a.z = "from_a";
+const b = property_get({}, "y", {});
+assert(is_nullish(property_get(b, "z", null)));
+assert(a.z === "from_a");
+assert(a !== b);  // now true because structures differ
+```
+
+## Nullish and missing
+
+- **`is_nullish(v)`** — true for `null` or `undefined`.
+- Missing property / missing variable without a default → undefined (nullish).
+- Prefer `property_get(obj, name, default)` / `variable_get(name, default)` over assuming property access creates containers.
+
+## Defaults that callers may mutate
+
+- Script literals such as `{}` and `[]` used as **function default arguments** may evaluate to a **shared** value (compiled / permanent).
+- Built-ins that return a caller-supplied default for a missing property/variable must **clone** into the call pool before return (see `property_get` / `variable_get`, issue **#110**).
+- When adding similar APIs, clone mutable defaults; for long-running / multi-request hosts (`afwfcgi`, model `on*`), residual mutations or freed pointers on a shared default cause crashes across invocations.
+
+## Assertions and process exit
+
+- **`assert(condition)`** / **`assert(condition, message)`** — failure throws `assertion_failed`.
+- Scripts run as **`afw -s script file.as`** must **`return` null or an integer 0–255** (tests typically `return 0` with `//? expect: 0`).
+- Interactive `afw -s script` without a file evaluates input as entered; multi-statement probes belong in a **file**.
+
+## Model / server scripts
+
+- Model `onGetObject` / `on*` bodies run in request-scoped pools on long-lived hosts. Prefer local objects; avoid mutating shared env state.
+- Reproduce server-only lifetime bugs in unit tests when possible (mutation isolation of defaults); use valgrind/`afwfcgi` when the failure needs multi-request free paths.
+
+## Related
+
+- Tests layout: `afw-tests`. Built-in execute bodies: `afw-function`. Value lifetimes: `afw-value-memory`.

--- a/.cursor/rules/afw-core-services.mdc
+++ b/.cursor/rules/afw-core-services.mdc
@@ -20,7 +20,7 @@ libafw is not only a script engine. Hosts, adapters, and policies plug in throug
 - Factories register as `adapter_type`; instances as `adapter_id`. Impl helpers in `afw_adapter_impl*`.
 - **Core built-in adapter types** (registered in `afw_environment_register_core.c`): e.g. `afw`, `file`, `model`, `runtime`. **Extension adapter types** (ldap, lmdb, vfs, …) use the same interfaces and register the same way — see `afw-extensions`.
 - **Objects** (`object/`): `afw_object_t` + meta/path/type/view. Prefer interface methods and existing helpers (`afw_object_create*`, property meta) over ad-hoc structs.
-- **Model** (`model/`): maps between adapter/requestor shapes; factory `afw_adapter_factory_model`.
+- **Model** (`model/`): maps between adapter/requestor shapes; factory `afw_adapter_factory_model`. Object-type `on*` handlers are Adaptive Script evaluated per request on long-lived hosts — treat defaults/mutables carefully (`afw-adaptive-script`, issue #110 / `afw-function` default clone).
 - **Runtime** (`runtime/`): read-only views of environment/metadata objects (`afw_runtime.h`, value accessors).
 - **Query** (`query_criteria/`): filters for retrieve.
 
@@ -42,4 +42,4 @@ libafw is not only a script engine. Hosts, adapters, and policies plug in throug
 3. **Register** factories/instances on the environment (`afw-environment`) so script and request paths resolve them by id/type — same APIs whether code lives in core or an extension.
 4. Allocate through pools/`xctx`; return adaptive objects/values, not raw malloc'd graphs.
 
-Related: `afw-environment`, `afw-core-layout`, `afw-headers`, `afw-c-runtime`, `afw-generate-metadata`.
+Related: `afw-environment`, `afw-core-layout`, `afw-headers`, `afw-c-runtime`, `afw-adaptive-script`, `afw-generate-metadata`.

--- a/.cursor/rules/afw-function.mdc
+++ b/.cursor/rules/afw-function.mdc
@@ -21,6 +21,18 @@ Metadata → generated bindings → env `function` registry → call nodes → `
 
 Caller context: `x->xctx`, allocate results in `x->p` or current `scope->p` (long-running: `afw-value-memory`).
 
+## Optional defaults and returned mutables
+
+When a built-in returns a **caller-supplied default** (or any value the script may mutate) because a property/variable/key was missing:
+
+1. Evaluate the default only when it is needed (`AFW_FUNCTION_PARAMETER_IS_PRESENT` + evaluate).
+2. **`afw_value_clone` the result into `x->p`** (or the appropriate result pool) before returning.
+3. Do **not** return a shared permanent / compiled literal (`{}`, `[]`, const objects) that the caller can mutate in place.
+
+**Why:** Script object/array literals used as defaults can be shared across evaluations. Without a clone, mutations stick (or dangle after pool free) across later calls — including multi-request `afwfcgi` / model `on*` paths. Reference fix: issue **#110** (`property_get`, `variable_get` in `afw_function_object.c` / `afw_function_miscellaneous.c`).
+
+Scalars and immutable permanents are usually fine without clone; prefer clone when the type is object, array, or otherwise mutable.
+
 ## Call path
 
 `afw_value_call_create` (`value/afw_value_call.c`) specializes by `argv[0]`:
@@ -46,7 +58,7 @@ Parser statement/expression nodes reference these `function_definition_*` symbol
 
 ```bash
 ./afwdev build --cdev -j
-afwdev test -j   # or --pattern for the function
+afwdev test -j   # or: afwdev test -p afw --test-pattern 'my_function'
 ```
 
-Skill: `add-adaptive-function`. Related: `afw-compile`, `afw-script-eval`, `afw-environment`, `afw-generate-metadata`.
+Skill: `add-adaptive-function`. Related: `afw-compile`, `afw-script-eval`, `afw-environment`, `afw-generate-metadata`, `afw-value-memory`, `afw-adaptive-script`, `afw-tests`.

--- a/.cursor/rules/afw-project.mdc
+++ b/.cursor/rules/afw-project.mdc
@@ -49,6 +49,7 @@ Use **`./afwdev`** when the build may refresh the installed `afwdev` itself; oth
 - Runtime mental model (always): `afw-runtime-model`
 - When in `src/afw/`: `afw-core-layout`, `afw-headers`, `afw-core-services`, `afw-environment`
 - Compile / value / function: `afw-compile`, `afw-compiler-ebnf`, `afw-script-eval`, `afw-function`, `afw-value-memory`
+- Adaptive Script authoring (tests, model `on*`, probes): `afw-adaptive-script`, `afw-tests`
 - When in `src/afw_command/`: `afw-command`
 - When in `src/afw_server_fcgi/`: `afw-server-fcgi`
 - When in `src/afw_{curl,ldap,lmdb,ubjson,vfs,yaml}/`: `afw-extensions`

--- a/.cursor/rules/afw-tests.mdc
+++ b/.cursor/rules/afw-tests.mdc
@@ -17,6 +17,37 @@ alwaysApply: false
 - Shebang: `#!/usr/bin/env -S afw --syntax test_script`
 - Metadata and cases via `//?` comments (multiple `//? test:` blocks per file).
 - Example pattern: `src/afw/tests/rql/eq.as`.
+- Typical case skeleton:
+
+```adaptive
+//?
+//? test: short_name
+//? description: What this case checks
+//? skip: false
+//? expect: 0
+//? source: ...
+
+assert(...);
+return 0;
+```
+
+- Each case is a **separate script** (fresh variables). Prefer focused cases over one huge case.
+- Language quirks (structural `===`, nullish, defaults): **`afw-adaptive-script`**.
+
+## Regression tests for runtime bugs
+
+When fixing a C/runtime bug, add `.as` coverage that fails without the fix:
+
+- Put cases next to related tests (`miscellaneous/`, category folder, or adapter group).
+- Mention the issue id in `//? description` (e.g. `issue #110`).
+- Prefer **in-process** isolation checks (mutate returned defaults/objects; assert later calls are clean) over requiring full `afwfcgi` when the defect is local.
+- Multi-request / use-after-free still warrants occasional `afwdev test --env-mode valgrind -j`.
+- Reference examples: `src/afw/tests/miscellaneous/property_get.as`, `variable_get.as` (default-object clone).
+
+## Object equality in asserts
+
+- Object/array `===` is **structural**. Fresh `{}`/`[]` pairs compare equal even when distinct instances.
+- Prove clone/isolation by **mutating** one result and asserting the other is unchanged (`afw-adaptive-script`).
 
 ## Python tests (afwdev python mode)
 - `.py` files always run in **python** mode (not the default `afw` env-mode runner).
@@ -41,14 +72,26 @@ afwdev test -j
 # Occasional memory check (much slower): before major PRs or memory work
 afwdev test --env-mode valgrind -j
 
-afwdev test --srcdir-pattern afw --test-pattern 'rql/.*'
-afwdev test --srcdir-pattern afw --tags rql
-afwdev test --srcdir-pattern afw --list
-afwdev test --srcdir-pattern afw --bail 1
+# Filename filter (regex on path under tests/)
+afwdev test -p afw --test-pattern 'miscellaneous/property_get'
+afwdev test -p afw --test-pattern 'rql/.*' --show-all
+afwdev test -p afw --tags rql
+afwdev test -p afw --list
+afwdev test -p afw --bail 1
 afwdev test -p afw_dev --tags json_schema --show-all
 ```
 
-Default `--env-mode` is `afw` (runs via the **`afw` CLI** from `src/afw_command` — see `afw-command`). Use `afwdev` from PATH after `--cdev` has installed it. `.py` tests still use python mode.
+- Filter flag is **`--test-pattern`** (not `--pattern`).
+- Default `--env-mode` is `afw` (runs via the **`afw` CLI** from `src/afw_command` — see `afw-command`). Use `afwdev` from PATH after `--cdev` has installed it. `.py` tests still use python mode.
+
+## Quick manual probes
+```bash
+# Multi-statement script file (preferred)
+afw -s script /path/to/probe.as   # return 0..255 or null
+
+# Interactive: evaluates as entered — awkward for multi-line scripts
+afw -s script
+```
 
 ## Other test styles
 - `src/afw_command/tests/` — Python-mode fixtures for `afw --local` (`local_test.py`), not `.as` test_script.

--- a/.cursor/rules/afw-value-memory.mdc
+++ b/.cursor/rules/afw-value-memory.mdc
@@ -30,6 +30,12 @@ Do not invent new lifetime paths; match existing create_* patterns.
 - Evaluation temporaries and results that belong to the current activation should use **current `scope->p`** (not a longer-lived pool) unless they intentionally escape.
 - Subpool + RC already handle bulk release and escape reparenting — polish the value-inf hooks and call sites; do not replace the pool model.
 
+## Shared mutables and defaults (issue #110 class)
+
+- **Permanent** values and some **compiled literals** (`{}`, `[]`, const objects) may be **shared** across evaluations or requests. Script may still mutate object/array contents via property assignment.
+- Built-ins that **return a default** for a missing property/variable/key must not hand back a shared mutable without **`afw_value_clone` into the call/result pool** (`afw-function`). Residual properties or use-after-free show up on the **second** request in long-running hosts.
+- Prefer unit tests that mutate one returned default and assert a later call gets a clean default (`afw-adaptive-script`, `afw-tests`). Multi-request free paths: `afwdev test --env-mode valgrind` and/or `afwfcgi`.
+
 ## Source of truth and producers
 
 - Metadata: `generate/objects/_AdaptiveDataTypeGenerate_/*.json` (`cType`, `special`, `scalar`, …).
@@ -53,4 +59,4 @@ Never hand-edit `generated/` — change generator or JSON, then `./afwdev build 
 
 ## Related
 
-- `afw-environment` (`register_core` bootstrap), `afw-script-eval`, `afw-c-runtime`, `afw-afwdev-generate`, `afw-generate-metadata`, `@AGENTS.md`
+- `afw-environment` (`register_core` bootstrap), `afw-script-eval`, `afw-function`, `afw-c-runtime`, `afw-adaptive-script`, `afw-afwdev-generate`, `afw-generate-metadata`, `@AGENTS.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,16 +105,17 @@ afwdev generate --srcdir-pattern '*'
 | `.cursor/rules/afw-server-fcgi.mdc` | `afwfcgi` FastCGI host (`src/afw_server_fcgi`) |
 | `.cursor/rules/afw-extensions.mdc` | Loadable extensions (curl/ldap/lmdb/ubjson/vfs/yaml) |
 | `.cursor/rules/afw-c-runtime.mdc` | C when editing `.c`/`.h` |
-| `.cursor/rules/afw-value-memory.mdc` | Value lifetimes / pools / long-running escape |
+| `.cursor/rules/afw-value-memory.mdc` | Value lifetimes / pools / shared mutables / long-running escape |
 | `.cursor/rules/afw-script-eval.mdc` | Compile/eval pipeline, scopes, statement_flow |
 | `.cursor/rules/afw-compile.mdc` | `afw_compile.h` API, compile types, parser map |
 | `.cursor/rules/afw-compiler-ebnf.mdc` | EBNF-in-comments harvest |
-| `.cursor/rules/afw-function.mdc` | Built-in execute_*, polymorphic, compiler_* |
+| `.cursor/rules/afw-function.mdc` | Built-in execute_*, polymorphic, compiler_*, default-clone |
+| `.cursor/rules/afw-adaptive-script.mdc` | Adaptive Script authoring (equality, nullish, defaults, probes) |
 | `.cursor/rules/afw-generate-metadata.mdc` | When editing `generate/` |
 | `.cursor/rules/afw-afwdev-python.mdc` | When editing `src/afw_dev` |
 | `.cursor/rules/afw-afwdev-generate.mdc` | When editing `_afwdev/generate/` generators |
 | `.cursor/rules/afw-json-schema.mdc` | JSON Schema projection / `generated/schemas` / schema tests |
-| `.cursor/rules/afw-tests.mdc` | When editing tests (`.as`, Python, `config.py`) |
+| `.cursor/rules/afw-tests.mdc` | When editing tests (`.as`, Python, `config.py`), regression style |
 | `.cursor/skills/add-adaptive-function/` | Add/change Adaptive functions or data types |
 | `.cursor/skills/afw-generate-build-test/` | Regenerate, build, validate, test |
 | `.cursorignore` | Skips `node_modules/`, `build/`, `generated/`, binaries |

--- a/src/afw/tests/miscellaneous/property_get.as
+++ b/src/afw/tests/miscellaneous/property_get.as
@@ -1,0 +1,89 @@
+#!/usr/bin/env -S afw --syntax test_script
+//?
+//? testScript: property_get.as
+//? customPurpose: Part of miscellaneous category tests
+//? description: Test object property_get, including default cloning (issue #110)
+//? sourceType: script
+//?
+//? test: property_get-existing
+//? description: property_get returns existing property and ignores default
+//? skip: false
+//? expect: 0
+//? source: ...
+
+const o = { "a": 1 };
+
+assert(property_get(o, "a") === 1);
+assert(property_get(o, "a", 99) === 1);
+
+return 0;
+
+//?
+//? test: property_get-missing-default
+//? description: property_get returns default or undefined when property is missing
+//? skip: false
+//? expect: 0
+//? source: ...
+
+const o = { "a": 1 };
+
+assert(property_get(o, "missing", 99) === 99);
+assert(is_nullish(property_get(o, "missing")));
+
+return 0;
+
+//?
+//? test: property_get-default-object-clone
+//? description: Default object from property_get is cloned so mutations do not leak (issue #110)
+//? skip: false
+//? expect: 0
+//? source: ...
+
+// Mutating a returned default must not affect a later default for the same expression.
+// Object === is structural equality, so independence is checked via mutation.
+const y_a = property_get({}, "y", {});
+y_a.z = "from_a";
+
+const y_b = property_get({}, "y", {});
+assert(
+    is_nullish(property_get(y_b, "z", null)),
+    "property_get default object was not cloned; residual property present"
+);
+assert(y_a.z === "from_a");
+assert(y_a !== y_b);
+
+return 0;
+
+//?
+//? test: property_get-issue-110-onGetObject-shape
+//? description: Nested default object mutation must not poison later calls (issue #110)
+//? skip: false
+//? expect: 0
+//? source: ...
+
+// Contrived shape from issue #110 onGetObject (without requiring model adapter/afwfcgi).
+function issue110_onGetObject_shape() {
+    const x = {};
+    const y = property_get(x, "y", {});
+
+    if (is_nullish(property_get(y, "z", null))) {
+        y.z = {};
+    }
+
+    return y;
+}
+
+const first = issue110_onGetObject_shape();
+assert(property_exists(first, "z") === true);
+first.z.marker = "from_first";
+
+const second = issue110_onGetObject_shape();
+assert(property_exists(second, "z") === true);
+assert(
+    is_nullish(property_get(second.z, "marker", null)),
+    "issue #110: shared default object retained residual nested property"
+);
+assert(first.z.marker === "from_first");
+assert(first !== second);
+
+return 0;

--- a/src/afw/tests/miscellaneous/variable_get.as
+++ b/src/afw/tests/miscellaneous/variable_get.as
@@ -2,11 +2,11 @@
 //?
 //? testScript: variable_get.as
 //? customPurpose: Part of miscellaneous category tests
-//? description: Test miscellaneous variable_get function
+//? description: Test miscellaneous variable_get function, including default cloning (issue #110)
 //? sourceType: script
 //?
 //? test: variable_get
-//? description: Test variable_get
+//? description: Test variable_get for an existing variable
 //? skip: false
 //? expect: 0
 //? source: ...
@@ -14,5 +14,40 @@
 let result: string = "x";
 
 assert(variable_get("result") === "x");
+assert(variable_get("result", "default") === "x");
+
+return 0;
+
+//?
+//? test: variable_get-missing-default
+//? description: variable_get returns default or undefined when variable is missing
+//? skip: false
+//? expect: 0
+//? source: ...
+
+assert(variable_get("absent_scalar_110", "default") === "default");
+assert(is_nullish(variable_get("absent_no_default_110")));
+
+return 0;
+
+//?
+//? test: variable_get-default-object-clone
+//? description: Default object from variable_get is cloned so mutations do not leak (issue #110)
+//? skip: false
+//? expect: 0
+//? source: ...
+
+// Mutating a returned default must not affect a later default for the same expression.
+// Object === is structural equality, so independence is checked via mutation.
+const d1 = variable_get("no_such_var_issue110", {});
+d1.z = "mutated";
+
+const d2 = variable_get("no_such_var_issue110", {});
+assert(
+    is_nullish(property_get(d2, "z", null)),
+    "variable_get default object was not cloned; residual property present"
+);
+assert(d1.z === "mutated");
+assert(d1 !== d2);
 
 return 0;


### PR DESCRIPTION
## Summary
- Add Adaptive Script regression tests for issue #110: `property_get` / `variable_get` clone default objects so mutations do not leak across calls.
- Document the fix class for future agents: new `afw-adaptive-script` rule plus updates to function, value-memory, tests, core-services, project rules, and `AGENTS.md`.

## Context
Issue #110 (shared default `{}` / residual mutation / segfault on second `afwfcgi` request) was already fixed in C (`afw_value_clone` on defaults). This branch locks in coverage and agent guidance.

## Test plan
- [x] `afwdev test -p afw --test-pattern 'property_get' --show-all` (4 passed)
- [x] `afwdev test -p afw --test-pattern 'variable_get' --show-all` (3 passed)
- [x] Optional: full `afwdev test -j` if desired before merge
