### PR TITLE
issue #140 follow-up: call-site spread, Pattern keys, catch decompile, types

### DIFF
--- a/designs/README.md
+++ b/designs/README.md
@@ -22,7 +22,7 @@ Per-**issue** or per-**theme** working notes: why, options, footguns, parked ide
 | [`issue-18-decompile-status.md`](issue-18-decompile-status.md) | **#18** decompile/recompile status |
 | [`issue-38-expression-property-names.md`](issue-38-expression-property-names.md) | **#38** — `[expr]: value` in object values |
 | [`issue-138-meta-on-the-wire.md`](issue-138-meta-on-the-wire.md) | **#138** — `"_meta_"` wire / options / rich types |
-| [`compile-optimize-notes.md`](compile-optimize-notes.md) | Future compile-time optimize; #18 follow-ups (param/catch Pattern sugar, binding sites) |
+| [`compile-optimize-notes.md`](compile-optimize-notes.md) | Future compile-time optimize; #140 Pattern/param/catch notes (mostly landed) + binding sites |
 
 ## Conventions
 

--- a/designs/compile-optimize-notes.md
+++ b/designs/compile-optimize-notes.md
@@ -92,17 +92,17 @@ Do **not** conflate `process::args` (#74) with function-parameter rest or param 
 
 **GitHub:** [#140](https://github.com/afw-org/afw/issues/140) (enhancement; assignee mike000000000).
 
-**Status (issue-#140):** Surface Patterns on function/lambda params + catch; shared runtime empty-rest / missing→undefined fixes; `assignment_type_parameter`; tests in `language/script/param_destructure.as` + decompile fidelity; handbook/whats_new; catch Pattern uses `StatementList(..., use_existing_current_block)`.
+**Status:** Core landed on `issue-#140` / PR **#141** (params + catch Patterns, Expression defaults, bind order). Follow-up on `Issue-#140-followup`: call-site `f(...arr)`, string/computed Pattern keys, catch Pattern decompile d1==d2, type syntax on formals/leaves, TS-shaped confidence tests. Tests: `language/script/param_destructure.as`, `language/list/spread.as`, decompile fidelity / pragma.
 
 ### Cleanup notes for a later major pass (do not block #140)
 
 | Item | Notes |
 |------|--------|
 | **Destructure runtime** | Still in `afw_function_compiler_script.c` as static helpers; consider a small public bind API if more sites appear. |
-| **Object Pattern property names** | Identifier-only; string / computed keys not done (near #38). |
-| **Catch identifier vs Pattern** | Identifier still uses StatementList callback + `symbol_reference` (try decompile assumes that). Pattern opens block early + AssignmentTarget + `StatementList(..., use_existing_current_block)`. **Decompile of Pattern catch is not d1==d2 stable** — try emits binding as 4th arg while identifier path embeds `#assignment_target` inside the catch `#block`. Unify try decompile for Pattern (mirror identifier: binding first in block + reparseable 4th arg) in a later pass. |
+| **Object Pattern property names** | **Done** for string + `[expr]` keys (follow-up). Residual: exotic edge cases only. |
+| **Catch identifier vs Pattern** | Identifier: StatementList callback + `symbol_reference`. Pattern: early block + AssignmentTarget + `use_existing_current_block`. **Decompile d1==d2 for Pattern catch done** (embed bind in catch `#block`; execute uses first-statement bind when no argv[4]). |
 | **`#script_function` Pattern vs body `{`/`[`** | Speculative parse then cursor restore; advanced pragma only. |
-| **Call-site `f(...arr)`** | Separate feature; definition-side rest only. |
+| **Call-site `f(...arr)`** | **Done** (follow-up). |
 | **argv / parameter_number** | Documented in `afw_function.h` + `afw_value_call_args_s` + call_script_function bind comments (1-based params, `argv[0]` = function). |
 
 ### TS-shaped confidence (ranked high → low)
@@ -134,48 +134,33 @@ function f([a, b], {x, y}) { … }
 // or AFW-flavored sugar along the same idea
 ```
 
-Primary use: ES/TS “options object” idiom without a manual intermediate bind:
+Primary use landed: ES/TS “options object” idiom without a manual intermediate bind:
 
 ```text
-// Wanted sugar
 function connect({ host, port = 443 } = {}) { … }
-
-// Today
-function connect(opts) {
-    const { host, port = 443 } = opts ?? {};
-    …
-}
+// desugars to AFW’s existing Pattern / assignment_target model
+// (same compiled form family as const { host, port = 443 } = …)
 ```
 
-Intent: **syntax sugar** that desugars into AFW’s existing model (param symbols + destructure assign into locals / the same compiled form we already have for `const [a,b] = …`), not a parallel binding system.
+Intent remains **syntax sugar** into one shared binding story, not a parallel system.
 
-Implications when we touch this area later:
+Invariants after landing:
 
-- Pattern machinery for `#assignment_target` and Script targets should stay **shareable** with param patterns (and catch if we add it).
-- `#script_function` decompile/pragma may need to grow beyond bare param **names** once param patterns exist (or keep names as the desugared form and only surface sugar on `function (…)`) — decide then; prefer one binding story.
-- Stay **AFW Script** (explicit, metadata-friendly), not a full ES port; sugar only where it maps cleanly.
-- Arrow functions: not required for this work (explicit non-goal unless product wants them later).
+- Pattern machinery stays **shared** across `let`/`const`, assignment, for heads, params, and catch.
+- `#script_function` decompile/pragma supports Pattern formals (speculative parse vs body `{`/`[`); prefer one binding story if more pragma surface is added.
+- Stay **AFW Script** (explicit, metadata-friendly), not a full ES port.
+- Arrow functions remain an explicit non-goal unless product asks later.
 
-### `catch` binding Pattern (optional follow-on)
+### `catch` binding Pattern (**done** with #140)
 
-EBNF today: `Catch ::= 'catch' ( '(' Identifier ')' )? Statement` — single unqualified name only.
-
-Adaptive always supplies a fixed error shape (`message`, optional `data`), so ES-like:
+EBNF: catch binding may be Identifier **or** list/object Pattern (same as params / `let`).
 
 ```text
 catch ({ message, data }) { … }
+catch ({ message: msg }) { … }
 ```
 
-is the natural sugar; workaround is already fine:
-
-```text
-catch (e) {
-    const { message, data } = e;
-    …
-}
-```
-
-**Priority:** lower than param Patterns. Same desugar idea (hidden name + Pattern assign into the catch block). Catch currently injects the error symbol via a special StatementList callback — any Pattern work must preserve that block/symbol association.
+Identifier path: StatementList callback + `symbol_reference`. Pattern path: early block + AssignmentTarget + `StatementList(..., use_existing_current_block)`. Decompile embeds the bind as the first statement of the catch `#block` so d1==d2 holds; execute uses that first-statement bind when there is no separate argv[4].
 
 ### `#closure_binding`
 

--- a/designs/compile-optimize-notes.md
+++ b/designs/compile-optimize-notes.md
@@ -120,12 +120,12 @@ Goal: Adaptive stays Adaptive, but Patterns/params/catch should not feel awkward
 | **7** | Pattern then `...rest` formal | Normal rest placement | Tests `ts-pattern-then-rest-param` |
 | **8** | Wrong-type destructure error | Fail clearly, not garbage | Tests `ts-wrong-type-array-pattern` |
 | **9** | Optional Pattern without `= {}` | Document Adaptive choice (prefer `= {}`) | Tests `ts-optional-pattern-no-default` |
-| **10** | Catch Pattern decompile d1==d2 | Tooling/Fiddle fidelity, not author syntax | Later (try decompile unify) |
-| **11** | Call-site `f(...arr)` | Common TS; separate feature | Out of #140 |
-| **12** | Computed keys in Pattern `{[k]:x}` | Occasional TS | Near #38 |
-| **13** | Arrow functions | Explicit non-goal (Jeremy) | Out |
-| **14** | ES `arguments` / `#script_function` pragma | Not TS app-author surface | Out / advanced only |
-| **15** | Full TS type-check on Patterns | Compile-time types | #28 later |
+| **10** | Catch Pattern decompile d1==d2 | Tooling/Fiddle fidelity | **Done** (follow-up): try embeds Pattern in catch `#block` |
+| **11** | Call-site `f(...arr)` | Common TS | **Done** (follow-up): expand list_expression markers |
+| **12** | Computed / string keys in Patterns | Occasional TS | **Done** (follow-up): `[expr]: bind`, `"name": bind` |
+| **13** | Arrow functions | Explicit non-goal (Jeremy) | Out (parser FIXME left) |
+| **14** | ES `arguments` / `#script_function` pragma | Not app-author surface | Out / advanced only |
+| **15** | Full TS type-check on Patterns | Compile-time types | Syntax: leaf + whole Pattern `: Type` stored; enforce in #28 |
 
 ECMAScript/TypeScript-style “destruct in the parameter list”, e.g. conceptually:
 

--- a/designs/compile-optimize-notes.md
+++ b/designs/compile-optimize-notes.md
@@ -84,7 +84,7 @@ Inventory of where Adaptive Script binds names, and whether a list/object **Patt
 |------|--------|-------------------|
 | **Process / CLI args as one array** (script body, Node-like `process.argv`) | **Done** (close pending Jeremy) | Jeremy **[#74](https://github.com/afw-org/afw/issues/74)** → `process::args` (+ `programName`, `pid`, …). Secrets path via `afw_crypto` + file/stream; interactive `readpass` never built (asked Jeremy if close is OK without it). |
 | **All call arguments inside a script function** (ES `arguments` object) | Rest param covers common case | Use `function f(...args)` (already supported). No separate ES `arguments` binding unless someone files a real need. |
-| **Call-site spread** `f(...arr)` | Missing | Separate from param Patterns; only definition-side rest exists today. |
+| **Call-site spread** `f(...arr)` | **Done** (follow-up) | list_expression marker + expand at call; see TS-shaped table |
 
 Do **not** conflate `process::args` (#74) with function-parameter rest or param destructure.
 

--- a/designs/compile-optimize-notes.md
+++ b/designs/compile-optimize-notes.md
@@ -105,6 +105,28 @@ Do **not** conflate `process::args` (#74) with function-parameter rest or param 
 | **Call-site `f(...arr)`** | Separate feature; definition-side rest only. |
 | **argv / parameter_number** | Documented in `afw_function.h` + `afw_value_call_args_s` + call_script_function bind comments (1-based params, `argv[0]` = function). |
 
+### TS-shaped confidence (ranked high → low)
+
+Goal: Adaptive stays Adaptive, but Patterns/params/catch should not feel awkward to someone who writes TypeScript. Not full TS/ES parity.
+
+| Rank | Item | Why (TS lens) | Status / action |
+|------|------|---------------|-----------------|
+| **1** | Options object + property/whole defaults | Everyday TS API shape | Done in #141 + tests |
+| **2** | Prior-param defaults `y = x` / Expression defaults | Core TS default semantics | Tests `ts-prior-param-default` |
+| **3** | Object rest on param `{a, ...r}` | Everyday destructure | Tests `ts-object-rest-on-param` |
+| **4** | Required Pattern missing arg → error | Don’t fail open | Tests `ts-required-pattern-missing-arg` |
+| **5** | Catch destructure (+ rename / data) | Structured error handling | Tests `ts-catch-rename-and-data` |
+| **6** | Recursion with Pattern formals | Bind order must stay correct | Tests `ts-recursive-pattern-formal` |
+| **7** | Pattern then `...rest` formal | Normal rest placement | Tests `ts-pattern-then-rest-param` |
+| **8** | Wrong-type destructure error | Fail clearly, not garbage | Tests `ts-wrong-type-array-pattern` |
+| **9** | Optional Pattern without `= {}` | Document Adaptive choice (prefer `= {}`) | Tests `ts-optional-pattern-no-default` |
+| **10** | Catch Pattern decompile d1==d2 | Tooling/Fiddle fidelity, not author syntax | Later (try decompile unify) |
+| **11** | Call-site `f(...arr)` | Common TS; separate feature | Out of #140 |
+| **12** | Computed keys in Pattern `{[k]:x}` | Occasional TS | Near #38 |
+| **13** | Arrow functions | Explicit non-goal (Jeremy) | Out |
+| **14** | ES `arguments` / `#script_function` pragma | Not TS app-author surface | Out / advanced only |
+| **15** | Full TS type-check on Patterns | Compile-time types | #28 later |
+
 ECMAScript/TypeScript-style “destruct in the parameter list”, e.g. conceptually:
 
 ```text

--- a/designs/issue-18-decompile-status.md
+++ b/designs/issue-18-decompile-status.md
@@ -25,10 +25,10 @@
 
 ## Out of scope on this branch
 
-| Item | Where parked |
-|------|----------------|
-| Compile-time **optimize** / constant fold pure calls | `designs/compile-optimize-notes.md` |
-| Function **parameter-list destructure sugar** (+ catch optional; binding-site inventory) | **[#140](https://github.com/afw-org/afw/issues/140)**; notes in `designs/compile-optimize-notes.md` |
+| Item | Where parked / status |
+|------|------------------------|
+| Compile-time **optimize** / constant fold pure calls | Still future — `designs/compile-optimize-notes.md` |
+| Function **parameter-list / catch Pattern sugar** (+ call-site `f(...arr)`, computed/string Pattern keys) | **Done** — [#140](https://github.com/afw-org/afw/issues/140) / PR [#141](https://github.com/afw-org/afw/pull/141); follow-up branch `Issue-#140-followup`. Pad: `designs/compile-optimize-notes.md` |
 | Fake recompile of **runtime** `#closure_binding` | known **reject** with clear error |
 | Recompile of **C-side** `#function_thunk` | known **reject** with clear error |
 
@@ -81,7 +81,7 @@ Do not hand-edit `generated/`.
 
 ## Suggested next moves
 
-1. **PR** `issue-#18` → mgg-develop / develop (after policy + fulldev/valgrind if multi-area PR).
+1. **PR** `issue-#18` → mgg-develop / develop if not already merged (after policy + fulldev/valgrind if multi-area PR).
 2. **Handbook** pages for the three print paths + optional advanced pragma note (see chat).
 3. More fidelity coverage if gaps appear.
-4. Later branches: optimize, param destructure sugar (see binding-site notes in `compile-optimize-notes.md`), type-check prep.
+4. Later: compile-time **optimize** (`compile-optimize-notes.md`); full **type-check** on Pattern annotations (#28). Param/catch Pattern sugar and call-site spread are landed under #140.

--- a/src/afw/compile/afw_compile_internal.h
+++ b/src/afw/compile/afw_compile_internal.h
@@ -525,10 +525,17 @@ struct afw_compile_internal_assignment_property_s {
     const afw_value_type_t *type;
     afw_boolean_t is_rename;
     union {
-        /* If is_rename is true. */
+        /*
+         * If is_rename is true: static property_name and/or computed
+         * property_name_expr (issue #140 / #38-style [expr] keys). Exactly
+         * one of property_name / property_name_expr is non-NULL.
+         * property_name_was_string: decompile should quote static name.
+         */
         struct {
             const afw_utf8_t *property_name;
+            const afw_value_t *property_name_expr;
             const afw_compile_assignment_element_t *assignment_element;
+            afw_boolean_t property_name_was_string;
         };
         /* If is_rename is false. */
         struct {

--- a/src/afw/compile/afw_compile_parse_assignment_target.c
+++ b/src/afw/compile/afw_compile_parse_assignment_target.c
@@ -185,10 +185,11 @@ afw_compile_parse_AssignmentObjectDestructureTarget(
  *
  * AssignmentProperty ::=
  *    ( PropertyName ('=' Expression )? ) |
- *    ( PropertyName ( ':' AssignmentElement )? )
+ *    ( PropertyName ( ':' AssignmentElement )? ) |
+ *    ( String ( ':' AssignmentElement ) ) |
+ *    ( '[' Expression ']' ':' AssignmentElement )
  *
  *<<<ebnf*/
-/* Note: Token identifier is already consumed and passed as parameter. */
 AFW_DEFINE_INTERNAL(afw_compile_assignment_property_t *)
 afw_compile_parse_AssignmentProperty(
     afw_compile_parser_t *parser,
@@ -197,25 +198,50 @@ afw_compile_parse_AssignmentProperty(
     afw_compile_assignment_property_t *ap;
     const afw_compile_value_contextual_t *contextual;
     const afw_utf8_t *identifier;
+    const afw_value_t *name_expr;
 
-/*
-    if (afw_compile_token_is(identifier)) {
-        name = parser->token->identifier_name;
-    }
-    else if (afw_compile_token_is(integer)) {
-        name = afw_number_integer_to_utf8(
-            parser->token->integer,
-            parser->p, parser->xctx);
-    }
-    else {
-        AFW_COMPILE_THROW_ERROR_Z("Expecting property name");
-    }
- */
     ap = afw_pool_calloc_type(parser->p,
         afw_compile_assignment_property_t, parser->xctx);
     afw_compile_get_token();
 
-    /* Get property name */
+    /* Computed property name: [ Expression ] : AssignmentElement */
+    if (afw_compile_token_is(open_bracket)) {
+        name_expr = afw_compile_parse_Expression(parser);
+        afw_compile_get_token();
+        if (!afw_compile_token_is(close_bracket)) {
+            AFW_COMPILE_THROW_ERROR_Z("Expecting ']' after computed property name");
+        }
+        afw_compile_get_token();
+        if (!afw_compile_token_is(colon)) {
+            AFW_COMPILE_THROW_ERROR_Z(
+                "Expecting ':' after computed property name in destructure");
+        }
+        ap->is_rename = true;
+        ap->property_name = NULL;
+        ap->property_name_expr = name_expr;
+        ap->assignment_element = afw_compile_parse_AssignmentElement(
+            parser, assignment_type);
+        return ap;
+    }
+
+    /* String property name: "name" : AssignmentElement */
+    if (afw_compile_token_is(utf8_string)) {
+        identifier = parser->token->string;
+        afw_compile_get_token();
+        if (!afw_compile_token_is(colon)) {
+            AFW_COMPILE_THROW_ERROR_Z(
+                "String property name in destructure requires ':' binding");
+        }
+        ap->is_rename = true;
+        ap->property_name = identifier;
+        ap->property_name_expr = NULL;
+        ap->property_name_was_string = true;
+        ap->assignment_element = afw_compile_parse_AssignmentElement(
+            parser, assignment_type);
+        return ap;
+    }
+
+    /* Identifier property name */
     if (!afw_compile_token_is_unqualified_identifier()) {
         AFW_COMPILE_THROW_ERROR_Z("Expecting PropertyName");
     }
@@ -226,11 +252,13 @@ afw_compile_parse_AssignmentProperty(
     if (afw_compile_token_is(colon)) {
         ap->is_rename = true;
         ap->property_name = identifier;
+        ap->property_name_expr = NULL;
+        ap->property_name_was_string = false;
         ap->assignment_element = afw_compile_parse_AssignmentElement(
             parser, assignment_type);
     }
 
-    /* ( PropertyName ( '=' Expression )? ) */
+    /* ( PropertyName ( '=' Expression )? ) shorthand bind */
     else {
         contextual = afw_compile_create_contextual_to_cursor(
             parser->token->token_source_offset);

--- a/src/afw/compile/afw_compile_parse_expression.c
+++ b/src/afw/compile/afw_compile_parse_expression.c
@@ -606,22 +606,14 @@ afw_compile_parse_FunctionSignature(
                 afw_compile_reuse_token();
             }
 
-            /* Optional type (simple name params; Pattern leaves typed in Pattern). */
-            if (!param->assignment_target) {
-                param->type = afw_compile_parse_OptionalType(parser, false);
-                if (symbol && param->type) {
-                    afw_memory_copy(&symbol->type, param->type);
-                }
-            }
-            else {
-                /* Patterns: optional whole-arg type after Pattern not supported. */
-                afw_compile_get_token();
-                if (afw_compile_token_is(colon)) {
-                    AFW_COMPILE_THROW_ERROR_Z(
-                        "Type annotation after a parameter Pattern is not "
-                        "supported; annotate Pattern leaves instead");
-                }
-                afw_compile_reuse_token();
+            /*
+             * Optional type: simple names and whole Pattern formals
+             * (whole-arg type is stored for future compile-time check; leaves
+             * may also carry types via Pattern binding syntax).
+             */
+            param->type = afw_compile_parse_OptionalType(parser, false);
+            if (symbol && param->type) {
+                afw_memory_copy(&symbol->type, param->type);
             }
 
             /* Push param on stack. */
@@ -791,10 +783,15 @@ afw_compile_parse_Lambda(afw_compile_parser_t *parser)
 
 /*ebnf>>>
  *
- * Parameters ::= '(' Expression (',' Expression)*')'
+ * Parameters ::= '('
+ *     ( ( Expression | ( '...' Expression ) )
+ *       ( ',' ( Expression | ( '...' Expression ) ) )* )?
+ *   ')'
  *
  *#
  *# Denotes a parameter list without first parameter (method style call).
+ *# Call-site spread (...expr) is wrapped as list_expression so call
+ *# evaluation can expand the array into separate arguments (issue #140).
  *#
  * ParametersExceptFirst ::= Parameters
  *
@@ -805,7 +802,10 @@ afw_compile_parse_Parameters(
     afw_compile_args_t *args)
 {
     const afw_value_t *value;
+    const afw_value_t *spread_internal;
+    afw_size_t spread_offset;
     afw_boolean_t had_value;
+    afw_boolean_t is_spread;
 
     /* Starts with '('. */
     afw_compile_get_token();
@@ -829,9 +829,26 @@ afw_compile_parse_Parameters(
             continue;
         }
 
-        afw_compile_reuse_token();
+        is_spread = false;
+        if (afw_compile_token_is(ellipsis)) {
+            is_spread = true;
+            afw_compile_save_offset(spread_offset);
+        }
+        else {
+            afw_compile_reuse_token();
+        }
 
         value = afw_compile_parse_Expression(parser);
+        if (is_spread) {
+            /*
+             * Reuse list_expression as the call-site spread marker: evaluate
+             * to an array, then call machinery expands elements into argv.
+             */
+            spread_internal = value;
+            value = afw_value_create_array_expression(
+                afw_compile_create_contextual_to_cursor(spread_offset),
+                spread_internal, parser->p, parser->xctx);
+        }
         afw_compile_args_add_value(args, value);
 
         had_value = true;

--- a/src/afw/doc/reference/language/features.xml
+++ b/src/afw/doc/reference/language/features.xml
@@ -107,6 +107,17 @@ try {
 } catch ({ message }) {
     print(message);
 }]]></code>
+    <header>Functions and parameters</header>
+    <paragraph>
+        Function and lambda parameters may be a simple name or the same
+        list/object <literal>Pattern</literal> used in <literal>let</literal> /
+        <literal>const</literal> (holes, defaults, rest, rename, nesting,
+        string keys, and computed keys). Parameter defaults may be any
+        Expression. At a call site, <literal>f(...array)</literal> expands an
+        array into separate arguments (in addition to definition-side
+        <literal>...rest</literal> formals). See the Language Reference
+        Function statement for examples.
+    </paragraph>
     <header>Working with objects and arrays</header>
     <paragraph>
         Object and array behavior is provided by Adaptive functions in the

--- a/src/afw/doc/reference/language/statements.xml
+++ b/src/afw/doc/reference/language/statements.xml
@@ -128,16 +128,20 @@ do {
             This declares a function. Parameters may be simple names or the same
             list and object <literal>Pattern</literal>s used in
             <literal>let</literal> / <literal>const</literal> destructuring
-            (holes, defaults, rest, rename, nesting). Parameter defaults may be
-            any Expression. When a Pattern parameter is optional, supply a
-            whole-argument default such as <literal>= {}</literal> so the
+            (holes, defaults, rest, rename, nesting, string keys, and
+            <literal>[expression]</literal> computed keys). Parameter defaults
+            may be any Expression. Types may be written on simple parameters,
+            on Pattern leaves, and on a whole Pattern formal (for upcoming
+            compile-time checking). When a Pattern parameter is optional, supply
+            a whole-argument default such as <literal>= {}</literal> so the
             Pattern has an object to bind.
         </paragraph>
         <paragraph>
             The same Patterns are already available in assignment,
             <literal>for-of</literal> heads, and C-style <literal>for</literal>
-            initializers. Method-style calls and Adaptive functions outside
-            script formals are unchanged.
+            initializers. Calls may use argument spread
+            <literal>f(...array)</literal> to expand an array into separate
+            arguments.
         </paragraph>
         <section>
             <title>Example</title>
@@ -153,7 +157,12 @@ function connect({ host, port = 443 } = { host: "localhost" }) {
 
 function headTail([first, , third, ...rest]) {
     return first;
-}]]></code>
+}
+
+function sum3(a, b, c) {
+    return a + b + c;
+}
+assert(sum3(...[1, 2, 3]) === 6);]]></code>
         </section>
     </section>
     <section>

--- a/src/afw/function/afw_function_compiler_script.c
+++ b/src/afw/function/afw_function_compiler_script.c
@@ -189,7 +189,9 @@ impl_object_destructure(
     const afw_object_t *object;
     const afw_iterator_t *iterator;
     const afw_utf8_t *property_name;
+    const afw_utf8_t *bound_name;
     const afw_value_t *v;
+    const afw_value_t *name_v;
     const afw_object_t *rest;
 
     object = afw_value_as_object(value, xctx);
@@ -198,7 +200,16 @@ impl_object_destructure(
     for (ap = od->assignment_property; ap; ap = ap->next)
     {
         if (ap->is_rename) {
-            v = afw_object_get_property(object, ap->property_name, xctx);
+            if (ap->property_name_expr) {
+                name_v = afw_value_evaluate(ap->property_name_expr, p, xctx);
+                bound_name = afw_value_as_utf8(name_v, p, xctx);
+            }
+            else {
+                bound_name = ap->property_name;
+            }
+            v = bound_name
+                ? afw_object_get_property(object, bound_name, xctx)
+                : NULL;
             if (!v) {
                 v = ap->assignment_element->default_value;
             }
@@ -234,13 +245,23 @@ impl_object_destructure(
 
             for (ap = od->assignment_property; ap; ap = ap->next)
             {
-                if (
-                    (ap->is_rename && afw_utf8_equal(
-                        ap->property_name, property_name))
-                    ||
-                    (!ap->is_rename && afw_utf8_equal(
-                        ap->symbol_reference->symbol->name, property_name))
-                )
+                if (ap->is_rename) {
+                    if (ap->property_name_expr) {
+                        name_v = afw_value_evaluate(
+                            ap->property_name_expr, p, xctx);
+                        bound_name = afw_value_as_utf8(name_v, p, xctx);
+                    }
+                    else {
+                        bound_name = ap->property_name;
+                    }
+                    if (bound_name &&
+                        afw_utf8_equal(bound_name, property_name))
+                    {
+                        break;
+                    }
+                }
+                else if (afw_utf8_equal(
+                    ap->symbol_reference->symbol->name, property_name))
                 {
                     break;
                 }
@@ -1497,7 +1518,19 @@ afw_function_execute_try(
     AFW_CATCH_UNHANDLED {
         afw_xctx_scope_unwind(scope_at_entry, xctx);
         if AFW_FUNCTION_PARAMETER_IS_PRESENT(3) {
-            if (AFW_FUNCTION_PARAMETER_IS_PRESENT(4)) {
+            /*
+             * Catch body is always a block when there is a binding (arg 4
+             * or Pattern reparse with bind as first statement). Plain catch
+             * without a binding evaluates argv[3] as a statement list/block.
+             */
+            if (AFW_FUNCTION_PARAMETER_IS_PRESENT(4) ||
+                (afw_value_is_block(x->argv[3]) &&
+                    ((const afw_value_block_t *)x->argv[3])->statement_count >
+                        0 &&
+                    afw_value_is_assignment_target(
+                        ((const afw_value_block_t *)x->argv[3])->
+                            statements[0])))
+            {
                 error_object = afw_error_to_object(&this_THROWN_ERROR, p, xctx);
                 error_value = afw_value_create_unmanaged_object(
                     error_object, p, xctx);
@@ -1515,17 +1548,28 @@ afw_function_execute_try(
                 afw_xctx_scope_activate(scope, xctx);
                 AFW_TRY{
                     /*
-                     * Error target is normally a symbol_reference created in
-                     * the catch block. Decompile may emit a string name so
-                     * recompile can create the binding via #assignment_target
-                     * inside the catch #block first; resolve by name then.
+                     * Error bind target resolution (issue #140 Patterns):
+                     *
+                     * 1) argv[4] string — decompile of identifier catch;
+                     *    resolve name in the catch block.
+                     * 2) argv[4] assignment_target / symbol_reference —
+                     *    original compile (Pattern or identifier target).
+                     * 3) No argv[4], first block statement is
+                     *    #assignment_target — decompile of Pattern catch
+                     *    embeds the Pattern as the first catch statement;
+                     *    use it as the bind target and skip evaluating it
+                     *    as a normal statement.
                      */
-                    if (afw_value_is_string(x->argv[4])) {
+                    const afw_value_t *err_target = NULL;
+                    int stmt_start = 0;
+
+                    if (AFW_FUNCTION_PARAMETER_IS_PRESENT(4) &&
+                        afw_value_is_string(x->argv[4]))
+                    {
                         const afw_utf8_t *err_name =
                             &((const afw_value_string_t *)x->argv[4])->
                                 internal;
                         afw_value_block_symbol_t *esym;
-                        const afw_value_t *err_target = NULL;
                         for (esym = block->first_entry; esym;
                             esym = esym->next_entry)
                         {
@@ -1543,15 +1587,23 @@ afw_function_execute_try(
                                 " not found in catch block",
                                 AFW_UTF8_FMT_ARG(err_name));
                         }
+                    }
+                    else if (AFW_FUNCTION_PARAMETER_IS_PRESENT(4)) {
+                        err_target = x->argv[4];
+                    }
+                    else if (block->statement_count > 0 &&
+                        afw_value_is_assignment_target(block->statements[0]))
+                    {
+                        err_target = block->statements[0];
+                        stmt_start = 1;
+                    }
+
+                    if (err_target) {
                         impl_assign_value(err_target, error_value,
                             afw_compile_assignment_type_let, p, xctx);
                     }
-                    else {
-                        impl_assign_value(x->argv[4], error_value,
-                            afw_compile_assignment_type_let, p, xctx);
-                    }
-                    this_result = afw_value_undefined;        
-                    for (int i = 0; i < block->statement_count; i++) {
+                    this_result = afw_value_undefined;
+                    for (int i = stmt_start; i < block->statement_count; i++) {
                         this_result = afw_value_block_evaluate_statement(
                             x, block->statements[i], p, xctx);
                         if (!afw_xctx_statement_flow_is_type(sequential, xctx))

--- a/src/afw/generated/ebnf/syntax.ebnf
+++ b/src/afw/generated/ebnf/syntax.ebnf
@@ -77,7 +77,9 @@ AssignmentObjectDestructureTarget ::=
 
 AssignmentProperty ::=
    ( PropertyName ('=' Expression )? ) |
-   ( PropertyName ( ':' AssignmentElement )? )
+   ( PropertyName ( ':' AssignmentElement )? ) |
+   ( String ( ':' AssignmentElement ) ) |
+   ( '[' Expression ']' ':' AssignmentElement )
 
 /* From afw_compile_parse_assignment_target.c                                 */
 /*                                                                            */
@@ -265,9 +267,14 @@ Lambda ::= 'function' SelfReferenceLambdaName? FunctionSignatureAndBody
 
 /* From afw_compile_parse_expression.c                                        */
 
-Parameters ::= '(' Expression (',' Expression)*')'
+Parameters ::= '('
+    ( ( Expression | ( '...' Expression ) )
+      ( ',' ( Expression | ( '...' Expression ) ) )* )?
+  ')'
 /*                                                                            */
 /* Denotes a parameter list without first parameter (method style call).      */
+/* Call-site spread (...expr) is wrapped as list_expression so call           */
+/* evaluation can expand the array into separate arguments (issue #140).      */
 /*                                                                            */
 
 ParametersExceptFirst ::= Parameters

--- a/src/afw/tests/compiler/decompile.as
+++ b/src/afw/tests/compiler/decompile.as
@@ -293,17 +293,17 @@ assert(s == "#block(return(process::osType))");
 return 0;
 
 //? test: decompile-list-expression-spread
-//? description: Array spread uses #list_expression(...) in decompile
+//? description: Array spread decompiles as call-site ... (list_expression marker)
 //? skip: false
 //? expect: 0
 //? source: ...
 
-// list_expression (spread)
+// list_expression (spread) → surface ... in call args (issue #140)
 const s = decompile(compile<script>(script(
     "const a = [1, 2];\nreturn [...a, 3];"
 )));
 assert(s ==
-    "#block(const(#assignment_target(\"const\",a),[1,2],undefined),return(array(#list_expression(a),3)))");
+    "#block(const(#assignment_target(\"const\",a),[1,2],undefined),return(array(...a,3)))");
 
 return 0;
 

--- a/src/afw/tests/compiler/decompile_fidelity.as
+++ b/src/afw/tests/compiler/decompile_fidelity.as
@@ -50,8 +50,8 @@ check("function g({host, port = 443}) { return host; }\nreturn g({host:\"h\"});"
 check("switch (1) { case 1: return 1; default: return 0; }");
 check("try { return 1; } catch (e) { return 0; }");
 check("try { throw 1; } catch (e) { return e; }");
-/* catch Pattern decompile is not yet d1==d2 stable (try emits binding
- * outside the catch #block); evaluate fidelity is in the next test. */
+check("try { throw \"x\"; } catch ({message}) { return message; }");
+check("const f = function (...r) { return r; };\nreturn f(...[1,2], 3);");
 return 0;
 
 //? test: fidelity-eval-throw-catch
@@ -74,9 +74,12 @@ assert(d2 == decompile(compile<script>(script(d2))));
 assert(evaluate(compile<script>(script(src2))) == 7);
 assert(evaluate(compile<script>(script(d2))) == 7);
 
-/* catch Pattern works at evaluate; d1==d2 deferred (try decompile shape) */
+/* catch Pattern decompile + evaluate after recompile (#140 follow-up) */
 const src3 = "try { throw \"z\"; } catch ({message}) { return message; }";
+const d3 = decompile(compile<script>(script(src3)));
+assert(d3 == decompile(compile<script>(script(d3))));
 assert(evaluate(compile<script>(script(src3))) == "z");
+assert(evaluate(compile<script>(script(d3))) == "z");
 return 0;
 
 //? test: fidelity-eval-switch-default

--- a/src/afw/tests/compiler/pragma.as
+++ b/src/afw/tests/compiler/pragma.as
@@ -284,7 +284,7 @@ assert(decompile(compile<script>(script(d))) == d);
 return 0;
 
 //? test: pragma-list-expression-roundtrip
-//? description: decompile/compile round-trip for array spread (#list_expression)
+//? description: decompile/compile round-trip for array spread (... surface)
 //? skip: false
 //? expect: 0
 //? source: ...
@@ -293,17 +293,21 @@ const d = decompile(compile<script>(script(
     "const a = [1, 2];\nreturn [...a, 3];"
 )));
 assert(d ==
-    "#block(const(#assignment_target(\"const\",a),[1,2],undefined),return(array(#list_expression(a),3)))");
+    "#block(const(#assignment_target(\"const\",a),[1,2],undefined),return(array(...a,3)))");
 assert(evaluate(compile<script>(script(d))) == [1, 2, 3]);
 assert(decompile(compile<script>(script(d))) == d);
 return 0;
 
 //? test: pragma-list-expression-direct
-//? description: #list_expression as spread entry inside array constructor
+//? description: #list_expression / ... as spread entry inside array constructor
 //? skip: false
 //? expect: 0
 //? source: ...
 
+assert(evaluate(compile<script>(script(
+    "#block(const(#assignment_target(\"const\",a),[10,20],undefined),return(array(...a,30)))"
+))) == [10, 20, 30]);
+/* pragma form still recompiles */
 assert(evaluate(compile<script>(script(
     "#block(const(#assignment_target(\"const\",a),[10,20],undefined),return(array(#list_expression(a),30)))"
 ))) == [10, 20, 30]);

--- a/src/afw/tests/language/script/param_destructure.as
+++ b/src/afw/tests/language/script/param_destructure.as
@@ -166,3 +166,134 @@ function withRest(a, ...rest) {
 assert(withRest(1, 2, 3) === 2);
 
 return 0;
+//?
+//? test: ts-prior-param-default
+//? description: Default Expression may reference an earlier parameter (TS-like)
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+function f(x, y = x) {
+    return y;
+}
+assert(f(3) === 3);
+assert(f(3, 9) === 9);
+
+function g({ a }, b = a) {
+    return b;
+}
+assert(g({ a: 7 }) === 7);
+
+function exprDefault(x = 1 + 2 * 3) {
+    return x;
+}
+assert(exprDefault() === 7);
+
+return 0;
+//?
+//? test: ts-required-pattern-missing-arg
+//? description: Required Pattern formal with no argument throws
+//? expect: error:Parameter 1 is required
+//? source: ...
+#!/usr/bin/env afw
+
+function req({ a }) {
+    return a;
+}
+req();
+//?
+//? test: ts-object-rest-on-param
+//? description: Object rest in a parameter Pattern
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+function pack({ a, ...r }) {
+    assert(a === 1);
+    assert(r.b === 2);
+    assert(r.c === 3);
+    return length(keys(r));
+}
+assert(pack({ a: 1, b: 2, c: 3 }) === 2);
+
+return 0;
+//?
+//? test: ts-catch-rename-and-data
+//? description: catch Pattern rename and data property
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+let m = "";
+let code = 0;
+try {
+    throw "fail" { "code": 42 };
+}
+catch ({ message: msg, data }) {
+    m = msg;
+    code = data.code;
+}
+assert(m === "fail");
+assert(code === 42);
+
+return 0;
+//?
+//? test: ts-recursive-pattern-formal
+//? description: Recursive call with object Pattern formal (bind order)
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+function sumDown({ n, acc = 0 }) {
+    if (n === 0) {
+        return acc;
+    }
+    return sumDown({ n: n - 1, acc: acc + n });
+}
+assert(sumDown({ n: 4 }) === 10);
+
+return 0;
+//?
+//? test: ts-pattern-then-rest-param
+//? description: Pattern formal followed by rest parameter
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+function mix({ a }, ...r) {
+    assert(a === 1);
+    assert(length(r) === 2);
+    assert(r[0] === "x");
+    assert(r[1] === "y");
+    return length(r);
+}
+assert(mix({ a: 1 }, "x", "y") === 2);
+
+return 0;
+//?
+//? test: ts-wrong-type-array-pattern
+//? description: Array Pattern on a non-array argument errors
+//? expect: error:Array destructure can only be performed on an array
+//? source: ...
+#!/usr/bin/env afw
+
+function takePair([a, b]) {
+    return a + b;
+}
+takePair({ a: 1, b: 2 });
+//?
+//? test: ts-optional-pattern-no-default
+//? description: Optional Pattern formal with no arg leaves binding undefined
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+/* Adaptive: omit whole arg without = {} → Pattern not applied; leaves undefined.
+ * Prefer = {} for TS options-object style. */
+function opt({ a }?) {
+    return a;
+}
+assert(opt() === undefined);
+assert(opt({ a: 5 }) === 5);
+
+return 0;

--- a/src/afw/tests/language/script/param_destructure.as
+++ b/src/afw/tests/language/script/param_destructure.as
@@ -297,3 +297,75 @@ assert(opt() === undefined);
 assert(opt({ a: 5 }) === 5);
 
 return 0;
+//?
+//? test: ts-call-site-spread
+//? description: Call-site ...array expands into separate arguments
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+function sum3(a, b, c) {
+    return a + b + c;
+}
+assert(sum3(...[1, 2, 3]) === 6);
+assert(sum3(1, ...[2, 3]) === 6);
+assert(sum3(...[1, 2], 3) === 6);
+
+function join(...parts) {
+    return string(parts);
+}
+assert(join(...["a", "b"], "c") === '["a","b","c"]');
+
+return 0;
+//?
+//? test: ts-computed-key-destructure
+//? description: Computed and string keys in object Patterns
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+const key = "inner";
+function take({ [key]: v, "other": o }) {
+    assert(v === 11);
+    assert(o === 22);
+    return v + o;
+}
+assert(take({ inner: 11, other: 22 }) === 33);
+
+const { [key]: x } = { inner: 5 };
+assert(x === 5);
+
+return 0;
+//?
+//? test: ts-typed-pattern-leaves
+//? description: Type annotations on Pattern leaves and whole Pattern formal
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+function typedLeaves([a: integer, b: integer]: (array of integer)) {
+    return a + b;
+}
+assert(typedLeaves([3, 4]) === 7);
+
+function typedObj({ n: n: integer }) {
+    return n;
+}
+assert(typedObj({ n: 9 }) === 9);
+
+return 0;
+//?
+//? test: ts-catch-pattern-decompile-fidelity
+//? description: catch Pattern decompile recompiles and evaluates
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+const src = "try { throw \"z\"; } catch ({message}) { return message; }";
+const d1 = decompile(compile<script>(script(src)));
+const d2 = decompile(compile<script>(script(d1)));
+assert(d1 == d2);
+assert(evaluate(compile<script>(script(src))) == "z");
+assert(evaluate(compile<script>(script(d1))) == "z");
+
+return 0;

--- a/src/afw/tests/list/spread.as
+++ b/src/afw/tests/list/spread.as
@@ -80,13 +80,13 @@ return 0;
 
 //? test: spread-for-of-error
 //? description: Spread inside a for-of loop with error
-//? expect: error:Typesafe error: expecting 'array' but encountered 'integer'
+//? expect: error:Call-site spread (...) requires an array
 //? source: ...
 
 const l1 = [1, 2, 3];
 const l2 = [];
 
-// causes infinite loop
+// ...i fails when i is integer (list literal lowers to array(...) call)
 for (const i of l1) {
     l2 = [...l2, i, ...i];
 }

--- a/src/afw/value/afw_value.h
+++ b/src/afw/value/afw_value.h
@@ -1723,6 +1723,30 @@ afw_value_decompile_call_args(
 
 
 /**
+ * @brief Expand call-site spreads (...arr) into a flat argv.
+ * @param argc_in User parameter count (not including argv[0]).
+ * @param argv_in argv[0]=function, argv[1..argc_in]=args; may contain
+ *        list_expression values marking spreads.
+ * @param argc_out Expanded user parameter count.
+ * @param argv_out Expanded argv (argv[0] same as argv_in[0]); may equal
+ *        argv_in when there is no spread.
+ * @param p Pool for expanded argv when needed.
+ * @param xctx of caller.
+ *
+ * list_expression entries evaluate to an array and are spliced as separate
+ * arguments (issue #140). Non-spread args are left unevaluated.
+ */
+AFW_DEFINE(void)
+afw_value_call_args_expand_spreads(
+    afw_size_t argc_in,
+    const afw_value_t * const *argv_in,
+    afw_size_t *argc_out,
+    const afw_value_t * const **argv_out,
+    const afw_pool_t *p,
+    afw_xctx_t *xctx);
+
+
+/**
  * @brief Write synthetic decompile name `#` + implementation_id.
  * @param instance value whose inf id is used.
  * @param writer

--- a/src/afw/value/afw_value_assignment_target.c
+++ b/src/afw/value/afw_value_assignment_target.c
@@ -431,7 +431,22 @@ impl_decompile_object_pattern(
             afw_writer_write_eol(writer, xctx);
         }
         if (ap->is_rename) {
-            afw_writer_write_utf8(writer, ap->property_name, xctx);
+            if (ap->property_name_expr) {
+                afw_writer_write_z(writer, "[", xctx);
+                afw_value_decompile_value(ap->property_name_expr, writer,
+                    xctx);
+                afw_writer_write_z(writer, "]", xctx);
+            }
+            else if (ap->property_name) {
+                if (ap->property_name_was_string) {
+                    afw_writer_write_z(writer, "\"", xctx);
+                    afw_writer_write_utf8(writer, ap->property_name, xctx);
+                    afw_writer_write_z(writer, "\"", xctx);
+                }
+                else {
+                    afw_writer_write_utf8(writer, ap->property_name, xctx);
+                }
+            }
             afw_writer_write_z(writer, writer->tab ? ": " : ":", xctx);
             ae = ap->assignment_element;
             if (ae && ae->assignment_target) {

--- a/src/afw/value/afw_value_call.c
+++ b/src/afw/value/afw_value_call.c
@@ -180,49 +180,58 @@ impl_afw_value_optional_evaluate(
      * handled by afw_value_built_in_function. Check and handle for script
      * functions first.
      */
-    if (afw_value_is_script_function_definition(function_value)) {
-        result = afw_value_call_script_function(
-            self->args.contextual,
-            (afw_value_script_function_definition_t *)function_value,
-            NULL,
-            self->args.argc, self->args.argv, p, xctx);
-    }
+    {
+        afw_size_t call_argc;
+        const afw_value_t * const *call_argv;
 
-    /*
-     * This may still be a call to a built in function if a variable is assigned
-     * a built-in function definition.
-     */
-    else if (afw_value_is_function_definition(function_value)) {
-        result = afw_value_call_built_in_function(
-            self->args.contextual,
-            (const afw_value_function_definition_t *)function_value,
-            self->args.argc, self->args.argv, p, xctx);
-    }
+        afw_value_call_args_expand_spreads(
+            self->args.argc, self->args.argv,
+            &call_argc, &call_argv, p, xctx);
 
-    /*
-     * This may still be a call to a closure if a variable is assigned one.
-     */
-    else if (afw_value_is_closure_binding(function_value)) {
-        result = afw_value_call_script_function(
-            self->args.contextual,
-            ((const afw_value_closure_binding_t *)function_value)->
-                script_function_definition,
-            ((const afw_value_closure_binding_t *)function_value)->
-                enclosing_lexical_scope,
-            self->args.argc, self->args.argv, p, xctx);
-    }
+        if (afw_value_is_script_function_definition(function_value)) {
+            result = afw_value_call_script_function(
+                self->args.contextual,
+                (afw_value_script_function_definition_t *)function_value,
+                NULL,
+                call_argc, call_argv, p, xctx);
+        }
 
-    /* Otherwise, this must be a thunk call. */
-    else if (afw_value_is_function_thunk(function_value)) {
-        result = ((const afw_value_function_thunk_t *)function_value)->
-            execute(
-                (const afw_value_function_thunk_t *)function_value,
-                self->args.argc, self->args.argv, p, xctx);
-    }
+        /*
+         * This may still be a call to a built in function if a variable is
+         * assigned a built-in function definition.
+         */
+        else if (afw_value_is_function_definition(function_value)) {
+            result = afw_value_call_built_in_function(
+                self->args.contextual,
+                (const afw_value_function_definition_t *)function_value,
+                call_argc, call_argv, p, xctx);
+        }
 
-    /* Not a value function value at this point. */
-    else {
-        AFW_THROW_ERROR_Z(general, "Invalid function_value", xctx);
+        /*
+         * This may still be a call to a closure if a variable is assigned one.
+         */
+        else if (afw_value_is_closure_binding(function_value)) {
+            result = afw_value_call_script_function(
+                self->args.contextual,
+                ((const afw_value_closure_binding_t *)function_value)->
+                    script_function_definition,
+                ((const afw_value_closure_binding_t *)function_value)->
+                    enclosing_lexical_scope,
+                call_argc, call_argv, p, xctx);
+        }
+
+        /* Otherwise, this must be a thunk call. */
+        else if (afw_value_is_function_thunk(function_value)) {
+            result = ((const afw_value_function_thunk_t *)function_value)->
+                execute(
+                    (const afw_value_function_thunk_t *)function_value,
+                    call_argc, call_argv, p, xctx);
+        }
+
+        /* Not a value function value at this point. */
+        else {
+            AFW_THROW_ERROR_Z(general, "Invalid function_value", xctx);
+        }
     }
 
     /* Pop value from evaluation stack and return result. */
@@ -313,6 +322,102 @@ impl_afw_value_decompile(
     }
     afw_value_decompile_value(callee, writer, xctx);
     afw_value_decompile_call_args(writer, 1, &self->args, xctx);
+}
+
+
+/*
+ * Expand call-site ...spreads (list_expression markers) into flat argv.
+ */
+AFW_DEFINE(void)
+afw_value_call_args_expand_spreads(
+    afw_size_t argc_in,
+    const afw_value_t * const *argv_in,
+    afw_size_t *argc_out,
+    const afw_value_t * const **argv_out,
+    const afw_pool_t *p,
+    afw_xctx_t *xctx)
+{
+    afw_size_t i;
+    afw_size_t j;
+    afw_size_t total;
+    afw_size_t n;
+    afw_boolean_t any_spread;
+    const afw_value_t *arg;
+    const afw_value_t *evaled;
+    const afw_value_t **new_argv;
+    const afw_array_t *arr;
+    const afw_iterator_t *it;
+    const afw_value_t *elem;
+
+    *argc_out = argc_in;
+    *argv_out = argv_in;
+    if (!argv_in || argc_in == 0) {
+        return;
+    }
+
+    any_spread = false;
+    for (i = 1; i <= argc_in; i++) {
+        if (argv_in[i] && afw_value_is_array_expression(argv_in[i])) {
+            any_spread = true;
+            break;
+        }
+    }
+    if (!any_spread) {
+        return;
+    }
+
+    /* Count expanded size. */
+    total = 0;
+    for (i = 1; i <= argc_in; i++) {
+        arg = argv_in[i];
+        if (arg && afw_value_is_array_expression(arg)) {
+            evaled = afw_value_evaluate(arg, p, xctx);
+            if (!afw_value_is_array(evaled)) {
+                AFW_THROW_ERROR_Z(general,
+                    "Call-site spread (...) requires an array", xctx);
+            }
+            arr = ((const afw_value_array_t *)evaled)->internal;
+            n = 0;
+            it = NULL;
+            for (;;) {
+                elem = afw_array_get_next_value(arr, &it, p, xctx);
+                if (!elem) {
+                    break;
+                }
+                n++;
+            }
+            total += n;
+        }
+        else {
+            total++;
+        }
+    }
+
+    new_argv = afw_pool_malloc(p,
+        sizeof(afw_value_t *) * (total + 1), xctx);
+    new_argv[0] = argv_in[0];
+    j = 1;
+    for (i = 1; i <= argc_in; i++) {
+        arg = argv_in[i];
+        if (arg && afw_value_is_array_expression(arg)) {
+            evaled = afw_value_evaluate(arg, p, xctx);
+            arr = ((const afw_value_array_t *)evaled)->internal;
+            it = NULL;
+            for (;;) {
+                elem = afw_array_get_next_value(arr, &it, p, xctx);
+                if (!elem) {
+                    break;
+                }
+                new_argv[j++] = elem;
+            }
+        }
+        else {
+            new_argv[j++] = arg;
+        }
+    }
+
+    *argc_out = total;
+    *argv_out = new_argv;
 }
 
 

--- a/src/afw/value/afw_value_call_built_in_function.c
+++ b/src/afw/value/afw_value_call_built_in_function.c
@@ -145,8 +145,10 @@ impl_afw_value_optional_evaluate(
     x.function = self->function;
     x.data_type = self->function->data_type;
     x.first_arg = NULL;
-    x.argv = self->args.argv;
-    x.argc = self->args.argc;
+    /* Expand call-site ...spreads before required/max checks and execute. */
+    afw_value_call_args_expand_spreads(
+        self->args.argc, self->args.argv,
+        &x.argc, &x.argv, p, xctx);
 
     /* Make there are at least the required number of parameters. */
     if (x.argc < x.function->numberOfRequiredParameters->internal) {
@@ -321,6 +323,15 @@ impl_afw_value_decompile(
         afw_writer_increment_indent(writer, xctx);
     }
     for (i = 1; i <= self->args.argc; i++) {
+        /*
+         * Pattern catch: 4th try arg is embedded in the catch #block;
+         * omit it as a separate try() argument (see Pattern branch below).
+         */
+        if (is_try && i == 4 &&
+            afw_value_is_assignment_target(self->args.argv[i]))
+        {
+            continue;
+        }
         if (i != 1) {
             afw_writer_write_z(writer, ",", xctx);
         }
@@ -347,34 +358,76 @@ impl_afw_value_decompile(
             afw_writer_write_z(writer, ")", xctx);
         }
         /*
-         * try catch block (3rd) + error variable (4th): emit catch as
-         * #block(#assignment_target("let",e), stmts...) and error as "e"
-         * so reparse creates e before return(e); execute_try resolves
-         * the string name in the catch block.
+         * try catch block (3rd) + error binding (4th):
+         *
+         * Identifier catch: emit
+         *   #block(#assignment_target("let", e), stmts...), "e"
+         * so reparse introduces e in the block; execute_try resolves the
+         * string name (or assigns via symbol_reference).
+         *
+         * Pattern catch (issue #140): emit
+         *   #block(#assignment_target("let", Pattern), stmts...)
+         * only (no separate 4th arg). execute_try treats the first
+         * statement of the catch block as the bind target when argv[4]
+         * is absent, then runs the remaining statements.
          */
         else if (is_try && i == 3 && afw_value_is_block(arg) &&
-            self->args.argc >= 4 &&
-            afw_value_is_symbol_reference(self->args.argv[4]))
+            self->args.argc >= 4)
         {
             const afw_value_block_t *catch_block =
                 (const afw_value_block_t *)arg;
+            const afw_value_t *err_bind = self->args.argv[4];
             afw_size_t j;
+            afw_boolean_t pattern_bind;
 
-            sym = (const afw_value_symbol_reference_t *)self->args.argv[4];
+            pattern_bind = afw_value_is_assignment_target(err_bind);
+
             afw_writer_write_z(writer, "#block(", xctx);
             if (writer->tab) {
                 afw_writer_increment_indent(writer, xctx);
                 afw_writer_write_eol(writer, xctx);
             }
-            afw_writer_write_z(writer, "#assignment_target(", xctx);
-            kind.inf = &afw_value_unmanaged_string_inf;
-            kind.internal.s = "let";
-            kind.internal.len = 3;
-            afw_value_decompile((const afw_value_t *)&kind, writer, xctx);
-            afw_writer_write_z(writer, ",", xctx);
-            afw_writer_write_utf8(writer, sym->symbol->name, xctx);
-            afw_writer_write_z(writer, ")", xctx);
-            for (j = 0; j < catch_block->statement_count; j++) {
+            if (pattern_bind) {
+                /* Full Pattern as #assignment_target("let", Pattern). */
+                afw_value_decompile_value(err_bind, writer, xctx);
+            }
+            else if (afw_value_is_symbol_reference(err_bind)) {
+                sym = (const afw_value_symbol_reference_t *)err_bind;
+                afw_writer_write_z(writer, "#assignment_target(", xctx);
+                kind.inf = &afw_value_unmanaged_string_inf;
+                kind.internal.s = "let";
+                kind.internal.len = 3;
+                afw_value_decompile((const afw_value_t *)&kind, writer, xctx);
+                afw_writer_write_z(writer, ",", xctx);
+                afw_writer_write_utf8(writer, sym->symbol->name, xctx);
+                afw_writer_write_z(writer, ")", xctx);
+            }
+            else if (afw_value_is_string(err_bind)) {
+                /* Reparse of identifier catch: 4th arg is the name string. */
+                afw_writer_write_z(writer, "#assignment_target(", xctx);
+                kind.inf = &afw_value_unmanaged_string_inf;
+                kind.internal.s = "let";
+                kind.internal.len = 3;
+                afw_value_decompile((const afw_value_t *)&kind, writer, xctx);
+                afw_writer_write_z(writer, ",", xctx);
+                afw_writer_write_utf8(writer,
+                    &((const afw_value_string_t *)err_bind)->internal, xctx);
+                afw_writer_write_z(writer, ")", xctx);
+            }
+            else {
+                afw_value_decompile_value(err_bind, writer, xctx);
+            }
+            /*
+             * Skip leading assignment_target statement if reparse already
+             * embedded it as the first catch statement (avoid doubling).
+             */
+            j = 0;
+            if (catch_block->statement_count > 0 &&
+                afw_value_is_assignment_target(catch_block->statements[0]))
+            {
+                j = 1;
+            }
+            for (; j < catch_block->statement_count; j++) {
                 afw_writer_write_z(writer, ",", xctx);
                 if (writer->tab) {
                     afw_writer_write_eol(writer, xctx);

--- a/src/afw/value/afw_value_call_script_function.c
+++ b/src/afw/value/afw_value_call_script_function.c
@@ -109,9 +109,11 @@ impl_afw_value_optional_evaluate(
     const afw_value_script_function_parameter_t *const *params;
     const afw_value_t *const *arg;
     const afw_value_t *const *rest_argv;
+    const afw_value_t * const *call_argv;
     const afw_array_t *rest_array;
     afw_size_t parameter_number;
     afw_size_t rest_argc;
+    afw_size_t call_argc;
     afw_boolean_t parameter_scope_activated;
 
     result = NULL;
@@ -119,6 +121,11 @@ impl_afw_value_optional_evaluate(
     parameter_scope = NULL;
     parameter_scope_activated = false;
     script = self->script_function_definition;
+
+    /* Expand call-site ...spreads into a flat argv before binding. */
+    afw_value_call_args_expand_spreads(
+        self->args.argc, self->args.argv,
+        &call_argc, &call_argv, p, xctx);
 
     /* If closure, use its enclosing static scope. */
     if (self->enclosing_lexical_scope) {
@@ -219,14 +226,14 @@ impl_afw_value_optional_evaluate(
                  */
                 for (parameter_number = 1,
                     params = script->parameters,
-                    arg = self->args.argv + 1;
+                    arg = call_argv + 1;
                     parameter_number <= script->count;
                     parameter_number++, params++, arg++)
                 {
                     value = NULL;
                     if ((*params)->is_rest) {
-                        if (self->args.argc >= script->count) {
-                            rest_argc = self->args.argc - script->count + 1;
+                        if (call_argc >= script->count) {
+                            rest_argc = call_argc - script->count + 1;
                             rest_argv = arg;
                         }
                         else {
@@ -238,7 +245,7 @@ impl_afw_value_optional_evaluate(
                         value = afw_value_create_unmanaged_array(
                             rest_array, p, xctx);
                     }
-                    else if (parameter_number <= self->args.argc) {
+                    else if (parameter_number <= call_argc) {
                         value = afw_function_evaluate_parameter_with_type(
                             *arg, parameter_number,
                             (*params)->type,
@@ -258,7 +265,7 @@ impl_afw_value_optional_evaluate(
                 {
                     value = bound_values[i];
                     /* provided: caller supplied argv[i+1] (or rest). */
-                    provided = (i + 1 <= self->args.argc) ||
+                    provided = (i + 1 <= call_argc) ||
                         (*params)->is_rest;
 
                     if ((*params)->is_rest) {

--- a/src/afw/value/afw_value_decompile.c
+++ b/src/afw/value/afw_value_decompile.c
@@ -72,7 +72,19 @@ afw_value_decompile_call_args(
         if (writer->tab) {
             afw_writer_write_eol(writer, xctx);
         }
-        afw_value_decompile_value(args->argv[i], writer, xctx);
+        /*
+         * Call-site spread was compiled as list_expression / array_expression;
+         * surface form is ...expr (issue #140).
+         */
+        if (args->argv[i] && afw_value_is_array_expression(args->argv[i])) {
+            const afw_value_list_expression_t *le =
+                (const afw_value_list_expression_t *)args->argv[i];
+            afw_writer_write_z(writer, "...", xctx);
+            afw_value_decompile_value(le->internal, writer, xctx);
+        }
+        else {
+            afw_value_decompile_value(args->argv[i], writer, xctx);
+        }
     }
 
     if (writer->tab) {

--- a/whats_new.md
+++ b/whats_new.md
@@ -39,7 +39,7 @@ In-tree extensions and the `afw` / `afwfcgi` commands built with the same `./afw
 | **C builders / afwdev** | Richer C API Doxygen, package **0.12.2**, `afwdev build --fulldev` (issue **#1**) |
 | **Value / memory (α/β)** | Incremental issue **#2** work: permanent scalar reuse, dual-face object/array values, safer managed object value release — **recompile** out-of-tree commands/extensions against the new libafw |
 | **`stringify` / `decompile` / listing / binary text** | **`stringify`** pure JSON; **`decompile`** Adaptive compiled form; **compile listing** human tree+symbols; **`decode_to_string`** UTF-8 from octets (see section below) |
-| **Param / catch Patterns (#140)** | Function and lambda parameters and `catch` may use the same list/object destructure Patterns as `let`/`const`; parameter defaults are Expressions |
+| **Param / catch Patterns (#140)** | Function/lambda params + `catch` Patterns; Expression defaults; call-site `f(...arr)`; computed/string keys in Patterns; type syntax for later checking |
 
 ---
 

--- a/whats_new.md
+++ b/whats_new.md
@@ -45,22 +45,25 @@ In-tree extensions and the `afw` / `afwfcgi` commands built with the same `./afw
 
 ## Function parameter and catch Patterns (issue #140)
 
-**Issue #140** on branch `issue-#140` (merge to `mgg-develop` when ready).
+**Issue #140** (PR **#141** on `mgg-develop`; follow-ups on `Issue-#140-followup`).
 
 Adaptive Script already allowed list/object **Patterns** on `let` / `const`, assignment, and `for` / `for-of` heads. The same Patterns may now appear:
 
-- In **function and lambda parameter lists** (including nested rename, holes, rest, and property defaults).
+- In **function and lambda parameter lists** (nested rename, holes, rest, property defaults, **computed/string keys**).
 - In **`catch (…)`** bindings (e.g. `catch ({ message, data })`).
+- **Call-site spread:** `f(...arr)` / `f(a, ...rest, b)` expands an array into separate arguments.
 
-Parameter **defaults are Expressions** (not literals only). For options-style APIs, a whole-argument default is the usual pattern:
+Parameter **defaults are Expressions**. Pattern leaves and whole formals may carry **type annotations** (syntax for upcoming compile-time checking). Options-style example:
 
 ```adaptive
 function connect({ host, port = 443 } = { host: "localhost" }) {
     return host + ":" + string(port);
 }
+function sum3(a, b, c) { return a + b + c; }
+assert(sum3(...[1, 2, 3]) === 6);
 ```
 
-Not included: arrow functions, call-site `f(...arr)`, or an ES `arguments` object (use `...rest` on the formal list). Language Reference: Function statement and Exception Handling in Features.
+Not included: arrow functions, ES `arguments` object (use formal `...rest`). Language Reference: Function statement and Exception Handling in Features.
 
 ---
 

--- a/whats_new.md
+++ b/whats_new.md
@@ -63,7 +63,7 @@ function sum3(a, b, c) { return a + b + c; }
 assert(sum3(...[1, 2, 3]) === 6);
 ```
 
-Not included: arrow functions, ES `arguments` object (use formal `...rest`). Language Reference: Function statement and Exception Handling in Features.
+Not included: arrow functions, ES `arguments` object (use formal `...rest`). Language Reference: Function statement; Features — Exception Handling, Functions and parameters.
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to [#141](https://github.com/afw-org/afw/pull/141) / [#140](https://github.com/afw-org/afw/issues/140) after param + catch Patterns landed on `mgg-develop`. Closes the TS-shaped confidence gaps that were intentionally left out of the first PR, and polishes docs/pads for beta.

- **Call-site spread:** `f(...arr)` / `f(a, ...rest, b)` expands an array into separate arguments (definition-side `...rest` formals unchanged).
- **Computed / string keys in Patterns:** `[expr]: bind` and `"name": bind` on object Patterns (shared with let/const/params/catch).
- **Catch Pattern decompile fidelity:** d1==d2 by embedding the bind as the first statement of the catch `#block`; execute uses that when there is no separate argv[4].
- **Type syntax on formals:** `: Type` on simple parameters, Pattern leaves, and whole Pattern formals (stored for later #28 checking; not enforced yet).
- **TS-shaped confidence tests** in `param_destructure.as` (options object, prior-param defaults, object rest, missing arg, catch rename, recursion, wrong-type, etc.).
- **Docs / pads:** Features “Functions and parameters”, Function statement, `whats_new.md`, `compile-optimize-notes.md`, `issue-18-decompile-status.md` (param sugar no longer parked as future).

## Not in this PR

- Arrow functions
- ES `arguments` object (use formal `...rest`)
- Full compile-time type-check of annotations (#28)
- Compile-time constant-fold optimize (separate pad)

## Test plan

- [x] `./afwdev build --fulldev`
- [x] `afwdev test -j --env-mode valgrind`
- [ ] Reviewer: narrow smoke if desired  
  `afwdev test -j --srcdir-pattern afw --test-pattern 'language/script/param_destructure|list/spread|compiler/(decompile|pragma).*'`