### PR TITLE
issue #38: expression property names in object values

### DIFF
--- a/.cursor/rules/afw-adaptive-script.mdc
+++ b/.cursor/rules/afw-adaptive-script.mdc
@@ -8,6 +8,9 @@ alwaysApply: false
 
 Use when writing or reviewing `.as` tests, model `on*` handlers, Fiddle snippets, or script-shaped conf.
 
+## Types in prose
+- Say **object** / **properties** and **array**, not “bag.” Historical data-type name **bag** was renamed list then **array** (see always-on `afw-project` terminology).
+
 ## Equality and identity
 
 - **`===` / `!==` on objects and arrays is structural** (deep equality), not pointer identity.

--- a/.cursor/rules/afw-json-schema.mdc
+++ b/.cursor/rules/afw-json-schema.mdc
@@ -24,7 +24,7 @@ alwaysApply: false
 - **Inheritance**: merge property maps with **child override** for the entity. Do **not** stack parent `.propertyTypes` as constraining `allOf` (breaks overrides and confuses editors). Record chain in `x-afw-inheritedObjectTypes` if useful for tests/tooling.
 - **required**: leaf object type only (not on shared `.propertyTypes` maps that would force ancestor-only fields on children).
 - Prefer **`additionalProperties: false`** (closed) over `unevaluatedProperties` for editor support.
-- Map `defaultValue` → `default`, `allowedValues`/`possibleValues` → `enum`; optional instance `_meta_` bag on closed composites.
+- Map `defaultValue` → `default`, `allowedValues`/`possibleValues` → `enum`; optional instance `_meta_` (wire/meta convention) on closed composites.
 - Verbose schemas are fine (generated, read-only). Optimize for VS Code-style consumers, not size.
 
 ## Wire-up

--- a/.cursor/rules/afw-model-adapter.mdc
+++ b/.cursor/rules/afw-model-adapter.mdc
@@ -38,7 +38,7 @@ Issue **#109** (Phase 1): **`mappedAdapterId` is optional**. Pure-script models 
 4. `current::mappedAdapterId` nullish when unset (do not throw).
 5. `begin_transaction`: if no mapped, do not session-cache NULL; if mapped, keep current behavior.
 6. Property-level mapping with **default** get/retrieve still needs mapped.
-7. During `on*`, **`current::`** (and **`custom::` / `adapter::` when pushed) are qualified variables (`contextType` on the hook property documents the bag). Optional **`qualifier("current")`** is a **snapshot** for debug/tools (can be large; not a hot path) — **`afw-qualified-variables`**.
+7. During `on*`, **`current::`** (and **`custom::` / `adapter::` when pushed) are qualified variables (`contextType` on the hook property documents the variable set). Optional **`qualifier("current")`** is a **snapshot** for debug/tools (can be large; not a hot path) — **`afw-qualified-variables`**.
 
 ## Tests
 

--- a/.cursor/rules/afw-project.mdc
+++ b/.cursor/rules/afw-project.mdc
@@ -14,6 +14,11 @@ Metadata-driven **C** runtime (`libafw`) plus Python **`afwdev`**. Define functi
 - Primary agent focus: **C + Python (afwdev)**. JS/admin app only when explicitly asked.
 - **Third-party deps must stay MIT-compatible** (AFW is MIT — see `LICENSE` / `COPYING`). Prefer BSD/MIT/Apache-2.0 libraries (e.g. **libedit** for line editing). Avoid GPL-only linkage such as **GNU readline**. If a package is on all supported distros (Ubuntu, Alpine, Rocky, OpenSUSE — see `docker/images/afw-dev-base/` and CI), it may be required; otherwise make it optional at CMake time and degrade gracefully. Keep Dockerfiles and build docs in sync with new packages.
 
+## Terminology (do not invent “bag” for objects)
+- Prefer **object** + **properties** / **property name**; ordered collections are **array** (historical renames: XACML-style **bag** → **list** → **array** so non-bag ops and array semantics could land cleanly).
+- Do **not** call an adaptive object a “bag” or “property bag” in new rules, docs, designs, or chat. Residual comments/APIs may still say “bag” (old polymorphic names, decompile, “bag of paths”); that is **legacy**, not the object model.
+- **Meta** is sideband (`object->meta` / meta APIs), not a normal property. Map content types may spell meta on the wire as `"_meta_"` — a serialization convention, not “meta is a bag property.”
+
 ## Layout
 - `src/afw` — **libafw core** (values, pools, xctx, compile/evaluate)
 - `src/afw_dev` — `afwdev` CLI

--- a/.cursor/rules/afw-qualified-variables.mdc
+++ b/.cursor/rules/afw-qualified-variables.mdc
@@ -31,7 +31,7 @@ Do **not** return C `NULL` for present undefined. Context **name tables**: if th
 ## Snapshot rules (issue #9)
 
 - **`afw_xctx_qualifier_object_create`:** walk **all** matching visible entries for the name (most recent first); each **contributes** into one accumulator. Per property name, **most recent wins** (contribute should skip names already set).
-- **Nullish:** no matching visible entry → C `NULL` / script `undefined` (not `{}`). Empty bag after contribute is still an object.
+- **Nullish:** no matching visible entry → C `NULL` / script `undefined` (not `{}`). Empty object after contribute is still an object.
 - **`qualifiers()`:** one nested snapshot per **active** qualifier name. If create returns `NULL`, **omit** the property — **never invent `{}`**.
 - Nested pushes are normal; stack restore / `AFW_TRY` peels entries as execution leaves scopes.
 

--- a/.cursor/rules/afw-runtime-model.mdc
+++ b/.cursor/rules/afw-runtime-model.mdc
@@ -28,6 +28,10 @@ Hierarchical pools (incl. xctx/scope subpools). Bulk free on pool/scope release;
 ## Design philosophy
 Immutability first; pool-centric lifetimes; metadata as single source of truth; curated TypeScript-like surface (lambdas, destructuring, types — not prototypes/loose JS). Prefer small patterned pieces over one-off machinery.
 
