### PR TITLE
Document that src/*/tests are permanent regression assets

### DIFF
--- a/.cursor/rules/afw-tests.mdc
+++ b/.cursor/rules/afw-tests.mdc
@@ -13,6 +13,13 @@ alwaysApply: false
 - Hooks in `config.py`: `before_all`, `before_each`, `after_each`, `after_all` when needed.
 - Optional `Tags = ["..."]` in `config.py` for `afwdev test --tags`.
 
+## Tests under `src/` are permanent regression assets
+
+- **Never delete or “clean up”** test sources under `src/*/tests/` (`.as`, conf, fixtures, `config.py`) unless the user explicitly asks.
+- They exist so future `afwdev test` runs catch regressions. Treat them as product code.
+- **`afwdev test` runs in a temp work directory** and does **not** modify the `src/` tree for normal cases. Do not remove `src/` test files thinking they are runner scratch.
+- If you see many untracked files under a test dir after a manual `afw --conf ./afw.conf` from that folder, those may be local relative-path outputs — still **do not remove tracked test sources** (`.as`, fixtures). Prefer leave untracked outputs alone or only delete clearly untracked runtime junk after confirming `git ls-files` keeps the suite.
+
 ## `.as` test_script
 - Shebang: `#!/usr/bin/env -S afw --syntax test_script`
 - Metadata and cases via `//?` comments (multiple `//? test:` blocks per file).


### PR DESCRIPTION
## Summary

Follow-up after #120 (stream work already merged into `mgg-develop`).

- Clarify in Cursor **afw-tests** rules that suites under `src/*/tests/` are permanent regression assets and must not be removed as “scratch”.
- Note that **`afwdev test` uses temp dirs** and does not rewrite the `src/` tree for normal runs.

The full #103 stream implementation and `stream_file.as` suite are already on `mgg-develop` via PR #120; this PR is the small agent-docs correction only.

## Test plan

- [x] Confirm `src/afw/tests/miscellaneous/stream_file/stream_file.as` exists on `mgg-develop` (from #120)
- [ ] Optional: `afwdev test -p afw --test-pattern stream_file -j`
