### PR TITLE
Complete compile-time substitution docs and TemplateString escapes (#97)

### DIFF
--- a/.cursor/rules/afw-compile.mdc
+++ b/.cursor/rules/afw-compile.mdc
@@ -19,7 +19,9 @@ Public entry for Adaptive syntaxes. Output is an **`afw_value_t`** (usually `com
 | `afw_compile_to_object` | Strict JSON → `afw_object_t` (not `compiled_value`) |
 | `afw_compile_shared_create` | Share literals across compiles on same pool |
 
-**Pool precedence** (one required): `shared->p` → `parent->p` → `p`. Nested compiles pass `parent` for shared symbols/contextual (e.g. `#{…}` in templates).
+**Pool precedence** (one required): `shared->p` → `parent->p` → `p`.
+
+**Nested compiles / `parent`:** Pass `parent` when the nested compile should share symbols and contextual with the outer compiled value. **Do not** pass `parent` for compile-time substitution (`#{…}`): `afw_compile_parse_CompileTimeSubstitution` uses a nested `afw_compile_to_value_with_callback` with `parent=NULL` and `shared=NULL` so the nested script is isolated (no outer locals). It evaluates the nested script immediately and embeds the result.
 
 ## Compile types (`AFW_COMPILE_TYPE_MAP` in `afw_common.h`)
 
@@ -38,7 +40,9 @@ Data-type hybrid `compileType` in `_AdaptiveDataTypeGenerate_` maps to these enu
 
 ## Residual check
 
-`none` | `to_newline` | `to_full` (default) | `to_close_brace` (nested `{…}` bodies — no residual check). Enforced in `afw_compile_lexical.c`.
+`none` | `to_newline` | `to_full` (default) | `to_close_brace`. Enforced in `afw_compile_lexical.c`.
+
+For `to_close_brace`: (1) residual-after-parse does **not** demand EOF (same as `none` in `afw_compile_check_for_residual`); (2) when `compile_type` is `script`, `afw_compile.c` passes `end_is_close_brace=true` to `parse_Script` so the nested body ends at `}`. Used for `#{…}` nested compiles (and similar braced fragments).
 
 ## Contextual
 
@@ -54,7 +58,7 @@ Data-type hybrid `compileType` in `_AdaptiveDataTypeGenerate_` maps to these enu
 | `afw_compile_parse_script.c` | Statements, `TestScript`, control flow |
 | `afw_compile_parse_expression.c` | Expressions, lambdas, operators → `call_built_in_function` |
 | `afw_compile_parse_value.c` | JSON literals / objects / lists |
-| `afw_compile_parse_template.c` | Templates; `#{…}` / `${…}` |
+| `afw_compile_parse_template.c` | Templates; `#{…}` (compile-time, isolated nested script) / `${…}` (eval-time, outer symbols); TemplateString `` `…` `` (string unescapes + `\#`/`\$` opener-suppress) |
 | `afw_compile_parse_assignment_target.c` | Destructuring targets |
 
 **Operator lowering:** expression parser emits calls to env **operator** `function_definition`s — requires `afw_generated_register` then `afw_function_internal_prepare_environment` (see `register_core.c`).

--- a/.cursor/rules/afw-compiler-ebnf.mdc
+++ b/.cursor/rules/afw-compiler-ebnf.mdc
@@ -23,7 +23,7 @@ Core owns the Adaptive Script / expression **compiler runtime** under `src/afw/c
 | Script / TestScript / statements | `afw_compile_parse_script.c` |
 | Expressions / operators / lambdas | `afw_compile_parse_expression.c` |
 | JSON / literals | `afw_compile_parse_value.c` |
-| Templates | `afw_compile_parse_template.c` |
+| Templates (`#{…}` / `${…}`, TemplateString) | `afw_compile_parse_template.c` — compile-time nested script is isolated (`parent=NULL`); `\#`/`\$` suppress openers |
 | Destructuring | `afw_compile_parse_assignment_target.c` |
 
 ## When changing the language

--- a/src/afw/compile/afw_compile_parse_template.c
+++ b/src/afw/compile/afw_compile_parse_template.c
@@ -128,11 +128,16 @@ afw_compile_parse_Substitution(afw_compile_parser_t *parser)
 
 /*ebnf>>>
  *
+ *# In Template and TemplateString bodies, '\#' and '\$' emit a literal '#' or
+ *# '$' so that '#{' / '${' substitution openers are not formed. TemplateString
+ *# also supports normal string escapes ('\\', '\n', '\`', ...).
+ *
  * Template ::=
  *    (
  *        ( Char - ['$' '#'] ) |
  *        ( ['$' '#'] ) |
  *        ( ['$' '#'] (Char - '{') ) |
+ *        ( '\\' ['$' '#'] ) |
  *        Substitution
  *    )*
  *
@@ -273,9 +278,24 @@ afw_compile_parse_TemplateString(afw_compile_parser_t *parser)
 
         /* Save cursor and get next code point. */
         afw_compile_save_cursor(previous_cursor);
-        cp = afw_compile_get_unescaped_code_point();
+        cp = afw_compile_get_code_point();
 
-        /* If '${' or '#{'}, indicate substitution and restore cursor. */
+        /*
+         * '\#' and '\$' suppress '#{' / '${' openers (same idea as Template).
+         * Other backslash escapes use normal string unescape.
+         */
+        if (cp == '\\') {
+            afw_compile_save_cursor(previous_cursor2);
+            cp2 = afw_compile_get_code_point();
+            if (cp2 == '$' || cp2 == '#') {
+                afw_compile_internal_s_push_code_point(parser, cp2);
+                continue;
+            }
+            afw_compile_restore_cursor(previous_cursor);
+            cp = afw_compile_get_unescaped_code_point();
+        }
+
+        /* If '${' or '#{', indicate substitution and restore cursor. */
         if (cp == '$' || cp == '#') {
             afw_compile_save_cursor(previous_cursor2);
             cp2 = afw_compile_get_code_point();
@@ -340,11 +360,3 @@ afw_compile_parse_TemplateString(afw_compile_parser_t *parser)
         (const afw_value_t * const *)values->elts,
         parser->p, parser->xctx);
 }
-
-
-
-/*ebnf>>>
- *
- * NamedTemplateString ::= '`' + ((Char - '$') | ('\$') | ('$' (Char - '{')) | '${' PropertyName '}') * '`'
- *
- *<<<ebnf*/

--- a/src/afw/doc/reference/language/expressions.xml
+++ b/src/afw/doc/reference/language/expressions.xml
@@ -3,16 +3,111 @@
     <title>Templates and Expressions</title>
     <header>Templates</header>
     <paragraph>
-        A template is a string literal that contains zero or more 
-        substitutions, where a substitution is a script or expression embedded 
-        inside <literal>{</literal> and <literal>}</literal>.
+        A template is a string that contains zero or more substitutions.
+        A substitution is a script embedded in either
+        <literal>#{</literal> … <literal>}</literal> (compile-time) or
+        <literal>${</literal> … <literal>}</literal> (evaluation-time).
     </paragraph>
     <paragraph>
-        The way that we interpret a template inside of an expression or script 
-        is by placing the template between <literal></literal> characters, also 
-        called a template string:
+        Inside an expression or script, a template string is written between
+        grave (backtick) characters:
     </paragraph>
-    <code>`The result of 1 + 1 is ${1 + 1}.`</code>
+    <code><![CDATA[`The result of 1 + 1 is ${1 + 1}.`
+`Hello #{'World'}!`
+`H#{'ello ' + 'Wor'}ld${'!'}`]]></code>
+    <paragraph>
+        Templates are also used as the compile type for application
+        <literal>qualifiedVariables</literal> and other conf values, and via
+        functions such as <literal>template()</literal>. Those use the same
+        substitution forms; only the surrounding syntax differs.
+    </paragraph>
+
+    <section>
+        <header>Compile-time and evaluation-time substitutions</header>
+        <paragraph>
+            There are two substitution openers:
+        </paragraph>
+        <code><![CDATA[#{ Script }   /* compile-time */
+${ Script }   /* evaluation-time */]]></code>
+        <paragraph>
+            <literal>#{…}</literal> is compiled and evaluated while the
+            containing source is compiled. The result is embedded as a fixed
+            value. The nested script is isolated: it cannot see
+            <literal>let</literal> / <literal>const</literal> locals from the
+            containing script. It can still call normal environment functions
+            available to the compiling host (for example
+            <literal>generate_uuid</literal> or
+            <literal>eval_from_file</literal> if registered). Side effects and
+            errors inside <literal>#{…}</literal> happen at compile or conf-load
+            time.
+        </paragraph>
+        <paragraph>
+            <literal>${…}</literal> is evaluated each time the template is
+            evaluated. When the template is compiled as part of a script, outer
+            locals are visible inside <literal>${…}</literal>.
+        </paragraph>
+        <code><![CDATA[const outer = 42;
+return `${outer}`;   /* → 42 */
+
+/* return #{outer};  → error: outer is not defined in the nested script */]]></code>
+        <paragraph>
+            Bare <literal>#{…}</literal> is also allowed as a Value in a script
+            (not only inside a template string). Bare
+            <literal>${…}</literal> is not a Value and is only valid inside a
+            template.
+        </paragraph>
+        <code><![CDATA[return #{1 + 2};     /* → 3 */
+/* return ${1 + 2};  → syntax error (Expecting Value) */]]></code>
+        <paragraph>
+            Each distinct <literal>#{…}</literal> site is evaluated once when
+            its containing unit is compiled. Different sites are not shared or
+            memoized with each other.
+        </paragraph>
+        <image generated-src="ebnf/syntax/diagram/CompileTimeSubstitution.png" />
+        <image generated-src="ebnf/syntax/diagram/EvaluationTimeSubstitution.png" />
+        <image generated-src="ebnf/syntax/diagram/Substitution.png" />
+    </section>
+
+    <section>
+        <header>Escaping openers</header>
+        <paragraph>
+            The openers are the two-character sequences
+            <literal>#{</literal> and <literal>${</literal>. A backslash before
+            <literal>#</literal> or <literal>$</literal> emits a literal
+            <literal>#</literal> or <literal>$</literal> so the opener is not
+            formed (the following <literal>{</literal> is ordinary text).
+            This applies in both raw templates and backtick template strings.
+        </paragraph>
+        <code><![CDATA[`\#{not a substitution} #{'is'}`
+/* → "#{not a substitution} is" */
+
+`\${not a substitution} ${'is'}`
+/* → "${not a substitution} is" */]]></code>
+        <paragraph>
+            In backtick template strings, normal string escapes still apply
+            (<literal>\\</literal>, <literal>\n</literal>,
+            <literal>\`</literal>, and so on).
+        </paragraph>
+        <image generated-src="ebnf/syntax/diagram/Template.png" />
+        <image generated-src="ebnf/syntax/diagram/TemplateString.png" />
+    </section>
+
+    <section>
+        <header>Templates in application conf</header>
+        <paragraph>
+            Application <literal>qualifiedVariables</literal> template strings
+            are compiled when the application conf is loaded (or reloaded).
+            <literal>#{…}</literal> runs then and embeds a static value for the
+            life of that compiled config.
+            <literal>${…}</literal> remains a template definition and re-runs
+            on each evaluation of that variable’s value. Use compile-time
+            substitution to freeze config (including one-shot values such as a
+            UUID or a function built once); use evaluation-time substitution
+            for values that must change per access (for example request-scoped
+            data).
+        </paragraph>
+    </section>
+
     <header>Expressions</header>
     <paragraph>
         An expression is a value composed, recursively, of one or more values, 
@@ -40,8 +135,11 @@
         <header>Values</header>
         <paragraph>
             Values are the fundamental components of an expression. They can be
-            Array Values, Object Values, Scalar Literals, Evaluations, 
-            Parenthesized Expressions or Template Strings.
+            list values, object values, scalar literals, evaluations,
+            parenthesized expressions, template strings, or compile-time
+            substitutions (<literal>#{…}</literal>). Evaluation-time
+            substitutions (<literal>${…}</literal>) are not bare values; they
+            appear only inside templates.
         </paragraph>
         <code><![CDATA[42
 "abc"
@@ -50,7 +148,8 @@ null
 [1, 2, 3]
 { "x": 42, "y": "abc" }
 (1 + 1) + 3
-`1 + 1 is {1 + 1}`]]></code>
+`1 + 1 is ${1 + 1}`
+#{1 + 2}]]></code>
     </section>
     <section>
         <header>Factors</header>

--- a/src/afw/doc/reference/language/qualified-variables.xml
+++ b/src/afw/doc/reference/language/qualified-variables.xml
@@ -23,4 +23,13 @@
         is a Qualified Variable that is provided by the Adaptive Models when 
         processing an object that is being mapped to another object.
     </paragraph>
+    <paragraph>
+        Application conf may define qualified variables under
+        <literal>qualifiedVariables</literal> using template strings. Those
+        templates are compiled when the application conf is loaded (or
+        reloaded). Compile-time substitutions (<literal>#{…}</literal>) run at
+        load time and freeze a value for that config; evaluation-time
+        substitutions (<literal>${…}</literal>) re-run each time the variable
+        is evaluated. See Templates and Expressions for details.
+    </paragraph>
 </doc>

--- a/src/afw/generated/ebnf/syntax.ebnf
+++ b/src/afw/generated/ebnf/syntax.ebnf
@@ -614,22 +614,22 @@ EvaluationTimeSubstitution ::= '${' Script '}'
 Substitution ::= CompileTimeSubstitution | EvaluationTimeSubstitution
 
 /* From afw_compile_parse_template.c                                          */
+/* In Template and TemplateString bodies, '\#' and '\$' emit a literal '#' or */
+/* '$' so that '#{' / '${' substitution openers are not formed. TemplateString */
+/* also supports normal string escapes ('\\', '\n', '\`', ...).               */
 
 Template ::=
    (
        ( Char - ['$' '#'] ) |
        ( ['$' '#'] ) |
        ( ['$' '#'] (Char - '{') ) |
+       ( '\\' ['$' '#'] ) |
        Substitution
    )*
 
 /* From afw_compile_parse_template.c                                          */
 
 TemplateString ::= '`' + Template + '`'
-
-/* From afw_compile_parse_template.c                                          */
-
-NamedTemplateString ::= '`' + ((Char - '$') | ('\$') | ('$' (Char - '{')) | '${' PropertyName '}') * '`'
 
 /* From afw_compile_parse_value.c                                             */
 /* Expression must produce a value of data type list.                         */

--- a/src/afw/tests/miscellaneous/substitution/substitution.as
+++ b/src/afw/tests/miscellaneous/substitution/substitution.as
@@ -353,3 +353,85 @@ is evaluated and assigned to variable does not reevaluate
 const x:unevaluated = evaluate(app::uuidEvalTime);
 
 return x == x;
+
+//?
+//? test: compile_time_outer_local_not_visible
+//? description: Outer locals are not visible inside compile-time substitution
+//? expect: error:Parse error at offset 0 around line 1 column 1: Unknown built-in function 'outer'
+//? source: ...
+
+const outer = 42;
+return #{outer};
+
+//?
+//? test: compile_time_throw
+//? description: throw inside compile-time substitution fails at compile time
+//? expect: error:Error during compile at offset 7 around line 2 column 7: boom
+//? source: ...
+
+return #{ throw "boom"; };
+
+//?
+//? test: template_string_escape_hash
+//? description: \# suppresses #{ opener in template string
+//? expect: "#{lit}"
+//? source: ...
+
+return `\#{lit}`;
+
+//?
+//? test: template_string_escape_dollar
+//? description: \$ suppresses ${ opener in template string
+//? expect: "${lit}"
+//? source: ...
+
+return `\${lit}`;
+
+//?
+//? test: template_string_sub_still_works
+//? description: #{ and ${ still substitute in template strings
+//? expect: "ab"
+//? source: ...
+
+return `#{'a'}${'b'}`;
+
+//?
+//? test: template_string_backslash
+//? description: \\ remains a normal string escape in template strings
+//? expect: "\\"
+//? source: ...
+
+return `\\`;
+
+//?
+//? test: template_string_mixed_escape_and_sub
+//? description: Mix opener-suppress and real substitution
+//? expect: "x#{y}z"
+//? source: ...
+
+return `x\#{y}${'z'}`;
+
+//?
+//? test: compile_time_value_integer
+//? description: Bare compile-time substitution as a Value
+//? expect: 3
+//? source: ...
+
+return #{1 + 2};
+
+//?
+//? test: compile_time_nested
+//? description: Nested compile-time substitutions
+//? expect: 3
+//? source: ...
+
+return #{ return #{1 + 2;}; };
+
+//?
+//? test: eval_time_outer_local_visible
+//? description: Outer locals are visible inside evaluation-time substitution
+//? expect: 42
+//? source: ...
+
+const outer = 42;
+return `${outer}`;

--- a/whats_new.md
+++ b/whats_new.md
@@ -16,6 +16,39 @@ Internal agent rules, Cursor docs, and pure test-infrastructure work are omitted
 | **`afw` CLI** | Optional interactive line editing and command history |
 | **JSON Schema** | Cleaner editor schemas for Adaptive object types |
 | **Process env** | One `current` on retrieve (issue **#71**); values are string if valid UTF-8 else hexBinary |
+| **Templates** | Compile-time substitution `#{…}` docs and tests; backtick `` `\#` `` / `` `\$` `` match raw templates (issue **#97**) |
+
+---
+
+## Compile-time template substitutions (issue #97)
+
+**Issue #97** (feature largely landed earlier as PR **#100**; completed on this branch)
+
+Templates support two substitution openers:
+
+| Syntax | When it runs | Outer script locals |
+|--------|----------------|---------------------|
+| `#{ Script }` | During compile (or application conf load for conf templates) | **Not** visible (isolated nested script) |
+| `${ Script }` | Each time the template is evaluated | Visible when the template is part of that script |
+
+Bare `#{…}` is also a **Value** in a script (`return #{1 + 2};`). Bare `${…}` is only valid **inside** a template, not as a bare value.
+
+Use compile-time substitution to freeze config (including one-shot values such as a UUID or a function built once at load). Use evaluation-time substitution when the value must change per access.
+
+### Escaping openers
+
+The openers are the two-character sequences `#{` and `${`. A backslash before `#` or `$` emits a literal `#` or `$` so the opener is not formed:
+
+```adaptive
+return `\#{not a sub} #{'is'}`;  /* → "#{not a sub} is" */
+return `\${not a sub} ${'is'}`;  /* → "${not a sub} is" */
+```
+
+This now works in **backtick template strings** the same way as in raw templates (`template(...)` / conf template compile type). Normal string escapes in backticks (`\\`, `\n`, `` \` ``, …) are unchanged.
+
+### Documentation
+
+Language reference **Templates and Expressions** and a short note under **Qualified Variables** describe the two forms, isolation, conf lifecycle, and escapes. Full Syntax EBNF / railroad diagrams refresh on a docs build.
 
 ---
 
@@ -219,6 +252,9 @@ Tracked suites under `src/*/tests` are permanent regression assets. `afwdev test
    leaving trailing bytes when shortening content, update callers—those cases
    now succeed with correct full-file content. Prefer setting `maxReadBytes`
    appropriately for server hosts.
+7. **Template strings:** if you relied on `` `\#…` `` or `` `\${…}` `` failing
+   with “Invalid escape code,” they now emit literal `#` / `$` (opener
+   suppress). Real `#{…}` / `${…}` substitutions are unchanged.
 
 ---
 
@@ -226,6 +262,7 @@ Tracked suites under `src/*/tests` are permanent regression assets. `afwdev test
 
 | Topic | Issue | PR |
 |-------|-------|-----|
+| Compile-time substitutions (docs / TemplateString escapes) | #97 | #100 (feature); *(this branch completes)* |
 | File streams | #103 | #120 |
 | VFS empty file / hardening | #79 | *(this branch)* |
 | Optional `mappedAdapterId` | #109 | #119 |


### PR DESCRIPTION
## Summary

- Completes open issue **#97** documentation and residual quality for compile-time substitutions (`#{…}`), on top of the feature from PR **#100**.
- Path-local fix so backtick **TemplateString** `\#` / `\$` suppress openers the same way as raw **Template** (string unescapes unchanged).
- Handbook rewrite (`expressions.xml`), conf note (`qualified-variables.xml`), agent-rule corrections, isolation/throw/escape tests, and **whats_new.md** entry for `mgg-develop` users.
- Removes unfinished **NamedTemplateString** EBNF-only stub.

## Test plan

- [x] `./afwdev build --cdev -j`
- [x] `afwdev test -p afw --test-pattern 'substitution' -j` (46 passed)
- [x] Docs/EBNF diagram rebuild on next `--all` or docs build (stale NamedTemplateString diagrams refresh automatically)

Closes #97