+## Naming values (short)
+- Structured values: **object** (named **properties**) and **array** (ordered). Do not call objects “bags” — **bag** is historical (XACML → list → array); see always-on `afw-project` terminology.
+- Object **meta** is sideband, separate from the property map.
+
 ## Process glue
 Capabilities (functions, data types, adapters, content types, …) are **registered into the environment** — core at create (`afw_environment_register_core.c` after `afw_generated_register`), extensions/commands later via the same APIs. See `afw-environment`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ Package manifest: [`afw-package.json`](afw-package.json) (`srcdirs`, `srcdirMani
 - **Pools**: hierarchical allocation (including per-scope subpools). Reference counting for escaping values (e.g. closures); bulk free when pools/scopes release.
 - **`compiled_value`**: owns a pool; evaluation uses scope-stack discipline and `statement_flow` for leave paths.
 - **Data-type value lifetimes** (inf chooses policy): **permanent** (built-in / life of AFW environment; usually const in the `.so`); **managed** (refcount or clone); **managed_slice** (utf8/memory view into a containing managed value); **unmanaged** (programmer/pool). Create APIs come from `data_type_bindings.py`. A main focus for long-running scripts is getting managed release/clone paths right and evaluating into `scope->p` — see [`.cursor/rules/afw-value-memory.mdc`](.cursor/rules/afw-value-memory.mdc).
+- **Terminology:** structured values are **object** (named **properties**) and **array** (ordered). Do **not** call objects “bags” — **bag** is historical (XACML-style bag → list → array). Object **meta** is sideband, not a normal property; map content types may use wire key `"_meta_"`. Always-on detail: [`.cursor/rules/afw-project.mdc`](.cursor/rules/afw-project.mdc).
 
 ## Interfaces vs script compiler vs environment
 

--- a/designs/README.md
+++ b/designs/README.md
@@ -20,6 +20,8 @@ Per-**issue** or per-**theme** working notes: why, options, footguns, parked ide
 | [`memory-management.md`](memory-management.md) | Umbrella **#2** — pools, value lifetimes, escape |
 | [`secrets-and-afw-crypto.md`](secrets-and-afw-crypto.md) | **#74** / `afw_crypto` design |
 | [`issue-18-decompile-status.md`](issue-18-decompile-status.md) | **#18** decompile/recompile status |
+| [`issue-38-expression-property-names.md`](issue-38-expression-property-names.md) | **#38** — `[expr]: value` in object values |
+| [`issue-138-meta-on-the-wire.md`](issue-138-meta-on-the-wire.md) | **#138** — `"_meta_"` wire / options / rich types |
 | [`compile-optimize-notes.md`](compile-optimize-notes.md) | Future compile-time optimize (not #18) |
 
 ## Conventions

--- a/designs/issue-138-meta-on-the-wire.md
+++ b/designs/issue-138-meta-on-the-wire.md
@@ -1,0 +1,24 @@
+# Issue #138 — Meta on the wire (pad)
+
+**GitHub:** [#138](https://github.com/afw-org/afw/issues/138)  
+**Labels:** `bug`, `enhancement`  
+**Assignees:** mike000000000, JeremyGrieshop  
+**Status:** Opened for design + multi-PR work; **does not block #38**.
+
+## One-line problem
+
+Sideband **meta** is real and load-bearing (adapters, object options, reconcile, UI/type info), but map content types spell it as reserved property name `"_meta_"`, which collides with free property names. Fix is encoding/view packaging—not banning the name in script or `afw_object`.
+
+## Remember when touching this
+
+- **Bug + enhancements:** collision fix and better delivery of rich type info / options / clients.  
+- **#38** only adds another way to hit an **existing** problem.  
+- **Do not** ban `"_meta_"` in language or normal property set.  
+- **Interim:** app data that round-trips map CTs should avoid property name `"_meta_"`.  
+- **Rich typing / `objectTypes` etc.:** historical goal was type-aware / dynamic client UI; XML was early primary CT; JSON won; large options bloat instances—discuss instance meta vs type fetch/cache without mandating one UI architecture.  
+- **reconcile_object**, file/LMDB essential meta, admin + TS client all in the blast radius.  
+- Full discussion lives on the **GitHub issue body**; expand this pad when implementation design starts.
+
+## Relationship to #38
+
+Implement expression property names without waiting on #138. Literal `_meta_:` peel stays; computed `"_meta_"` = normal property.

--- a/designs/issue-38-expression-property-names.md
+++ b/designs/issue-38-expression-property-names.md
@@ -1,0 +1,216 @@
+# Issue #38 — Expression property names in object values
+
+**GitHub:** [#38](https://github.com/afw-org/afw/issues/38)  
+**Branch:** `issue-#38`  
+**Status:** Implemented on branch `issue-#38` (2026-08). User-facing notes in `whats_new.md`.  
+**Related (do not block #38):** [#138](https://github.com/afw-org/afw/issues/138) — meta on the wire / `"_meta_"` encoding.
+
+## What ships
+
+In an **object value** (expression-mode `{ … }` only), a property name may be a **bracketed expression**, same string-key idea as existing `obj[expr]` get/set:
+
+```adaptive
+{ [expression]: value }
+```
+
+Also still valid (unchanged): identifier keys, string-literal keys, `...spread`.
+
+**Not in scope:** property/method shorthand, getters, prototypes, non-identifier **variable** names, destructure computed keys, JSON-strict object text gaining brackets.
+
+## Mental model (AFW only — no ES comparisons in user docs)
+
+| Binding / name | Rule |
+|----------------|------|
+| Variables, parameters, functions | Lexical **Identifier** only |
+| Object **property** names | Strings; identifier form is sugar when the name is a valid identifier |
+| `obj.name` / `obj["…"]` / `obj[var]` | Already supported (get and assign via `reference_by_key`) |
+| `{ [expr]: v }` | **#38** — construct-time expression key |
+
+Historical intent of brackets: property names that are **not** identifiers (spaces, SQL-ish columns, etc.), not “relax variable naming.”
+
+## Docs
+
+- Describe Adaptive Script only (identifier / string / `[expr]` property names).  
+- Do **not** frame as ECMAScript/JS in handbook.  
+- Update `features.xml` / `objects-and-arrays.xml` (today they mark `[y]: 3` invalid).  
+- EBNF in `afw_compile_parse_Object` comments + harvest as usual.
+
+## Implementation sketch (for the plan)
+
+1. **Parse** (`afw_compile_parse_value.c` / `ObjectValue`): accept `'[' Expression ']' ':' Expression` alongside identifier/string and spread.  
+2. **Eval construction:** static names can stay on a compile-time object; expression names (and mix with spread / unevaluated values) need deferred construction—extend or generalize `object_expression` / call graph (ordered entries: static | computed | spread).  
+3. **Name evaluation:** same as assignment through `reference_by_key` — string or `as_utf8` / convert-to-string; no special identifier rules for bracket keys.  
+4. **Left-to-right** application; last write wins on duplicate names (incl. after eval).  
+5. **Literal `_meta_:`** keep **current** peel → `meta_set_meta_object` (parse sideband).  
+6. **Computed name that evaluates to `"_meta_"`:** treat as **normal property** (same as `obj["_meta_"] = …`). Do **not** invent new language meta rules; collision on JSON/YAML/UBJSON is **#138**.  
+7. **Embedded nested objects:** computed names break “property name known before parsing value” embedding; create non-embedded when name is expression.  
+8. **Decompile / listing:** emit `[…]: …`.  
+9. **Tests:** non-identifier fixed via string (already); expression keys; template/concat; mix with spread; last-wins; pure JSON mode rejects brackets; regression that `obj[k]` still works.
+
+## Explicit non-decisions for #38
+
+- Content-type dual encoding / kill reserved `"_meta_"` → **#138**.  
+- Do not ban `set_property(…, "_meta_", …)`.  
+- Destructure still identifier-only property side unless a later issue.
+
+## Implementation plan
+
+### Goal
+
+Ship `{ [expression]: value }` in Adaptive Script **object values** only, with AFW-only docs/tests. No #138 encoding work.
+
+### Current construction paths (baseline)
+
+`afw_compile_parse_Object(..., allow_expression, …)` today:
+
+| Situation | Result |
+|-----------|--------|
+| All property names static; all values evaluated | Unmanaged **object** (+ optional literal `_meta_` via `meta_set_meta_object`) |
+| Static names; some values not yet evaluated | **`object_expression`** — bag of known names, eval values on evaluate |
+| Any `...spread` | Call to **`add_properties`** (base object/`object_expression` + spread objects) |
+
+`object_expression` **cannot** hold expression names: eval walks `get_next_property` with fixed names.
+
+`obj[key]` get/set already uses `reference_by_key` + string/`as_utf8` for names.
+
+### Recommended approach
+
+**A. Parse** — When `allow_expression` is true, accept property name forms:
+
+- unqualified **Identifier**
+- **String** (existing strict vs relaxed quote rules)
+- **`[` Expression `]`** (new; only if `allow_expression`)
+
+Strict JSON / non-expression object parse: **reject** `[` as property name (unchanged “Invalid property name”).
+
+EBNF update `ObjectValue` only (not `Object` / `ObjectLiteral` / pure JSON).
+
+**B. Representation when any name is an expression**
+
+Do **not** force everything through a static-name bag.
+
+Introduce an ordered **entry list** for deferred construction (preferred: extend the value model rather than a one-off compile-only struct that never evaluates cleanly):
+
+Each entry is one of:
+
+1. **Static pair** — `property_name` (utf8) + `value` (may be expression)  
+2. **Expression-name pair** — `name_expr` + `value`  
+3. **Spread** — `object_expr` (existing `...`)
+
+On evaluate (into current pool):
+
+1. Create mutable unmanaged object.  
+2. For each entry left to right:  
+   - static: `set_property(name, evaluate(value))`  
+   - expression name: evaluate name → string (same as assign path: string or `afw_value_as_utf8` / convert); evaluate value; `set_property`  
+   - spread: evaluate object; copy properties onto target (same semantics as `add_properties` source merge)  
+3. Last write wins on duplicate names.  
+4. Return object value.
+
+**Optimization:** If **no** expression-name entries and **no** spreads, keep **today’s** paths (plain object / `object_expression` / `add_properties` only). That limits risk to the new syntax and mixed cases that need ordered entries.
+
+**Literal `_meta_:`** (static name only): keep peel → install meta on the result object when construction finishes (only when name is the **literal** identifier/string `_meta_` at parse time, not when a computed name evaluates to that string).
+
+**Computed name → `"_meta_"`:** normal `set_property` (documents #138 footgun; no language magic).
+
+**C. Where to put the entry-list value**
+
+Pick one during implement (plan preference first):
+
+1. **Preferred:** New value inf e.g. `object_literal` / `object_construct` with `entries[]` + contextual — evaluate/decompile/listing like `object_expression` / `list_expression`. Register in value registry.  
+2. **Alternative:** Lower to a built-in (new or synthetic) that takes a structured args array — more generate churn, easier decompile as call.
+
+Prefer (1) unless entry list fits an existing pattern with less code.
+
+**D. Nested objects / embedding**
+
+When the **parent** property name is an expression name, do not use `parser->property_name` for `AFW_OBJECT_CREATE_ENTITY_OR_EMBEDDED` embedding into a parent bag under a known name:
+
+- Parse value with `property_name` unset / force unmanaged create for that child.  
+- Attach only after the name expression is evaluated at eval time.
+
+Static-name nested objects can keep current embedding behavior.
+
+**E. Decompile / compiler listing / pragmas**
+
+- Listing: show expression-name entries as property name expressions + value listing.  
+- Decompile: emit `{ [ <name decompile> ]: <value>, ... }` and preserve spreads.  
+- If #list_expression-style pragma exists for objects, only add if needed for round-trip tests; don’t invent unless decompile fidelity requires it.
+
+**F. Docs (AFW-only prose)**
+
+- `src/afw/doc/reference/language/features.xml` — remove “invalid (computed name)”; describe expression names.  
+- `src/afw/doc/reference/language/objects-and-arrays.xml` — property names: identifier, string, or bracket expression.  
+- No ECMAScript comparisons.
+
+**G. Tests** (new or extend under `src/afw/tests/…`)
+
+| Case | Expect |
+|------|--------|
+| `{ [k]: 1 }` with `k` string var | property set |
+| `{ ["a b"]: 1 }` | non-identifier name |
+| `` { [`p${n}`]: v } `` | template key |
+| Mix static + expression + spread | order + last-wins |
+| Expression value + expression name | both eval |
+| Nested object under expression name | works; no wrong embed |
+| Pure `json` / strict object | `[` name is syntax error |
+| `obj[k]=` still works | regression |
+| Decompile or listing smoke if easy | optional but good |
+| Literal `_meta_: { path: ... }` still meta | no change |
+| `{ ["_meta_"]: 1 }` | bag property if set_property allows (no throw) |
+
+**H. Build / verify**
+
+```bash
+./afwdev build --cdev
+afwdev test -j --srcdir-pattern afw --test-pattern '…'   # narrow while iterating
+# before PR: ./afwdev build --fulldev && afwdev test -j --env-mode valgrind
+```
+
+Generate only if new function metadata is chosen (path 2); path 1 may be hand C only.
+
+### Work phases
+
+| Phase | Work | Done when |
+|-------|------|-----------|
+| **1. Parse** | Token `[` as name; parse Expression; colon; value; EBNF | Syntax accepted only in expression mode; rejected in JSON |
+| **2. Construct** | Entry list + evaluate; keep fast path for static-only | `{ [k]: v }` evaluates correctly |
+| **3. Edges** | Spread mix, nesting, `_meta_` literal vs computed, name string conversion | Tests green |
+| **4. Decompile/listing** | Emit/list expression names | Listing/decompile don’t crash; fidelity if practical |
+| **5. Docs + tests** | Handbook XML; full test file | Docs match behavior |
+| **6. Verify** | `--cdev` + focused tests; fulldev/valgrind before PR | Maintainer bar |
+
+### Out of scope (explicit)
+
+- #138 dual encoding / reserved-key fix  
+- Destructure `{ [k]: x }`  
+- Property/method shorthand  
+- Changing variable identifier rules  
+
+### Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Breaking static object / spread paths | Keep existing paths when no expression names |
+| Meta / embed footguns | Literal `_meta_` only; unmanaged children for expr names |
+| Name type chaos | Mirror `reference_by_key` assign conversion |
+| Decompile gap | Minimum: no crash; improve fidelity if cheap |
+
+### Success criteria
+
+- Scripts can build objects with expression property names in one object value.  
+- Behavior matches `let o={}; o[k]=v` for the key/value pair.  
+- Docs AFW-only; tests cover main cases.  
+- No requirement to solve #138.
+
+### Implementation status
+
+Done on working tree (hold commit for review):
+
+- `afw_value_object_construct` value inf (entries: static / name_expr / spread)
+- Parse `[ Expression ]` names in `ObjectValue`; migrate static/spread to construct when needed
+- Tests: `src/afw/tests/language/script/object_expression_names.as` (11 passed)
+- Docs: `features.xml`, `objects-and-arrays.xml`
+- Fast path unchanged when no expression property names
+
+Commit when maintainer asks.

--- a/src/afw/compile/afw_compile_parse_value.c
+++ b/src/afw/compile/afw_compile_parse_value.c
@@ -244,12 +244,14 @@ afw_compile_parse_List(
  *    '{'
  *        (
  *            (
- *                ( ( String | Identifier ) ':' Expression ) |
+ *                ( ( String | Identifier | '[' Expression ']' )
+ *                    ':' Expression ) |
  *                ('...' ObjectExpression )
  *            )
  *            ( ','
  *                (
- *                    ( ( String | Identifier ) ':' Expression ) |
+ *                    ( ( String | Identifier | '[' Expression ']' )
+ *                        ':' Expression ) |
  *                    ('...' ObjectExpression )
  *                )
  *            )*
@@ -259,6 +261,72 @@ afw_compile_parse_List(
  *
  *
  *<<<ebnf*/
+
+/*
+ * Append one object_construct entry (expression-mode object values with
+ * expression property names and/or when construct path is required).
+ */
+static afw_value_object_construct_entry_t *
+impl_object_construct_entry_append(
+    afw_compile_parser_t *parser,
+    afw_value_object_construct_entry_t **entries_head,
+    afw_value_object_construct_entry_t **entries_tail,
+    afw_value_object_construct_entry_type_t type,
+    const afw_utf8_t *static_name,
+    const afw_value_t *name_expr,
+    const afw_value_t *value,
+    const afw_value_t *spread_expr)
+{
+    afw_value_object_construct_entry_t *e;
+
+    e = afw_pool_calloc_type(parser->p,
+        afw_value_object_construct_entry_t, parser->xctx);
+    e->type = type;
+    e->static_name = static_name;
+    e->name_expr = name_expr;
+    e->value = value;
+    e->spread_expr = spread_expr;
+    e->next = NULL;
+    if (!*entries_head) {
+        *entries_head = e;
+    }
+    else {
+        (*entries_tail)->next = e;
+    }
+    *entries_tail = e;
+    return e;
+}
+
+
+/*
+ * Move properties already stored on obj into static construct entries
+ * (used when an expression property name appears after static properties).
+ */
+static void
+impl_object_migrate_properties_to_entries(
+    afw_compile_parser_t *parser,
+    const afw_object_t *obj,
+    afw_value_object_construct_entry_t **entries_head,
+    afw_value_object_construct_entry_t **entries_tail)
+{
+    const afw_iterator_t *iterator;
+    const afw_utf8_t *name;
+    const afw_value_t *v;
+
+    if (!obj) {
+        return;
+    }
+    for (iterator = NULL;;) {
+        v = afw_object_get_next_property(obj, &iterator, &name, parser->xctx);
+        if (!v) {
+            break;
+        }
+        impl_object_construct_entry_append(parser, entries_head, entries_tail,
+            afw_value_object_construct_entry_static, name, NULL, v, NULL);
+    }
+}
+
+
 AFW_DEFINE_INTERNAL(const afw_value_t *)
 afw_compile_parse_Object(
     afw_compile_parser_t *parser,
@@ -267,6 +335,7 @@ afw_compile_parse_Object(
 {
     const afw_object_t *obj;
     const afw_value_t *v;
+    const afw_value_t *name_expr;
     const afw_object_t *embedding_object;
     const afw_utf8_t *property_name;
     const afw_object_t *_meta_;
@@ -277,6 +346,12 @@ afw_compile_parse_Object(
     afw_size_t start_offset;
     afw_boolean_t save_doing_object_spread;
     afw_boolean_t is_object_expression;
+    afw_boolean_t use_construct;
+    afw_boolean_t name_is_expression;
+    afw_value_object_construct_entry_t *entries_head;
+    afw_value_object_construct_entry_t *entries_tail;
+    const afw_utf8_t *saved_parser_property_name;
+    afw_size_t i;
 
     /* Return NULL if next token is not '{'. */
     afw_compile_save_cursor(start_offset);
@@ -297,6 +372,9 @@ afw_compile_parse_Object(
     args = NULL;
     result = NULL;
     is_object_expression = false;
+    use_construct = false;
+    entries_head = NULL;
+    entries_tail = NULL;
 
     /*
      * Save parser->embedding_object and set to new object.
@@ -316,6 +394,8 @@ afw_compile_parse_Object(
 
             afw_compile_get_token();
             parser->property_name = NULL;
+            name_expr = NULL;
+            name_is_expression = false;
 
             if (parser->strict) {
                 if (afw_compile_token_is(utf8_string) &&
@@ -335,42 +415,112 @@ afw_compile_parse_Object(
                 parser->property_name = parser->token->identifier_name;
             }
 
+            /*
+             * Expression property name: '[' Expression ']' (object values only).
+             */
+            else if (allow_expression &&
+                afw_compile_token_is(open_bracket))
+            {
+                name_expr = afw_compile_parse_Expression(parser);
+                afw_compile_get_token();
+                if (!afw_compile_token_is(close_bracket)) {
+                    AFW_COMPILE_THROW_ERROR_Z(
+                        "Expecting ']' after expression property name");
+                }
+                name_is_expression = true;
+
+                /* Switch to construct path; migrate prior static/spread state. */
+                if (!use_construct) {
+                    /*
+                     * Prior ...spreads were building add_properties args.
+                     * Turn each source object into a construct spread entry so
+                     * expression names can follow spreads in source order.
+                     */
+                    if (args) {
+                        afw_compile_args_finalize(args, &argc, &argv);
+                        /* argv[0] is add_properties; argv[1..] are sources. */
+                        for (i = 1; i < argc; i++) {
+                            if (argv[i]) {
+                                impl_object_construct_entry_append(parser,
+                                    &entries_head, &entries_tail,
+                                    afw_value_object_construct_entry_spread,
+                                    NULL, NULL, NULL, argv[i]);
+                            }
+                        }
+                        args = NULL;
+                        result = NULL;
+                        /*
+                         * obj after spreads is already an argument in args when
+                         * static properties followed a spread; do not migrate
+                         * it again (would duplicate).
+                         */
+                    }
+                    else {
+                        impl_object_migrate_properties_to_entries(parser, obj,
+                            &entries_head, &entries_tail);
+                    }
+                    use_construct = true;
+                    /*
+                     * Stop embedding children into the compile-time bag; entries
+                     * hold values and evaluate attaches them after name eval.
+                     */
+                    parser->embedding_object = NULL;
+                    obj = NULL;
+                    is_object_expression = false;
+                }
+            }
+
             /* If spread operator. */
             if (allow_expression && afw_compile_token_is(ellipsis)) {
 
-                /*
-                 * If this is first spread, start making args for add_entries().
-                 */
-                if (!args) {
-                    args = afw_compile_args_create(parser);
-                    afw_compile_args_add_value(args,
-                        &afw_function_definition_add_properties.pub);
-                    if (is_object_expression) {
-                        result = afw_value_create_object_expression(
-                            afw_compile_create_contextual_to_cursor(start_offset),
-                            obj, parser->p, parser->xctx);
-                    }
-                    else {
-                        result = NULL;
-                    }
-                    afw_compile_args_add_value(args, result);
-                    is_object_expression = false;
+                /* Construct path: spread as an ordered entry. */
+                if (use_construct) {
+                    save_doing_object_spread = parser->doing_object_spread;
+                    parser->doing_object_spread = true;
+                    v = afw_compile_parse_Expression(parser);
+                    parser->doing_object_spread = save_doing_object_spread;
+                    impl_object_construct_entry_append(parser,
+                        &entries_head, &entries_tail,
+                        afw_value_object_construct_entry_spread,
+                        NULL, NULL, NULL, v);
                 }
+                else {
+                    /*
+                     * If this is first spread, start making args for
+                     * add_properties().
+                     */
+                    if (!args) {
+                        args = afw_compile_args_create(parser);
+                        afw_compile_args_add_value(args,
+                            &afw_function_definition_add_properties.pub);
+                        if (is_object_expression) {
+                            result = afw_value_create_object_expression(
+                                afw_compile_create_contextual_to_cursor(
+                                    start_offset),
+                                obj, parser->p, parser->xctx);
+                        }
+                        else {
+                            result = NULL;
+                        }
+                        afw_compile_args_add_value(args, result);
+                        is_object_expression = false;
+                    }
 
-                /* Add spread object expression to args. */
-                save_doing_object_spread = parser->doing_object_spread;
-                parser->doing_object_spread = true;
-                v = afw_compile_parse_Expression(parser);
-                parser->doing_object_spread = save_doing_object_spread;
-                afw_compile_args_add_value(args, v);
+                    /* Add spread object expression to args. */
+                    save_doing_object_spread = parser->doing_object_spread;
+                    parser->doing_object_spread = true;
+                    v = afw_compile_parse_Expression(parser);
+                    parser->doing_object_spread = save_doing_object_spread;
+                    afw_compile_args_add_value(args, v);
 
-                /* A new object will be started if needed. */
-                obj = NULL;
+                    /* A new object will be started if needed. */
+                    obj = NULL;
+                }
             }
 
             /* If not spread */
             else {
-                if (!parser->property_name) {
+                if (!name_is_expression && !parser->property_name) {
                     AFW_COMPILE_THROW_ERROR_Z("Invalid property name");
                 }
 
@@ -379,6 +529,15 @@ afw_compile_parse_Object(
                 if (!afw_compile_token_is(colon)) {
                     AFW_COMPILE_THROW_ERROR_Z(
                         "Name of an object value must be followed by a colon");
+                }
+
+                /*
+                 * Expression property name: do not embed nested objects under
+                 * a known property name (name is not known until evaluate).
+                 */
+                saved_parser_property_name = parser->property_name;
+                if (name_is_expression) {
+                    parser->property_name = NULL;
                 }
 
                 /* Next should be a value. */
@@ -393,8 +552,36 @@ afw_compile_parse_Object(
                     v = afw_compile_parse_Json(parser);
                 }
 
+                parser->property_name = saved_parser_property_name;
+
+                /* Construct path: append static or expression-name entry. */
+                if (use_construct || name_is_expression) {
+                    if (name_is_expression) {
+                        impl_object_construct_entry_append(parser,
+                            &entries_head, &entries_tail,
+                            afw_value_object_construct_entry_name_expr,
+                            NULL, name_expr, v, NULL);
+                    }
+                    else if (afw_utf8_equal(parser->property_name,
+                        afw_s__meta_))
+                    {
+                        /* Literal _meta_ still installs sideband meta. */
+                        if (!afw_value_is_object(v)) {
+                            AFW_COMPILE_THROW_ERROR_Z(
+                                "'_meta_' property must be an object");
+                        }
+                        _meta_ = ((const afw_value_object_t *)v)->internal;
+                    }
+                    else {
+                        impl_object_construct_entry_append(parser,
+                            &entries_head, &entries_tail,
+                            afw_value_object_construct_entry_static,
+                            parser->property_name, NULL, v, NULL);
+                    }
+                }
+
                 /* If this is _meta_ property, set meta in object. */
-                if (afw_utf8_equal(parser->property_name, afw_s__meta_)) {
+                else if (afw_utf8_equal(parser->property_name, afw_s__meta_)) {
                     if (!afw_value_is_object(v)) {
                         AFW_COMPILE_THROW_ERROR_Z(
                             "'_meta_' property must be an object");
@@ -451,8 +638,15 @@ afw_compile_parse_Object(
         }
     }
 
+    /* Expression property names: ordered construct value. */
+    if (use_construct) {
+        result = afw_value_create_object_construct(
+            afw_compile_create_contextual_to_cursor(start_offset),
+            entries_head, _meta_, parser->p, parser->xctx);
+    }
+
     /* If there were spread operators, result is call to add_properties(). */
-    if (args) {
+    else if (args) {
         afw_compile_args_finalize(args, &argc, &argv);
         result = afw_value_call_built_in_function_create(
             afw_compile_create_contextual_to_cursor(start_offset),

--- a/src/afw/doc/reference/language/features.xml
+++ b/src/afw/doc/reference/language/features.xml
@@ -121,15 +121,22 @@ let y = 2;
         <literal>higher_order_array</literal>.
     </paragraph>
     <paragraph>
-        Object property names in initializers may be identifiers or string
-        literals. Computed property names in the initializer are not
-        supported.
+        Object property names in an object value may be an identifier, a string
+        literal, or an expression in square brackets. Bracket expressions are
+        evaluated when the object value is evaluated; the result is used as the
+        property name (a string). This is the same idea as
+        <literal>obj[expression]</literal> for get and assignment. Variable and
+        parameter names remain lexical identifiers.
     </paragraph>
-    <code><![CDATA[let x = {
-    a:   1, // valid
-    "b": 2, // valid
-    [y]: 3, // invalid (computed name)
+    <code><![CDATA[let y = "c";
+let x = {
+    a:   1,
+    "b": 2,
+    [y]: 3,
+    ["Customer Name"]: "Ada"
 };
+assert(x.c === 3);
+assert(x["Customer Name"] === "Ada");
 
 let names = keys(x);
 let a = [1, 2];

--- a/src/afw/doc/reference/language/objects-and-arrays.xml
+++ b/src/afw/doc/reference/language/objects-and-arrays.xml
@@ -22,17 +22,24 @@
 
     <header>Objects</header>
     <paragraph>
-        Object literals use property names and values. Property names may be
-        identifiers or string literals. Computed property names in the
-        initializer are not supported.
+        Object values use property names and values. A property name may be an
+        identifier, a string literal, or an expression in square brackets.
+        Bracket expressions are evaluated when the object value is evaluated;
+        the result is the property name (a string). Names that are not valid
+        identifiers (for example names with spaces) use a string literal or a
+        bracket expression. The same bracket form is used for
+        <literal>obj[name]</literal> get and assignment on an existing object.
     </paragraph>
-    <code><![CDATA[let o = {
+    <code><![CDATA[let key = "b";
+let o = {
     a: 1,
-    "b": "hello"
+    "Customer Name": "hello",
+    [key]: true
 };
 o.c = true;
 assert(o.a === 1);
-assert(property_get(o, "b") === "hello");
+assert(property_get(o, "Customer Name") === "hello");
+assert(o.b === true);
 assert(property_exists(o, "c") === true);]]></code>
     <paragraph>
         Core property helpers include <literal>property_get</literal>,

--- a/src/afw/generated/afwdev_generated_variables.cmake
+++ b/src/afw/generated/afwdev_generated_variables.cmake
@@ -462,6 +462,7 @@ set(AFWDEV_GENERATED_SOURCE_LIST
     value/afw_value_meta.c
     value/afw_value_meta_values_list.c
     value/afw_value_meta_values_object.c
+    value/afw_value_object_construct.c
     value/afw_value_object_expression.c
     value/afw_value_qualified_variable_reference.c
     value/afw_value_reference_by_key.c

--- a/src/afw/generated/ebnf/syntax.ebnf
+++ b/src/afw/generated/ebnf/syntax.ebnf
@@ -725,12 +725,14 @@ ObjectValue ::=
    '{'
        (
            (
-               ( ( String | Identifier ) ':' Expression ) |
+               ( ( String | Identifier | '[' Expression ']' )
+                   ':' Expression ) |
                ('...' ObjectExpression )
            )
            ( ','
                (
-                   ( ( String | Identifier ) ':' Expression ) |
+                   ( ( String | Identifier | '[' Expression ']' )
+                       ':' Expression ) |
                    ('...' ObjectExpression )
                )
            )*

--- a/src/afw/include/afw_common_opaques.h
+++ b/src/afw/include/afw_common_opaques.h
@@ -922,6 +922,22 @@ typedef struct afw_value_object_expression_s
 afw_value_object_expression_t;
 
 /**
+ * @brief Opaque `afw_value_object_construct_t`.
+ *
+ * Object value with ordered property entries (static name, expression name,
+ * and/or spread). Used when an object value includes expression property
+ * names. See afw_value_internal.h.
+ */
+typedef struct afw_value_object_construct_s
+afw_value_object_construct_t;
+
+/**
+ * @brief Opaque object-construct entry.
+ */
+typedef struct afw_value_object_construct_entry_s
+afw_value_object_construct_entry_t;
+
+/**
  * @brief Opaque `afw_value_qualified_variable_reference_t`.
  *
  * See afw_value_internal.h for struct and more information.

--- a/src/afw/tests/language/script/object_expression_names.as
+++ b/src/afw/tests/language/script/object_expression_names.as
@@ -1,0 +1,156 @@
+#!/usr/bin/env -S afw --syntax test_script
+//?
+//? testScript: object_expression_names.as
+//? customPurpose: Part of language/script tests
+//? description: Expression property names in object values (issue #38)
+//? sourceType: script
+//?
+//? test: expression-name-variable
+//? description: Property name from a variable expression
+//? skip: false
+//? expect: 0
+//? source: ...
+
+const k = "status";
+const o = { [k]: "ok", id: 1 };
+assert(o.status === "ok");
+assert(o.id === 1);
+assert(o[k] === "ok");
+return 0;
+
+//?
+//? test: expression-name-string-literal
+//? description: Bracket name with string literal (non-identifier)
+//? skip: false
+//? expect: 0
+//? source: ...
+
+const o = { ["Customer Name"]: "Ada", n: 2 };
+assert(o["Customer Name"] === "Ada");
+assert(o.n === 2);
+return 0;
+
+//?
+//? test: expression-name-concat
+//? description: Property name from string concatenation
+//? skip: false
+//? expect: 0
+//? source: ...
+
+const n = 3;
+const o = { ["col " + string(n)]: 42 };
+assert(o["col 3"] === 42);
+return 0;
+
+//?
+//? test: expression-name-template
+//? description: Property name from template string
+//? skip: false
+//? expect: 0
+//? source: ...
+
+const n = 7;
+const o = { [`prefix_${n}`]: true };
+assert(o.prefix_7 === true);
+assert(o[`prefix_${n}`] === true);
+return 0;
+
+//?
+//? test: expression-name-mix-static-and-spread
+//? description: Static keys, expression key, and spread; last wins
+//? skip: false
+//? expect: 0
+//? source: ...
+
+const base = { a: 1, b: 2 };
+const k = "b";
+const o = {
+    ...base,
+    c: 3,
+    [k]: 99
+};
+assert(o.a === 1);
+assert(o.b === 99);
+assert(o.c === 3);
+return 0;
+
+//?
+//? test: expression-name-before-static
+//? description: Expression name first then static properties
+//? skip: false
+//? expect: 0
+//? source: ...
+
+const k = "x";
+const o = { [k]: 10, y: 20 };
+assert(o.x === 10);
+assert(o.y === 20);
+return 0;
+
+//?
+//? test: expression-name-nested-object
+//? description: Nested object value under expression property name
+//? skip: false
+//? expect: 0
+//? source: ...
+
+const k = "child";
+const o = { [k]: { inner: 5 } };
+assert(o.child.inner === 5);
+assert(o[k].inner === 5);
+return 0;
+
+//?
+//? test: expression-name-expression-value
+//? description: Both name and value are expressions
+//? skip: false
+//? expect: 0
+//? source: ...
+
+const k = "sum";
+const o = { [k]: 1 + 2 };
+assert(o.sum === 3);
+return 0;
+
+//?
+//? test: expression-name-matches-assign
+//? description: Object value form matches obj[k] = v assignment
+//? skip: false
+//? expect: 0
+//? source: ...
+
+const k = "field";
+const via_assign = {};
+via_assign[k] = "v";
+const via_literal = { [k]: "v" };
+assert(via_assign[k] === via_literal[k]);
+assert(via_literal.field === "v");
+return 0;
+
+//?
+//? test: literal-meta-still-sideband
+//? description: Literal _meta_ still installs sideband (not a normal property)
+//? skip: false
+//? expect: 0
+//? source: ...
+
+const o = {
+    _meta_: { objectId: "x1" },
+    a: 1
+};
+assert(o.a === 1);
+assert(property_exists(o, "_meta_") === false);
+return 0;
+
+//?
+//? test: expression-name-meta-string-is-property
+//? description: Computed name _meta_ is a normal property (not sideband)
+//? skip: false
+//? expect: 0
+//? source: ...
+
+const k = "_meta_";
+const o = { [k]: 123 };
+assert(property_exists(o, "_meta_") === true);
+assert(o["_meta_"] === 123);
+return 0;

--- a/src/afw/value/afw_value.c
+++ b/src/afw/value/afw_value.c
@@ -975,6 +975,10 @@ afw_value_register_core_value_infs(afw_xctx_t *xctx)
         &afw_value_object_expression_inf, xctx);
 
     afw_environment_register_value_inf(
+        &afw_value_object_construct_inf.rti.implementation_id,
+        &afw_value_object_construct_inf, xctx);
+
+    afw_environment_register_value_inf(
         &afw_value_reference_by_key_inf.rti.implementation_id,
         &afw_value_reference_by_key_inf, xctx);
 

--- a/src/afw/value/afw_value.h
+++ b/src/afw/value/afw_value.h
@@ -317,6 +317,12 @@ afw_value_object_expression_inf;
 
 
 
+/** @brief Value object construct inf (expression property names). */
+AFW_DECLARE_CONST_DATA(afw_value_inf_t)
+afw_value_object_construct_inf;
+
+
+
 /** @brief Value qualified_variable_reference inf. */
 AFW_DECLARE_CONST_DATA(afw_value_inf_t)
 afw_value_qualified_variable_reference_inf;
@@ -650,6 +656,20 @@ afw_value_is_fully_evaluated(
 ( \
     (A_VALUE) && \
     (A_VALUE)->inf == &afw_value_object_expression_inf \
+)
+
+
+
+/**
+ * @brief Macro to determine if value is an object construct
+ *     (ordered entries; expression property names).
+ * @param A_VALUE to test.
+ * @return boolean result.
+ */
+#define afw_value_is_object_construct(A_VALUE) \
+( \
+    (A_VALUE) && \
+    (A_VALUE)->inf == &afw_value_object_construct_inf \
 )
 
 
@@ -1436,6 +1456,24 @@ AFW_DEFINE(const afw_value_t *)
 afw_value_create_object_expression(
     const afw_compile_value_contextual_t *contextual,
     const afw_object_t *internal,
+    const afw_pool_t *p, afw_xctx_t *xctx);
+
+
+
+/**
+ * @brief Create an object construct value (expression property names).
+ * @param contextual information for the expression.
+ * @param entries head of ordered entry list (pool-owned).
+ * @param meta optional meta object from literal `_meta_` or NULL.
+ * @param p pool used for value.
+ * @param xctx of caller.
+ * @return Created afw_value_t.
+ */
+AFW_DEFINE(const afw_value_t *)
+afw_value_create_object_construct(
+    const afw_compile_value_contextual_t *contextual,
+    const afw_value_object_construct_entry_t *entries,
+    const afw_object_t *meta,
     const afw_pool_t *p, afw_xctx_t *xctx);
 
 

--- a/src/afw/value/afw_value_internal.h
+++ b/src/afw/value/afw_value_internal.h
@@ -488,6 +488,64 @@ struct afw_value_object_expression_s {
 
 
 
+/** @brief Kind of one entry in an object_construct value. */
+typedef enum {
+    /** Static property name + value expression. */
+    afw_value_object_construct_entry_static,
+
+    /** Expression property name + value expression. */
+    afw_value_object_construct_entry_name_expr,
+
+    /** Spread of an object expression (...obj). */
+    afw_value_object_construct_entry_spread
+} afw_value_object_construct_entry_type_t;
+
+
+
+/** @brief One ordered entry for object_construct. */
+struct afw_value_object_construct_entry_s {
+    afw_value_object_construct_entry_type_t type;
+
+    /** Static name when type is static; otherwise NULL. */
+    const afw_utf8_t *static_name;
+
+    /** Name expression when type is name_expr; otherwise NULL. */
+    const afw_value_t *name_expr;
+
+    /** Value expression for static / name_expr; NULL for spread. */
+    const afw_value_t *value;
+
+    /** Object expression when type is spread; otherwise NULL. */
+    const afw_value_t *spread_expr;
+
+    /** Next entry or NULL. */
+    afw_value_object_construct_entry_t *next;
+};
+
+
+
+/** @brief struct for object construct value (expression property names). */
+struct afw_value_object_construct_s {
+    /* Value inf union with afw_value_t pub to reduce casting needed. */
+    union {
+        const afw_value_inf_t *inf;
+        afw_value_t pub;
+    };
+
+    const afw_compile_value_contextual_t *contextual;
+
+    /** Head of ordered entry list. */
+    const afw_value_object_construct_entry_t *entries;
+
+    /**
+     * Optional meta object from a literal `_meta_` property in source.
+     * Installed on the evaluated object after properties are set.
+     */
+    const afw_object_t *meta;
+};
+
+
+
 /** @brief Struct for reference_by_key value. */
 struct afw_value_reference_by_key_s {
     /* Value inf union with afw_value_t pub to reduce casting needed. */

--- a/src/afw/value/afw_value_object_construct.c
+++ b/src/afw/value/afw_value_object_construct.c
@@ -1,0 +1,266 @@
+// See the 'COPYING' file in the project root for licensing information.
+/*
+ * Interface afw_value Implementation for Object Construct
+ *
+ * Copyright (c) 2010-2024 Clemson University
+ *
+ */
+
+/**
+ * @file afw_value_object_construct.c
+ * @brief afw_value implementation for object construct (expression property names)
+ */
+
+#include "afw_internal.h"
+
+
+#define impl_afw_value_optional_release NULL
+#define impl_afw_value_clone_or_reference NULL
+
+#define impl_afw_value_get_evaluated_meta \
+    afw_value_internal_get_evaluated_meta_for_object
+
+#define impl_afw_value_get_evaluated_metas \
+    afw_value_internal_get_evaluated_metas_for_object
+
+#define impl_afw_value_create_iterator NULL
+
+/* Declares and rti/inf defines for interface afw_value */
+#define AFW_IMPLEMENTATION_ID "object_construct"
+#define AFW_IMPLEMENTATION_INF_SPECIFIER AFW_DEFINE_CONST_DATA
+#define AFW_IMPLEMENTATION_INF_LABEL afw_value_object_construct_inf
+#include "afw_value_impl_declares.h"
+
+
+/* Create function for object construct value. */
+AFW_DEFINE(const afw_value_t *)
+afw_value_create_object_construct(
+    const afw_compile_value_contextual_t *contextual,
+    const afw_value_object_construct_entry_t *entries,
+    const afw_object_t *meta,
+    const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    afw_value_object_construct_t *self;
+
+    self = afw_pool_calloc(p, sizeof(afw_value_object_construct_t), xctx);
+    self->inf = &afw_value_object_construct_inf;
+    self->contextual = contextual;
+    self->entries = entries;
+    self->meta = meta;
+    return &self->pub;
+}
+
+
+/*
+ * Resolve a property name value to utf8 (same idea as reference_by_key assign).
+ */
+static const afw_utf8_t *
+impl_name_from_value(
+    const afw_value_t *name_value,
+    const afw_pool_t *p,
+    afw_xctx_t *xctx)
+{
+    const afw_utf8_t *name;
+
+    if (!name_value) {
+        AFW_THROW_ERROR_Z(evaluate,
+            "Object property name expression evaluated to undefined",
+            xctx);
+    }
+    if (afw_value_is_string(name_value)) {
+        return &((const afw_value_string_t *)name_value)->internal;
+    }
+    name = afw_value_as_utf8(name_value, p, xctx);
+    if (!name) {
+        AFW_THROW_ERROR_Z(evaluate,
+            "Object property name expression must produce a string",
+            xctx);
+    }
+    return name;
+}
+
+
+/*
+ * Implementation of method optional_evaluate for interface afw_value.
+ */
+const afw_value_t *
+impl_afw_value_optional_evaluate(
+    const afw_value_t *instance,
+    const afw_pool_t *p,
+    afw_xctx_t *xctx)
+{
+    const afw_value_object_construct_t *self =
+        (const afw_value_object_construct_t *)instance;
+    const afw_value_object_construct_entry_t *e;
+    const afw_object_t *to;
+    const afw_object_t *from;
+    const afw_value_t *v;
+    const afw_value_t *name_v;
+    const afw_utf8_t *property_name;
+    const afw_iterator_t *iterator;
+    const afw_compile_value_contextual_t *saved_contextual;
+
+    saved_contextual = xctx->error->contextual;
+    xctx->error->contextual = self->contextual;
+
+    to = afw_object_create_unmanaged(p, xctx);
+
+    for (e = self->entries; e; e = e->next) {
+        if (e->type == afw_value_object_construct_entry_spread) {
+            v = afw_value_evaluate(e->spread_expr, p, xctx);
+            if (!v || !afw_value_is_object(v)) {
+                AFW_THROW_ERROR_Z(evaluate,
+                    "Object spread must evaluate to an object",
+                    xctx);
+            }
+            from = ((const afw_value_object_t *)v)->internal;
+            for (iterator = NULL;;) {
+                v = afw_object_get_next_property(from, &iterator,
+                    &property_name, xctx);
+                if (!v) {
+                    break;
+                }
+                v = afw_value_evaluate(v, p, xctx);
+                afw_object_set_property(to, property_name, v, xctx);
+            }
+        }
+        else if (e->type == afw_value_object_construct_entry_name_expr) {
+            name_v = afw_value_evaluate(e->name_expr, p, xctx);
+            property_name = impl_name_from_value(name_v, p, xctx);
+            v = afw_value_evaluate(e->value, p, xctx);
+            afw_object_set_property(to, property_name, v, xctx);
+        }
+        else {
+            /* static */
+            v = afw_value_evaluate(e->value, p, xctx);
+            afw_object_set_property(to, e->static_name, v, xctx);
+        }
+    }
+
+    if (self->meta) {
+        afw_object_meta_set_meta_object(to, self->meta, xctx);
+    }
+
+    xctx->error->contextual = saved_contextual;
+    return afw_value_create_unmanaged_object(to, p, xctx);
+}
+
+
+/*
+ * Implementation of method get_data_type for interface afw_value.
+ */
+const afw_data_type_t *
+impl_afw_value_get_data_type(
+    const afw_value_t *instance,
+    afw_xctx_t *xctx)
+{
+    return afw_data_type_object;
+}
+
+
+/*
+ * Implementation of method compiler_listing for interface afw_value.
+ */
+void
+impl_afw_value_produce_compiler_listing(
+    const afw_value_t *instance,
+    const afw_writer_t *writer,
+    afw_xctx_t *xctx)
+{
+    const afw_value_object_construct_t *self =
+        (const afw_value_object_construct_t *)instance;
+    const afw_value_object_construct_entry_t *e;
+
+    afw_value_compiler_listing_begin_value(writer, instance,
+        self->contextual, xctx);
+    afw_writer_write_z(writer, ": [", xctx);
+    afw_writer_write_eol(writer, xctx);
+    afw_writer_increment_indent(writer, xctx);
+
+    AFW_VALUE_COMPILER_LISTING_IF_NOT_LIMIT_EXCEEDED
+    for (e = self->entries; e; e = e->next) {
+        if (e->type == afw_value_object_construct_entry_spread) {
+            afw_writer_write_z(writer, "spread ", xctx);
+            afw_value_compiler_listing_value(e->spread_expr, writer, xctx);
+        }
+        else if (e->type == afw_value_object_construct_entry_name_expr) {
+            afw_writer_write_z(writer, "property [", xctx);
+            afw_value_compiler_listing_value(e->name_expr, writer, xctx);
+            afw_writer_write_z(writer, "] ", xctx);
+            afw_value_compiler_listing_value(e->value, writer, xctx);
+        }
+        else {
+            afw_writer_write_z(writer, "property ", xctx);
+            afw_writer_write_utf8(writer, e->static_name, xctx);
+            afw_writer_write_z(writer, " ", xctx);
+            afw_value_compiler_listing_value(e->value, writer, xctx);
+        }
+    }
+
+    afw_writer_decrement_indent(writer, xctx);
+    afw_writer_write_z(writer, "]", xctx);
+    afw_writer_write_eol(writer, xctx);
+}
+
+
+/*
+ * Implementation of method decompile for interface afw_value.
+ */
+void
+impl_afw_value_decompile(
+    const afw_value_t *instance,
+    const afw_writer_t *writer,
+    afw_xctx_t *xctx)
+{
+    const afw_value_object_construct_t *self =
+        (const afw_value_object_construct_t *)instance;
+    const afw_value_object_construct_entry_t *e;
+    afw_boolean_t first;
+
+    afw_writer_write_z(writer, "{", xctx);
+    first = true;
+    for (e = self->entries; e; e = e->next) {
+        if (!first) {
+            afw_writer_write_z(writer, ", ", xctx);
+        }
+        first = false;
+        if (e->type == afw_value_object_construct_entry_spread) {
+            afw_writer_write_z(writer, "...", xctx);
+            afw_value_decompile_value(e->spread_expr, writer, xctx);
+        }
+        else if (e->type == afw_value_object_construct_entry_name_expr) {
+            afw_writer_write_z(writer, "[", xctx);
+            afw_value_decompile_value(e->name_expr, writer, xctx);
+            afw_writer_write_z(writer, "]: ", xctx);
+            afw_value_decompile_value(e->value, writer, xctx);
+        }
+        else {
+            /* Quoted string key is always valid Adaptive object syntax. */
+            afw_data_type_write_as_expression(
+                afw_data_type_string, writer, e->static_name, xctx);
+            afw_writer_write_z(writer, ": ", xctx);
+            afw_value_decompile_value(e->value, writer, xctx);
+        }
+    }
+    afw_writer_write_z(writer, "}", xctx);
+}
+
+
+/*
+ * Implementation of method get_info for interface afw_value.
+ */
+void
+impl_afw_value_get_info(
+    const afw_value_t *instance,
+    afw_value_info_t *info,
+    const afw_pool_t *p,
+    afw_xctx_t *xctx)
+{
+    const afw_value_object_construct_t *self =
+        (const afw_value_object_construct_t *)instance;
+
+    afw_memory_clear(info);
+    info->value_inf_id = &instance->inf->rti.implementation_id;
+    info->contextual = self->contextual;
+    info->optimized_value = instance;
+}

--- a/src/afw/value/afw_value_object_expression.c
+++ b/src/afw/value/afw_value_object_expression.c
@@ -94,7 +94,7 @@ impl_afw_value_get_data_type(
 /*
  * Implementation of method compiler_listing for interface afw_value.
  *
- * Walk unevaluated property values on the compile-time object bag. Do not use
+ * Walk unevaluated property values on the compile-time object. Do not use
  * afw_value_as_object() / data_type object listing here — that evaluates the
  * expression (fails for free variables during compile listing).
  */

--- a/src/afw/xctx/afw_xctx.h
+++ b/src/afw/xctx/afw_xctx.h
@@ -827,7 +827,7 @@ afw_xctx_qualifier_stack_qualifiers_object_push(
 /**
  * @brief Push qualifier on to stack.
  * @param qualifier or NULL.
- * @param qualifier_object optional object bag (may be NULL).
+ * @param qualifier_object optional object of properties (may be NULL).
  * @param secure access to this qualifier is allowed.
  * @param get_cb get variable by name (hot path).
  * @param contribute_cb contribute variables into a snapshot object (required;
@@ -905,7 +905,7 @@ afw_xctx_qualifier_stack_qualifier_object_push(
  * @return New memory object (never a live view), or NULL if no matching
  *    visible stack entry for that qualifier (nullish to scripts). Walks most
  *    recent → older; every matching visible entry contributes (most recent
- *    wins per property name). Empty bag after contribute is still an object.
+ *    wins per property name). Empty object after contribute is still an object.
  */
 AFW_DEFINE(const afw_object_t *)
 afw_xctx_qualifier_object_create(

--- a/src/afw/xctx/afw_xctx_qualifier_object.c
+++ b/src/afw/xctx/afw_xctx_qualifier_object.c
@@ -51,7 +51,7 @@ impl_entry_visible_for_snapshot(
  * Walk most recent → older. Every matching visible entry contributes into one
  * accumulator (contribute_cb should leave existing property names alone so the
  * most recent definition wins). Returns NULL if no matching visible entry
- * (nullish to scripts). Empty bag after contribute is still an object, not NULL.
+ * (nullish to scripts). Empty object after contribute is still an object, not NULL.
  */
 AFW_DEFINE(const afw_object_t *)
 afw_xctx_qualifier_object_create(

--- a/whats_new.md
+++ b/whats_new.md
@@ -21,6 +21,7 @@ In-tree extensions and the `afw` / `afwfcgi` commands built with the same `./afw
 | Area | What changed |
 |------|----------------|
 | **Object / array helpers (#55)** | `keys` / `values` / `entries`, `at`, `push`/`pop`/`shift`/`unshift`, `splice`, `freeze`, `every`/`some` — **recompile** out-of-tree commands/extensions |
+| **Expression property names (#38)** | Object values may use `{ [expression]: value }` (same idea as `obj[expr]` get/set) |
 | **Qualified variables** | `qualifier()` / `qualifiers()` snapshots (issue **#9**); multi-frame **`::` get** uses first **defining** frame (same as snapshots) |
 | **Retrieve arrays** | Optional **`maxObjects`** on materializing `retrieve_objects` (default **100**; issue **#49**) |
 | **Admin / JS client** | `AfwModel` passes **`maxObjects: 0`** for full metadata catalogs so admin loads after #49 |
@@ -95,6 +96,36 @@ Language Reference: **Objects and Arrays**
 (`src/afw/doc/reference/language/objects-and-arrays.xml`), linked from the
 Language index. Function Reference pages for each function are generated from
 metadata when docs are built.
+
+---
+
+## Expression property names in object values (issue #38)
+
+**Issue #38** on `mgg-develop` (branch `issue-#38`).
+
+In an **object value**, a property name may be an **expression in square brackets**, not only an identifier or string literal. The expression is evaluated when the object value is evaluated; the result is used as the property name (a string). This matches **`obj[expression]`** get and assignment on an existing object.
+
+```adaptive
+const col = "Customer Name";
+const n = 2;
+const row = {
+    id: 1,
+    [col]: "Ada",
+    ["col " + string(n)]: 42,
+    ...defaults
+};
+assert(row["Customer Name"] === "Ada");
+assert(row["col 2"] === 42);
+```
+
+### Notes
+
+- **Variables** remain lexical identifiers; only **property names** can be any string (via a string literal or a bracket expression).
+- Pure **JSON** object text still allows only the usual JSON property-name forms (no expression brackets).
+- A **literal** `_meta_: { … }` property in source still installs **sideband meta** (not a normal property). A **bracket** name that evaluates to `"_meta_"` sets a **normal** property under that name — map content types that reserve `"_meta_"` on the wire are a separate topic (issue **#138**).
+- Handbook: Language Reference **Objects and Arrays** and **Features** (working with objects).
+
+Tests: `src/afw/tests/language/script/object_expression_names.as`.
 
 ---
 

--- a/whats_new.md
+++ b/whats_new.md
@@ -799,7 +799,7 @@ Tracked suites under `src/*/tests` are permanent regression assets. `afwdev test
 | `qualifier` / `qualifiers` snapshots | #9 | #129 (includes admin `maxObjects: 0` client fix) |
 | Permanent `src/*/tests` regression assets | — | #121 (docs only) |
 | `afw --allow` + YAML block strings / integers | #14 | — (feature earlier; regression tests on `mgg-develop`) |
-| Expression property names in object values | #38 | — (branch `issue-#38`) |
+| Expression property names in object values | #38 | #139 |
 | Meta on the wire / reserved `"_meta_"` (design) | #138 | — (open; not required for #38) |
 
 ---

--- a/whats_new.md
+++ b/whats_new.md
@@ -799,6 +799,8 @@ Tracked suites under `src/*/tests` are permanent regression assets. `afwdev test
 | `qualifier` / `qualifiers` snapshots | #9 | #129 (includes admin `maxObjects: 0` client fix) |
 | Permanent `src/*/tests` regression assets | — | #121 (docs only) |
 | `afw --allow` + YAML block strings / integers | #14 | — (feature earlier; regression tests on `mgg-develop`) |
+| Expression property names in object values | #38 | — (branch `issue-#38`) |
+| Meta on the wire / reserved `"_meta_"` (design) | #138 | — (open; not required for #38) |
 
 ---
 


### PR DESCRIPTION
## Summary

- Support Adaptive Script object values of the form `{ [expression]: value }` (same string-key idea as `obj[expression]` get/set).
- New `object_construct` value path for ordered static names, expression names, and spreads; existing static-only / spread-only paths unchanged when no expression names appear.
- Handbook updates (AFW-only wording), `whats_new.md`, regression tests, and design pads for #38 and related meta-on-the-wire work (#138, not in this PR).

## Details

Property **names** in object values may be an identifier, a string literal, or a bracketed expression. Variable/parameter names remain lexical identifiers.

Literal `_meta_: { … }` still installs sideband meta. A bracket name that evaluates to `"_meta_"` sets a normal property (wire collision with map content types is tracked in #138).

## Test plan

- [x] `./afwdev build --cdev` (during development)
- [x] `afwdev test` focused on `object_expression_names` (11 tests)
- [x] `./afwdev build --fulldev`
- [x] `afwdev test -j --env-mode valgrind` (maintainer full verify)

## Related

- Closes #38
- See also #138 (meta on the wire; out of scope here)