### PR TITLE
#52: convert interface implementations to AFW_*_SELF_T

### DIFF
--- a/src/afw/adapter/afw_adapter.c
+++ b/src/afw/adapter/afw_adapter.c
@@ -721,7 +721,7 @@ afw_adapter_internal_register_service_type(afw_xctx_t *xctx)
  */
 afw_integer_t
 impl_afw_service_type_related_instance_count (
-    const afw_service_type_t * instance,
+    const afw_service_type_t * self,
     const afw_utf8_t * id,
     afw_xctx_t *xctx)
 {
@@ -760,7 +760,7 @@ impl_afw_service_type_related_instance_count (
  */
 void
 impl_afw_service_type_start_cede_p (
-    const afw_service_type_t * instance,
+    const afw_service_type_t * self,
     const afw_object_t * properties,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
@@ -800,7 +800,7 @@ impl_afw_service_type_start_cede_p (
  */
 void
 impl_afw_service_type_stop (
-    const afw_service_type_t * instance,
+    const afw_service_type_t * self,
     const afw_utf8_t * id,
     afw_xctx_t *xctx)
 {
@@ -814,11 +814,11 @@ impl_afw_service_type_stop (
  */
 void
 impl_afw_service_type_restart_cede_p (
-    const afw_service_type_t * instance,
+    const afw_service_type_t * self,
     const afw_object_t * properties,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {
     /* Count on already running. Start will restart if necessary. */
-    impl_afw_service_type_start_cede_p(instance, properties, p, xctx);
+    impl_afw_service_type_start_cede_p(self, properties, p, xctx);
 }

--- a/src/afw/adapter/afw_adapter_impl.c
+++ b/src/afw/adapter/afw_adapter_impl.c
@@ -635,7 +635,7 @@ afw_adapter_impl_set_object_types_fully_loaded(
  */
 const afw_object_type_t *
 impl_afw_adapter_object_type_cache_get(
-    const afw_adapter_object_type_cache_t *instance,
+    const afw_adapter_object_type_cache_t *self,
     const afw_utf8_t *object_type_id,
     afw_boolean_t *final_result,
     afw_xctx_t *xctx)
@@ -644,7 +644,7 @@ impl_afw_adapter_object_type_cache_get(
     const afw_adapter_t *adapter;
     afw_adapter_impl_t *impl;
 
-    adapter = instance->session->adapter;
+    adapter = self->session->adapter;
     impl = (afw_adapter_impl_t *)adapter->impl;
     *final_result = impl->object_types_fully_loaded;
 
@@ -668,14 +668,14 @@ impl_afw_adapter_object_type_cache_get(
  */
 void
 impl_afw_adapter_object_type_cache_set(
-    const afw_adapter_object_type_cache_t *instance,
+    const afw_adapter_object_type_cache_t *self,
     const afw_object_type_t *object_type,
     afw_xctx_t *xctx)
 {
     const afw_adapter_t *adapter;
     afw_adapter_impl_t *impl;
 
-    adapter = instance->session->adapter;
+    adapter = self->session->adapter;
     impl = (afw_adapter_impl_t *)adapter->impl;
 
     if (!impl->object_types_ht) {
@@ -699,15 +699,15 @@ impl_afw_adapter_object_type_cache_set(
  */
 void
 impl_afw_adapter_destroy(
-    const afw_adapter_t *instance,
+    const afw_adapter_t *self,
     afw_xctx_t *xctx)
 {
-    afw_adapter_impl_t *impl = (afw_adapter_impl_t *)instance->impl;
+    afw_adapter_impl_t *impl = (afw_adapter_impl_t *)self->impl;
 
     /** @fixme Add common prologue code. */
 
-    /* Call wrapped instance method. */
-    impl->wrapped_inf->destroy(instance, xctx);
+    /* Call wrapped self method. */
+    impl->wrapped_inf->destroy(self, xctx);
 
     /** @fixme Add common epilogue code. */
 }
@@ -719,28 +719,28 @@ impl_afw_adapter_destroy(
  */
 const afw_adapter_session_t *
 impl_afw_adapter_create_adapter_session(
-    const afw_adapter_t *instance,
+    const afw_adapter_t *self,
     afw_xctx_t *xctx)
 {
-    afw_adapter_impl_t *impl = (afw_adapter_impl_t *)instance->impl;
-    AFW_ADAPTER_SESSION_SELF_T *self;
+    afw_adapter_impl_t *impl = (afw_adapter_impl_t *)self->impl;
+    AFW_ADAPTER_SESSION_SELF_T *session;
 
     /* Create session self. */
-    self = afw_xctx_calloc_type(AFW_ADAPTER_SESSION_SELF_T, xctx);
-    self->pub.adapter = instance;
-    self->pub.inf = &impl_afw_adapter_session_inf;
-    self->pub.p = xctx->p;
+    session = afw_xctx_calloc_type(AFW_ADAPTER_SESSION_SELF_T, xctx);
+    session->pub.adapter = self;
+    session->pub.inf = &impl_afw_adapter_session_inf;
+    session->pub.p = xctx->p;
 
     /** @fixme Add common prologue code. */
 
-    /* Call wrapped instance method. */
-    self->wrapped_session =
-        impl->wrapped_inf->create_adapter_session(instance, xctx);
+    /* Call wrapped self method. */
+    session->wrapped_session =
+        impl->wrapped_inf->create_adapter_session(self, xctx);
 
     /** @fixme Add common epilogue code. */
 
     /* Return result. */
-    return &self->pub;
+    return &session->pub;
 }
 
 
@@ -750,17 +750,17 @@ impl_afw_adapter_create_adapter_session(
  */
 const afw_object_t *
 impl_afw_adapter_get_additional_metrics(
-    const afw_adapter_t *instance,
+    const afw_adapter_t *self,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    afw_adapter_impl_t *impl = (afw_adapter_impl_t *)instance->impl;
+    afw_adapter_impl_t *impl = (afw_adapter_impl_t *)self->impl;
     const afw_object_t *result;
 
     /** @fixme Add common prologue code. */
 
-    /* Call wrapped instance method. */
-    result = impl->wrapped_inf->get_additional_metrics(instance,
+    /* Call wrapped self method. */
+    result = impl->wrapped_inf->get_additional_metrics(self,
         p, xctx);
 
     /** @fixme Add common epilogue code. */
@@ -1602,18 +1602,18 @@ impl_afw_adapter_session_get_object_type_cache_interface(
  */
 const afw_utf8_t *
 impl_afw_adapter_journal_add_entry(
-    const afw_adapter_journal_t * instance,
+    const afw_adapter_journal_t * self,
     const afw_adapter_impl_request_t * impl_request,
     const afw_object_t * entry,
     afw_xctx_t *xctx)
 {
-    afw_adapter_impl_session_t *self =
-        (afw_adapter_impl_session_t *)(instance->session);
+    afw_adapter_impl_session_t *session =
+        (afw_adapter_impl_session_t *)(self->session);
     const afw_utf8_t *result;
 
     /** @fixme authorization check */
 
-    result = afw_adapter_journal_add_entry(self->wrapped_journal,
+    result = afw_adapter_journal_add_entry(session->wrapped_journal,
         impl_request, entry, xctx);
     return result;
 }
@@ -1623,7 +1623,7 @@ impl_afw_adapter_journal_add_entry(
  */
 void
 impl_afw_adapter_journal_get_entry(
-    const afw_adapter_journal_t * instance,
+    const afw_adapter_journal_t * self,
     const afw_adapter_impl_request_t * impl_request,
     afw_adapter_journal_option_t option,
     const afw_utf8_t * consumer_id,
@@ -1632,12 +1632,12 @@ impl_afw_adapter_journal_get_entry(
     const afw_object_t * response,
     afw_xctx_t *xctx)
 {
-    afw_adapter_impl_session_t *self =
-        (afw_adapter_impl_session_t *)(instance->session);
+    afw_adapter_impl_session_t *session =
+        (afw_adapter_impl_session_t *)(self->session);
 
     /** @fixme authorization check */
 
-    afw_adapter_journal_get_entry(self->wrapped_journal,
+    afw_adapter_journal_get_entry(session->wrapped_journal,
         impl_request, option, consumer_id, entry_cursor,
         limit, response, xctx);
 }
@@ -1648,17 +1648,17 @@ impl_afw_adapter_journal_get_entry(
  */
 void
 impl_afw_adapter_journal_mark_entry_consumed(
-    const afw_adapter_journal_t * instance,
+    const afw_adapter_journal_t * self,
     const afw_adapter_impl_request_t * impl_request,
     const afw_utf8_t * consumer_id,
     const afw_utf8_t * entry_cursor,
     afw_xctx_t *xctx)
 {
-    afw_adapter_impl_session_t *self =
-        (afw_adapter_impl_session_t *)(instance->session);
+    afw_adapter_impl_session_t *session =
+        (afw_adapter_impl_session_t *)(self->session);
 
     /** @fixme authorization check */
 
-    afw_adapter_journal_mark_entry_consumed(self->wrapped_journal,
+    afw_adapter_journal_mark_entry_consumed(session->wrapped_journal,
         impl_request, consumer_id, entry_cursor, xctx);
 }

--- a/src/afw/array/afw_array_const_array.c
+++ b/src/afw/array/afw_array_const_array.c
@@ -21,6 +21,8 @@
 
 /* Declares and rti/inf defines for interface afw_array */
 #define AFW_IMPLEMENTATION_ID "afw_array_const_array_of_values"
+typedef struct impl_afw_array_const_array_of_values_self_s impl_afw_array_const_array_of_values_self_t;
+#define AFW_ARRAY_SELF_T impl_afw_array_const_array_of_values_self_t
 #include "afw_array_impl_declares.h"
 
 /** @fixme
@@ -139,7 +141,7 @@ afw_array_const_create_null_terminated_array_of_values(
  */
 void
 impl_afw_array_release (
-    const afw_array_t * instance,
+    AFW_ARRAY_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Nothing to do. */
@@ -152,11 +154,9 @@ impl_afw_array_release (
  */
 afw_size_t
 impl_afw_array_get_count(
-    const afw_array_t * instance,
+    AFW_ARRAY_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    impl_afw_array_const_array_of_values_self_t * self = 
-        (impl_afw_array_const_array_of_values_self_t *)instance;
 
     return self->end_of_values - self->values;
 }
@@ -168,7 +168,7 @@ impl_afw_array_get_count(
  */
 const afw_data_type_t *
 impl_afw_array_get_data_type(
-    const afw_array_t * instance,
+    AFW_ARRAY_SELF_T *self,
     afw_xctx_t *xctx)
 {
     return NULL;
@@ -181,14 +181,12 @@ impl_afw_array_get_data_type(
  */
 afw_boolean_t
 impl_afw_array_get_entry_internal(
-    const afw_array_t * instance,
+    AFW_ARRAY_SELF_T *self,
     afw_integer_t index,
     const afw_data_type_t * * data_type,
     const void * * internal,
     afw_xctx_t *xctx)
 {
-    impl_afw_array_const_array_of_values_self_t * self = 
-        (impl_afw_array_const_array_of_values_self_t *)instance;
     afw_size_t i, count;
     const afw_value_t *value;
 
@@ -220,13 +218,11 @@ impl_afw_array_get_entry_internal(
  */
 const afw_value_t *
 impl_afw_array_get_entry_value(
-    const afw_array_t * instance,
+    AFW_ARRAY_SELF_T *self,
     afw_integer_t index,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {
-    impl_afw_array_const_array_of_values_self_t * self = 
-        (impl_afw_array_const_array_of_values_self_t *)instance;
     afw_size_t i, count;
     const afw_value_t *value;
 
@@ -246,14 +242,12 @@ impl_afw_array_get_entry_value(
  */
 afw_boolean_t
 impl_afw_array_get_next_internal(
-    const afw_array_t * instance,
+    AFW_ARRAY_SELF_T *self,
     const afw_iterator_t * * iterator,
     const afw_data_type_t * * data_type,
     const void * * internal,
     afw_xctx_t *xctx)
 {
-    impl_afw_array_const_array_of_values_self_t * self = 
-        (impl_afw_array_const_array_of_values_self_t *)instance;
     const afw_value_t *const *values;
 
     /* If iterator is NULL, set it to values. */
@@ -293,13 +287,11 @@ impl_afw_array_get_next_internal(
  */
 const afw_value_t *
 impl_afw_array_get_next_value(
-    const afw_array_t * instance,
+    AFW_ARRAY_SELF_T *self,
     const afw_iterator_t * * iterator,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {
-    impl_afw_array_const_array_of_values_self_t *self =
-        (impl_afw_array_const_array_of_values_self_t *)instance;
     const afw_value_t *const *values;
 
     /* If iterator is NULL, set it to values. */
@@ -331,7 +323,7 @@ impl_afw_array_get_next_value(
  */
 const afw_array_setter_t *
 impl_afw_array_get_setter(
-    const afw_array_t * instance,
+    AFW_ARRAY_SELF_T *self,
     afw_xctx_t *xctx)
 {
     return NULL;

--- a/src/afw/array/afw_array_memory.c
+++ b/src/afw/array/afw_array_memory.c
@@ -21,6 +21,8 @@
 
 /* Declares and rti/inf defines for interface afw_array */
 #define AFW_IMPLEMENTATION_ID "memory"
+typedef struct afw_memory_internal_array_s afw_memory_internal_array_t;
+#define AFW_ARRAY_SELF_T afw_memory_internal_array_t
 #include "afw_array_impl_declares.h"
 #include "afw_array_setter_impl_declares.h"
 
@@ -109,7 +111,7 @@ afw_array_create_with_options(
  */
 void
 impl_afw_array_release(
-    const afw_array_t * instance,
+    AFW_ARRAY_SELF_T *self,
     afw_xctx_t *xctx) {
 
     /*
@@ -130,10 +132,9 @@ impl_afw_array_release(
  */
 afw_size_t
 impl_afw_array_get_count(
-    const afw_array_t * instance,
+    AFW_ARRAY_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_memory_internal_array_t *self = (afw_memory_internal_array_t *)instance;
 
     return self->count;
 }
@@ -145,10 +146,9 @@ impl_afw_array_get_count(
  */
 const afw_data_type_t *
 impl_afw_array_get_data_type(
-    const afw_array_t * instance,
+    AFW_ARRAY_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_memory_internal_array_t *self = (afw_memory_internal_array_t *)instance;
 
     return self->data_type;
 }
@@ -160,7 +160,7 @@ impl_afw_array_get_data_type(
  */
 afw_boolean_t
 impl_afw_array_get_entry_internal(
-    const afw_array_t * instance,
+    AFW_ARRAY_SELF_T *self,
     afw_integer_t index,
     const afw_data_type_t * * data_type,
     const void * * internal,
@@ -168,7 +168,7 @@ impl_afw_array_get_entry_internal(
 {
     const afw_value_t *value;
 
-    value = impl_afw_array_get_entry_value(instance, index, NULL, xctx);
+    value = impl_afw_array_get_entry_value(self, index, NULL, xctx);
     if (value) {
         *internal = AFW_VALUE_INTERNAL(value);
         if (data_type) {
@@ -192,12 +192,11 @@ impl_afw_array_get_entry_internal(
  */
 const afw_value_t *
 impl_afw_array_get_entry_value(
-    const afw_array_t * instance,
+    AFW_ARRAY_SELF_T *self,
     afw_integer_t index,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {
-    afw_memory_internal_array_t *self = (afw_memory_internal_array_t *)instance;
     afw_memory_internal_array_entry_t *ep;
     afw_integer_t resolved;
 
@@ -230,13 +229,12 @@ impl_afw_array_get_entry_value(
  */
 afw_boolean_t
 impl_afw_array_get_next_internal(
-    const afw_array_t * instance,
+    AFW_ARRAY_SELF_T *self,
     const afw_iterator_t * * iterator,
     const afw_data_type_t * * data_type,
     const void * * internal,
     afw_xctx_t *xctx)
 {
-    afw_memory_internal_array_t *self = (afw_memory_internal_array_t *)instance;
     afw_memory_internal_array_entry_t *ep;
 
     /* If iterator is NULL, locate first else locate next. */
@@ -276,12 +274,11 @@ impl_afw_array_get_next_internal(
  */
 const afw_value_t *
 impl_afw_array_get_next_value(
-    const afw_array_t * instance,
+    AFW_ARRAY_SELF_T *self,
     const afw_iterator_t * * iterator,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {
-    afw_memory_internal_array_t *self = (afw_memory_internal_array_t *)instance;
     afw_memory_internal_array_entry_t *ep;
 
     /* If iterator is NULL, locate first else locate next and update iterator. */
@@ -313,10 +310,9 @@ impl_afw_array_get_next_value(
  */
 const afw_array_setter_t *
 impl_afw_array_get_setter(
-    const afw_array_t * instance,
+    AFW_ARRAY_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_memory_internal_array_t *self = (afw_memory_internal_array_t *)instance;
 
     return (self->immutable) ? NULL : &self->setter;
 }
@@ -516,13 +512,13 @@ impl_entry_at(
  */
 void
 impl_afw_array_setter_set_immutable(
-    const afw_array_setter_t * instance,
+    const afw_array_setter_t * self,
     afw_xctx_t *xctx)
 {
-    afw_memory_internal_array_t *self =
-        (afw_memory_internal_array_t *)((afw_array_setter_t *)instance)->array;
+    afw_memory_internal_array_t *array_self =
+        (afw_memory_internal_array_t *)((afw_array_setter_t *)self)->array;
 
-    self->immutable = true;
+    array_self->immutable = true;
 }
 
 
@@ -533,42 +529,42 @@ impl_afw_array_setter_set_immutable(
  */
 const afw_data_type_t *
 impl_afw_array_setter_determine_data_type_and_set_immutable(
-    const afw_array_setter_t * instance,
+    const afw_array_setter_t * self,
     afw_xctx_t *xctx)
 {
-    afw_memory_internal_array_t *self =
-        (afw_memory_internal_array_t *)((afw_array_setter_t *)instance)->array;
+    afw_memory_internal_array_t *array_self =
+        (afw_memory_internal_array_t *)((afw_array_setter_t *)self)->array;
     afw_memory_internal_array_entry_t *ep;
 
     /* Make immutable if not already. */
-    if (self->immutable) {
+    if (array_self->immutable) {
         AFW_LIST_ERROR_OBJECT_IMMUTABLE;
     }
-    self->immutable = true;
+    array_self->immutable = true;
 
     /* If data type not known yet, try to determine it. */
-    if (!self->data_type) {
-        for (ep = APR_RING_FIRST(self->ring);
-            ep != APR_RING_SENTINEL(self->ring,
+    if (!array_self->data_type) {
+        for (ep = APR_RING_FIRST(array_self->ring);
+            ep != APR_RING_SENTINEL(array_self->ring,
                 afw_memory_internal_array_entry_s, link);
             ep = APR_RING_NEXT(ep, link))
         {
-            if (!self->data_type) {
-                self->data_type =
+            if (!array_self->data_type) {
+                array_self->data_type =
                     afw_value_get_data_type(ep->value, xctx);
             }
             else {
-                if (self->data_type !=
+                if (array_self->data_type !=
                     afw_value_get_data_type(ep->value, xctx))
                 {
-                    self->data_type = NULL;
+                    array_self->data_type = NULL;
                     break;
                 }
             }
         }
     }
 
-    return self->data_type;
+    return array_self->data_type;
 }
 
 
@@ -578,24 +574,24 @@ impl_afw_array_setter_determine_data_type_and_set_immutable(
  */
 void
 impl_afw_array_setter_push_value(
-    const afw_array_setter_t * instance,
+    const afw_array_setter_t * self,
     const afw_value_t * value,
     afw_xctx_t *xctx)
 {
-    afw_memory_internal_array_t *self =
-        (afw_memory_internal_array_t *)((afw_array_setter_t *)instance)->array;
+    afw_memory_internal_array_t *array_self =
+        (afw_memory_internal_array_t *)((afw_array_setter_t *)self)->array;
     afw_memory_internal_array_entry_t *ep;
     afw_boolean_t was_empty;
 
-    was_empty = (self->count == 0);
-    impl_note_value_data_type(self, value, was_empty, xctx);
+    was_empty = (array_self->count == 0);
+    impl_note_value_data_type(array_self, value, was_empty, xctx);
 
     ep = afw_pool_calloc_type(
-        self->pub.p, afw_memory_internal_array_entry_t, xctx);
+        array_self->pub.p, afw_memory_internal_array_entry_t, xctx);
     ep->value = value;
-    APR_RING_INSERT_TAIL(self->ring, ep,
+    APR_RING_INSERT_TAIL(array_self->ring, ep,
         afw_memory_internal_array_entry_s, link);
-    self->count++;
+    array_self->count++;
 }
 
 
@@ -605,17 +601,17 @@ impl_afw_array_setter_push_value(
  */
 void
 impl_afw_array_setter_push_internal(
-    const afw_array_setter_t * instance,
+    const afw_array_setter_t * self,
     const afw_data_type_t *data_type,
     const void * internal,
     afw_xctx_t *xctx)
 {
-    afw_memory_internal_array_t *self =
-        (afw_memory_internal_array_t *)((afw_array_setter_t *)instance)->array;
+    afw_memory_internal_array_t *array_self =
+        (afw_memory_internal_array_t *)((afw_array_setter_t *)self)->array;
     const afw_value_t *value;
 
-    value = afw_value_common_create(internal, data_type, self->pub.p, xctx);
-    impl_afw_array_setter_push_value(instance, value, xctx);
+    value = afw_value_common_create(internal, data_type, array_self->pub.p, xctx);
+    impl_afw_array_setter_push_value(self, value, xctx);
 }
 
 
@@ -625,17 +621,17 @@ impl_afw_array_setter_push_internal(
  */
 const afw_value_t *
 impl_afw_array_setter_pop_value(
-    const afw_array_setter_t * instance,
+    const afw_array_setter_t * self,
     afw_boolean_t *found,
     afw_xctx_t *xctx)
 {
-    afw_memory_internal_array_t *self =
-        (afw_memory_internal_array_t *)((afw_array_setter_t *)instance)->array;
+    afw_memory_internal_array_t *array_self =
+        (afw_memory_internal_array_t *)((afw_array_setter_t *)self)->array;
     afw_memory_internal_array_entry_t *ep;
     const afw_value_t *value;
 
     /* Empty: NULL; optional found=false (undefined in script if ignored). */
-    if (self->count == 0) {
+    if (array_self->count == 0) {
         if (found) {
             *found = false;
         }
@@ -645,11 +641,11 @@ impl_afw_array_setter_pop_value(
     if (found) {
         *found = true;
     }
-    ep = APR_RING_LAST(self->ring);
+    ep = APR_RING_LAST(array_self->ring);
     value = ep->value;
     APR_RING_REMOVE(ep, link);
-    self->count--;
-    impl_maybe_clear_generic_data_type(self);
+    array_self->count--;
+    impl_maybe_clear_generic_data_type(array_self);
     return value;
 }
 
@@ -660,17 +656,17 @@ impl_afw_array_setter_pop_value(
  */
 const afw_value_t *
 impl_afw_array_setter_shift_value(
-    const afw_array_setter_t * instance,
+    const afw_array_setter_t * self,
     afw_boolean_t *found,
     afw_xctx_t *xctx)
 {
-    afw_memory_internal_array_t *self =
-        (afw_memory_internal_array_t *)((afw_array_setter_t *)instance)->array;
+    afw_memory_internal_array_t *array_self =
+        (afw_memory_internal_array_t *)((afw_array_setter_t *)self)->array;
     afw_memory_internal_array_entry_t *ep;
     const afw_value_t *value;
 
     /* Empty: NULL; optional found=false (undefined in script if ignored). */
-    if (self->count == 0) {
+    if (array_self->count == 0) {
         if (found) {
             *found = false;
         }
@@ -680,11 +676,11 @@ impl_afw_array_setter_shift_value(
     if (found) {
         *found = true;
     }
-    ep = APR_RING_FIRST(self->ring);
+    ep = APR_RING_FIRST(array_self->ring);
     value = ep->value;
     APR_RING_REMOVE(ep, link);
-    self->count--;
-    impl_maybe_clear_generic_data_type(self);
+    array_self->count--;
+    impl_maybe_clear_generic_data_type(array_self);
     return value;
 }
 
@@ -695,55 +691,55 @@ impl_afw_array_setter_shift_value(
  */
 void
 impl_afw_array_setter_insert_value(
-    const afw_array_setter_t * instance,
+    const afw_array_setter_t * self,
     afw_integer_t index,
     const afw_value_t * value,
     afw_xctx_t *xctx)
 {
-    afw_memory_internal_array_t *self =
-        (afw_memory_internal_array_t *)((afw_array_setter_t *)instance)->array;
+    afw_memory_internal_array_t *array_self =
+        (afw_memory_internal_array_t *)((afw_array_setter_t *)self)->array;
     afw_memory_internal_array_entry_t *lep;
     afw_memory_internal_array_entry_t *nep;
     afw_size_t count;
     afw_size_t at;
     afw_boolean_t was_empty;
 
-    was_empty = (self->count == 0);
-    impl_note_value_data_type(self, value, was_empty, xctx);
+    was_empty = (array_self->count == 0);
+    impl_note_value_data_type(array_self, value, was_empty, xctx);
 
-    count = self->count;
+    count = array_self->count;
     at = impl_resolve_insert_index(index, count, xctx);
 
     nep = afw_pool_calloc_type(
-        self->pub.p, afw_memory_internal_array_entry_t, xctx);
+        array_self->pub.p, afw_memory_internal_array_entry_t, xctx);
     nep->value = value;
 
     /* index 0 = unshift (front); index == count = push (append). */
     if (at == 0) {
-        APR_RING_INSERT_HEAD(self->ring, nep,
+        APR_RING_INSERT_HEAD(array_self->ring, nep,
             afw_memory_internal_array_entry_s, link);
-        self->count++;
+        array_self->count++;
         return;
     }
 
     if (at >= count) {
-        APR_RING_INSERT_TAIL(self->ring, nep,
+        APR_RING_INSERT_TAIL(array_self->ring, nep,
             afw_memory_internal_array_entry_s, link);
-        self->count++;
+        array_self->count++;
         return;
     }
 
-    lep = impl_entry_at(self, at);
+    lep = impl_entry_at(array_self, at);
     if (lep) {
         APR_RING_INSERT_BEFORE(lep, nep, link);
-        self->count++;
+        array_self->count++;
         return;
     }
 
     /* Should not reach. */
-    APR_RING_INSERT_TAIL(self->ring, nep,
+    APR_RING_INSERT_TAIL(array_self->ring, nep,
         afw_memory_internal_array_entry_s, link);
-    self->count++;
+    array_self->count++;
 }
 
 
@@ -753,19 +749,19 @@ impl_afw_array_setter_insert_value(
  */
 void
 impl_afw_array_setter_insert_internal(
-    const afw_array_setter_t * instance,
+    const afw_array_setter_t * self,
     afw_integer_t index,
     const afw_data_type_t * data_type,
     const void * internal,
     afw_xctx_t *xctx)
 {
-    afw_memory_internal_array_t *self =
-        (afw_memory_internal_array_t *)((afw_array_setter_t *)instance)->array;
+    afw_memory_internal_array_t *array_self =
+        (afw_memory_internal_array_t *)((afw_array_setter_t *)self)->array;
     const afw_value_t *value;
 
     value = afw_value_common_create(
-        internal, data_type, self->pub.p, xctx);
-    impl_afw_array_setter_insert_value(instance, index, value, xctx);
+        internal, data_type, array_self->pub.p, xctx);
+    impl_afw_array_setter_insert_value(self, index, value, xctx);
 }
 
 
@@ -775,20 +771,20 @@ impl_afw_array_setter_insert_internal(
  */
 void
 impl_afw_array_setter_set_value(
-    const afw_array_setter_t *instance,
+    const afw_array_setter_t *self,
     afw_integer_t index,
     const afw_value_t *value,
     afw_xctx_t *xctx)
 {
-    afw_memory_internal_array_t *self =
-        (afw_memory_internal_array_t *)((afw_array_setter_t *)instance)->array;
+    afw_memory_internal_array_t *array_self =
+        (afw_memory_internal_array_t *)((afw_array_setter_t *)self)->array;
     afw_memory_internal_array_entry_t *lep;
     afw_size_t at;
 
-    at = impl_resolve_element_index(index, self->count, xctx);
-    impl_note_value_data_type(self, value, false, xctx);
+    at = impl_resolve_element_index(index, array_self->count, xctx);
+    impl_note_value_data_type(array_self, value, false, xctx);
 
-    lep = impl_entry_at(self, at);
+    lep = impl_entry_at(array_self, at);
     if (!lep) {
         AFW_THROW_ERROR_Z(general, "Index out of bounds", xctx);
     }
@@ -808,26 +804,26 @@ impl_afw_array_setter_set_value(
  */
 void
 impl_afw_array_setter_remove_value_by_index(
-    const afw_array_setter_t *instance,
+    const afw_array_setter_t *self,
     afw_integer_t index,
     afw_xctx_t *xctx)
 {
-    afw_memory_internal_array_t *self =
-        (afw_memory_internal_array_t *)((afw_array_setter_t *)instance)->array;
+    afw_memory_internal_array_t *array_self =
+        (afw_memory_internal_array_t *)((afw_array_setter_t *)self)->array;
     afw_memory_internal_array_entry_t *lep;
     afw_size_t at;
 
-    at = impl_resolve_element_index(index, self->count, xctx);
+    at = impl_resolve_element_index(index, array_self->count, xctx);
 
-    lep = impl_entry_at(self, at);
+    lep = impl_entry_at(array_self, at);
     if (!lep) {
         AFW_THROW_ERROR_Z(general, "Index out of bounds", xctx);
     }
 
     /* @fixme #2: optional_release lep->value when hold-on-store lands. */
     APR_RING_REMOVE(lep, link);
-    self->count--;
-    impl_maybe_clear_generic_data_type(self);
+    array_self->count--;
+    impl_maybe_clear_generic_data_type(array_self);
 }
 
 
@@ -837,21 +833,21 @@ impl_afw_array_setter_remove_value_by_index(
  */
 void
 impl_afw_array_setter_remove_value(
-    const afw_array_setter_t * instance,
+    const afw_array_setter_t * self,
     const afw_value_t * value,
     afw_xctx_t *xctx)
 {
-    afw_memory_internal_array_t *self =
-        (afw_memory_internal_array_t *)((afw_array_setter_t *)instance)->array;
+    afw_memory_internal_array_t *array_self =
+        (afw_memory_internal_array_t *)((afw_array_setter_t *)self)->array;
     afw_memory_internal_array_entry_t *ep;
 
-    APR_RING_FOREACH(ep, self->ring, afw_memory_internal_array_entry_s, link)
+    APR_RING_FOREACH(ep, array_self->ring, afw_memory_internal_array_entry_s, link)
     {
         if (afw_value_equal(value, ep->value, xctx)) {
             /* @fixme #2: optional_release ep->value when hold-on-store lands. */
             APR_RING_REMOVE(ep, link);
-            self->count--;
-            impl_maybe_clear_generic_data_type(self);
+            array_self->count--;
+            impl_maybe_clear_generic_data_type(array_self);
             return;
         }
     }
@@ -866,16 +862,16 @@ impl_afw_array_setter_remove_value(
  */
 void
 impl_afw_array_setter_remove_internal(
-    const afw_array_setter_t * instance,
+    const afw_array_setter_t * self,
     const afw_data_type_t *data_type,
     const void * internal,
     afw_xctx_t *xctx)
 {
-    afw_memory_internal_array_t *self =
-        (afw_memory_internal_array_t *)((afw_array_setter_t *)instance)->array;
+    afw_memory_internal_array_t *array_self =
+        (afw_memory_internal_array_t *)((afw_array_setter_t *)self)->array;
     afw_memory_internal_array_entry_t *ep;
 
-    APR_RING_FOREACH(ep, self->ring, afw_memory_internal_array_entry_s, link)
+    APR_RING_FOREACH(ep, array_self->ring, afw_memory_internal_array_entry_s, link)
     {
         if (afw_value_get_data_type(ep->value, xctx) == data_type &&
             memcmp(
@@ -884,8 +880,8 @@ impl_afw_array_setter_remove_internal(
         {
             /* @fixme #2: optional_release ep->value when hold-on-store lands. */
             APR_RING_REMOVE(ep, link);
-            self->count--;
-            impl_maybe_clear_generic_data_type(self);
+            array_self->count--;
+            impl_maybe_clear_generic_data_type(array_self);
             return;
         }
     }
@@ -900,21 +896,21 @@ impl_afw_array_setter_remove_internal(
  */
 void
 impl_afw_array_setter_remove_all_values(
-    const afw_array_setter_t * instance,
+    const afw_array_setter_t * self,
     afw_xctx_t *xctx)
 {
-    afw_memory_internal_array_t *self =
-        (afw_memory_internal_array_t *)((afw_array_setter_t *)instance)->array;
+    afw_memory_internal_array_t *array_self =
+        (afw_memory_internal_array_t *)((afw_array_setter_t *)self)->array;
 
     /*
      * @fixme #2: walk ring and optional_release each element value before
      * re-init when hold-on-store lands (see impl_optional_release_value).
      */
-    APR_RING_INIT(self->ring, afw_memory_internal_array_entry_s, link);
-    self->count = 0;
+    APR_RING_INIT(array_self->ring, afw_memory_internal_array_entry_s, link);
+    array_self->count = 0;
 
-    if (self->generic) {
-        self->data_type = NULL;
+    if (array_self->generic) {
+        array_self->data_type = NULL;
     }
 }
 

--- a/src/afw/array/afw_array_wrapper_for_array.c
+++ b/src/afw/array/afw_array_wrapper_for_array.c
@@ -22,6 +22,7 @@
 #define AFW_IMPLEMENTATION_ID "afw_array_wrapper_for_array"
 #define AFW_IMPLEMENTATION_INF_SPECIFIER AFW_DEFINE_CONST_DATA
 #define AFW_IMPLEMENTATION_INF_LABEL afw_array_wrapper_for_array_inf
+#define AFW_ARRAY_SELF_T afw_array_wrapper_for_array_self_t
 #include "afw_array_impl_declares.h"
 #undef AFW_IMPLEMENTATION_INF_SPECIFIER
 #undef AFW_IMPLEMENTATION_INF_LABEL
@@ -152,7 +153,7 @@ afw_array_convert_to_array_of_strings(
  */
 void
 impl_afw_array_release (
-    const afw_array_t * instance,
+    AFW_ARRAY_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Nothing to do. */
@@ -165,11 +166,9 @@ impl_afw_array_release (
  */
 afw_size_t
 impl_afw_array_get_count(
-    const afw_array_t * instance,
+    AFW_ARRAY_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_array_wrapper_for_array_self_t * self = 
-        (afw_array_wrapper_for_array_self_t *)instance;
     
     return self->count;
 }
@@ -181,11 +180,9 @@ impl_afw_array_get_count(
  */
 const afw_data_type_t *
 impl_afw_array_get_data_type(
-    const afw_array_t * instance,
+    AFW_ARRAY_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_array_wrapper_for_array_self_t * self = 
-        (afw_array_wrapper_for_array_self_t *)instance;
   
     return self->data_type;
 }
@@ -197,14 +194,12 @@ impl_afw_array_get_data_type(
  */
 afw_boolean_t
 impl_afw_array_get_entry_internal(
-    const afw_array_t * instance,
+    AFW_ARRAY_SELF_T *self,
     afw_integer_t index,
     const afw_data_type_t * * data_type,
     const void * *internal,
     afw_xctx_t *xctx)
 {
-    afw_array_wrapper_for_array_self_t * self = 
-        (afw_array_wrapper_for_array_self_t *)instance;
     const void *e;
     afw_size_t count;
     afw_size_t i;
@@ -264,7 +259,7 @@ impl_afw_array_get_entry_internal(
  */
 const afw_value_t *
 impl_afw_array_get_entry_value(
-    const afw_array_t * instance,
+    AFW_ARRAY_SELF_T *self,
     afw_integer_t index,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
@@ -273,7 +268,7 @@ impl_afw_array_get_entry_value(
     const void *internal;
     const afw_value_t *result;
 
-    if (impl_afw_array_get_entry_internal(instance,
+    if (impl_afw_array_get_entry_internal(self,
         index, &data_type, &internal, xctx))
     {
         result = afw_value_common_create(
@@ -294,14 +289,12 @@ impl_afw_array_get_entry_value(
  */
 afw_boolean_t
 impl_afw_array_get_next_internal(
-    const afw_array_t * instance,
+    AFW_ARRAY_SELF_T *self,
     const afw_iterator_t * * iterator,
     const afw_data_type_t * * data_type,
     const void * * internal,
     afw_xctx_t *xctx)
 {
-    afw_array_wrapper_for_array_self_t * self = 
-        (afw_array_wrapper_for_array_self_t *)instance;
     afw_size_t size;
 
     /* If iterator is NULL, point to first value in array. */
@@ -348,13 +341,11 @@ impl_afw_array_get_next_internal(
  */
 const afw_value_t *
 impl_afw_array_get_next_value(
-    const afw_array_t * instance,
+    AFW_ARRAY_SELF_T *self,
     const afw_iterator_t * * iterator,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {
-    afw_array_wrapper_for_array_self_t * self = 
-        (afw_array_wrapper_for_array_self_t *)instance;
     const afw_value_t *result;
     afw_size_t size;
 
@@ -402,7 +393,7 @@ impl_afw_array_get_next_value(
  */
 const afw_array_setter_t *
 impl_afw_array_get_setter(
-    const afw_array_t * instance,
+    AFW_ARRAY_SELF_T *self,
     afw_xctx_t *xctx)
 {
     return NULL;

--- a/src/afw/authorization/afw_authorization.c
+++ b/src/afw/authorization/afw_authorization.c
@@ -1291,7 +1291,7 @@ afw_authorization_internal_register_service_and_conf(
  */
 afw_integer_t
 impl_afw_service_type_related_instance_count (
-    const afw_service_type_t * instance,
+    const afw_service_type_t * self,
     const afw_utf8_t * id,
     afw_xctx_t *xctx)
 {
@@ -1330,7 +1330,7 @@ impl_afw_service_type_related_instance_count (
  */
 void
 impl_afw_service_type_start_cede_p (
-    const afw_service_type_t * instance,
+    const afw_service_type_t * self,
     const afw_object_t * properties,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
@@ -1373,7 +1373,7 @@ impl_afw_service_type_start_cede_p (
  */
 void
 impl_afw_service_type_stop (
-    const afw_service_type_t * instance,
+    const afw_service_type_t * self,
     const afw_utf8_t * id,
     afw_xctx_t *xctx)
 {
@@ -1387,11 +1387,11 @@ impl_afw_service_type_stop (
  */
 void
 impl_afw_service_type_restart_cede_p (
-    const afw_service_type_t * instance,
+    const afw_service_type_t * self,
     const afw_object_t * properties,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {
     /* Count on already running. Start will restart if necessary. */
-    impl_afw_service_type_start_cede_p(instance, properties, p, xctx);
+    impl_afw_service_type_start_cede_p(self, properties, p, xctx);
 }

--- a/src/afw/authorization/afw_authorization_handler_type_script.c
+++ b/src/afw/authorization/afw_authorization_handler_type_script.c
@@ -18,6 +18,7 @@
 /* Declares and rti/inf defines for interface afw_authorization_handler */
 #define AFW_IMPLEMENTATION_ID "script"
 #include "afw_authorization_handler_factory_impl_declares.h"
+#define AFW_AUTHORIZATION_HANDLER_SELF_T afw_authorization_handler_script_self_t
 #include "afw_authorization_handler_impl_declares.h"
 
 
@@ -37,7 +38,7 @@ impl_authorization_handler_factory_instance = {
  */
 const afw_authorization_handler_t *
 impl_afw_authorization_handler_factory_create_authorization_handler_cede_p(
-    const afw_authorization_handler_factory_t * instance,
+    const afw_authorization_handler_factory_t * self,
     const afw_object_t *properties,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
@@ -146,12 +147,12 @@ afw_authorization_handler_type_script_create_cede_p(
  */
 void
 impl_afw_authorization_handler_destroy(
-    const afw_authorization_handler_t * instance,
+    AFW_AUTHORIZATION_HANDLER_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    /* Assign instance pointer to self. */
+    /* Assign &self->pub pointer to self. */
     // afw_authorization_handler_script_self_t * self =
-    //     (afw_authorization_handler_script_self_t *)instance;
+    //     (afw_authorization_handler_script_self_t *)&self->pub;
 
     /* Add code, if needed. */
 }
@@ -164,15 +165,13 @@ impl_afw_authorization_handler_destroy(
  */
 const afw_value_t *
 impl_afw_authorization_handler_check(
-    const afw_authorization_handler_t * instance,
+    AFW_AUTHORIZATION_HANDLER_SELF_T *self,
     const afw_value_t *resource_id,
     const afw_value_t *object,
     const afw_value_t *action_id,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {
-    afw_authorization_handler_script_self_t *self =
-        (afw_authorization_handler_script_self_t *)instance;
     const afw_value_t *result;
     int top;
 

--- a/src/afw/content_type/afw_content_type_application_afw.c
+++ b/src/afw/content_type/afw_content_type_application_afw.c
@@ -21,6 +21,8 @@
 #include "afw_content_type_impl_declares.h"
 #undef AFW_IMPLEMENTATION_INF_SPECIFIER
 #undef AFW_IMPLEMENTATION_INF_LABEL
+typedef struct afw_content_type_application_afw_stream_self_s afw_content_type_application_afw_stream_self_t;
+#define AFW_STREAM_SELF_T afw_content_type_application_afw_stream_self_t
 #include "afw_stream_impl_declares.h"
 
 
@@ -113,7 +115,7 @@ impl_afw_content_type_application_afw =
  */
 const afw_value_t *
 impl_afw_content_type_raw_to_value(
-    const afw_content_type_t * instance,
+    const afw_content_type_t * self,
     const afw_memory_t * raw,
     const afw_utf8_t * source_location,
     const afw_pool_t * p,
@@ -131,7 +133,7 @@ impl_afw_content_type_raw_to_value(
  */
 const afw_object_t *
 impl_afw_content_type_raw_to_object(
-    const afw_content_type_t * instance,
+    const afw_content_type_t * self,
     const afw_memory_t * raw,
     const afw_utf8_t * source_location,
     const afw_utf8_t * adapter_id,
@@ -152,7 +154,7 @@ impl_afw_content_type_raw_to_object(
  */
 void
 impl_afw_content_type_write_value(
-    const afw_content_type_t * instance,
+    const afw_content_type_t * self,
     const afw_value_t * value,
     const afw_object_options_t * options,
     void * context,
@@ -170,7 +172,7 @@ impl_afw_content_type_write_value(
  */
 const afw_content_type_object_list_writer_t *
 impl_afw_content_type_create_object_list_writer(
-    const afw_content_type_t * instance,
+    const afw_content_type_t * self,
     const afw_object_options_t * options,
     void * context,
     afw_write_cb_t callback,
@@ -178,7 +180,7 @@ impl_afw_content_type_create_object_list_writer(
     afw_xctx_t *xctx)
 {
     return afw_content_type_impl_create_object_list_writer(
-        instance, options, context, callback,
+        self, options, context, callback,
         &impl_raw_begin_object_list,
         &impl_raw_object_separator,
         &impl_raw_last_object_separator,
@@ -217,13 +219,11 @@ impl_afw_stream_write_cb(
  */
 void
 impl_afw_stream_release(
-    const afw_stream_t *instance,
+    AFW_STREAM_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_content_type_application_afw_stream_self_t *self =
-        (afw_content_type_application_afw_stream_self_t *)instance;
 
-    impl_afw_stream_flush(instance, xctx);
+    impl_afw_stream_flush(self, xctx);
     afw_pool_release(self->pub.p, xctx);
 }
 
@@ -232,12 +232,12 @@ impl_afw_stream_release(
  */
 afw_size_t
 impl_afw_stream_read(
-    const afw_stream_t *instance,
+    AFW_STREAM_SELF_T *self,
     void *buffer,
     afw_size_t size,
     afw_xctx_t *xctx)
 {
-    (void)instance;
+    (void)&self->pub;
     (void)buffer;
     (void)size;
     AFW_THROW_ERROR_Z(general, "Stream is not readable.", xctx);
@@ -248,11 +248,9 @@ impl_afw_stream_read(
  */
 void
 impl_afw_stream_flush(
-    const afw_stream_t *instance,
+    AFW_STREAM_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_content_type_application_afw_stream_self_t *self =
-        (afw_content_type_application_afw_stream_self_t *)instance;
     const afw_utf8_t *header;
     afw_size_t size;
 
@@ -285,7 +283,7 @@ impl_afw_stream_flush(
  */
 void
 impl_afw_stream_write(
-    const afw_stream_t *instance,
+    AFW_STREAM_SELF_T *self,
     const void *buffer,
     afw_size_t size,
     afw_xctx_t *xctx)
@@ -293,7 +291,7 @@ impl_afw_stream_write(
     if (size == 0) {
         return;
     }
-    impl_afw_stream_write_cb((void *)instance, buffer, size, instance->p, xctx);
+    impl_afw_stream_write_cb((void *)&self->pub, buffer, size, self->pub.p, xctx);
 }
 
 

--- a/src/afw/content_type/afw_content_type_impl.c
+++ b/src/afw/content_type/afw_content_type_impl.c
@@ -19,6 +19,8 @@
  * afw_content_type_object_list_writer
  */
 #define AFW_IMPLEMENTATION_ID "impl"
+typedef struct impl_afw_content_type_object_list_writer_self_s impl_afw_content_type_object_list_writer_self_t;
+#define AFW_CONTENT_TYPE_OBJECT_LIST_WRITER_SELF_T impl_afw_content_type_object_list_writer_self_t
 #include "afw_content_type_object_list_writer_impl_declares.h"
 
 
@@ -90,12 +92,10 @@ afw_content_type_impl_create_object_list_writer(
  */
 void
 impl_afw_content_type_object_list_writer_release(
-    const afw_content_type_object_list_writer_t * instance,
+    AFW_CONTENT_TYPE_OBJECT_LIST_WRITER_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    /* Assign instance pointer to self. */
-    impl_afw_content_type_object_list_writer_self_t * self =
-        (impl_afw_content_type_object_list_writer_self_t *)instance;
+    /* Assign &self->pub pointer to self. */
 
     /* If objects have been written, write last separator if there is one. */
     if (self->object_count > 0 &&
@@ -124,14 +124,12 @@ impl_afw_content_type_object_list_writer_release(
  */
 void
 impl_afw_content_type_object_list_writer_write_object(
-    const afw_content_type_object_list_writer_t * instance,
+    AFW_CONTENT_TYPE_OBJECT_LIST_WRITER_SELF_T *self,
     const afw_object_t * object,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    /* Assign instance pointer to self. */
-    impl_afw_content_type_object_list_writer_self_t * self =
-        (impl_afw_content_type_object_list_writer_self_t *)instance;
+    /* Assign &self->pub pointer to self. */
     const afw_memory_t *raw;
     const afw_value_t *value;
 

--- a/src/afw/environment/afw_environment_registry_object.c
+++ b/src/afw/environment/afw_environment_registry_object.c
@@ -70,7 +70,7 @@ afw_environment_registry_object_get_current(afw_xctx_t *xctx)
  */
 void
 impl_afw_object_release (
-    const afw_object_t * instance,
+    const afw_object_t * self,
     afw_xctx_t *xctx)
 {
     /* Nothing to do. */
@@ -83,7 +83,7 @@ impl_afw_object_release (
  */
 void
 impl_afw_object_get_reference (
-    const afw_object_t * instance,
+    const afw_object_t * self,
     afw_xctx_t *xctx)
 {
     /* Nothing to do. */
@@ -94,11 +94,11 @@ impl_afw_object_get_reference (
  */
 afw_size_t
 impl_afw_object_get_count(
-    const afw_object_t * instance,
+    const afw_object_t * self,
     afw_xctx_t * xctx)
 {
 //    <afwdev {prefixed_interface_name}>_self_t *self =
-//        (<afwdev {prefixed_interface_name}>_self_t *)instance;
+//        (<afwdev {prefixed_interface_name}>_self_t *)self;
 
     /** @todo Add code to implement method. */
     AFW_THROW_ERROR_Z(general, "Method not implemented.", xctx);
@@ -149,7 +149,7 @@ impl_make_registry_type_value(
  */
 const afw_value_t *
 impl_afw_object_get_property (
-    const afw_object_t * instance,
+    const afw_object_t * self,
     const afw_utf8_t * property_name,
     afw_xctx_t *xctx)
 {
@@ -170,7 +170,7 @@ impl_afw_object_get_property (
  */
 const afw_value_t *
 impl_afw_object_get_next_property (
-    const afw_object_t * instance,
+    const afw_object_t * self,
     const afw_iterator_t * * iterator,
     const afw_utf8_t * * property_name,
     afw_xctx_t *xctx)
@@ -218,11 +218,11 @@ impl_afw_object_get_next_property (
  */
 afw_boolean_t
 impl_afw_object_has_property (
-    const afw_object_t * instance,
+    const afw_object_t * self,
     const afw_utf8_t * property_name,
     afw_xctx_t *xctx)
 {
-    return impl_afw_object_get_property(instance, property_name, xctx) != NULL;
+    return impl_afw_object_get_property(self, property_name, xctx) != NULL;
 }
 
 
@@ -232,7 +232,7 @@ impl_afw_object_has_property (
  */
 const afw_object_setter_t *
 impl_afw_object_get_setter (
-    const afw_object_t * instance,
+    const afw_object_t * self,
     afw_xctx_t *xctx)
 {
     /* Immutable. */

--- a/src/afw/environment/afw_environment_variables_object.c
+++ b/src/afw/environment/afw_environment_variables_object.c
@@ -24,6 +24,8 @@
 
 /* Declares and rti/inf defines for interface afw_object */
 #define AFW_IMPLEMENTATION_ID "environment_variables"
+typedef struct impl_self_s impl_self_t;
+#define AFW_OBJECT_SELF_T impl_self_t
 #include "afw_object_impl_declares.h"
 
 typedef struct impl_self_s {
@@ -148,10 +150,9 @@ afw_environment_create_environment_variables_object(
  */
 void
 impl_afw_object_release(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    impl_self_t *self = (impl_self_t *)instance;
 
     afw_object_release(self->properties, xctx);
 }
@@ -163,10 +164,9 @@ impl_afw_object_release(
  */
 void
 impl_afw_object_get_reference (
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    impl_self_t *self = (impl_self_t *)instance;
 
     afw_object_get_reference(self->properties, xctx);
 }
@@ -176,10 +176,9 @@ impl_afw_object_get_reference (
  */
 afw_size_t
 impl_afw_object_get_count(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t * xctx)
 {
-    impl_self_t *self = (impl_self_t *)instance;
 
     /* If all variable not loaded yet, load them. */
     if (!self->all_variables_loaded) {
@@ -194,12 +193,12 @@ impl_afw_object_get_count(
  */
 const afw_value_t *
 impl_afw_object_get_meta(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
     return afw_object_impl_get_meta(
-        instance, p, xctx);
+        &self->pub, p, xctx);
 }
 
 
@@ -208,11 +207,10 @@ impl_afw_object_get_meta(
  */
 const afw_value_t *
 impl_afw_object_get_property(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t * property_name,
     afw_xctx_t *xctx)
 {
-    impl_self_t *self = (impl_self_t *)instance;
     const char *s;
     const afw_value_t *value;
     const afw_utf8_z_t *property_name_z;
@@ -247,13 +245,13 @@ impl_afw_object_get_property(
  */
 const afw_value_t *
 impl_afw_object_get_property_meta(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t *property_name,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
     return afw_object_impl_get_property_meta(
-        instance, property_name, p, xctx);
+        &self->pub, property_name, p, xctx);
 }
 
 
@@ -263,12 +261,11 @@ impl_afw_object_get_property_meta(
  */
 const afw_value_t *
 impl_afw_object_get_next_property(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_iterator_t * * iterator,
     const afw_utf8_t * * property_name,
     afw_xctx_t *xctx)
 {
-    impl_self_t *self = (impl_self_t *)instance;
 
     /* Materialize full environ into cache once; cache is source of truth. */
     if (!self->all_variables_loaded) {
@@ -286,14 +283,14 @@ impl_afw_object_get_next_property(
  */
 const afw_value_t *
 impl_afw_object_get_next_property_meta(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_iterator_t **iterator,
     const afw_utf8_t **property_name,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
     return afw_object_impl_get_next_property_meta(
-        instance, iterator, property_name, p, xctx);
+        &self->pub, iterator, property_name, p, xctx);
 }
 
 
@@ -303,14 +300,13 @@ impl_afw_object_get_next_property_meta(
  */
 afw_boolean_t
 impl_afw_object_has_property(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t * property_name,
     afw_xctx_t *xctx)
 {
     const afw_value_t *value;
 
-    value = impl_afw_object_get_property(
-        instance, property_name, xctx);
+    value = impl_afw_object_get_property(self, property_name, xctx);
 
     return (value != NULL);
 }
@@ -322,7 +318,7 @@ impl_afw_object_has_property(
  */
 const afw_object_setter_t *
 impl_afw_object_get_setter (
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Is readonly. */

--- a/src/afw/file/afw_file.c
+++ b/src/afw/file/afw_file.c
@@ -19,7 +19,9 @@
 /* Declares and rti/inf defines for interface afw_adapter_factory */
 #define AFW_IMPLEMENTATION_ID "file"
 #include "afw_adapter_factory_impl_declares.h"
+#define AFW_ADAPTER_SELF_T afw_file_internal_adapter_t
 #include "afw_adapter_impl_declares.h"
+#define AFW_ADAPTER_SESSION_SELF_T afw_file_internal_adapter_session_t
 #include "afw_adapter_session_impl_declares.h"
 
 
@@ -269,7 +271,7 @@ afw_file_adapter_factory_get()
  */
 const afw_adapter_t *
 impl_afw_adapter_factory_create_adapter_cede_p (
-    const afw_adapter_factory_t * instance,
+    const afw_adapter_factory_t * self,
     const afw_object_t * properties,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
@@ -375,11 +377,11 @@ afw_file_adapter_create_cede_p(
  */
 void
 impl_afw_adapter_destroy(
-    const afw_adapter_t * instance,
+    AFW_ADAPTER_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Release pool. */
-    afw_pool_release(instance->p, xctx);
+    afw_pool_release(self->pub.p, xctx);
 }
 
 
@@ -388,10 +390,9 @@ impl_afw_adapter_destroy(
  */
 const afw_adapter_session_t *
 impl_afw_adapter_create_adapter_session (
-    const afw_adapter_t * instance,
+    AFW_ADAPTER_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_file_internal_adapter_t *self = (afw_file_internal_adapter_t *)instance;
     afw_file_internal_adapter_session_t *session;
 
     session = afw_xctx_calloc_type(afw_file_internal_adapter_session_t, xctx);
@@ -400,7 +401,7 @@ impl_afw_adapter_create_adapter_session (
     session->pub.p = xctx->p;
     session->adapter = self;
 
-    /* Adapter session instance holds event journal instance. */
+    /* Adapter session &self->pub holds event journal &self->pub. */
     session->journal.inf = afw_file_internal_get_journal_inf();
     session->journal.session = (afw_adapter_session_t *)session;
 
@@ -415,7 +416,7 @@ impl_afw_adapter_create_adapter_session (
  */
 const afw_object_t *
 impl_afw_adapter_get_additional_metrics(
-    const afw_adapter_t * instance,
+    AFW_ADAPTER_SELF_T *self,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {
@@ -446,7 +447,7 @@ impl_get_full_path(
  */
 void
 impl_afw_adapter_session_destroy(
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Nothing to do. */
@@ -459,7 +460,7 @@ impl_afw_adapter_session_destroy(
  */
 void
 impl_afw_adapter_session_retrieve_objects(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_query_criteria_t *criteria,
@@ -469,7 +470,6 @@ impl_afw_adapter_session_retrieve_objects(
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    afw_file_internal_adapter_session_t * self = (afw_file_internal_adapter_session_t *)instance;
     afw_file_internal_adapter_t *adapter = (afw_file_internal_adapter_t *)self->adapter;
     const char *dirname_z;
     const afw_utf8_t *full_path;
@@ -549,7 +549,7 @@ impl_afw_adapter_session_retrieve_objects(
             AFW_UTF8_FMT_OPTIONAL_ARG(adapter->filename_suffix));
 
         /*
-         * Load file to memory and convert to object instance.  Ceed control
+         * Load file to memory and convert to object &self->pub.  Ceed control
          * of obj_p to object.
          */
         raw = afw_file_to_memory(full_path, (apr_size_t)finfo.size,
@@ -591,7 +591,7 @@ impl_afw_adapter_session_retrieve_objects(
  */
 void
 impl_afw_adapter_session_get_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *object_id,
@@ -601,7 +601,6 @@ impl_afw_adapter_session_get_object(
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    afw_file_internal_adapter_session_t * self = (afw_file_internal_adapter_session_t *)instance;
     afw_file_internal_adapter_t *adapter = (afw_file_internal_adapter_t *)self->adapter;
     const afw_utf8_t *full_path;
     const afw_memory_t *raw;
@@ -616,7 +615,7 @@ impl_afw_adapter_session_get_object(
         obj_p, xctx);
 
     /*
-     * Load file to memory and convert to object instance.  Ceed control
+     * Load file to memory and convert to object &self->pub.  Ceed control
      * of obj_p to object.
      */
     raw = afw_file_to_memory(full_path, 0, obj_p, xctx);
@@ -635,7 +634,7 @@ impl_afw_adapter_session_get_object(
  */
 const afw_utf8_t *
 impl_afw_adapter_session_add_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *suggested_object_id,
@@ -643,7 +642,6 @@ impl_afw_adapter_session_add_object(
     const afw_object_t *adapter_type_specific,
     afw_xctx_t *xctx)
 {
-    afw_file_internal_adapter_session_t * self = (afw_file_internal_adapter_session_t *)instance;
     afw_file_internal_adapter_t *adapter = (afw_file_internal_adapter_t *)self->adapter;
     const afw_utf8_t *full_path;
     const afw_memory_t *raw;
@@ -669,7 +667,7 @@ impl_afw_adapter_session_add_object(
  */
 void
 impl_afw_adapter_session_modify_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *object_id,
@@ -677,8 +675,6 @@ impl_afw_adapter_session_modify_object(
     const afw_object_t *adapter_type_specific,
     afw_xctx_t *xctx)
 {
-    afw_file_internal_adapter_session_t * self =
-        (afw_file_internal_adapter_session_t *)instance;
     afw_file_internal_adapter_t *adapter =
         (afw_file_internal_adapter_t *)self->adapter;
     const afw_object_t *object;
@@ -727,7 +723,7 @@ impl_afw_adapter_session_modify_object(
  */
 void
 impl_afw_adapter_session_replace_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *object_id,
@@ -735,7 +731,6 @@ impl_afw_adapter_session_replace_object(
     const afw_object_t *adapter_type_specific,
     afw_xctx_t *xctx)
 {
-    afw_file_internal_adapter_session_t * self = (afw_file_internal_adapter_session_t *)instance;
     afw_file_internal_adapter_t *adapter = (afw_file_internal_adapter_t *)self->adapter;
     const afw_utf8_t *full_path;
     const afw_memory_t *raw;
@@ -762,14 +757,13 @@ impl_afw_adapter_session_replace_object(
  */
 void
 impl_afw_adapter_session_delete_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *object_id,
     const afw_object_t *adapter_type_specific,
     afw_xctx_t *xctx)
 {
-    afw_file_internal_adapter_session_t * self = (afw_file_internal_adapter_session_t *)instance;
     afw_file_internal_adapter_t *adapter = (afw_file_internal_adapter_t *)self->adapter;
     const afw_utf8_t *full_path;
 
@@ -784,7 +778,7 @@ impl_afw_adapter_session_delete_object(
  */
 const afw_adapter_transaction_t *
 impl_afw_adapter_session_begin_transaction(
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* This adapter does not support transactions. */
@@ -797,12 +791,11 @@ impl_afw_adapter_session_begin_transaction(
  */
 const afw_adapter_journal_t *
 impl_afw_adapter_session_get_journal_interface(
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_file_internal_adapter_session_t * self = (afw_file_internal_adapter_session_t *)instance;
 
-    /* Return event journal instance. */
+    /* Return event journal &self->pub. */
     return (afw_adapter_journal_t *)&self->journal;
 }
 
@@ -814,7 +807,7 @@ impl_afw_adapter_session_get_journal_interface(
  */
 const afw_adapter_key_value_t *
 impl_afw_adapter_session_get_key_value_interface (
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Key value interface is not supported by this adapter. */
@@ -826,7 +819,7 @@ impl_afw_adapter_session_get_key_value_interface (
  */
 const afw_adapter_impl_index_t *
 impl_afw_adapter_session_get_index_interface (
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Key value interface is not supported by this adapter. */
@@ -840,7 +833,7 @@ impl_afw_adapter_session_get_index_interface (
  */
 const afw_adapter_object_type_cache_t *
 impl_afw_adapter_session_get_object_type_cache_interface(
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* There is on adapter cache. */

--- a/src/afw/file/afw_file_journal.c
+++ b/src/afw/file/afw_file_journal.c
@@ -271,13 +271,13 @@ error_peer_apr:
  */
 const afw_utf8_t *
 impl_afw_adapter_journal_add_entry_internal(
-    const afw_adapter_journal_t * instance,
+    const afw_adapter_journal_t * self,
     const afw_adapter_impl_request_t * impl_request,
     const afw_object_t * entry,
     afw_xctx_t *xctx)
 {
     afw_file_internal_adapter_session_t * session = 
-        (afw_file_internal_adapter_session_t *)instance->session;
+        (afw_file_internal_adapter_session_t *)self->session;
     afw_file_internal_adapter_t *adapter = session->adapter;
     const afw_memory_t *encoded;
     afw_memory_t temp_raw;
@@ -545,20 +545,20 @@ error_old_journal_apr:
  */
 const afw_utf8_t *
 impl_afw_adapter_journal_add_entry(
-    const afw_adapter_journal_t * instance,
+    const afw_adapter_journal_t * self,
     const afw_adapter_impl_request_t * impl_request,
     const afw_object_t * entry,
     afw_xctx_t *xctx)
 {
     afw_file_internal_adapter_session_t * session = 
-        (afw_file_internal_adapter_session_t *)instance->session;
+        (afw_file_internal_adapter_session_t *)self->session;
     afw_file_internal_adapter_t *adapter = session->adapter;
     const afw_utf8_t *result;
 
     AFW_LOCK_WRITE_BEGIN(adapter->journal_rw_lock) {
 
         result = impl_afw_adapter_journal_add_entry_internal(
-            instance, impl_request, entry, xctx);
+            self, impl_request, entry, xctx);
     } 
 
     AFW_LOCK_WRITE_END;
@@ -572,7 +572,7 @@ impl_afw_adapter_journal_add_entry(
  */
 void
 impl_afw_adapter_journal_get_entry_internal(
-    const afw_adapter_journal_t * instance,
+    const afw_adapter_journal_t * self,
     const afw_adapter_impl_request_t * impl_request,
     afw_adapter_journal_option_t option,
     const afw_utf8_t * consumer_id,
@@ -582,7 +582,7 @@ impl_afw_adapter_journal_get_entry_internal(
     afw_xctx_t *xctx)
 {
     afw_file_internal_adapter_session_t * session =
-        (afw_file_internal_adapter_session_t *)instance->session;
+        (afw_file_internal_adapter_session_t *)self->session;
     afw_file_internal_adapter_t *adapter = session->adapter;
     const afw_pool_t *p = xctx->p;
     apr_pool_t *apr_p = afw_pool_get_apr_pool(p);
@@ -684,7 +684,7 @@ impl_afw_adapter_journal_get_entry_internal(
     if (use_consumer) {
         
         /* Get peer object. */
-        peer = impl_open_and_retrieve_peer_object(instance, consumer_id,
+        peer = impl_open_and_retrieve_peer_object(self, consumer_id,
             &peer_f, &full_peer_path_z, xctx);
 
         /* If using consumer cursors, set variables as appropriate. */
@@ -820,7 +820,7 @@ impl_afw_adapter_journal_get_entry_internal(
             /* Else if check_filter, set applicable using filter. */
             else if (check_filter) {
                 applicable = afw_adapter_impl_is_journal_entry_applicable(
-                    instance, entry, peer, &filter, xctx);
+                    self, entry, peer, &filter, xctx);
             }
 
             /* Else entry is applicable. */
@@ -883,7 +883,7 @@ impl_afw_adapter_journal_get_entry_internal(
         }
 
         /* Replace peer object and close. */
-        impl_write_and_close_peer_object(instance, peer, peer_f,
+        impl_write_and_close_peer_object(self, peer, peer_f,
             full_peer_path_z, xctx);
  
     }
@@ -924,7 +924,7 @@ error_journal:
  */
 void
 impl_afw_adapter_journal_get_entry(
-    const afw_adapter_journal_t * instance,
+    const afw_adapter_journal_t * self,
     const afw_adapter_impl_request_t * impl_request,
     afw_adapter_journal_option_t option,
     const afw_utf8_t * consumer_id,
@@ -934,13 +934,13 @@ impl_afw_adapter_journal_get_entry(
     afw_xctx_t *xctx)
 {
     afw_file_internal_adapter_session_t * session =
-        (afw_file_internal_adapter_session_t *)instance->session;
+        (afw_file_internal_adapter_session_t *)self->session;
     afw_file_internal_adapter_t *adapter = session->adapter;
 
     AFW_LOCK_READ_BEGIN(adapter->journal_rw_lock) {
 
         impl_afw_adapter_journal_get_entry_internal(
-            instance,
+            self,
             impl_request,
             option,
             consumer_id,
@@ -960,7 +960,7 @@ impl_afw_adapter_journal_get_entry(
  */
 void
 impl_afw_adapter_journal_mark_entry_consumed(
-    const afw_adapter_journal_t * instance,
+    const afw_adapter_journal_t * self,
     const afw_adapter_impl_request_t * impl_request,
     const afw_utf8_t * consumer_id,
     const afw_utf8_t * entry_cursor,
@@ -973,7 +973,7 @@ impl_afw_adapter_journal_mark_entry_consumed(
     const afw_dateTime_t *now;
 
 
-    peer = impl_open_and_retrieve_peer_object(instance,
+    peer = impl_open_and_retrieve_peer_object(self,
         consumer_id, &peer_f,
         &full_peer_path_z, xctx);
 
@@ -994,6 +994,6 @@ impl_afw_adapter_journal_mark_entry_consumed(
         now, xctx);
 
     /* Write peer object and close. */
-    impl_write_and_close_peer_object(instance, peer, peer_f, full_peer_path_z,
+    impl_write_and_close_peer_object(self, peer, peer_f, full_peer_path_z,
         xctx);
 }

--- a/src/afw/json/afw_json.c
+++ b/src/afw/json/afw_json.c
@@ -80,7 +80,7 @@ AFW_DEFINE(void) afw_json_register(afw_xctx_t *xctx)
  */
 const afw_value_t *
 impl_afw_content_type_raw_to_value(
-    const afw_content_type_t * instance,
+    const afw_content_type_t * self,
     const afw_memory_t * raw,
     const afw_utf8_t * source_location,
     const afw_pool_t * p,
@@ -97,7 +97,7 @@ impl_afw_content_type_raw_to_value(
  */
 const afw_object_t *
 impl_afw_content_type_raw_to_object(
-    const afw_content_type_t * instance,
+    const afw_content_type_t * self,
     const afw_memory_t * raw,
     const afw_utf8_t * source_location,
     const afw_utf8_t * adapter_id,
@@ -134,7 +134,7 @@ impl_afw_content_type_raw_to_object(
  */
 void
 impl_afw_content_type_write_value(
-    const afw_content_type_t * instance,
+    const afw_content_type_t * self,
     const afw_value_t * value,
     const afw_object_options_t *options,
     void * context,
@@ -152,14 +152,14 @@ impl_afw_content_type_write_value(
  */
 const afw_content_type_object_list_writer_t *
 impl_afw_content_type_create_object_list_writer(
-    const afw_content_type_t * instance,
+    const afw_content_type_t * self,
     const afw_object_options_t *options,
     void * context,
     afw_write_cb_t callback,
     const afw_pool_t *p, afw_xctx_t *xctx)
 {
     return afw_content_type_impl_create_object_list_writer(
-        instance, options, context, callback,
+        self, options, context, callback,
         &impl_raw_begin_object_list,
         &impl_raw_object_separator,
         &impl_raw_last_object_separator,

--- a/src/afw/log/afw_log.c
+++ b/src/afw/log/afw_log.c
@@ -440,10 +440,10 @@ void afw_log_internal_conf_type_create_cede_p(
  */
 void
 impl_afw_log_destroy(
-    const afw_log_t * instance,
+    const afw_log_t * self,
     afw_xctx_t *xctx)
 {
-    afw_pool_release(instance->p, xctx);
+    afw_pool_release(self->p, xctx);
 }
 
 
@@ -452,11 +452,11 @@ impl_afw_log_destroy(
  */
 void
 impl_afw_log_set_own_mask(
-    const afw_log_t * instance,
+    const afw_log_t * self,
     afw_log_priority_mask_t mask,
     afw_xctx_t *xctx)
 {
-    afw_log_impl_t *impl = (afw_log_impl_t *)instance->impl;
+    afw_log_impl_t *impl = (afw_log_impl_t *)self->impl;
 
     /* Set mask. */
     impl->mask = mask;
@@ -568,7 +568,7 @@ impl_write_formatted_message(
  */
 void
 impl_afw_log_write(
-    const afw_log_t * instance,
+    const afw_log_t * self,
     afw_log_priority_t priority,
     const afw_utf8_z_t * source_z,
     const afw_utf8_t * message,
@@ -578,7 +578,7 @@ impl_afw_log_write(
     afw_boolean_t lock_held;
     afw_boolean_t log_found;
 
-    wa.self = (impl_afw_log_self_t *)instance;
+    wa.self = (impl_afw_log_self_t *)self;
     wa.p = NULL;
     wa.priority = priority;
     wa.source_z = source_z;
@@ -664,7 +664,7 @@ afw_log_internal_register_service_type(afw_xctx_t *xctx)
  */
 afw_integer_t
 impl_afw_service_type_related_instance_count (
-    const afw_service_type_t * instance,
+    const afw_service_type_t * self,
     const afw_utf8_t * id,
     afw_xctx_t *xctx)
 {
@@ -681,7 +681,7 @@ impl_afw_service_type_related_instance_count (
  */
 void
 impl_afw_service_type_start_cede_p (
-    const afw_service_type_t * instance,
+    const afw_service_type_t * self,
     const afw_object_t * properties,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
@@ -718,11 +718,11 @@ impl_afw_service_type_start_cede_p (
  */
 void
 impl_afw_service_type_stop (
-    const afw_service_type_t * instance,
+    const afw_service_type_t * self,
     const afw_utf8_t * id,
     afw_xctx_t *xctx)
 {
-    impl_afw_log_self_t *self;
+    impl_afw_log_self_t *log_self;
     impl_log_entry_t *e;
 
     afw_environment_register_log(id, NULL, xctx);
@@ -732,8 +732,8 @@ impl_afw_service_type_stop (
      * found, no error is thrown.
      */
     AFW_LOCK_BEGIN(xctx->env->active_log_list_lock) {
-        self = (impl_afw_log_self_t *)xctx->env->log;
-        for (e = self->head->first_log; e; e = e->next)
+        log_self = (impl_afw_log_self_t *)xctx->env->log;
+        for (e = log_self->head->first_log; e; e = e->next)
         {
             if (e->log && afw_utf8_equal(&e->log->log_id, id)) {
                 /** @fixme Need to be able to destroy, but runtime object might
@@ -758,7 +758,7 @@ impl_afw_service_type_stop (
  */
 void
 impl_afw_service_type_restart_cede_p (
-    const afw_service_type_t * instance,
+    const afw_service_type_t * self,
     const afw_object_t * properties,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
@@ -767,7 +767,7 @@ impl_afw_service_type_restart_cede_p (
      * This counts on afw_service only calling if not started, so if stopped,
      * this will start log. Restart is same as start at this point.
      */
-    impl_afw_service_type_start_cede_p(instance, properties, p, xctx);
+    impl_afw_service_type_start_cede_p(self, properties, p, xctx);
 }
 
 

--- a/src/afw/log/afw_log_file.c
+++ b/src/afw/log/afw_log_file.c
@@ -53,21 +53,21 @@ afw_log_file_factory_get()
  */
 const afw_log_t *
 impl_afw_log_factory_create_log_cede_p (
-    const afw_log_factory_t * instance,
+    const afw_log_factory_t * self,
     const afw_object_t * properties,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {
-    impl_afw_log_file_self_t *self;
+    impl_afw_log_file_self_t *log_file_self;
 
-    self = (impl_afw_log_file_self_t *)afw_log_impl_create_cede_p(
+    log_file_self = (impl_afw_log_file_self_t *)afw_log_impl_create_cede_p(
         &impl_afw_log_inf, sizeof(impl_afw_log_file_self_t),
         properties, p, xctx);
 
     /* Finish processing parameters implementation specific parameters. */
 
-    /* Return new instance. */
-    return (afw_log_t *)self;
+    /* Return new log_file_self. */
+    return (afw_log_t *)log_file_self;
 }
 
 
@@ -77,10 +77,10 @@ impl_afw_log_factory_create_log_cede_p (
  */
 void
 impl_afw_log_destroy(
-    const afw_log_t * instance,
+    const afw_log_t * self,
     afw_xctx_t *xctx)
 {
-    afw_pool_release(instance->p, xctx);
+    afw_pool_release(self->p, xctx);
 }
 
 
@@ -90,11 +90,11 @@ impl_afw_log_destroy(
  */
 void
 impl_afw_log_set_own_mask(
-    const afw_log_t * instance,
+    const afw_log_t * self,
     afw_log_priority_mask_t mask,
     afw_xctx_t *xctx)
 {
-    afw_log_impl_t *impl = (afw_log_impl_t *)instance->impl;
+    afw_log_impl_t *impl = (afw_log_impl_t *)self->impl;
 
     /* Set mask. */
     impl->mask = mask;
@@ -107,7 +107,7 @@ impl_afw_log_set_own_mask(
  */
 void
 impl_afw_log_write(
-    const afw_log_t * instance,
+    const afw_log_t * self,
     afw_log_priority_t priority,
     const afw_utf8_z_t * source_z,
     const afw_utf8_t * message,

--- a/src/afw/log/afw_log_standard.c
+++ b/src/afw/log/afw_log_standard.c
@@ -53,21 +53,21 @@ afw_log_standard_factory_get()
  */
 const afw_log_t *
 impl_afw_log_factory_create_log_cede_p (
-    const afw_log_factory_t * instance,
+    const afw_log_factory_t * self,
     const afw_object_t * properties,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {
-    impl_afw_log_standard_self_t *self;
+    impl_afw_log_standard_self_t *log_standard_self;
 
-    self = (impl_afw_log_standard_self_t *)afw_log_impl_create_cede_p(
+    log_standard_self = (impl_afw_log_standard_self_t *)afw_log_impl_create_cede_p(
         &impl_afw_log_inf, sizeof(impl_afw_log_standard_self_t),
         properties, p, xctx);
 
     /* Finish processing parameters implementation specific parameters. */
 
-    /* Return new instance. */
-    return (afw_log_t *)self;
+    /* Return new log_standard_self. */
+    return (afw_log_t *)log_standard_self;
 }
 
 
@@ -77,10 +77,10 @@ impl_afw_log_factory_create_log_cede_p (
  */
 void
 impl_afw_log_destroy(
-    const afw_log_t * instance,
+    const afw_log_t * self,
     afw_xctx_t *xctx)
 {
-    afw_pool_release(instance->p, xctx);
+    afw_pool_release(self->p, xctx);
 }
 
 
@@ -90,11 +90,11 @@ impl_afw_log_destroy(
  */
 void
 impl_afw_log_set_own_mask(
-    const afw_log_t * instance,
+    const afw_log_t * self,
     afw_log_priority_mask_t mask,
     afw_xctx_t *xctx)
 {
-    afw_log_impl_t *impl = (afw_log_impl_t *)instance->impl;
+    afw_log_impl_t *impl = (afw_log_impl_t *)self->impl;
 
     /* Set mask. */
     impl->mask = mask;
@@ -107,7 +107,7 @@ impl_afw_log_set_own_mask(
  */
 void
 impl_afw_log_write(
-    const afw_log_t * instance,
+    const afw_log_t * self,
     afw_log_priority_t priority,
     const afw_utf8_z_t * source_z,
     const afw_utf8_t * message,

--- a/src/afw/model/afw_model_adapter.c
+++ b/src/afw/model/afw_model_adapter.c
@@ -18,7 +18,9 @@
 /* Declares and rti/inf defines for interface afw_adapter */
 #define AFW_IMPLEMENTATION_ID "model"
 #include "afw_adapter_factory_impl_declares.h"
+#define AFW_ADAPTER_SELF_T afw_model_internal_adapter_self_t
 #include "afw_adapter_impl_declares.h"
+#define AFW_ADAPTER_SESSION_SELF_T afw_model_internal_adapter_session_self_t
 #include "afw_adapter_session_impl_declares.h"
 #include "afw_adapter_object_type_cache_impl_declares.h"
 
@@ -917,7 +919,7 @@ afw_model_adapter_create_cede_p(
  */
 const afw_adapter_t *
 impl_afw_adapter_factory_create_adapter_cede_p (
-    const afw_adapter_factory_t * instance,
+    const afw_adapter_factory_t * self,
     const afw_object_t * properties,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
@@ -931,11 +933,11 @@ impl_afw_adapter_factory_create_adapter_cede_p (
  */
 void
 impl_afw_adapter_destroy (
-    const afw_adapter_t * instance,
+    AFW_ADAPTER_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Release pool. */
-    afw_pool_release(instance->p, xctx);
+    afw_pool_release(self->pub.p, xctx);
 }
 
 
@@ -945,17 +947,15 @@ impl_afw_adapter_destroy (
  */
 const afw_adapter_session_t *
 impl_afw_adapter_create_adapter_session (
-    const afw_adapter_t * instance,
+    AFW_ADAPTER_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_model_internal_adapter_self_t * self =
-        (afw_model_internal_adapter_self_t *)instance;
     afw_model_internal_adapter_session_self_t *session;
 
     session = afw_xctx_calloc_type(afw_model_internal_adapter_session_self_t,
         xctx);
     session->pub.inf = &impl_afw_adapter_session_inf;
-    session->pub.adapter = instance;
+    session->pub.adapter = &self->pub;
     session->pub.p = xctx->p;
     session->adapter = self;
 
@@ -987,7 +987,7 @@ impl_afw_adapter_create_adapter_session (
  */
 const afw_object_t *
 impl_afw_adapter_get_additional_metrics (
-    const afw_adapter_t * instance,
+    AFW_ADAPTER_SELF_T *self,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {
@@ -1002,11 +1002,9 @@ impl_afw_adapter_get_additional_metrics (
  */
 void
 impl_afw_adapter_session_destroy (
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_model_internal_adapter_session_self_t * self = 
-        (afw_model_internal_adapter_session_self_t *)instance;
 
     if (self->model_location_adapter) {
         afw_adapter_release(self->model_location_adapter, xctx);
@@ -1090,7 +1088,7 @@ impl_model_object_cb(
  */
 void
 impl_afw_adapter_session_retrieve_objects(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_query_criteria_t *criteria,
@@ -1100,10 +1098,8 @@ impl_afw_adapter_session_retrieve_objects(
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    afw_model_internal_adapter_session_self_t * self =
-        (afw_model_internal_adapter_session_self_t *)instance;
     afw_model_internal_adapter_self_t * adapter =
-        (afw_model_internal_adapter_self_t *)instance->adapter;
+        (afw_model_internal_adapter_self_t *)self->pub.adapter;
     afw_model_internal_context_t *ctx;
     afw_model_internal_object_cb_context_t cb_ctx;
     apr_hash_index_t *hi;
@@ -1222,7 +1218,7 @@ impl_afw_adapter_session_retrieve_objects(
  */
 void
 impl_afw_adapter_session_get_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *object_id,
@@ -1232,10 +1228,8 @@ impl_afw_adapter_session_get_object(
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    afw_model_internal_adapter_session_self_t * self =
-        (afw_model_internal_adapter_session_self_t *)instance;
     afw_model_internal_adapter_self_t *adapter =
-        (afw_model_internal_adapter_self_t *)instance->adapter;
+        (afw_model_internal_adapter_self_t *)self->pub.adapter;
     afw_model_internal_context_t *ctx;
     afw_model_internal_object_cb_context_t cb_ctx;
     const afw_object_t *object;
@@ -1465,7 +1459,7 @@ afw_model_internal_complete_ctx_default_add_object(
  */
 const afw_utf8_t *
 impl_afw_adapter_session_add_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *suggested_object_id,
@@ -1473,8 +1467,6 @@ impl_afw_adapter_session_add_object(
     const afw_object_t *adapter_type_specific,
     afw_xctx_t *xctx)
 {
-    afw_model_internal_adapter_session_self_t * self =
-        (afw_model_internal_adapter_session_self_t *)instance;
     afw_model_internal_context_t *ctx;
     const afw_utf8_t *mapped_object_id;
     const afw_object_t *journal_entry;
@@ -1637,7 +1629,7 @@ afw_model_internal_complete_ctx_default_modify_object(
  */
 void
 impl_afw_adapter_session_modify_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *object_id,
@@ -1645,8 +1637,6 @@ impl_afw_adapter_session_modify_object(
     const afw_object_t *adapter_type_specific,
     afw_xctx_t *xctx)
 {
-    afw_model_internal_adapter_session_self_t * self =
-        (afw_model_internal_adapter_session_self_t *)instance;
     afw_model_internal_context_t *ctx;
     const afw_value_t *value;
     const afw_object_t *journal_entry;
@@ -1739,7 +1729,7 @@ afw_model_internal_complete_ctx_default_replace_object(
  */
 void
 impl_afw_adapter_session_replace_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *object_id,
@@ -1747,8 +1737,6 @@ impl_afw_adapter_session_replace_object(
     const afw_object_t *adapter_type_specific,
     afw_xctx_t *xctx)
 {
-    afw_model_internal_adapter_session_self_t * self =
-        (afw_model_internal_adapter_session_self_t *)instance;
     afw_model_internal_context_t *ctx;
     const afw_object_t *journal_entry;
     const afw_value_t *value;
@@ -1835,15 +1823,13 @@ afw_model_internal_complete_ctx_default_delete_object(
  */
 void
 impl_afw_adapter_session_delete_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *object_id,
     const afw_object_t *adapter_type_specific,
     afw_xctx_t *xctx)
 {
-    afw_model_internal_adapter_session_self_t * self =
-        (afw_model_internal_adapter_session_self_t *)instance;
     afw_model_internal_context_t *ctx;
     const afw_object_t *journal_entry;
     const afw_value_t *value;
@@ -1913,11 +1899,11 @@ impl_afw_adapter_session_delete_object(
  */
 const afw_adapter_transaction_t *
 impl_afw_adapter_session_begin_transaction (
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
     afw_model_internal_adapter_self_t * adapter =
-        (afw_model_internal_adapter_self_t *)instance->adapter;
+        (afw_model_internal_adapter_self_t *)self->pub.adapter;
 
     /*
      * If no mappedAdapterId (pure-script model), there is no mapped backend
@@ -1942,7 +1928,7 @@ impl_afw_adapter_session_begin_transaction (
  */
 const afw_adapter_journal_t *
 impl_afw_adapter_session_get_journal_interface (
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* There is no journal interface for model adapter. */
@@ -1956,7 +1942,7 @@ impl_afw_adapter_session_get_journal_interface (
  */
 const afw_adapter_key_value_t *
 impl_afw_adapter_session_get_key_value_interface (
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* There is no key_value interface for model adapter. */
@@ -1970,7 +1956,7 @@ impl_afw_adapter_session_get_key_value_interface (
  */
 const afw_adapter_impl_index_t *
 impl_afw_adapter_session_get_index_interface (
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* There is no index interface for model adapter. */
@@ -1985,16 +1971,14 @@ impl_afw_adapter_session_get_index_interface (
  */
 const afw_adapter_object_type_cache_t *
 impl_afw_adapter_session_get_object_type_cache_interface(
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_model_internal_adapter_session_self_t * self =
-        (afw_model_internal_adapter_session_self_t *)instance;
 
     afw_adapter_impl_object_type_cache_initialize(
         &self->object_type_cache,
         &impl_afw_adapter_object_type_cache_inf,
-        instance, true, xctx);
+        &self->pub, true, xctx);
 
     return &self->object_type_cache;
 }
@@ -2006,13 +1990,13 @@ impl_afw_adapter_session_get_object_type_cache_interface(
  */
 const afw_object_type_t *
 impl_afw_adapter_object_type_cache_get(
-    const afw_adapter_object_type_cache_t * instance,
+    const afw_adapter_object_type_cache_t * self,
     const afw_utf8_t * object_type_id,
     afw_boolean_t * final_result,
     afw_xctx_t *xctx)
 {
     afw_model_internal_adapter_session_self_t * session =
-        (afw_model_internal_adapter_session_self_t *)instance->session;
+        (afw_model_internal_adapter_session_self_t *)self->session;
     const afw_object_type_t *result;
     afw_model_t *model = (afw_model_t *)session->model;
 
@@ -2039,12 +2023,12 @@ impl_afw_adapter_object_type_cache_get(
  */
 void
 impl_afw_adapter_object_type_cache_set(
-    const afw_adapter_object_type_cache_t * instance,
+    const afw_adapter_object_type_cache_t * self,
     const afw_object_type_t * object_type,
     afw_xctx_t *xctx)
 {
     afw_model_internal_adapter_session_self_t * session =
-        (afw_model_internal_adapter_session_self_t *)instance->session;
+        (afw_model_internal_adapter_session_self_t *)self->session;
     afw_model_t *model = (afw_model_t *)session->model;
 
     AFW_ADAPTER_IMPL_LOCK_WRITE_BEGIN(session->model_location_adapter)

--- a/src/afw/object/afw_object_aggregate_external.c
+++ b/src/afw/object/afw_object_aggregate_external.c
@@ -26,6 +26,7 @@
 
 /* Declares and rti/inf defines for interface afw_object */
 #define AFW_IMPLEMENTATION_ID "afw_object_aggregate_external"
+#define AFW_OBJECT_SELF_T afw_object_aggregate_external_self_t
 #include "afw_object_impl_declares.h"
 
 
@@ -55,7 +56,7 @@ afw_object_aggregate_external_create(
  */
 void
 impl_afw_object_release(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Not managed. */
@@ -66,7 +67,7 @@ impl_afw_object_release(
  */
 void
 impl_afw_object_get_reference(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Not managed. */
@@ -77,11 +78,11 @@ impl_afw_object_get_reference(
  */
 afw_size_t
 impl_afw_object_get_count(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t * xctx)
 {
 //    <afwdev {prefixed_interface_name}>_self_t *self =
-//        (<afwdev {prefixed_interface_name}>_self_t *)instance;
+//        (<afwdev {prefixed_interface_name}>_self_t *)&self->pub;
 
     /** @todo Add code to implement method. */
     AFW_THROW_ERROR_Z(general, "Method not implemented.", xctx);
@@ -93,12 +94,10 @@ impl_afw_object_get_count(
  */
 const afw_value_t *
 impl_afw_object_get_property(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t * property_name,
     afw_xctx_t *xctx)
 {
-    afw_object_aggregate_external_self_t *self =
-        (afw_object_aggregate_external_self_t *)instance;
     const afw_object_t * const *obj;
     const afw_value_t *result;
 
@@ -117,13 +116,11 @@ impl_afw_object_get_property(
  */
 const afw_value_t *
 impl_afw_object_get_next_property(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_iterator_t * * iterator,
     const afw_utf8_t * * property_name,
     afw_xctx_t *xctx)
 {
-    afw_object_aggregate_external_self_t *self =
-        (afw_object_aggregate_external_self_t *)instance;
     const afw_value_t *result;
 
     if (!*iterator) {
@@ -154,11 +151,11 @@ impl_afw_object_get_next_property(
  */
 afw_boolean_t
 impl_afw_object_has_property(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t * property_name,
     afw_xctx_t *xctx)
 {
-    return impl_afw_object_get_property(instance, property_name, xctx) != NULL;
+    return impl_afw_object_get_property(self, property_name, xctx) != NULL;
 }
 
 /*
@@ -166,11 +163,9 @@ impl_afw_object_has_property(
  */
 const afw_object_setter_t *
 impl_afw_object_get_setter(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_object_aggregate_external_self_t *self =
-        (afw_object_aggregate_external_self_t *)instance;
 
     return afw_object_get_setter(*self->object_list, xctx);
 }

--- a/src/afw/object/afw_object_composite.c
+++ b/src/afw/object/afw_object_composite.c
@@ -27,6 +27,7 @@
 
 /* Declares and rti/inf defines for interface afw_object */
 #define AFW_IMPLEMENTATION_ID "composite"
+#define AFW_OBJECT_SELF_T afw_object_internal_composite_self_t
 #include "afw_object_impl_declares.h"
 
 
@@ -85,7 +86,7 @@ afw_object_create_composite(
  */
 void
 impl_afw_object_release(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
 
@@ -96,7 +97,7 @@ impl_afw_object_release(
  */
 void
 impl_afw_object_get_reference(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
 
@@ -107,11 +108,11 @@ impl_afw_object_get_reference(
  */
 afw_size_t
 impl_afw_object_get_count(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t * xctx)
 {
 //    <afwdev {prefixed_interface_name}>_self_t *self =
-//        (<afwdev {prefixed_interface_name}>_self_t *)instance;
+//        (<afwdev {prefixed_interface_name}>_self_t *)&self->pub;
 
     /** @todo Add code to implement method. */
     AFW_THROW_ERROR_Z(general, "Method not implemented.", xctx);
@@ -123,12 +124,10 @@ impl_afw_object_get_count(
  */
 const afw_value_t *
 impl_afw_object_get_property(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t *property_name,
     afw_xctx_t *xctx)
 {
-    afw_object_internal_composite_self_t *self =
-        (afw_object_internal_composite_self_t *)instance;
     const afw_object_t * *e;
     const afw_object_t *o;
     const afw_value_t *result;
@@ -172,7 +171,7 @@ typedef struct {
  */
 const afw_value_t *
 impl_afw_object_get_next_property(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_iterator_t **iterator,
     const afw_utf8_t **property_name,
     afw_xctx_t *xctx)
@@ -189,13 +188,13 @@ impl_afw_object_get_next_property(
  */
 afw_boolean_t
 impl_afw_object_has_property(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t *property_name,
     afw_xctx_t *xctx)
 {
     afw_boolean_t result;
 
-    result = impl_afw_object_get_property(instance, property_name, xctx)
+    result = impl_afw_object_get_property(self, property_name, xctx)
         != NULL;
 
     return result;      
@@ -206,7 +205,7 @@ impl_afw_object_has_property(
  */
 const afw_object_setter_t *
 impl_afw_object_get_setter(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Don't allow setting directly to meta object.  Use delta. */

--- a/src/afw/object/afw_object_const_key_value.c
+++ b/src/afw/object/afw_object_const_key_value.c
@@ -27,6 +27,7 @@
 
 /* Declares and rti/inf defines for interface afw_object */
 #define AFW_IMPLEMENTATION_ID "afw_object_const_key_value"
+#define AFW_OBJECT_SELF_T afw_object_const_key_value_self_t
 #include "afw_object_impl_declares.h"
 
 
@@ -86,7 +87,7 @@ afw_object_create_const_from_key_value_strings_z(
  */
 void
 impl_afw_object_release(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Not reference counted. */
@@ -97,7 +98,7 @@ impl_afw_object_release(
  */
 void
 impl_afw_object_get_reference(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Not reference counted. */
@@ -108,11 +109,11 @@ impl_afw_object_get_reference(
  */
 afw_size_t
 impl_afw_object_get_count(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t * xctx)
 {
 //    <afwdev {prefixed_interface_name}>_self_t *self =
-//        (<afwdev {prefixed_interface_name}>_self_t *)instance;
+//        (<afwdev {prefixed_interface_name}>_self_t *)&self->pub;
 
     /** @todo Add code to implement method. */
     AFW_THROW_ERROR_Z(general, "Method not implemented.", xctx);
@@ -124,12 +125,10 @@ impl_afw_object_get_count(
  */
 const afw_value_t *
 impl_afw_object_get_property(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t * property_name,
     afw_xctx_t *xctx)
 {
-    afw_object_const_key_value_self_t *self =
-        (afw_object_const_key_value_self_t *)instance;
     const afw_object_const_key_value_string_entry_t *e;
 
     for (e = self->entry; e < self->entry_end; e++) {
@@ -146,13 +145,11 @@ impl_afw_object_get_property(
  */
 const afw_value_t *
 impl_afw_object_get_next_property(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_iterator_t * * iterator,
     const afw_utf8_t * * property_name,
     afw_xctx_t *xctx)
 {
-    afw_object_const_key_value_self_t *self =
-        (afw_object_const_key_value_self_t *)instance;
     const afw_object_const_key_value_string_entry_t *e;
     const afw_value_t *result;
 
@@ -184,11 +181,11 @@ impl_afw_object_get_next_property(
  */
 afw_boolean_t
 impl_afw_object_has_property(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t * property_name,
     afw_xctx_t *xctx)
 {
-    return impl_afw_object_get_property(instance, property_name, xctx) != NULL;
+    return impl_afw_object_get_property(self, property_name, xctx) != NULL;
 }
 
 /*
@@ -196,7 +193,7 @@ impl_afw_object_has_property(
  */
 const afw_object_setter_t *
 impl_afw_object_get_setter(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
     return NULL;

--- a/src/afw/object/afw_object_impl_property_meta.c
+++ b/src/afw/object/afw_object_impl_property_meta.c
@@ -37,6 +37,7 @@
  */
 /* Declares and rti/inf defines for interface afw_object */
 #define AFW_IMPLEMENTATION_ID "object_impl_property_meta"
+#define AFW_OBJECT_SELF_T afw_object_impl_property_meta_object_self_t
 #include "afw_object_impl_declares.h"
 #include "afw_object_setter_impl_declares.h"
 
@@ -165,7 +166,7 @@ static const afw_object_impl_name_handler_t *impl_handler_end =
  */
 void
 impl_afw_object_release(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /** @todo Add code to implement method. */
@@ -180,7 +181,7 @@ impl_afw_object_release(
  */
 void
 impl_afw_object_get_reference(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Nothing to do? */
@@ -191,11 +192,11 @@ impl_afw_object_get_reference(
  */
 afw_size_t
 impl_afw_object_get_count(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t * xctx)
 {
 //    <afwdev {prefixed_interface_name}>_self_t *self =
-//        (<afwdev {prefixed_interface_name}>_self_t *)instance;
+//        (<afwdev {prefixed_interface_name}>_self_t *)&self->pub;
 
     /** @todo Add code to implement method. */
     AFW_THROW_ERROR_Z(general, "Method not implemented.", xctx);
@@ -207,12 +208,10 @@ impl_afw_object_get_count(
  */
 const afw_value_t *
 impl_afw_object_get_property(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t *property_name,
     afw_xctx_t *xctx)
 {
-    afw_object_impl_property_meta_object_self_t *self =
-        (afw_object_impl_property_meta_object_self_t *)instance;
     const afw_object_impl_name_handler_t *h;
 
     /* If get callback for this property, return it's result. */
@@ -243,13 +242,11 @@ impl_afw_object_get_property(
  */
 const afw_value_t *
 impl_afw_object_get_next_property(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_iterator_t **iterator,
     const afw_utf8_t **property_name,
     afw_xctx_t *xctx)
 {
-    afw_object_impl_property_meta_object_self_t *self =
-        (afw_object_impl_property_meta_object_self_t *)instance;
     const afw_object_impl_name_handler_t *h;
     const afw_value_t *result;
     const afw_utf8_t *next_property_name;
@@ -335,11 +332,11 @@ impl_afw_object_get_next_property(
  */
 afw_boolean_t
 impl_afw_object_has_property(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t *property_name,
     afw_xctx_t *xctx)
 {
-    return impl_afw_object_get_property(instance, property_name, xctx) != NULL;
+    return impl_afw_object_get_property(self, property_name, xctx) != NULL;
 }
 
 
@@ -349,11 +346,9 @@ impl_afw_object_has_property(
  */
 const afw_object_setter_t *
 impl_afw_object_get_setter(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_object_impl_property_meta_object_self_t *self =
-        (afw_object_impl_property_meta_object_self_t *)instance;
 
     return (!self->is_immutable &&
         afw_object_get_setter(self->owning_object, xctx))
@@ -368,13 +363,13 @@ impl_afw_object_get_setter(
  */
 void
 impl_afw_object_setter_set_immutable(
-    const afw_object_setter_t *instance,
+    const afw_object_setter_t *self,
     afw_xctx_t *xctx)
 {
-    afw_object_impl_property_meta_object_self_t *self =
-        (afw_object_impl_property_meta_object_self_t *)instance->object;
+    afw_object_impl_property_meta_object_self_t *object_impl_property_meta_object_self =
+        (afw_object_impl_property_meta_object_self_t *)self->object;
 
-    self->is_immutable = true;
+    object_impl_property_meta_object_self->is_immutable = true;
 }
 
 
@@ -384,19 +379,19 @@ impl_afw_object_setter_set_immutable(
  */
 void
 impl_afw_object_setter_set_property(
-    const afw_object_setter_t *instance,
+    const afw_object_setter_t *self,
     const afw_utf8_t *property_name,
     const afw_value_t *value,
     afw_xctx_t *xctx)
 {
-    afw_object_impl_property_meta_object_self_t *self =
-        (afw_object_impl_property_meta_object_self_t *)instance->object;
+    afw_object_impl_property_meta_object_self_t *object_impl_property_meta_object_self =
+        (afw_object_impl_property_meta_object_self_t *)self->object;
     const afw_object_impl_name_handler_t *h;
 
     for (h = &impl_handler[0]; h < impl_handler_end; h++) {
         if (afw_utf8_equal(h->property_name, property_name)) {
             if (h->set) {
-                h->set(self, property_name, value, xctx);
+                h->set(object_impl_property_meta_object_self, property_name, value, xctx);
                 return;
             }
             break;
@@ -404,8 +399,8 @@ impl_afw_object_setter_set_property(
     }
 
     afw_object_meta_set_property_type_property(
-        ((const afw_value_object_t *)&self->meta_object_value)->internal,
-        self->property_name,
+        ((const afw_value_object_t *)&object_impl_property_meta_object_self->meta_object_value)->internal,
+        object_impl_property_meta_object_self->property_name,
         property_name, value, xctx);
 }
 

--- a/src/afw/object/afw_object_memory.c
+++ b/src/afw/object/afw_object_memory.c
@@ -24,6 +24,7 @@
 
 /* Declares and rti/inf defines for interface afw_object */
 #define AFW_IMPLEMENTATION_ID "memory"
+#define AFW_OBJECT_SELF_T afw_object_internal_memory_object_t
 #include "afw_object_impl_declares.h"
 #include "afw_object_setter_impl_declares.h"
 
@@ -135,11 +136,9 @@ afw_object_insure_embedded_exists(
  */
 void
 impl_afw_object_release(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_object_internal_memory_object_t * self =
-        (afw_object_internal_memory_object_t *)instance;
     const afw_object_t *entity;
 
     /* If unmanaged, just return. */
@@ -152,13 +151,13 @@ impl_afw_object_release(
      * return.
      */
     if (self->managed_by_entity) {
-        AFW_OBJECT_GET_ENTITY(entity, instance);
+        AFW_OBJECT_GET_ENTITY(entity, &self->pub);
         afw_object_release(entity, xctx);
         return;
     }
 
     /* Release pool holding managed object. */
-    afw_pool_release(instance->p, xctx);
+    afw_pool_release(self->pub.p, xctx);
 }
 
 
@@ -167,11 +166,9 @@ impl_afw_object_release(
  */
 void
 impl_afw_object_get_reference(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_object_internal_memory_object_t * self =
-        (afw_object_internal_memory_object_t *)instance;
     const afw_object_t *entity;
 
     /* If unmanaged, just return. */
@@ -182,13 +179,13 @@ impl_afw_object_get_reference(
      * and return.
      */
     if (self->managed_by_entity) {
-        AFW_OBJECT_GET_ENTITY(entity, instance);
+        AFW_OBJECT_GET_ENTITY(entity, &self->pub);
         afw_object_get_reference(entity, xctx);
         return;
     }
 
     /* Increment reference count of pool holding this managed object.  */
-    afw_pool_get_reference(instance->p, xctx);
+    afw_pool_get_reference(self->pub.p, xctx);
 }
 
 /*
@@ -196,11 +193,11 @@ impl_afw_object_get_reference(
  */
 afw_size_t
 impl_afw_object_get_count(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t * xctx)
 {
 //    <afwdev {prefixed_interface_name}>_self_t *self =
-//        (<afwdev {prefixed_interface_name}>_self_t *)instance;
+//        (<afwdev {prefixed_interface_name}>_self_t *)&self->pub;
 
     /** @todo Add code to implement method. */
     AFW_THROW_ERROR_Z(general, "Method not implemented.", xctx);
@@ -213,14 +210,12 @@ impl_afw_object_get_count(
  */
 const afw_value_t *
 impl_afw_object_get_property(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t * property_name,
     afw_xctx_t *xctx)
 {
     /** @fixme Add parent support. */
 
-    afw_object_internal_memory_object_t *self =
-        (afw_object_internal_memory_object_t *)instance;
     const afw_value_t *value;
     afw_object_internal_name_value_entry_t *e;
 
@@ -245,13 +240,11 @@ impl_afw_object_get_property(
  */
 const afw_value_t *
 impl_afw_object_get_next_property(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_iterator_t * * iterator,
     const afw_utf8_t * * property_name,
     afw_xctx_t *xctx)
 {
-    afw_object_internal_memory_object_t *self =
-        (afw_object_internal_memory_object_t *)instance;
     afw_object_internal_name_value_entry_t *e;
 
     /* If iterator is NULL, get first. */
@@ -294,14 +287,14 @@ impl_afw_object_get_next_property(
  */
 afw_boolean_t
 impl_afw_object_has_property(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t * property_name,
     afw_xctx_t *xctx)
 {
     const afw_value_t *value;
 
     /* Search for property.  If found, set exists to true. */
-    value = impl_afw_object_get_property(instance, property_name, xctx);
+    value = impl_afw_object_get_property(self, property_name, xctx);
 
     /* Return true or false. */
     return (value) ? AFW_TRUE : AFW_FALSE;
@@ -314,12 +307,10 @@ impl_afw_object_has_property(
  */
 const afw_object_setter_t *
 impl_afw_object_get_setter (
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    /* Assign instance pointer to self. */
-    afw_object_internal_memory_object_t * self = 
-        (afw_object_internal_memory_object_t *)instance;
+    /* Assign &self->pub pointer to self. */
 
     return (self->immutable) ? NULL : &self->setter;
 }
@@ -331,15 +322,15 @@ impl_afw_object_get_setter (
  */
 void
 impl_afw_object_setter_set_immutable (
-    const afw_object_setter_t * instance,
+    const afw_object_setter_t * self,
     afw_xctx_t *xctx)
 {
     /* Set self to object associated with setter. */
-    afw_object_internal_memory_object_t * self = 
-        (afw_object_internal_memory_object_t *)instance->object;
+    afw_object_internal_memory_object_t * memory_object_self = 
+        (afw_object_internal_memory_object_t *)self->object;
 
     /* Set object to immutable. */
-    self->immutable = true;
+    memory_object_self->immutable = true;
 }
 
 
@@ -348,20 +339,20 @@ impl_afw_object_setter_set_immutable (
  */
 void
 impl_afw_object_setter_set_property(
-    const afw_object_setter_t * instance,
+    const afw_object_setter_t * self,
     const afw_utf8_t * property_name,
     const afw_value_t * value,
     afw_xctx_t *xctx)
 {
     /* Set self to object associated with setter. */
-    afw_object_internal_memory_object_t *self =
-        (afw_object_internal_memory_object_t *)instance->object;
+    afw_object_internal_memory_object_t *memory_object_self =
+        (afw_object_internal_memory_object_t *)self->object;
     afw_object_internal_name_value_entry_t *e;
     afw_object_internal_name_value_entry_t *final_e;
 
-    AFW_OBJECT_IMPL_ASSERT_SELF_MUTABLE;
+    do { if (memory_object_self->immutable) { AFW_OBJECT_ERROR_OBJECT_IMMUTABLE; } } while (0);
 
-    for (e = self->first_property,final_e = NULL; e; e = e->next) {
+    for (e = memory_object_self->first_property,final_e = NULL; e; e = e->next) {
         final_e = e;
         if (afw_utf8_equal(e->name, property_name)) {
             e->value = value;
@@ -371,7 +362,7 @@ impl_afw_object_setter_set_property(
     if (!value) {
         return; /* Delete property just return. */
     }
-    e = afw_pool_calloc_type(instance->object->p,
+    e = afw_pool_calloc_type(self->object->p,
         afw_object_internal_name_value_entry_t, xctx);
     e->name = (property_name) ? property_name : afw_s_a_empty_string;
 
@@ -380,17 +371,17 @@ impl_afw_object_setter_set_property(
      * object and property name needs to be correct, plus path and related
      * meta needs to be clear.  Might involve clone, but
      * afw_object_create_embedded() also calls this, so if embedded
-     * object is this instance, no clone needed.  Also consider that clone
+     * object is this self, no clone needed.  Also consider that clone
      * might not should be used since the one setting property might want
      * to add properties after doing the set.
      */
-    e->value = (self->clone_on_set)
-        ? afw_value_clone(value, self->pub.p, xctx)
+    e->value = (memory_object_self->clone_on_set)
+        ? afw_value_clone(value, memory_object_self->pub.p, xctx)
         : value;
     if (final_e) {
         final_e->next = e;
     }
     else {
-        self->first_property = e;
+        memory_object_self->first_property = e;
     }
 }

--- a/src/afw/object/afw_object_memory_associative_array.c
+++ b/src/afw/object/afw_object_memory_associative_array.c
@@ -16,6 +16,8 @@
 
 /* Declares and rti/inf defines for interface afw_object_associative_array */
 #define AFW_IMPLEMENTATION_ID "memory"
+typedef struct impl_afw_object_associative_array_self_s impl_afw_object_associative_array_self_t;
+#define AFW_OBJECT_ASSOCIATIVE_ARRAY_SELF_T impl_afw_object_associative_array_self_t
 #include "afw_object_associative_array_impl_declares.h"
 
 /* Self */
@@ -61,12 +63,10 @@ afw_object_memory_associative_array_create(
  */
 void
 impl_afw_object_associative_array_release (
-    const afw_object_associative_array_t * instance,
+    AFW_OBJECT_ASSOCIATIVE_ARRAY_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    /* Assign instance pointer to self. */
-    impl_afw_object_associative_array_self_t * self = 
-        (impl_afw_object_associative_array_self_t *)instance;
+    /* Assign &self->pub pointer to self. */
 
     apr_hash_index_t *hi;
     const void *key;
@@ -76,7 +76,7 @@ impl_afw_object_associative_array_release (
     /* Decrement reference count and release object and array's pool if zero. */
     if (afw_atomic_integer_decrement(&self->reference_count) == 0) {
         for (hi = apr_hash_first(
-                afw_pool_get_apr_pool(instance->p), self->objects);
+                afw_pool_get_apr_pool(self->pub.p), self->objects);
             hi;
             hi = apr_hash_next(hi))
         {
@@ -84,7 +84,7 @@ impl_afw_object_associative_array_release (
             afw_object_release(object, xctx);
         }
 
-        afw_pool_release(instance->p, xctx);
+        afw_pool_release(self->pub.p, xctx);
     }
 }
 
@@ -95,12 +95,10 @@ impl_afw_object_associative_array_release (
  */
 void
 impl_afw_object_associative_array_get_reference (
-    const afw_object_associative_array_t * instance,
+    AFW_OBJECT_ASSOCIATIVE_ARRAY_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    /* Assign instance pointer to self. */
-    impl_afw_object_associative_array_self_t * self = 
-        (impl_afw_object_associative_array_self_t *)instance;
+    /* Assign &self->pub pointer to self. */
 
     /* Increment reference count. */
     afw_atomic_integer_increment(&self->reference_count);
@@ -120,13 +118,11 @@ impl_release_object(void *data, void *data2,
  */
 const afw_object_t *
 impl_afw_object_associative_array_get (
-    const afw_object_associative_array_t * instance,
+    AFW_OBJECT_ASSOCIATIVE_ARRAY_SELF_T *self,
     const afw_utf8_t * key,
     afw_xctx_t *xctx)
 {
-    /* Assign instance pointer to self. */
-    impl_afw_object_associative_array_self_t * self = 
-        (impl_afw_object_associative_array_self_t *)instance;
+    /* Assign &self->pub pointer to self. */
 
     const afw_object_t *object;
 
@@ -154,13 +150,11 @@ impl_afw_object_associative_array_get (
  */
 const afw_object_t *
 impl_afw_object_associative_array_get_associated_object_reference (
-    const afw_object_associative_array_t * instance,
+    AFW_OBJECT_ASSOCIATIVE_ARRAY_SELF_T *self,
     const afw_utf8_t * key,
     afw_xctx_t *xctx)
 {
-    /* Assign instance pointer to self. */
-    impl_afw_object_associative_array_self_t * self = 
-        (impl_afw_object_associative_array_self_t *)instance;
+    /* Assign &self->pub pointer to self. */
 
     const afw_object_t *object;
 
@@ -183,7 +177,7 @@ impl_afw_object_associative_array_get_associated_object_reference (
  */
 void
 impl_afw_object_associative_array_for_each (
-    const afw_object_associative_array_t * instance,
+    AFW_OBJECT_ASSOCIATIVE_ARRAY_SELF_T *self,
     void * context,
     afw_object_cb_t cb,
     afw_xctx_t *xctx)
@@ -200,14 +194,12 @@ impl_afw_object_associative_array_for_each (
  */
 void
 impl_afw_object_associative_array_set (
-    const afw_object_associative_array_t * instance,
+    AFW_OBJECT_ASSOCIATIVE_ARRAY_SELF_T *self,
     const afw_utf8_t * key,
     const afw_object_t * object,
     afw_xctx_t *xctx)
 {
-    /* Assign instance pointer to self. */
-    impl_afw_object_associative_array_self_t * self = 
-        (impl_afw_object_associative_array_self_t *)instance;
+    /* Assign &self->pub pointer to self. */
 
     const afw_object_t *existing;
 

--- a/src/afw/object/afw_object_meta.c
+++ b/src/afw/object/afw_object_meta.c
@@ -26,6 +26,7 @@
 
 /* Declares and rti/inf defines for interface afw_object */
 #define AFW_IMPLEMENTATION_ID "object_meta"
+#define AFW_OBJECT_SELF_T afw_object_meta_object_t
 #include "afw_object_impl_declares.h"
 #include "afw_object_setter_impl_declares.h"
 
@@ -841,11 +842,9 @@ afw_object_meta_add_thrown_property_error(
  */
 void
 impl_afw_object_release(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_object_meta_object_t *self =
-        (afw_object_meta_object_t *)instance;
 
     afw_object_release(self->pub.meta.embedding_object, xctx);
 }
@@ -855,11 +854,9 @@ impl_afw_object_release(
  */
 void
 impl_afw_object_get_reference(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_object_meta_object_t *self =
-        (afw_object_meta_object_t *)instance;
 
     afw_object_get_reference(self->pub.meta.embedding_object, xctx);
 }
@@ -869,11 +866,11 @@ impl_afw_object_get_reference(
  */
 afw_size_t
 impl_afw_object_get_count(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t * xctx)
 {
 //    <afwdev {prefixed_interface_name}>_self_t *self =
-//        (<afwdev {prefixed_interface_name}>_self_t *)instance;
+//        (<afwdev {prefixed_interface_name}>_self_t *)&self->pub;
 
     /** @todo Add code to implement method. */
     AFW_THROW_ERROR_Z(general, "Method not implemented.", xctx);
@@ -885,12 +882,10 @@ impl_afw_object_get_count(
  */
 const afw_value_t *
 impl_afw_object_get_property(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t *property_name,
     afw_xctx_t *xctx)
 {
-    afw_object_meta_object_t *self =
-        (afw_object_meta_object_t *)instance;
     const afw_value_t *result;
 
     result = afw_object_get_property(self->delta, property_name, xctx);
@@ -918,13 +913,11 @@ typedef struct {
  */
 const afw_value_t *
 impl_afw_object_get_next_property(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_iterator_t **iterator,
     const afw_utf8_t **property_name,
     afw_xctx_t *xctx)
 {
-    afw_object_meta_object_t *self =
-        (afw_object_meta_object_t *)instance;
     const afw_value_t *result;
     const afw_utf8_t *next_property_name;
     impl_get_next_property_iterator_t *i;
@@ -984,12 +977,10 @@ impl_afw_object_get_next_property(
  */
 afw_boolean_t
 impl_afw_object_has_property(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t *property_name,
     afw_xctx_t *xctx)
 {
-    afw_object_meta_object_t *self =
-        (afw_object_meta_object_t *)instance;
     afw_boolean_t result;
 
     result = afw_object_has_property(self->delta, property_name, xctx);
@@ -1002,11 +993,9 @@ impl_afw_object_has_property(
  */
 const afw_object_setter_t *
 impl_afw_object_get_setter(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_object_meta_object_t *self =
-        (afw_object_meta_object_t *)instance;
 
     return &self->setter;
 }
@@ -1017,7 +1006,7 @@ impl_afw_object_get_setter(
  */
 void
 impl_afw_object_setter_set_immutable(
-    const afw_object_setter_t * instance,
+    const afw_object_setter_t * self,
     afw_xctx_t *xctx)
 {
     /** @todo Add code to implement method. */
@@ -1030,26 +1019,26 @@ impl_afw_object_setter_set_immutable(
  */
 void
 impl_afw_object_setter_set_property(
-    const afw_object_setter_t * instance,
+    const afw_object_setter_t * self,
     const afw_utf8_t * property_name,
     const afw_value_t * value,
     afw_xctx_t *xctx)
 {
-    afw_object_meta_object_t *self =
-        (afw_object_meta_object_t *)instance->object;
+    afw_object_meta_object_t *object_meta_object_self =
+        (afw_object_meta_object_t *)self->object;
 
     if (afw_utf8_equal(property_name, afw_s_path)) {
         AFW_VALUE_ASSERT_IS_ANYURI_OR_STRING(value, xctx);
         afw_object_meta_set_ids_using_path(
-            self->pub.meta.embedding_object,
+            object_meta_object_self->pub.meta.embedding_object,
             &((const afw_value_anyURI_t *)value)->internal,
             xctx);
     }
 
     else {
-        if (!self->delta) {
-            self->delta = afw_object_create_unmanaged(self->pub.p, xctx);
+        if (!object_meta_object_self->delta) {
+            object_meta_object_self->delta = afw_object_create_unmanaged(object_meta_object_self->pub.p, xctx);
         }
-        afw_object_set_property(self->delta, property_name, value, xctx);
+        afw_object_set_property(object_meta_object_self->delta, property_name, value, xctx);
     }
 }

--- a/src/afw/object/afw_object_meta_accessor.c
+++ b/src/afw/object/afw_object_meta_accessor.c
@@ -27,6 +27,7 @@
 
 /* Declares and rti/inf defines for interface afw_object */
 #define AFW_IMPLEMENTATION_ID "afw_object_meta_accessor"
+#define AFW_OBJECT_SELF_T afw_object_internal_meta_accessor_self_t
 #include "afw_object_impl_declares.h"
 
 
@@ -64,7 +65,7 @@ afw_object_meta_create_accessor_with_options(
 
     /* If there are no properties to return, return NULL. */
     iterator = NULL;
-    if (!impl_afw_object_get_next_property((afw_object_t *)self,
+    if (!impl_afw_object_get_next_property(self,
         &iterator, &property_name, xctx))
     {
         return NULL;
@@ -81,7 +82,7 @@ afw_object_meta_create_accessor_with_options(
  */
 void
 impl_afw_object_release(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Nothing to do. */
@@ -94,7 +95,7 @@ impl_afw_object_release(
  */
 void
 impl_afw_object_get_reference(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* There is no intent to implement this method. */
@@ -106,11 +107,11 @@ impl_afw_object_get_reference(
  */
 afw_size_t
 impl_afw_object_get_count(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t * xctx)
 {
 //    <afwdev {prefixed_interface_name}>_self_t *self =
-//        (<afwdev {prefixed_interface_name}>_self_t *)instance;
+//        (<afwdev {prefixed_interface_name}>_self_t *)&self->pub;
 
     /** @todo Add code to implement method. */
     AFW_THROW_ERROR_Z(general, "Method not implemented.", xctx);
@@ -123,7 +124,7 @@ impl_afw_object_get_count(
  */
 const afw_value_t *
 impl_afw_object_get_property(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t *property_name,
     afw_xctx_t *xctx)
 {
@@ -138,13 +139,11 @@ impl_afw_object_get_property(
  */
 const afw_value_t *
 impl_afw_object_get_next_property(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_iterator_t **iterator,
     const afw_utf8_t **property_name,
     afw_xctx_t *xctx)
 {
-    afw_object_internal_meta_accessor_self_t *self =
-        (afw_object_internal_meta_accessor_self_t *)instance;
     const afw_pool_t *p = self->pub.p;
     const afw_value_t *result = NULL;
     const afw_utf8_t *s;
@@ -316,7 +315,7 @@ return_result:
  */
 afw_boolean_t
 impl_afw_object_has_property(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t *property_name,
     afw_xctx_t *xctx)
 {
@@ -331,7 +330,7 @@ impl_afw_object_has_property(
  */
 const afw_object_setter_t *
 impl_afw_object_get_setter(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* There is no intent to implement this method. */

--- a/src/afw/object/afw_object_properties_callback.c
+++ b/src/afw/object/afw_object_properties_callback.c
@@ -27,6 +27,7 @@
 
 /* Declares and rti/inf defines for interface afw_object */
 #define AFW_IMPLEMENTATION_ID "properties_callback"
+#define AFW_OBJECT_SELF_T afw_object_internal_properties_callback_self_t
 #include "afw_object_impl_declares.h"
 #include "afw_object_setter_impl_declares.h"
 
@@ -69,7 +70,7 @@ afw_object_create_properties_callback(
  */
 void
 impl_afw_object_release(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
 
@@ -80,7 +81,7 @@ impl_afw_object_release(
  */
 void
 impl_afw_object_get_reference(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
 
@@ -91,11 +92,11 @@ impl_afw_object_get_reference(
  */
 afw_size_t
 impl_afw_object_get_count(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t * xctx)
 {
 //    <afwdev {prefixed_interface_name}>_self_t *self =
-//        (<afwdev {prefixed_interface_name}>_self_t *)instance;
+//        (<afwdev {prefixed_interface_name}>_self_t *)&self->pub;
 
     /** @todo Add code to implement method. */
     AFW_THROW_ERROR_Z(general, "Method not implemented.", xctx);
@@ -107,12 +108,10 @@ impl_afw_object_get_count(
  */
 const afw_value_t *
 impl_afw_object_get_property(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t *property_name,
     afw_xctx_t *xctx)
 {
-    afw_object_internal_properties_callback_self_t *self =
-        (afw_object_internal_properties_callback_self_t *)instance;
     const afw_object_properties_callback_entry_t *e;
     const afw_value_t *result;
 
@@ -133,13 +132,11 @@ impl_afw_object_get_property(
  */
 const afw_value_t *
 impl_afw_object_get_next_property(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_iterator_t **iterator,
     const afw_utf8_t **property_name,
     afw_xctx_t *xctx)
 {
-    afw_object_internal_properties_callback_self_t *self =
-        (afw_object_internal_properties_callback_self_t *)instance;
     const afw_value_t *result;
     const afw_object_properties_callback_entry_t *e;
 
@@ -172,13 +169,13 @@ impl_afw_object_get_next_property(
  */
 afw_boolean_t
 impl_afw_object_has_property(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t *property_name,
     afw_xctx_t *xctx)
 {
     afw_boolean_t result;
 
-    result = impl_afw_object_get_property(instance, property_name, xctx)
+    result = impl_afw_object_get_property(self, property_name, xctx)
         != NULL;
 
     return result;      
@@ -189,11 +186,9 @@ impl_afw_object_has_property(
  */
 const afw_object_setter_t *
 impl_afw_object_get_setter(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_object_internal_properties_callback_self_t *self =
-        (afw_object_internal_properties_callback_self_t *)instance;
 
     return (self->immutable) ? NULL : &self->setter;
 }
@@ -203,13 +198,13 @@ impl_afw_object_get_setter(
  */
 void
 impl_afw_object_setter_set_immutable(
-    const afw_object_setter_t * instance,
+    const afw_object_setter_t * self,
     afw_xctx_t *xctx)
 {
-    afw_object_internal_properties_callback_self_t *self =
-        (afw_object_internal_properties_callback_self_t *)instance->object;
+    afw_object_internal_properties_callback_self_t *properties_callback_self =
+        (afw_object_internal_properties_callback_self_t *)self->object;
 
-    self->immutable = true;
+    properties_callback_self->immutable = true;
 }
 
 /*
@@ -217,23 +212,23 @@ impl_afw_object_setter_set_immutable(
  */
 void
 impl_afw_object_setter_set_property(
-    const afw_object_setter_t * instance,
+    const afw_object_setter_t * self,
     const afw_utf8_t * property_name,
     const afw_value_t * value,
     afw_xctx_t *xctx)
 {
-    afw_object_internal_properties_callback_self_t *self =
-        (afw_object_internal_properties_callback_self_t *)instance->object;
+    afw_object_internal_properties_callback_self_t *properties_callback_self =
+        (afw_object_internal_properties_callback_self_t *)self->object;
     const afw_object_properties_callback_entry_t *e;
 
-    if (!self->immutable) {
-        for (e = self->callbacks; e < self->end; e++)
+    if (!properties_callback_self->immutable) {
+        for (e = properties_callback_self->callbacks; e < properties_callback_self->end; e++)
         {
             if (afw_utf8_equal(e->property_name, property_name)) {
                 if (!e->set) {
                     break;
                 }
-                e->set(self->data, property_name, value, xctx);
+                e->set(properties_callback_self->data, property_name, value, xctx);
                 return;
             }
         }

--- a/src/afw/object/afw_object_view.c
+++ b/src/afw/object/afw_object_view.c
@@ -30,6 +30,7 @@
 
 /* Object view object implementation. */
 #define AFW_IMPLEMENTATION_ID "afw_object_view"
+#define AFW_OBJECT_SELF_T afw_object_view_internal_object_self_t
 #include "afw_object_impl_declares.h"
 
 /*--- Macros. ---*/
@@ -1173,19 +1174,18 @@ impl_object_create(
  */
 void
 impl_afw_object_release (
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_object_view_internal_object_self_t * self;
-    const afw_object_t *entity;
+        const afw_object_t *entity;
 
     /* Methods release and get_reference act on the entity. */
-    AFW_OBJECT_GET_ENTITY(entity, instance);
-    self = (afw_object_view_internal_object_self_t *)entity;
+    AFW_OBJECT_GET_ENTITY(entity, &self->pub);
+    self = (AFW_OBJECT_SELF_T *)entity;
 
     /* Decrement count and release object's pool if zero. */
     if (afw_atomic_integer_decrement(&self->view->reference_count) == 0) {
-        afw_pool_release(instance->p, xctx);
+        afw_pool_release(self->pub.p, xctx);
     }
 }
 
@@ -1196,15 +1196,14 @@ impl_afw_object_release (
  */
 void
 impl_afw_object_get_reference (
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_object_view_internal_object_self_t * self;
     const afw_object_t *entity;
 
     /* Methods release and get_reference act on the entity. */
-    AFW_OBJECT_GET_ENTITY(entity, instance);
-    self = (afw_object_view_internal_object_self_t *)entity;
+    AFW_OBJECT_GET_ENTITY(entity, &self->pub);
+    self = (AFW_OBJECT_SELF_T *)entity;
 
     /* Increment reference count. */
     afw_atomic_integer_increment(&self->view->reference_count);
@@ -1215,11 +1214,11 @@ impl_afw_object_get_reference (
  */
 afw_size_t
 impl_afw_object_get_count(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t * xctx)
 {
 //    <afwdev {prefixed_interface_name}>_self_t *self =
-//        (<afwdev {prefixed_interface_name}>_self_t *)instance;
+//        (<afwdev {prefixed_interface_name}>_self_t *)&self->pub;
 
     /** @todo Add code to implement method. */
     AFW_THROW_ERROR_Z(general, "Method not implemented.", xctx);
@@ -1231,12 +1230,10 @@ impl_afw_object_get_count(
  */
 const afw_value_t *
 impl_afw_object_get_property(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t * property_name,
     afw_xctx_t *xctx)
 {
-    afw_object_view_internal_object_self_t * self =
-        (afw_object_view_internal_object_self_t *)instance;
     afw_object_view_property_t *prop;
 
     prop = impl_get_property(self, property_name);
@@ -1251,13 +1248,11 @@ impl_afw_object_get_property(
  */
 const afw_value_t *
 impl_afw_object_get_next_property(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_iterator_t * * iterator,
     const afw_utf8_t * * property_name,
     afw_xctx_t *xctx)
 {
-    afw_object_view_internal_object_self_t * self =
-        (afw_object_view_internal_object_self_t *)instance;
     const afw_value_t *result;
     afw_object_view_property_t *prop;
 
@@ -1301,11 +1296,11 @@ impl_afw_object_get_next_property(
  */
 afw_boolean_t
 impl_afw_object_has_property (
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t * property_name,
     afw_xctx_t *xctx)
 {
-    return (impl_afw_object_get_property(instance,
+    return (impl_afw_object_get_property(self,
         property_name, xctx) != NULL);
 }
 
@@ -1316,7 +1311,7 @@ impl_afw_object_has_property (
  */
 const afw_object_setter_t *
 impl_afw_object_get_setter (
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Views are immutable. */

--- a/src/afw/os/nix/afw_os_log.c
+++ b/src/afw/os/nix/afw_os_log.c
@@ -100,7 +100,7 @@ afw_os_log_create(
  */
 const afw_log_t *
 impl_afw_log_factory_create_log_cede_p (
-    const afw_log_factory_t * instance,
+    const afw_log_factory_t * self,
     const afw_object_t * properties,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
@@ -115,7 +115,7 @@ impl_afw_log_factory_create_log_cede_p (
  */
 void
 impl_afw_log_destroy(
-    const afw_log_t * instance,
+    const afw_log_t * self,
     afw_xctx_t *xctx)
 {
     /* 
@@ -126,7 +126,7 @@ impl_afw_log_destroy(
      */
     closelog();
 
-    afw_pool_release(instance->p, xctx);
+    afw_pool_release(self->p, xctx);
 }
 
 
@@ -136,11 +136,11 @@ impl_afw_log_destroy(
  */
 void
 impl_afw_log_set_own_mask(
-    const afw_log_t * instance,
+    const afw_log_t * self,
     afw_log_priority_mask_t mask,
     afw_xctx_t *xctx)
 {
-    afw_log_impl_t *impl = (afw_log_impl_t *)instance->impl;
+    afw_log_impl_t *impl = (afw_log_impl_t *)self->impl;
 
     /* Set mask. */
     impl->mask = mask;
@@ -153,7 +153,7 @@ impl_afw_log_set_own_mask(
  */
 void
 impl_afw_log_write(
-    const afw_log_t * instance,
+    const afw_log_t * self,
     afw_log_priority_t priority,
     const afw_utf8_z_t * source_z,
     const afw_utf8_t * message,

--- a/src/afw/os/win/afw_os_log.c
+++ b/src/afw/os/win/afw_os_log.c
@@ -16,6 +16,8 @@
 
 /* Declares and rti/inf defines for interface afw_log */
 #define AFW_IMPLEMENTATION_ID "event_log"
+typedef struct impl_afw_log_self_s impl_afw_os_log_self_;
+#define AFW_LOG_SELF_T impl_afw_os_log_self_
 #include "afw_log_impl_declares.h"
 #include "afw_log_factory_impl_declares.h"
 
@@ -71,7 +73,7 @@ AFW_DEFINE(const afw_log_t *) afw_os_log_create(
  */
 const afw_log_t *
 impl_afw_log_factory_create_log_cede_p (
-    const afw_log_factory_t * instance,
+    const afw_log_factory_t * self,
     const afw_object_t * properties,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
@@ -85,10 +87,10 @@ impl_afw_log_factory_create_log_cede_p (
  */
 void
 impl_afw_log_destroy(
-    const afw_log_t * instance,
+    AFW_LOG_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_pool_release(instance->p, xctx);
+    afw_pool_release(self->pub.p, xctx);
 }
 
 
@@ -97,14 +99,12 @@ impl_afw_log_destroy(
  */
 void
 impl_afw_log_set_own_mask(
-    const afw_log_t * instance,
+    AFW_LOG_SELF_T *self,
     afw_log_priority_mask_t mask,
     afw_xctx_t *xctx)
 {
-    /* Assign instance pointer to self. */
-    impl_afw_os_log_self_ * self =
-        (impl_afw_os_log_self_ *)instance;
-    afw_log_impl_t *impl = (afw_log_impl_t *)instance->impl;
+    /* Assign &self->pub pointer to self. */
+    afw_log_impl_t *impl = (afw_log_impl_t *)self->pub.impl;
 
     /* Set mask. */
     impl->mask = mask;
@@ -117,15 +117,13 @@ impl_afw_log_set_own_mask(
  */
 void
 impl_afw_log_write(
-    const afw_log_t * instance,
+    AFW_LOG_SELF_T *self,
     afw_log_priority_t priority,
     const afw_utf8_z_t * source_z,
     const afw_utf8_t * message,
     afw_xctx_t *xctx)
 {
-    /* Assign instance pointer to self. */
-    impl_afw_os_log_self_ * self =
-        (impl_afw_os_log_self_ *)instance;
+    /* Assign &self->pub pointer to self. */
 
     /** @fixme Write to event log. */
     fprintf(xctx->env->stderr_fd,

--- a/src/afw/request/afw_request.c
+++ b/src/afw/request/afw_request.c
@@ -16,6 +16,8 @@
 
 /* Declares and rti/inf defines for interface afw_content_type */
 #define AFW_IMPLEMENTATION_ID "request"
+typedef struct afw_request_response_body_raw_writer_self_s afw_request_response_body_raw_writer_self_t;
+#define AFW_STREAM_SELF_T afw_request_response_body_raw_writer_self_t
 #include "afw_stream_impl_declares.h"
 
 
@@ -295,13 +297,11 @@ impl_response_write_cb(
  */
 void
 impl_afw_stream_release(
-    const afw_stream_t *instance,
+    AFW_STREAM_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_request_response_body_raw_writer_self_t *self =
-        (afw_request_response_body_raw_writer_self_t *)instance;
 
-    impl_afw_stream_flush(instance, xctx);
+    impl_afw_stream_flush(self, xctx);
     afw_pool_release(self->pub.p, xctx);
 }
 
@@ -310,12 +310,12 @@ impl_afw_stream_release(
  */
 afw_size_t
 impl_afw_stream_read(
-    const afw_stream_t *instance,
+    AFW_STREAM_SELF_T *self,
     void *buffer,
     afw_size_t size,
     afw_xctx_t *xctx)
 {
-    (void)instance;
+    (void)&self->pub;
     (void)buffer;
     (void)size;
     AFW_THROW_ERROR_Z(general, "Stream is not readable.", xctx);
@@ -326,11 +326,9 @@ impl_afw_stream_read(
  */
 void
 impl_afw_stream_flush(
-    const afw_stream_t *instance,
+    AFW_STREAM_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_request_response_body_raw_writer_self_t *self =
-        (afw_request_response_body_raw_writer_self_t *)instance;
 
     afw_request_flush_response(self->request, xctx);
 }
@@ -340,7 +338,7 @@ impl_afw_stream_flush(
  */
 void
 impl_afw_stream_write(
-    const afw_stream_t *instance,
+    AFW_STREAM_SELF_T *self,
     const void *buffer,
     afw_size_t size,
     afw_xctx_t *xctx)
@@ -349,7 +347,7 @@ impl_afw_stream_write(
         return;
     }
 
-    impl_response_write_cb((void *)instance, buffer, size,
+    impl_response_write_cb((void *)&self->pub, buffer, size,
         xctx->p, xctx);
 }
 

--- a/src/afw/request/afw_request_handler_adapter.c
+++ b/src/afw/request/afw_request_handler_adapter.c
@@ -22,6 +22,7 @@
 
 /* Declares and rti/inf defines for interface afw_request_handler */
 #define AFW_IMPLEMENTATION_ID "adapter"
+#define AFW_REQUEST_HANDLER_SELF_T afw_request_handler_adapter_internal_self_t
 #include "afw_request_handler_impl_declares.h"
 
 
@@ -99,7 +100,7 @@ static afw_boolean_t impl_retrieve_cb(const afw_object_t *object,
  */
 void
 impl_afw_request_handler_release(
-    const afw_request_handler_t * instance,
+    AFW_REQUEST_HANDLER_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Resources will be released when execution context (xctx) is released. */
@@ -111,7 +112,7 @@ impl_afw_request_handler_release(
  */
 void
 impl_afw_request_handler_process(
-    const afw_request_handler_t * instance,
+    AFW_REQUEST_HANDLER_SELF_T *self,
     const afw_request_t * request,
     afw_xctx_t *xctx)
 {
@@ -124,7 +125,6 @@ impl_afw_request_handler_process(
     const afw_stream_t *stream;
     impl_retrieve_cb_context_t retrieve_cb_context;
 
-    afw_request_handler_adapter_internal_self_t * self = (afw_request_handler_adapter_internal_self_t *)instance;
 
     /* Parse the path. */
     parsed_path = afw_object_path_parse(request->uri, NULL, self->default_options,

--- a/src/afw/request/afw_request_handler_director.c
+++ b/src/afw/request/afw_request_handler_director.c
@@ -17,6 +17,8 @@
 
 /* Declares and rti/inf defines for interface afw_request_handler */
 #define AFW_IMPLEMENTATION_ID "director"
+typedef struct self_request_handler_director_s self_request_handler_director_t;
+#define AFW_REQUEST_HANDLER_SELF_T self_request_handler_director_t
 #include "afw_request_handler_impl_declares.h"
 
 
@@ -63,7 +65,7 @@ afw_request_handler_director_create(
  */
 void
 impl_afw_request_handler_release(
-    const afw_request_handler_t * instance,
+    AFW_REQUEST_HANDLER_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /*
@@ -81,12 +83,10 @@ impl_afw_request_handler_release(
  */
 void
 impl_afw_request_handler_process(
-    const afw_request_handler_t * instance,
+    AFW_REQUEST_HANDLER_SELF_T *self,
     const afw_request_t * request,
     afw_xctx_t *xctx)
 {
-    self_request_handler_director_t *self =
-        (self_request_handler_director_t *)instance;
     const afw_request_handler_entry_t *request_handler_entry;
 
     /* Call appropriate handler. */

--- a/src/afw/request/afw_request_handler_factory_adapter.c
+++ b/src/afw/request/afw_request_handler_factory_adapter.c
@@ -41,7 +41,7 @@ afw_request_handler_factory_adapter =
  */
 const afw_request_handler_t *
 impl_afw_request_handler_factory_create_request_handler_cede_p (
-    const afw_request_handler_factory_t * instance,
+    const afw_request_handler_factory_t * self,
     const afw_object_t * properties,
     const afw_pool_t * p,
     afw_xctx_t *xctx)

--- a/src/afw/runtime/afw_runtime.c
+++ b/src/afw/runtime/afw_runtime.c
@@ -19,6 +19,8 @@
 #define AFW_IMPLEMENTATION_ID "afw_runtime"
 #include "afw_adapter_factory_impl_declares.h"
 #include "afw_adapter_impl_declares.h"
+typedef struct impl_afw_adapter_session_self_s impl_afw_adapter_session_self_t;
+#define AFW_ADAPTER_SESSION_SELF_T impl_afw_adapter_session_self_t
 #include "afw_adapter_session_impl_declares.h"
 
 typedef struct {
@@ -607,7 +609,7 @@ afw_runtime_get_adapter_factory()
  */
 const afw_adapter_t *
 impl_afw_adapter_factory_create_adapter_cede_p (
-    const afw_adapter_factory_t * instance,
+    const afw_adapter_factory_t * self,
     const afw_object_t * properties,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
@@ -632,11 +634,11 @@ impl_afw_adapter_factory_create_adapter_cede_p (
  */
 void
 impl_afw_adapter_destroy (
-    const afw_adapter_t * instance,
+    const afw_adapter_t * self,
     afw_xctx_t *xctx)
 {
     /* Release pool. */
-    afw_pool_release(instance->p, xctx);
+    afw_pool_release(self->p, xctx);
 }
 
 
@@ -653,19 +655,19 @@ afw_runtime_get_internal_session(afw_xctx_t *xctx)
  */
 const afw_adapter_session_t *
 impl_afw_adapter_create_adapter_session (
-    const afw_adapter_t * instance,
+    const afw_adapter_t *self,
     afw_xctx_t *xctx)
 {
-    impl_afw_adapter_session_self_t *self;
+    impl_afw_adapter_session_self_t *session;
     const afw_pool_t *session_p;
 
-    session_p = afw_pool_create(xctx->p, xctx);;
-    self = afw_pool_calloc_type(session_p, impl_afw_adapter_session_self_t, xctx);
-    self->pub.inf = &impl_afw_adapter_session_inf;
-    self->pub.adapter = instance;
-    self->pub.p = session_p;
+    session_p = afw_pool_create(xctx->p, xctx);
+    session = afw_pool_calloc_type(session_p, impl_afw_adapter_session_self_t, xctx);
+    session->pub.inf = &impl_afw_adapter_session_inf;
+    session->pub.adapter = self;
+    session->pub.p = session_p;
 
-    return (const afw_adapter_session_t *)self;
+    return (const afw_adapter_session_t *)session;
 }
 
 
@@ -674,7 +676,7 @@ impl_afw_adapter_create_adapter_session (
  */
 const afw_object_t *
 impl_afw_adapter_get_additional_metrics (
-    const afw_adapter_t * instance,
+    const afw_adapter_t * self,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {
@@ -690,12 +692,10 @@ impl_afw_adapter_get_additional_metrics (
  */
 void
 impl_afw_adapter_session_destroy (
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    /* Assign instance pointer to self. */
-    impl_afw_adapter_session_self_t * self = 
-        (impl_afw_adapter_session_self_t *)instance;
+    /* Assign &self->pub pointer to self. */
 
     /* Release pool. */
     afw_pool_release(self->pub.p, xctx);
@@ -711,7 +711,7 @@ impl_afw_adapter_session_destroy (
  */
 void
 impl_afw_adapter_session_retrieve_objects(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_query_criteria_t *criteria,
@@ -730,10 +730,10 @@ impl_afw_adapter_session_retrieve_objects(
     const impl_ht_object_entry *entry;
 
     /* If this is a custom handled object type, call its function and return. */
-    if (instance) {
+    if (&self->pub) {
         custom = afw_environment_get_runtime_custom(object_type_id, xctx);
         if (custom) {
-            custom->retrieve_objects(instance, impl_request,
+            custom->retrieve_objects(&self->pub, impl_request,
                 object_type_id, criteria,
                 context, callback, NULL, p, xctx);
             return;
@@ -776,7 +776,7 @@ impl_afw_adapter_session_retrieve_objects(
  */
 void
 impl_afw_adapter_session_get_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *object_id,
@@ -792,7 +792,7 @@ impl_afw_adapter_session_get_object(
     /* If this is a custom handled object type, call its function and return. */
     custom = afw_environment_get_runtime_custom(object_type_id, xctx);
     if (custom) {
-        custom->get_object(instance, impl_request,
+        custom->get_object(&self->pub, impl_request,
             object_type_id, object_id,
             context, callback, adapter_type_specific, p, xctx);
         return;
@@ -812,7 +812,7 @@ impl_afw_adapter_session_get_object(
  */
 const afw_utf8_t *
 impl_afw_adapter_session_add_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *suggested_object_id,
@@ -830,7 +830,7 @@ impl_afw_adapter_session_add_object(
  */
 void
 impl_afw_adapter_session_modify_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *object_id,
@@ -848,7 +848,7 @@ impl_afw_adapter_session_modify_object(
  */
 void
 impl_afw_adapter_session_replace_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *object_id,
@@ -866,7 +866,7 @@ impl_afw_adapter_session_replace_object(
  */
 void
 impl_afw_adapter_session_delete_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *object_id,
@@ -884,7 +884,7 @@ impl_afw_adapter_session_delete_object(
  */
 const afw_adapter_transaction_t *
 impl_afw_adapter_session_begin_transaction (
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* No transaction support. */
@@ -898,7 +898,7 @@ impl_afw_adapter_session_begin_transaction (
  */
 const afw_adapter_journal_t *
 impl_afw_adapter_session_get_journal_interface (
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* No journal support. */
@@ -912,7 +912,7 @@ impl_afw_adapter_session_get_journal_interface (
  */
 const afw_adapter_key_value_t *
 impl_afw_adapter_session_get_key_value_interface (
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* No key support. */
@@ -926,7 +926,7 @@ impl_afw_adapter_session_get_key_value_interface (
  */
 const afw_adapter_impl_index_t *
 impl_afw_adapter_session_get_index_interface (
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* No index support. */
@@ -940,16 +940,14 @@ impl_afw_adapter_session_get_index_interface (
  */
 const afw_adapter_object_type_cache_t *
 impl_afw_adapter_session_get_object_type_cache_interface(
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    impl_afw_adapter_session_self_t *self =
-        (impl_afw_adapter_session_self_t *)instance;
 
     afw_adapter_impl_object_type_cache_initialize(
         &self->object_type_cache,
         &afw_adapter_impl_object_type_cache_inf,
-        instance, true, xctx);
+        &self->pub, true, xctx);
 
     return &self->object_type_cache;
 }

--- a/src/afw/runtime/afw_runtime_const_meta.c
+++ b/src/afw/runtime/afw_runtime_const_meta.c
@@ -29,6 +29,7 @@
 
 /* Declares and rti/inf defines for interface afw_object */
 #define AFW_IMPLEMENTATION_ID "afw_runtime_const_meta"
+#define AFW_OBJECT_SELF_T afw_runtime_const_object_meta_object_t
 #include "afw_object_impl_declares.h"
 
 /*
@@ -41,15 +42,25 @@ afw_runtime_inf_const_meta_object_inf = {
         AFW_UTF8_LITERAL(__FILE__),
         AFW_UTF8_LITERAL(AFW_IMPLEMENTATION_ID)
     },
+    (afw_object_release_t)
     impl_afw_object_release,
+    (afw_object_get_reference_t)
     impl_afw_object_get_reference,
+    (afw_object_get_count_t)
     impl_afw_object_get_count,
+    (afw_object_get_meta_t)
     impl_afw_object_get_meta,
+    (afw_object_get_property_t)
     impl_afw_object_get_property,
+    (afw_object_get_property_meta_t)
     impl_afw_object_get_property_meta,
+    (afw_object_get_next_property_t)
     impl_afw_object_get_next_property,
+    (afw_object_get_next_property_meta_t)
     impl_afw_object_get_next_property_meta,
+    (afw_object_has_property_t)
     impl_afw_object_has_property,
+    (afw_object_get_setter_t)
     impl_afw_object_get_setter
 };
 
@@ -60,7 +71,7 @@ afw_runtime_inf_const_meta_object_inf = {
  */
 void
 impl_afw_object_release (
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Nothing to do. */
@@ -73,7 +84,7 @@ impl_afw_object_release (
  */
 void
 impl_afw_object_get_reference (
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Nothing to do. */
@@ -84,11 +95,11 @@ impl_afw_object_get_reference (
  */
 afw_size_t
 impl_afw_object_get_count(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t * xctx)
 {
 //    <afwdev {prefixed_interface_name}>_self_t *self =
-//        (<afwdev {prefixed_interface_name}>_self_t *)instance;
+//        (<afwdev {prefixed_interface_name}>_self_t *)&self->pub;
 
     /** @todo Add code to implement method. */
     AFW_THROW_ERROR_Z(general, "Method not implemented.", xctx);
@@ -100,13 +111,11 @@ impl_afw_object_get_count(
  */
 const afw_value_t *
 impl_afw_object_get_property (
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t * property_name,
     afw_xctx_t *xctx)
 {
-    /* Assign instance pointer to self. */
-    afw_runtime_const_object_meta_object_t * self = 
-        (afw_runtime_const_object_meta_object_t *)instance;
+    /* Assign &self->pub pointer to self. */
     const afw_value_t *result;
 
     result = NULL;
@@ -128,14 +137,12 @@ impl_afw_object_get_property (
  */
 const afw_value_t *
 impl_afw_object_get_next_property (
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_iterator_t * * iterator,
     const afw_utf8_t * * property_name,
     afw_xctx_t *xctx)
 {
-    /* Assign instance pointer to self. */
-    afw_runtime_const_object_meta_object_t * self = 
-        (afw_runtime_const_object_meta_object_t *)instance;
+    /* Assign &self->pub pointer to self. */
 
 
     /* Parent paths is only property. */
@@ -161,7 +168,7 @@ impl_afw_object_get_next_property (
  */
 afw_boolean_t
 impl_afw_object_has_property (
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t * property_name,
     afw_xctx_t *xctx)
 {
@@ -175,7 +182,7 @@ impl_afw_object_has_property (
  */
 const afw_object_setter_t *
 impl_afw_object_get_setter (
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* No setter. */

--- a/src/afw/stream/afw_stream_fd.c
+++ b/src/afw/stream/afw_stream_fd.c
@@ -18,6 +18,8 @@
 
 /* Declares and rti/inf defines for interface afw_stream */
 #define AFW_IMPLEMENTATION_ID "afw_stream_fd"
+typedef struct afw_stream_fd_self_s afw_stream_fd_self_t;
+#define AFW_STREAM_SELF_T afw_stream_fd_self_t
 #include "afw_stream_impl_declares.h"
 
 
@@ -110,11 +112,9 @@ impl_afw_stream_fd_write_cb(
  */
 void
 impl_afw_stream_release(
-    const afw_stream_t *instance,
+    AFW_STREAM_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_stream_fd_self_t *self =
-        (afw_stream_fd_self_t *)instance;
     FILE *f;
     int err;
 
@@ -135,11 +135,9 @@ impl_afw_stream_release(
  */
 void
 impl_afw_stream_flush(
-    const afw_stream_t *instance,
+    AFW_STREAM_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_stream_fd_self_t *self =
-        (afw_stream_fd_self_t *)instance;
     int err;
 
     if (self->fd) {
@@ -158,13 +156,11 @@ impl_afw_stream_flush(
  */
 afw_size_t
 impl_afw_stream_read(
-    const afw_stream_t *instance,
+    AFW_STREAM_SELF_T *self,
     void *buffer,
     afw_size_t size,
     afw_xctx_t *xctx)
 {
-    afw_stream_fd_self_t *self =
-        (afw_stream_fd_self_t *)instance;
     size_t n;
     int err;
 
@@ -195,13 +191,13 @@ impl_afw_stream_read(
  */
 void
 impl_afw_stream_write(
-    const afw_stream_t *instance,
+    AFW_STREAM_SELF_T *self,
     const void *buffer,
     afw_size_t size,
     afw_xctx_t *xctx)
 {
-    impl_afw_stream_fd_write_cb((void *)instance, buffer, size,
-        instance->p, xctx);
+    impl_afw_stream_fd_write_cb((void *)&self->pub, buffer, size,
+        self->pub.p, xctx);
 }
 
 

--- a/src/afw/utf8/afw_utf8_stream.c
+++ b/src/afw/utf8/afw_utf8_stream.c
@@ -23,6 +23,7 @@ typedef struct {
 
 
 #define AFW_IMPLEMENTATION_ID "afw_utf8_stream"
+#define AFW_STREAM_SELF_T impl_utf8_stream_self_t
 #include "afw_stream_impl_declares.h"
 
 /*
@@ -97,11 +98,9 @@ afw_utf8_stream_get_current_cached_string(
  */
 void
 impl_afw_stream_release(
-    const afw_stream_t * instance,
+    AFW_STREAM_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    impl_utf8_stream_self_t *self =
-        (impl_utf8_stream_self_t *)instance;
 
     /* Release stream resources. */
     afw_pool_release(self->pub.p, xctx);
@@ -112,7 +111,7 @@ impl_afw_stream_release(
  */
 void
 impl_afw_stream_flush(
-    const afw_stream_t *instance,
+    AFW_STREAM_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Ignore flush. */
@@ -123,12 +122,12 @@ impl_afw_stream_flush(
  */
 afw_size_t
 impl_afw_stream_read(
-    const afw_stream_t *instance,
+    AFW_STREAM_SELF_T *self,
     void *buffer,
     afw_size_t size,
     afw_xctx_t *xctx)
 {
-    (void)instance;
+    (void)&self->pub;
     (void)buffer;
     (void)size;
     AFW_THROW_ERROR_Z(general, "Stream is not readable.", xctx);
@@ -139,13 +138,11 @@ impl_afw_stream_read(
  */
 void
 impl_afw_stream_write(
-    const afw_stream_t * instance,
+    AFW_STREAM_SELF_T *self,
     const void * buffer,
     afw_size_t size,
     afw_xctx_t *xctx)
 {
-    impl_utf8_stream_self_t *self =
-        (impl_utf8_stream_self_t *)instance;
     const afw_octet_t *c;
     afw_size_t count;
 

--- a/src/afw/utf8/afw_utf8_writer.c
+++ b/src/afw/utf8/afw_utf8_writer.c
@@ -23,6 +23,7 @@ typedef struct {
 
 
 #define AFW_IMPLEMENTATION_ID "afw_utf8_writer"
+#define AFW_WRITER_SELF_T impl_utf8_writer_self_t
 #include "afw_writer_impl_declares.h"
 
 /*
@@ -97,11 +98,9 @@ afw_utf8_writer_current_string(
  */
 void
 impl_afw_writer_release(
-    const afw_writer_t * instance,
+    AFW_WRITER_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    impl_utf8_writer_self_t *self =
-        (impl_utf8_writer_self_t *)instance;
 
     /* Release writer resources. */
     afw_pool_release(self->pub.p, xctx);
@@ -112,7 +111,7 @@ impl_afw_writer_release(
  */
 void
 impl_afw_writer_flush(
-    const afw_writer_t *instance,
+    AFW_WRITER_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Ignore flush. */
@@ -123,13 +122,11 @@ impl_afw_writer_flush(
  */
 void
 impl_afw_writer_write(
-    const afw_writer_t * instance,
+    AFW_WRITER_SELF_T *self,
     const void * buffer,
     afw_size_t size,
     afw_xctx_t *xctx)
 {
-    impl_utf8_writer_self_t *self =
-        (impl_utf8_writer_self_t *)instance;
     afw_size_t count, i;
     const afw_octet_t *c;
 
@@ -158,11 +155,9 @@ impl_afw_writer_write(
  */
 void
 impl_afw_writer_write_eol(
-    const afw_writer_t * instance,
+    AFW_WRITER_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    impl_utf8_writer_self_t *self =
-        (impl_utf8_writer_self_t *)instance;
 
     if (self->pub.tab) {
         APR_ARRAY_PUSH(self->ary, char) = '\n';
@@ -175,11 +170,9 @@ impl_afw_writer_write_eol(
  */
 void
 impl_afw_writer_increment_indent(
-    const afw_writer_t * instance,
+    AFW_WRITER_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    impl_utf8_writer_self_t *self =
-        (impl_utf8_writer_self_t *)instance;
 
     self->pub.indent++;
 }
@@ -189,11 +182,9 @@ impl_afw_writer_increment_indent(
  */
 void
 impl_afw_writer_decrement_indent(
-    const afw_writer_t * instance,
+    AFW_WRITER_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    impl_utf8_writer_self_t *self =
-        (impl_utf8_writer_self_t *)instance;
 
     self->pub.indent--;
 }

--- a/src/afw/value/afw_value_assignment_target.c
+++ b/src/afw/value/afw_value_assignment_target.c
@@ -25,6 +25,7 @@
 #define AFW_IMPLEMENTATION_INF_SPECIFIER AFW_DEFINE_CONST_DATA
 #define AFW_IMPLEMENTATION_INF_LABEL afw_value_assignment_target_inf
 #define impl_afw_value_create_iterator NULL
+#define AFW_VALUE_SELF_T afw_value_assignment_target_t
 #include "afw_value_impl_declares.h"
 
 
@@ -72,12 +73,10 @@ afw_value_assignment_target_create(
  */
 const afw_value_t *
 impl_afw_value_optional_evaluate(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {
-    const afw_value_assignment_target_t *self =
-        (const afw_value_assignment_target_t *)instance;
 
     if (self->assignment_target->target_type ==
         afw_compile_assignment_target_type_symbol_reference)
@@ -85,7 +84,7 @@ impl_afw_value_optional_evaluate(
         return &self->assignment_target->symbol_reference->pub;
     }
 
-    return instance;
+    return &self->pub;
 }
 
 /*
@@ -93,7 +92,7 @@ impl_afw_value_optional_evaluate(
  */
 const afw_data_type_t *
 impl_afw_value_get_data_type(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     afw_xctx_t *xctx)
 {
     return NULL;
@@ -104,7 +103,7 @@ impl_afw_value_get_data_type(
  */
 const afw_value_t *
 impl_afw_value_get_evaluated_meta(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
@@ -244,14 +243,12 @@ impl_object_destructure_produce_compiler_listing(
  */
 void
 impl_afw_value_produce_compiler_listing(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t *writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_assignment_target_t *self =
-        (const afw_value_assignment_target_t *)instance;
 
-    afw_value_compiler_listing_begin_value(writer, instance,
+    afw_value_compiler_listing_begin_value(writer, &self->pub,
         self->contextual, xctx);
     afw_writer_write_z(writer, " ", xctx);
     afw_writer_write_utf8(writer,
@@ -564,16 +561,14 @@ afw_value_decompile_assignment_pattern(
  */
 void
 impl_afw_value_decompile(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t * writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_assignment_target_t *self =
-        (const afw_value_assignment_target_t *)instance;
     afw_value_string_t type_string;
     const afw_utf8_t *type_id;
 
-    afw_value_decompile_write_synthetic_function_name(instance, writer, xctx);
+    afw_value_decompile_write_synthetic_function_name(&self->pub, writer, xctx);
     afw_writer_write_z(writer, "(", xctx);
     if (writer->tab) {
         afw_writer_increment_indent(writer, xctx);
@@ -592,7 +587,7 @@ impl_afw_value_decompile(
         afw_writer_write_eol(writer, xctx);
     }
 
-    impl_decompile_pattern(instance, writer, xctx);
+    impl_decompile_pattern(&self->pub, writer, xctx);
 
     if (writer->tab) {
         afw_writer_write_eol(writer, xctx);
@@ -606,18 +601,16 @@ impl_afw_value_decompile(
  */
 void
 impl_afw_value_get_info(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     afw_value_info_t *info,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    const afw_value_assignment_target_t *self =
-        (const afw_value_assignment_target_t *)instance;
 
     afw_memory_clear(info);
-    info->value_inf_id = &instance->inf->rti.implementation_id;
+    info->value_inf_id = &self->pub.inf->rti.implementation_id;
     info->contextual = self->contextual;
-    info->optimized_value = instance;
+    info->optimized_value = &self->pub;
 
     /* Note: Maybe something can be done for optimized_value_data_type. */
 }

--- a/src/afw/value/afw_value_block.c
+++ b/src/afw/value/afw_value_block.c
@@ -30,6 +30,7 @@
 #define AFW_IMPLEMENTATION_ID "block"
 #define AFW_IMPLEMENTATION_INF_SPECIFIER AFW_DEFINE_CONST_DATA
 #define AFW_IMPLEMENTATION_INF_LABEL afw_value_block_inf
+#define AFW_VALUE_SELF_T afw_value_block_t
 #include "afw_value_impl_declares.h"
 
 #define IMPL_TEMP_FIX_ASSIGNS(XX) \
@@ -193,7 +194,7 @@ afw_value_block_finalize(
  */
 const afw_value_t *
 impl_afw_value_optional_evaluate(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {
@@ -206,7 +207,7 @@ impl_afw_value_optional_evaluate(
 
     /* Evaluate block. */
     result = afw_value_block_evaluate_block(
-        &x, (const afw_value_block_t *)instance, p, xctx);
+        &x, (const afw_value_block_t *)&self->pub, p, xctx);
 
     return result;
 }
@@ -216,7 +217,7 @@ impl_afw_value_optional_evaluate(
  */
 const afw_data_type_t *
 impl_afw_value_get_data_type(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     afw_xctx_t *xctx)
 {
     return NULL;
@@ -227,16 +228,14 @@ impl_afw_value_get_data_type(
  */
 void
 impl_afw_value_produce_compiler_listing(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t *writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_block_t *self =
-        (const afw_value_block_t *)instance;
     afw_value_block_symbol_t *symbol;
     afw_size_t i;
 
-    afw_value_compiler_listing_begin_value(writer, instance,
+    afw_value_compiler_listing_begin_value(writer, &self->pub,
         self->contextual, xctx);
 
     afw_writer_write_z(writer, " number=", xctx);
@@ -298,14 +297,12 @@ impl_afw_value_produce_compiler_listing(
  */
 void
 impl_afw_value_decompile(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t * writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_block_t *self =
-        (const afw_value_block_t *)instance;
 
-    afw_value_decompile_write_synthetic_function_name(instance, writer, xctx);
+    afw_value_decompile_write_synthetic_function_name(&self->pub, writer, xctx);
     afw_value_decompile_value_list(writer, self->statement_count,
         self->statements, xctx);
 }
@@ -316,18 +313,16 @@ impl_afw_value_decompile(
  */
 void
 impl_afw_value_get_info(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     afw_value_info_t *info,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    const afw_value_block_t *self =
-        (const afw_value_block_t *)instance;
 
     afw_memory_clear(info);
-    info->value_inf_id = &instance->inf->rti.implementation_id;
+    info->value_inf_id = &self->pub.inf->rti.implementation_id;
     info->contextual = self->contextual;
-    info->optimized_value = instance;
+    info->optimized_value = &self->pub;
 
     /* Note: Maybe something can be done for optimized_value_data_type. */
 }

--- a/src/afw/value/afw_value_call.c
+++ b/src/afw/value/afw_value_call.c
@@ -30,6 +30,7 @@
 #define AFW_IMPLEMENTATION_ID "call"
 #define AFW_IMPLEMENTATION_INF_SPECIFIER AFW_DEFINE_CONST_DATA
 #define AFW_IMPLEMENTATION_INF_LABEL afw_value_call_inf
+#define AFW_VALUE_SELF_T afw_value_call_t
 #include "afw_value_impl_declares.h"
 
 
@@ -145,18 +146,16 @@ afw_value_call_create(
  */
 const afw_value_t *
 impl_afw_value_optional_evaluate(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {
-    const afw_value_call_t *self =
-        (const afw_value_call_t *)instance;
     const afw_compile_value_contextual_t *saved_contextual;
     const afw_value_t *function_value;
     const afw_value_t *result;
 
     /* Push value on evaluation stack. */
-    afw_xctx_evaluation_stack_push_value(instance, xctx);
+    afw_xctx_evaluation_stack_push_value(&self->pub, xctx);
     saved_contextual = xctx->error->contextual;
     xctx->error->contextual = self->args.contextual;
 
@@ -246,7 +245,7 @@ impl_afw_value_optional_evaluate(
  */
 const afw_data_type_t *
 impl_afw_value_get_data_type(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     afw_xctx_t *xctx)
 {
     return NULL;
@@ -258,14 +257,12 @@ impl_afw_value_get_data_type(
  */
 void
 impl_afw_value_produce_compiler_listing(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t *writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_call_t *self =
-        (const afw_value_call_t *)instance;
 
-    afw_value_compiler_listing_begin_value(writer, instance,
+    afw_value_compiler_listing_begin_value(writer, &self->pub,
         self->args.contextual, xctx);
     afw_writer_write_z(writer, ": [", xctx);
     afw_writer_write_eol(writer, xctx);
@@ -278,7 +275,7 @@ impl_afw_value_produce_compiler_listing(
         afw_writer_write_eol(writer, xctx);
     }
 
-    if (self->optimized_value != instance) {
+    if (self->optimized_value != &self->pub) {
         afw_writer_write_z(writer, "optimized_value: ", xctx);
         afw_value_produce_compiler_listing(self->optimized_value, writer, xctx);
         afw_writer_write_eol(writer, xctx);
@@ -308,12 +305,10 @@ impl_afw_value_produce_compiler_listing(
  */
 void
 impl_afw_value_decompile(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t * writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_call_t *self =
-        (const afw_value_call_t *)instance;
     const afw_value_t *callee;
 
     callee = self->function_value;
@@ -426,16 +421,14 @@ afw_value_call_args_expand_spreads(
  */
 void
 impl_afw_value_get_info(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     afw_value_info_t *info,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    const afw_value_call_t *self =
-        (const afw_value_call_t *)instance;
 
     afw_memory_clear(info);
-    info->value_inf_id = &instance->inf->rti.implementation_id;
+    info->value_inf_id = &self->pub.inf->rti.implementation_id;
     info->contextual = self->args.contextual;
     info->evaluated_data_type = self->evaluated_data_type;
     info->optimized_value = self->optimized_value;

--- a/src/afw/value/afw_value_call_built_in_function.c
+++ b/src/afw/value/afw_value_call_built_in_function.c
@@ -30,6 +30,7 @@
 #define AFW_IMPLEMENTATION_ID "call_built_in_function"
 #define AFW_IMPLEMENTATION_INF_SPECIFIER AFW_DEFINE_CONST_DATA
 #define AFW_IMPLEMENTATION_INF_LABEL afw_value_call_built_in_function_inf
+#define AFW_VALUE_SELF_T afw_value_call_built_in_function_t
 #include "afw_value_impl_declares.h"
 
 
@@ -113,7 +114,7 @@ afw_value_call_built_in_function(
     /* Optimize is set to false since this is one time call. */
     value = afw_value_call_built_in_function_create(
         contextual, argc, argv, false, p, xctx);
-    return impl_afw_value_optional_evaluate(value, p, xctx);
+    return impl_afw_value_optional_evaluate((AFW_VALUE_SELF_T *)value, p, xctx);
 }
 
 
@@ -123,18 +124,16 @@ afw_value_call_built_in_function(
  */
 const afw_value_t *
 impl_afw_value_optional_evaluate(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {
-    const afw_value_call_built_in_function_t *self =
-        (const afw_value_call_built_in_function_t *)instance;
     const afw_compile_value_contextual_t *saved_contextual;
     const afw_value_t *result;
     afw_function_execute_t x;
 
     /* Push value on evaluation stack. */
-    afw_xctx_evaluation_stack_push_value(instance, xctx);
+    afw_xctx_evaluation_stack_push_value(&self->pub, xctx);
     saved_contextual = xctx->error->contextual;
     xctx->error->contextual = self->args.contextual;
 
@@ -225,7 +224,7 @@ impl_afw_value_optional_evaluate(
  */
 const afw_data_type_t *
 impl_afw_value_get_data_type(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     afw_xctx_t *xctx)
 {
     return NULL;
@@ -237,14 +236,12 @@ impl_afw_value_get_data_type(
  */
 void
 impl_afw_value_produce_compiler_listing(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t *writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_call_built_in_function_t *self =
-        (const afw_value_call_built_in_function_t *)instance;
 
-    afw_value_compiler_listing_begin_value(writer, instance,
+    afw_value_compiler_listing_begin_value(writer, &self->pub,
         self->args.contextual, xctx);
     afw_writer_write_z(writer, ": [", xctx);
     afw_writer_write_eol(writer, xctx);
@@ -257,7 +254,7 @@ impl_afw_value_produce_compiler_listing(
         afw_writer_write_eol(writer, xctx);
     }
 
-    if (self->optimized_value != instance) {
+    if (self->optimized_value != &self->pub) {
         afw_writer_write_z(writer, "optimized_value: ", xctx);
         afw_value_produce_compiler_listing(self->optimized_value, writer, xctx);
         afw_writer_write_eol(writer, xctx);
@@ -290,12 +287,10 @@ impl_afw_value_produce_compiler_listing(
  */
 void
 impl_afw_value_decompile(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t * writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_call_built_in_function_t *self =
-        (const afw_value_call_built_in_function_t *)instance;
     const afw_utf8_t *fid;
     const afw_value_t *arg;
     const afw_value_symbol_reference_t *sym;
@@ -466,17 +461,15 @@ impl_afw_value_decompile(
  */
 void
 impl_afw_value_get_info(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     afw_value_info_t *info,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    const afw_value_call_built_in_function_t *self =
-        (const afw_value_call_built_in_function_t *)instance;
 
     afw_memory_clear(info);
     info->detail = &self->function->functionId->internal;
-    info->value_inf_id = &instance->inf->rti.implementation_id;
+    info->value_inf_id = &self->pub.inf->rti.implementation_id;
     info->contextual = self->args.contextual;
     info->evaluated_data_type = self->evaluated_data_type;
     info->optimized_value = self->optimized_value;

--- a/src/afw/value/afw_value_call_test_script.c
+++ b/src/afw/value/afw_value_call_test_script.c
@@ -30,6 +30,7 @@
 #define AFW_IMPLEMENTATION_ID "call_test_script"
 #define AFW_IMPLEMENTATION_INF_SPECIFIER AFW_DEFINE_CONST_DATA
 #define AFW_IMPLEMENTATION_INF_LABEL afw_value_call_test_script_inf
+#define AFW_VALUE_SELF_T afw_value_call_test_script_t
 #include "afw_value_impl_declares.h"
 
 
@@ -61,12 +62,10 @@ afw_value_call_test_script_create(
  */
 const afw_value_t *
 impl_afw_value_optional_evaluate(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {
-    const afw_value_call_test_script_t *self =
-        (const afw_value_call_test_script_t *)instance;
     const afw_iterator_t *iterator;
     const afw_array_t *tests;
     const afw_object_t *test;
@@ -308,7 +307,7 @@ impl_afw_value_optional_evaluate(
  */
 const afw_data_type_t *
 impl_afw_value_get_data_type(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     afw_xctx_t *xctx)
 {
     return NULL;
@@ -320,12 +319,10 @@ impl_afw_value_get_data_type(
  */
 void
 impl_afw_value_produce_compiler_listing(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t *writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_call_test_script_t *self =
-        (const afw_value_call_test_script_t *)instance;
     const afw_pool_t *p;
     const afw_array_t *tests;
     const afw_object_t *test;
@@ -365,7 +362,7 @@ impl_afw_value_produce_compiler_listing(
     }
 
     /* Begin listing for test script. */
-    afw_value_compiler_listing_begin_value(writer, instance, &contextual, xctx);
+    afw_value_compiler_listing_begin_value(writer, &self->pub, &contextual, xctx);
     afw_writer_write_z(writer, ": [", xctx);
     afw_writer_write_eol(writer, xctx);
     afw_writer_increment_indent(writer, xctx);
@@ -543,15 +540,13 @@ impl_afw_value_produce_compiler_listing(
  */
 void
 impl_afw_value_decompile(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t * writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_call_test_script_t *self =
-        (const afw_value_call_test_script_t *)instance;
     const afw_value_t *argv[1];
 
-    afw_value_decompile_write_synthetic_function_name(instance, writer, xctx);
+    afw_value_decompile_write_synthetic_function_name(&self->pub, writer, xctx);
     argv[0] = self->test_script_object_value
         ? (const afw_value_t *)self->test_script_object_value
         : NULL;
@@ -564,20 +559,18 @@ impl_afw_value_decompile(
  */
 void
 impl_afw_value_get_info(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     afw_value_info_t *info,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    const afw_value_call_test_script_t *self =
-        (const afw_value_call_test_script_t *)instance;
 
     afw_memory_clear(info);
     info->detail = afw_s_test_script;
-    info->value_inf_id = &instance->inf->rti.implementation_id;
+    info->value_inf_id = &self->pub.inf->rti.implementation_id;
     info->contextual = self->contextual;
     info->evaluated_data_type = afw_data_type_object;
-    info->optimized_value = instance;
+    info->optimized_value = &self->pub;
 
     /* Note: Maybe something can be done for optimized_value_data_type. */
 }

--- a/src/afw/value/afw_value_compiled_value.c
+++ b/src/afw/value/afw_value_compiled_value.c
@@ -30,6 +30,7 @@
 #define AFW_IMPLEMENTATION_ID "compiled_value"
 #define AFW_IMPLEMENTATION_INF_SPECIFIER AFW_DEFINE_CONST_DATA
 #define AFW_IMPLEMENTATION_INF_LABEL afw_value_compiled_value_inf
+#define AFW_VALUE_SELF_T afw_value_compiled_value_t
 #include "afw_value_impl_declares.h"
 
 
@@ -38,12 +39,10 @@
  */
 const afw_value_t *
 impl_afw_value_optional_evaluate(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {
-    const afw_value_compiled_value_t *self =
-        (const afw_value_compiled_value_t *)instance;
     const afw_value_t *result;
     int nelts;
 
@@ -85,7 +84,7 @@ impl_afw_value_optional_evaluate(
  */
 const afw_data_type_t *
 impl_afw_value_get_data_type(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Compiled values are always data type unevaluated. */
@@ -97,18 +96,16 @@ impl_afw_value_get_data_type(
  */
 void
 impl_afw_value_produce_compiler_listing(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t *writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_compiled_value_t *self =
-        (const afw_value_compiled_value_t *)instance;
     const afw_utf8_t *reference_id;
 
     reference_id = afw_value_compiler_listing_for_child(
-        instance, writer, xctx);
+        &self->pub, writer, xctx);
 
-    afw_value_compiler_listing_begin_value(writer, instance,
+    afw_value_compiler_listing_begin_value(writer, &self->pub,
         self->contextual, xctx);
     afw_writer_write_z(writer,
         " // See below beginning with: ---CompiledValue ",
@@ -122,12 +119,10 @@ impl_afw_value_produce_compiler_listing(
  */
 void
 impl_afw_value_decompile(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t * writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_compiled_value_t *self =
-        (const afw_value_compiled_value_t *)instance;
 
     afw_value_decompile(self->root_value, writer, xctx);
     /*FIXME Improve */
@@ -139,12 +134,12 @@ impl_afw_value_decompile(
  */
 void
 impl_afw_value_get_info(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     afw_value_info_t *info,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
     afw_memory_clear(info);
-    info->value_inf_id = &instance->inf->rti.implementation_id;
-    info->optimized_value = instance;
+    info->value_inf_id = &self->pub.inf->rti.implementation_id;
+    info->optimized_value = &self->pub;
 }

--- a/src/afw/value/afw_value_compiler_listing.c
+++ b/src/afw/value/afw_value_compiler_listing.c
@@ -16,6 +16,7 @@
 
 
 #define AFW_IMPLEMENTATION_ID "afw_value_compiler_listing_writer"
+#define AFW_WRITER_SELF_T afw_value_compiler_listing_t
 #include "afw_writer_impl_declares.h"
 
 static const afw_utf8_octet_t
@@ -80,7 +81,7 @@ impl_afw_writer_write_raw_cb(
  */
 void
 impl_afw_writer_release(
-    const afw_writer_t *instance,
+    AFW_WRITER_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Don't do anything. */
@@ -93,7 +94,7 @@ impl_afw_writer_release(
  */
 void
 impl_afw_writer_flush(
-    const afw_writer_t *instance,
+    AFW_WRITER_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Ignore flush. */
@@ -177,13 +178,11 @@ impl_write_source_line(
  */
 void
 impl_afw_writer_write(
-    const afw_writer_t *instance,
+    AFW_WRITER_SELF_T *self,
     const void *buffer,
     afw_size_t size,
     afw_xctx_t *xctx)
 {
-    afw_value_compiler_listing_t *self =
-        (afw_value_compiler_listing_t *)instance;
     afw_size_t count, i;
     const afw_octet_t *c;
     afw_boolean_t line_written;
@@ -251,11 +250,9 @@ impl_afw_writer_write(
  */
 void
 impl_afw_writer_write_eol(
-    const afw_writer_t *instance,
+    AFW_WRITER_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_value_compiler_listing_t *self =
-        (afw_value_compiler_listing_t *)instance;
 
     if (self->writer.tab) {
         APR_ARRAY_PUSH(self->ary, char) = '\n';
@@ -268,11 +265,9 @@ impl_afw_writer_write_eol(
  */
 void
 impl_afw_writer_increment_indent(
-    const afw_writer_t *instance,
+    AFW_WRITER_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_value_compiler_listing_t *self =
-        (afw_value_compiler_listing_t *)instance;
 
     self->writer.indent++;
 }
@@ -282,11 +277,9 @@ impl_afw_writer_increment_indent(
  */
 void
 impl_afw_writer_decrement_indent(
-    const afw_writer_t *instance,
+    AFW_WRITER_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_value_compiler_listing_t *self =
-        (afw_value_compiler_listing_t *)instance;
 
     if (self->writer.indent == 0) {
         AFW_THROW_ERROR_Z(general,

--- a/src/afw/value/afw_value_function_definition.c
+++ b/src/afw/value/afw_value_function_definition.c
@@ -41,6 +41,7 @@
 #define AFW_IMPLEMENTATION_ID "function_definition"
 #define AFW_IMPLEMENTATION_INF_SPECIFIER AFW_DEFINE_CONST_DATA
 #define AFW_IMPLEMENTATION_INF_LABEL afw_value_function_definition_inf
+#define AFW_VALUE_SELF_T afw_value_function_definition_t
 #include "afw_value_impl_declares.h"
 
 
@@ -49,7 +50,7 @@
  */
 const afw_data_type_t *
 impl_afw_value_get_data_type(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     afw_xctx_t *xctx)
 {
     return afw_data_type_object;
@@ -61,14 +62,12 @@ impl_afw_value_get_data_type(
  */
 void
 impl_afw_value_produce_compiler_listing(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t *writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_function_definition_t *self =
-        (const afw_value_function_definition_t *)instance;
 
-    afw_value_compiler_listing_begin_value(writer, instance, NULL, xctx);
+    afw_value_compiler_listing_begin_value(writer, &self->pub, NULL, xctx);
     afw_writer_write_z(writer, " ", xctx);
     afw_writer_write_utf8(writer, &self->functionId->internal, xctx);
     afw_writer_write_eol(writer, xctx);
@@ -79,12 +78,10 @@ impl_afw_value_produce_compiler_listing(
  */
 void
 impl_afw_value_decompile(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t * writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_function_definition_t *self =
-        (const afw_value_function_definition_t *)instance;
 
     afw_writer_write_utf8(writer, &self->functionId->internal, xctx);
 }
@@ -94,18 +91,16 @@ impl_afw_value_decompile(
  */
 void
 impl_afw_value_get_info(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     afw_value_info_t *info,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    const afw_value_function_definition_t *self =
-        (const afw_value_function_definition_t *)instance;
 
     afw_memory_clear(info);
-    info->value_inf_id = &instance->inf->rti.implementation_id;
+    info->value_inf_id = &self->pub.inf->rti.implementation_id;
     info->detail = &self->functionId->internal;
-    info->optimized_value = instance;
+    info->optimized_value = &self->pub;
 
     /* Note: Maybe something can be done for optimized_value_data_type. */
 }

--- a/src/afw/value/afw_value_function_thunk.c
+++ b/src/afw/value/afw_value_function_thunk.c
@@ -41,6 +41,7 @@
 #define AFW_IMPLEMENTATION_ID "function_thunk"
 #define AFW_IMPLEMENTATION_INF_SPECIFIER AFW_DEFINE_CONST_DATA
 #define AFW_IMPLEMENTATION_INF_LABEL afw_value_function_thunk_inf
+#define AFW_VALUE_SELF_T afw_value_function_thunk_t
 #include "afw_value_impl_declares.h"
 
 
@@ -77,7 +78,7 @@ afw_value_function_thunk_create_impl(
  */
 const afw_data_type_t *
 impl_afw_value_get_data_type(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     afw_xctx_t *xctx)
 {
     return NULL;
@@ -89,14 +90,12 @@ impl_afw_value_get_data_type(
  */
 void
 impl_afw_value_produce_compiler_listing(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t *writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_function_thunk_t *self =
-        (const afw_value_function_thunk_t *)instance;
 
-    afw_value_compiler_listing_begin_value(writer, instance,
+    afw_value_compiler_listing_begin_value(writer, &self->pub,
         NULL, xctx);
     afw_writer_write_z(writer, ": [", xctx);
     afw_writer_write_eol(writer, xctx);
@@ -117,15 +116,13 @@ impl_afw_value_produce_compiler_listing(
  */
 void
 impl_afw_value_decompile(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t * writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_function_thunk_t *self =
-        (const afw_value_function_thunk_t *)instance;
     afw_value_string_t detail_value;
 
-    afw_value_decompile_write_synthetic_function_name(instance, writer, xctx);
+    afw_value_decompile_write_synthetic_function_name(&self->pub, writer, xctx);
     afw_writer_write_z(writer, "(", xctx);
     if (writer->tab) {
         afw_writer_increment_indent(writer, xctx);
@@ -159,18 +156,16 @@ impl_afw_value_decompile(
  */
 void
 impl_afw_value_get_info(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     afw_value_info_t *info,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    const afw_value_function_thunk_t *self =
-        (const afw_value_function_thunk_t *)instance;
 
     afw_memory_clear(info);
-    info->value_inf_id = &instance->inf->rti.implementation_id;
+    info->value_inf_id = &self->pub.inf->rti.implementation_id;
     info->detail = self->detail;
-    info->optimized_value = instance;
+    info->optimized_value = &self->pub;
 
     /* Note: Maybe something can be done for optimized_value_data_type. */
 }

--- a/src/afw/value/afw_value_list_expression.c
+++ b/src/afw/value/afw_value_list_expression.c
@@ -29,6 +29,7 @@
 #define AFW_IMPLEMENTATION_ID "list_expression"
 #define AFW_IMPLEMENTATION_INF_SPECIFIER AFW_DEFINE_CONST_DATA
 #define AFW_IMPLEMENTATION_INF_LABEL afw_value_list_expression_inf
+#define AFW_VALUE_SELF_T afw_value_list_expression_t
 #include "afw_value_impl_declares.h"
 
 /* Create function for list expression value. */
@@ -52,12 +53,10 @@ afw_value_create_array_expression(
  */
 const afw_value_t *
 impl_afw_value_optional_evaluate(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {
-    const afw_value_list_expression_t *self =
-        (const afw_value_list_expression_t *)instance;
     const afw_value_t *result;
 
     result = afw_value_evaluate(self->internal, p, xctx);
@@ -70,7 +69,7 @@ impl_afw_value_optional_evaluate(
  */
 const afw_data_type_t *
 impl_afw_value_get_data_type(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     afw_xctx_t *xctx)
 {
     return afw_data_type_array;
@@ -81,14 +80,12 @@ impl_afw_value_get_data_type(
  */
 void
 impl_afw_value_produce_compiler_listing(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t *writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_list_expression_t *self =
-        (const afw_value_list_expression_t *)instance;
 
-    afw_value_compiler_listing_begin_value(writer, instance,
+    afw_value_compiler_listing_begin_value(writer, &self->pub,
         self->contextual, xctx);
     afw_writer_write_z(writer, ": [", xctx);
     afw_writer_write_eol(writer, xctx);
@@ -108,15 +105,13 @@ impl_afw_value_produce_compiler_listing(
  */
 void
 impl_afw_value_decompile(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t *writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_list_expression_t *self =
-        (const afw_value_list_expression_t *)instance;
     const afw_value_t *argv[1];
 
-    afw_value_decompile_write_synthetic_function_name(instance, writer, xctx);
+    afw_value_decompile_write_synthetic_function_name(&self->pub, writer, xctx);
     argv[0] = self->internal;
     afw_value_decompile_value_list(writer, 1, argv, xctx);
 }
@@ -126,18 +121,16 @@ impl_afw_value_decompile(
  */
 void
 impl_afw_value_get_info(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     afw_value_info_t *info,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    const afw_value_list_expression_t *self =
-        (const afw_value_list_expression_t *)instance;
 
     afw_memory_clear(info);
-    info->value_inf_id = &instance->inf->rti.implementation_id;
+    info->value_inf_id = &self->pub.inf->rti.implementation_id;
     info->contextual = self->contextual;
-    info->optimized_value = instance;
+    info->optimized_value = &self->pub;
 
     /* Note: Maybe something can be done for optimized_value_data_type. */
 }

--- a/src/afw/value/afw_value_meta.c
+++ b/src/afw/value/afw_value_meta.c
@@ -26,6 +26,7 @@
 
 /* Declares and rti/inf defines for interface afw_object */
 #define AFW_IMPLEMENTATION_ID "value_meta"
+#define AFW_OBJECT_SELF_T afw_value_meta_object_self_t
 #include "afw_object_impl_declares.h"
 #include "afw_object_setter_impl_declares.h"
 
@@ -115,7 +116,7 @@ static const afw_value_meta_name_handler_t *impl_handler_end =
  */
 void
 impl_afw_object_release(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /** @todo Add code to implement method. */
@@ -130,7 +131,7 @@ impl_afw_object_release(
  */
 void
 impl_afw_object_get_reference(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Nothing to do? */
@@ -141,11 +142,11 @@ impl_afw_object_get_reference(
  */
 afw_size_t
 impl_afw_object_get_count(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t * xctx)
 {
 //    <afwdev {prefixed_interface_name}>_self_t *self =
-//        (<afwdev {prefixed_interface_name}>_self_t *)instance;
+//        (<afwdev {prefixed_interface_name}>_self_t *)&self->pub;
 
     /** @todo Add code to implement method. */
     AFW_THROW_ERROR_Z(general, "Method not implemented.", xctx);
@@ -157,12 +158,10 @@ impl_afw_object_get_count(
  */
 const afw_value_t *
 impl_afw_object_get_property(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t *property_name,
     afw_xctx_t *xctx)
 {
-    afw_value_meta_object_self_t *self =
-        (afw_value_meta_object_self_t *)instance;
     const afw_value_meta_name_handler_t *h;
 
     /* If get callback for this property, return it's result. */
@@ -192,13 +191,11 @@ impl_afw_object_get_property(
  */
 const afw_value_t *
 impl_afw_object_get_next_property(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_iterator_t **iterator,
     const afw_utf8_t **property_name,
     afw_xctx_t *xctx)
 {
-    afw_value_meta_object_self_t *self =
-        (afw_value_meta_object_self_t *)instance;
     const afw_value_meta_name_handler_t *h;
     const afw_value_t *result;
     const afw_utf8_t *next_property_name;
@@ -285,12 +282,12 @@ impl_afw_object_get_next_property(
  */
 afw_boolean_t
 impl_afw_object_has_property(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t *property_name,
     afw_xctx_t *xctx)
 {
     return
-        (impl_afw_object_get_property(instance, property_name, xctx) != NULL);
+        (impl_afw_object_get_property(self, property_name, xctx) != NULL);
 }
 
 
@@ -300,11 +297,9 @@ impl_afw_object_has_property(
  */
 const afw_object_setter_t *
 impl_afw_object_get_setter(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_value_meta_object_self_t *self =
-        (afw_value_meta_object_self_t *)instance;
 
     return (self->immutable) ? NULL : &self->setter;
 }
@@ -316,14 +311,14 @@ impl_afw_object_get_setter(
  */
 void
 impl_afw_object_setter_set_immutable(
-    const afw_object_setter_t *instance,
+    const afw_object_setter_t *self,
     afw_xctx_t *xctx)
 {
-    afw_value_meta_object_self_t *self =
-        (afw_value_meta_object_self_t *)instance->object;
+    afw_value_meta_object_self_t *meta_object_self =
+        (afw_value_meta_object_self_t *)self->object;
 
     /* Set object to immutable. */
-    self->immutable = true;
+    meta_object_self->immutable = true;
 }
 
 /*
@@ -331,33 +326,33 @@ impl_afw_object_setter_set_immutable(
  */
 void
 impl_afw_object_setter_set_property(
-    const afw_object_setter_t *instance,
+    const afw_object_setter_t *self,
     const afw_utf8_t *property_name,
     const afw_value_t *value,
     afw_xctx_t *xctx)
 {
-    afw_value_meta_object_self_t *self =
-        (afw_value_meta_object_self_t *)instance->object;
+    afw_value_meta_object_self_t *meta_object_self =
+        (afw_value_meta_object_self_t *)self->object;
     const afw_value_meta_name_handler_t *h;
 
-    AFW_OBJECT_IMPL_ASSERT_SELF_MUTABLE;
+    do { if (meta_object_self->immutable) { AFW_OBJECT_ERROR_OBJECT_IMMUTABLE; } } while (0);
 
     /* If get callback for this property, return it's result. */
     for (h = &impl_handler[0]; h < impl_handler_end; h++) {
         if (afw_utf8_equal(h->property_name, property_name)) {
             if (h->set) {
-                h->set(self, property_name, value, xctx);
+                h->set(meta_object_self, property_name, value, xctx);
                 return;
             }
             break;
         }
     }
 
-    if (!self->additional) {
-        self->additional = afw_object_create_unmanaged(self->pub.p, xctx);
+    if (!meta_object_self->additional) {
+        meta_object_self->additional = afw_object_create_unmanaged(meta_object_self->pub.p, xctx);
     }
 
-    afw_object_set_property(self->additional, property_name, value, xctx);
+    afw_object_set_property(meta_object_self->additional, property_name, value, xctx);
 }
 
 

--- a/src/afw/value/afw_value_meta_values_list.c
+++ b/src/afw/value/afw_value_meta_values_list.c
@@ -20,6 +20,7 @@
 
 /* Declares and rti/inf defines for interface afw_array */
 #define AFW_IMPLEMENTATION_ID "afw_value_meta_values_list"
+#define AFW_ARRAY_SELF_T afw_value_meta_values_list_list_self_t
 #include "afw_array_impl_declares.h"
 
 
@@ -34,10 +35,10 @@ typedef struct {
  */
 void
 impl_afw_array_release(
-    const afw_array_t *instance,
+    AFW_ARRAY_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    /* Nothing to release; instance lives in its create pool. */
+    /* Nothing to release; &self->pub lives in its create pool. */
 }
 
 
@@ -46,11 +47,9 @@ impl_afw_array_release(
  */
 afw_size_t
 impl_afw_array_get_count(
-    const afw_array_t *instance,
+    AFW_ARRAY_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_value_meta_values_list_list_self_t *self =
-        (afw_value_meta_values_list_list_self_t *)instance;
 
     return afw_array_get_count(self->associated_value->internal, xctx);
 }
@@ -61,7 +60,7 @@ impl_afw_array_get_count(
  */
 const afw_data_type_t *
 impl_afw_array_get_data_type(
-    const afw_array_t *instance,
+    AFW_ARRAY_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Each entry is a meta object. */
@@ -74,7 +73,7 @@ impl_afw_array_get_data_type(
  */
 afw_boolean_t
 impl_afw_array_get_entry_internal(
-    const afw_array_t *instance,
+    AFW_ARRAY_SELF_T *self,
     afw_integer_t index,
     const afw_data_type_t **data_type,
     const void **internal,
@@ -82,7 +81,7 @@ impl_afw_array_get_entry_internal(
 {
     const afw_value_t *value;
 
-    value = impl_afw_array_get_entry_value(instance, index, instance->p, xctx);
+    value = impl_afw_array_get_entry_value(self, index, self->pub.p, xctx);
     if (value) {
         *internal = AFW_VALUE_INTERNAL(value);
         if (data_type) {
@@ -104,13 +103,11 @@ impl_afw_array_get_entry_internal(
  */
 const afw_value_t *
 impl_afw_array_get_entry_value(
-    const afw_array_t *instance,
+    AFW_ARRAY_SELF_T *self,
     afw_integer_t index,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    afw_value_meta_values_list_list_self_t *self =
-        (afw_value_meta_values_list_list_self_t *)instance;
     const afw_value_t *entry_value;
     afw_value_meta_object_self_t *meta_self;
     const afw_pool_t *use_p;
@@ -137,7 +134,7 @@ impl_afw_array_get_entry_value(
  */
 afw_boolean_t
 impl_afw_array_get_next_internal(
-    const afw_array_t *instance,
+    AFW_ARRAY_SELF_T *self,
     const afw_iterator_t **iterator,
     const afw_data_type_t **data_type,
     const void **internal,
@@ -145,7 +142,7 @@ impl_afw_array_get_next_internal(
 {
     const afw_value_t *value;
 
-    value = impl_afw_array_get_next_value(instance, iterator, instance->p, xctx);
+    value = impl_afw_array_get_next_value(self, iterator, self->pub.p, xctx);
     if (value) {
         *internal = AFW_VALUE_INTERNAL(value);
         if (data_type) {
@@ -167,19 +164,20 @@ impl_afw_array_get_next_internal(
  */
 const afw_value_t *
 impl_afw_array_get_next_value(
-    const afw_array_t *instance,
+    AFW_ARRAY_SELF_T *self,
     const afw_iterator_t **iterator,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    afw_value_meta_values_list_list_self_t *self =
-        (afw_value_meta_values_list_list_self_t *)instance;
     const afw_value_t *entry_value;
     afw_value_meta_object_self_t *meta_self;
     const afw_pool_t *use_p;
     impl_meta_values_list_iterator_t *state;
 
     use_p = p ? p : self->pub.p;
+    if (!use_p) {
+        use_p = xctx->p;
+    }
 
     if (!*iterator) {
         state = afw_pool_calloc_type(use_p,
@@ -216,7 +214,7 @@ impl_afw_array_get_next_value(
  */
 const afw_array_setter_t *
 impl_afw_array_get_setter(
-    const afw_array_t *instance,
+    AFW_ARRAY_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Meta values views are immutable. */

--- a/src/afw/value/afw_value_meta_values_object.c
+++ b/src/afw/value/afw_value_meta_values_object.c
@@ -20,6 +20,7 @@
 
 /* Declares and rti/inf defines for interface afw_array */
 #define AFW_IMPLEMENTATION_ID "afw_value_meta_values_object"
+#define AFW_ARRAY_SELF_T afw_value_meta_values_object_list_self_t
 #include "afw_array_impl_declares.h"
 
 
@@ -33,10 +34,10 @@ typedef struct {
  */
 void
 impl_afw_array_release(
-    const afw_array_t *instance,
+    AFW_ARRAY_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    /* Nothing to release; instance lives in its create pool. */
+    /* Nothing to release; &self->pub lives in its create pool. */
 }
 
 
@@ -45,11 +46,9 @@ impl_afw_array_release(
  */
 afw_size_t
 impl_afw_array_get_count(
-    const afw_array_t *instance,
+    AFW_ARRAY_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_value_meta_values_object_list_self_t *self =
-        (afw_value_meta_values_object_list_self_t *)instance;
     const afw_iterator_t *iterator;
     const afw_utf8_t *property_name;
     afw_size_t count;
@@ -74,7 +73,7 @@ impl_afw_array_get_count(
  */
 const afw_data_type_t *
 impl_afw_array_get_data_type(
-    const afw_array_t *instance,
+    AFW_ARRAY_SELF_T *self,
     afw_xctx_t *xctx)
 {
     return afw_data_type_object;
@@ -86,7 +85,7 @@ impl_afw_array_get_data_type(
  */
 afw_boolean_t
 impl_afw_array_get_entry_internal(
-    const afw_array_t *instance,
+    AFW_ARRAY_SELF_T *self,
     afw_integer_t index,
     const afw_data_type_t **data_type,
     const void **internal,
@@ -94,7 +93,7 @@ impl_afw_array_get_entry_internal(
 {
     const afw_value_t *value;
 
-    value = impl_afw_array_get_entry_value(instance, index, instance->p, xctx);
+    value = impl_afw_array_get_entry_value(self, index, self->pub.p, xctx);
     if (value) {
         *internal = AFW_VALUE_INTERNAL(value);
         if (data_type) {
@@ -116,13 +115,11 @@ impl_afw_array_get_entry_internal(
  */
 const afw_value_t *
 impl_afw_array_get_entry_value(
-    const afw_array_t *instance,
+    AFW_ARRAY_SELF_T *self,
     afw_integer_t index,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    afw_value_meta_values_object_list_self_t *self =
-        (afw_value_meta_values_object_list_self_t *)instance;
     const afw_iterator_t *iterator;
     const afw_utf8_t *property_name;
     const afw_value_t *property_value;
@@ -184,7 +181,7 @@ impl_afw_array_get_entry_value(
  */
 afw_boolean_t
 impl_afw_array_get_next_internal(
-    const afw_array_t *instance,
+    AFW_ARRAY_SELF_T *self,
     const afw_iterator_t **iterator,
     const afw_data_type_t **data_type,
     const void **internal,
@@ -192,7 +189,7 @@ impl_afw_array_get_next_internal(
 {
     const afw_value_t *value;
 
-    value = impl_afw_array_get_next_value(instance, iterator, instance->p, xctx);
+    value = impl_afw_array_get_next_value(self, iterator, self->pub.p, xctx);
     if (value) {
         *internal = AFW_VALUE_INTERNAL(value);
         if (data_type) {
@@ -214,13 +211,11 @@ impl_afw_array_get_next_internal(
  */
 const afw_value_t *
 impl_afw_array_get_next_value(
-    const afw_array_t *instance,
+    AFW_ARRAY_SELF_T *self,
     const afw_iterator_t **iterator,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    afw_value_meta_values_object_list_self_t *self =
-        (afw_value_meta_values_object_list_self_t *)instance;
     const afw_value_t *property_value;
     const afw_utf8_t *property_name;
     afw_value_meta_object_self_t *meta_self;
@@ -228,6 +223,9 @@ impl_afw_array_get_next_value(
     impl_meta_values_object_iterator_t *state;
 
     use_p = p ? p : self->pub.p;
+    if (!use_p) {
+        use_p = xctx->p;
+    }
 
     if (!*iterator) {
         state = afw_pool_calloc_type(use_p,
@@ -260,7 +258,7 @@ impl_afw_array_get_next_value(
  */
 const afw_array_setter_t *
 impl_afw_array_get_setter(
-    const afw_array_t *instance,
+    AFW_ARRAY_SELF_T *self,
     afw_xctx_t *xctx)
 {
     return NULL;

--- a/src/afw/value/afw_value_object_construct.c
+++ b/src/afw/value/afw_value_object_construct.c
@@ -29,6 +29,7 @@
 #define AFW_IMPLEMENTATION_ID "object_construct"
 #define AFW_IMPLEMENTATION_INF_SPECIFIER AFW_DEFINE_CONST_DATA
 #define AFW_IMPLEMENTATION_INF_LABEL afw_value_object_construct_inf
+#define AFW_VALUE_SELF_T afw_value_object_construct_t
 #include "afw_value_impl_declares.h"
 
 
@@ -85,12 +86,10 @@ impl_name_from_value(
  */
 const afw_value_t *
 impl_afw_value_optional_evaluate(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    const afw_value_object_construct_t *self =
-        (const afw_value_object_construct_t *)instance;
     const afw_value_object_construct_entry_t *e;
     const afw_object_t *to;
     const afw_object_t *from;
@@ -151,7 +150,7 @@ impl_afw_value_optional_evaluate(
  */
 const afw_data_type_t *
 impl_afw_value_get_data_type(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     afw_xctx_t *xctx)
 {
     return afw_data_type_object;
@@ -163,15 +162,13 @@ impl_afw_value_get_data_type(
  */
 void
 impl_afw_value_produce_compiler_listing(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t *writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_object_construct_t *self =
-        (const afw_value_object_construct_t *)instance;
     const afw_value_object_construct_entry_t *e;
 
-    afw_value_compiler_listing_begin_value(writer, instance,
+    afw_value_compiler_listing_begin_value(writer, &self->pub,
         self->contextual, xctx);
     afw_writer_write_z(writer, ": [", xctx);
     afw_writer_write_eol(writer, xctx);
@@ -208,12 +205,10 @@ impl_afw_value_produce_compiler_listing(
  */
 void
 impl_afw_value_decompile(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t *writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_object_construct_t *self =
-        (const afw_value_object_construct_t *)instance;
     const afw_value_object_construct_entry_t *e;
     afw_boolean_t first;
 
@@ -251,16 +246,14 @@ impl_afw_value_decompile(
  */
 void
 impl_afw_value_get_info(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     afw_value_info_t *info,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    const afw_value_object_construct_t *self =
-        (const afw_value_object_construct_t *)instance;
 
     afw_memory_clear(info);
-    info->value_inf_id = &instance->inf->rti.implementation_id;
+    info->value_inf_id = &self->pub.inf->rti.implementation_id;
     info->contextual = self->contextual;
-    info->optimized_value = instance;
+    info->optimized_value = &self->pub;
 }

--- a/src/afw/value/afw_value_object_expression.c
+++ b/src/afw/value/afw_value_object_expression.c
@@ -29,6 +29,7 @@
 #define AFW_IMPLEMENTATION_ID "object_expression"
 #define AFW_IMPLEMENTATION_INF_SPECIFIER AFW_DEFINE_CONST_DATA
 #define AFW_IMPLEMENTATION_INF_LABEL afw_value_object_expression_inf
+#define AFW_VALUE_SELF_T afw_value_object_expression_t
 #include "afw_value_impl_declares.h"
 
 
@@ -54,7 +55,7 @@ afw_value_create_object_expression(
  */
 const afw_value_t *
 impl_afw_value_optional_evaluate(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {
@@ -64,7 +65,7 @@ impl_afw_value_optional_evaluate(
     const afw_iterator_t *iterator;
     const afw_utf8_t *property_name;
 
-    from = ((const afw_value_object_expression_t *)instance)->internal;
+    from = ((const afw_value_object_expression_t *)&self->pub)->internal;
     to = afw_object_create_unmanaged(p, xctx);
 
     for (iterator = NULL;;) {
@@ -85,7 +86,7 @@ impl_afw_value_optional_evaluate(
  */
 const afw_data_type_t *
 impl_afw_value_get_data_type(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     afw_xctx_t *xctx)
 {
     return afw_data_type_object;
@@ -100,17 +101,15 @@ impl_afw_value_get_data_type(
  */
 void
 impl_afw_value_produce_compiler_listing(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t *writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_object_expression_t *self =
-        (const afw_value_object_expression_t *)instance;
     const afw_iterator_t *iterator;
     const afw_utf8_t *property_name;
     const afw_value_t *pv;
 
-    afw_value_compiler_listing_begin_value(writer, instance,
+    afw_value_compiler_listing_begin_value(writer, &self->pub,
         self->contextual, xctx);
     afw_writer_write_z(writer, ": [", xctx);
     afw_writer_write_eol(writer, xctx);
@@ -139,14 +138,14 @@ impl_afw_value_produce_compiler_listing(
  */
 void
 impl_afw_value_decompile(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t *writer,
     afw_xctx_t *xctx)
 {
     afw_data_type_write_as_expression(
         afw_data_type_object,
         writer,
-        (const void *)&(((const afw_value_common_t *)instance)->internal),
+        (const void *)&(((const afw_value_common_t *)&self->pub)->internal),
         xctx);
 }
 
@@ -155,18 +154,16 @@ impl_afw_value_decompile(
  */
 void
 impl_afw_value_get_info(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     afw_value_info_t *info,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    const afw_value_object_expression_t *self =
-        (const afw_value_object_expression_t *)instance;
 
     afw_memory_clear(info);
-    info->value_inf_id = &instance->inf->rti.implementation_id;
+    info->value_inf_id = &self->pub.inf->rti.implementation_id;
     info->contextual = self->contextual;
-    info->optimized_value = instance;
+    info->optimized_value = &self->pub;
 
     /* Note: Maybe something can be done for optimized_value_data_type. */
 }

--- a/src/afw/value/afw_value_qualified_variable_reference.c
+++ b/src/afw/value/afw_value_qualified_variable_reference.c
@@ -27,6 +27,7 @@
 #define AFW_IMPLEMENTATION_ID "qualified_variable_reference"
 #define AFW_IMPLEMENTATION_INF_SPECIFIER AFW_DEFINE_CONST_DATA
 #define AFW_IMPLEMENTATION_INF_LABEL afw_value_qualified_variable_reference_inf
+#define AFW_VALUE_SELF_T afw_value_qualified_variable_reference_t
 #include "afw_value_impl_declares.h"
 
 
@@ -71,17 +72,15 @@ afw_value_qualified_variable_reference_create(
  */
 const afw_value_t *
 impl_afw_value_optional_evaluate(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {
-    const afw_value_qualified_variable_reference_t *self =
-        (const afw_value_qualified_variable_reference_t *)instance;
     const afw_value_t *result;
     const afw_compile_value_contextual_t *saved_contextual;
 
     /* Push value on evaluation stack. */
-    afw_xctx_evaluation_stack_push_value(instance, xctx);
+    afw_xctx_evaluation_stack_push_value(&self->pub, xctx);
     saved_contextual = xctx->error->contextual;
     xctx->error->contextual = self->contextual;
 
@@ -100,7 +99,7 @@ impl_afw_value_optional_evaluate(
  */
 const afw_data_type_t *
 impl_afw_value_get_data_type(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     afw_xctx_t *xctx)
 {
     return NULL;
@@ -112,16 +111,14 @@ impl_afw_value_get_data_type(
  */
 const afw_value_t *
 impl_afw_value_get_evaluated_meta(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    const afw_value_qualified_variable_reference_t *self =
-        (const afw_value_qualified_variable_reference_t *)instance;
     afw_value_meta_object_self_t *meta;
 
     meta = afw_value_internal_create_meta_object_self(
-        instance, p, xctx);
+        &self->pub, p, xctx);
     meta->key = self->optionally_qualified_name;
     if (afw_value_is_object(meta->evaluated_value)) {
         meta->additional =
@@ -137,14 +134,12 @@ impl_afw_value_get_evaluated_meta(
  */
 void
 impl_afw_value_produce_compiler_listing(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t *writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_qualified_variable_reference_t *self =
-        (const afw_value_qualified_variable_reference_t *)instance;
 
-    afw_value_compiler_listing_begin_value(writer, instance,
+    afw_value_compiler_listing_begin_value(writer, &self->pub,
         self->contextual, xctx);
     afw_writer_write_z(writer, " ", xctx);
     if (self->qualifier.len > 0) {
@@ -161,12 +156,10 @@ impl_afw_value_produce_compiler_listing(
  */
 void
 impl_afw_value_decompile(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t * writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_qualified_variable_reference_t *self =
-        (const afw_value_qualified_variable_reference_t *)instance;
 
     if (self->qualifier.len > 0) {
         afw_writer_write_utf8(writer, &self->qualifier, xctx);
@@ -182,16 +175,14 @@ impl_afw_value_decompile(
  */
 void
 impl_afw_value_get_info(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     afw_value_info_t *info,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    const afw_value_qualified_variable_reference_t *self =
-        (const afw_value_qualified_variable_reference_t *)instance;
 
     afw_memory_clear(info);
-    info->value_inf_id = &instance->inf->rti.implementation_id;
+    info->value_inf_id = &self->pub.inf->rti.implementation_id;
     info->contextual = self->contextual;
     info->detail = self->backtrace_detail;
     info->evaluated_data_type = self->evaluated_data_type;

--- a/src/afw/value/afw_value_reference_by_key.c
+++ b/src/afw/value/afw_value_reference_by_key.c
@@ -27,6 +27,7 @@
 #define AFW_IMPLEMENTATION_ID "reference_by_key"
 #define AFW_IMPLEMENTATION_INF_SPECIFIER AFW_DEFINE_CONST_DATA
 #define AFW_IMPLEMENTATION_INF_LABEL afw_value_reference_by_key_inf
+#define AFW_VALUE_SELF_T afw_value_reference_by_key_t
 #include "afw_value_impl_declares.h"
 
 /** @fixme Should have list entry by index too. */
@@ -87,12 +88,10 @@ afw_value_reference_by_key_create(
  */
 const afw_value_t *
 impl_afw_value_optional_evaluate(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {
-    const afw_value_reference_by_key_t *self =
-        (const afw_value_reference_by_key_t *)instance;
 
     const afw_value_t *v;
     const afw_value_object_t *object_value;
@@ -104,7 +103,7 @@ impl_afw_value_optional_evaluate(
     const afw_compile_value_contextual_t *saved_contextual;
 
     /* Push value on evaluation stack. */
-    afw_xctx_evaluation_stack_push_value(instance, xctx);
+    afw_xctx_evaluation_stack_push_value(&self->pub, xctx);
     saved_contextual = xctx->error->contextual;
     xctx->error->contextual = self->contextual;
 
@@ -170,7 +169,7 @@ impl_afw_value_optional_evaluate(
  */
 const afw_data_type_t *
 impl_afw_value_get_data_type(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     afw_xctx_t *xctx)
 {
     return NULL;
@@ -181,12 +180,10 @@ impl_afw_value_get_data_type(
  */
 const afw_value_t *
 impl_afw_value_get_evaluated_meta(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    const afw_value_reference_by_key_t *self =
-        (const afw_value_reference_by_key_t *)instance;
     const afw_value_t *result;
     const afw_value_t *key;
     const afw_value_t *aggregate_value;
@@ -232,14 +229,12 @@ impl_afw_value_get_evaluated_meta(
  */
 void
 impl_afw_value_produce_compiler_listing(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t *writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_reference_by_key_t *self =
-        (const afw_value_reference_by_key_t *)instance;
 
-    afw_value_compiler_listing_begin_value(writer, instance,
+    afw_value_compiler_listing_begin_value(writer, &self->pub,
         self->contextual, xctx);
     afw_writer_write_z(writer, ": [", xctx);
     afw_writer_write_eol(writer, xctx);
@@ -262,7 +257,7 @@ impl_afw_value_produce_compiler_listing(
         afw_writer_write_eol(writer, xctx);
     }
 
-    if (self->optimized_value != instance) {
+    if (self->optimized_value != &self->pub) {
         afw_writer_write_z(writer, "optimized_value: ", xctx);
         afw_value_produce_compiler_listing(self->optimized_value, writer, xctx);
         afw_writer_write_eol(writer, xctx);
@@ -278,12 +273,10 @@ impl_afw_value_produce_compiler_listing(
  */
 void
 impl_afw_value_decompile(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t * writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_reference_by_key_t *self =
-        (const afw_value_reference_by_key_t *)instance;
 
     afw_value_decompile(self->aggregate_value, writer, xctx);
     afw_writer_write_z(writer, "[", xctx);
@@ -297,16 +290,14 @@ impl_afw_value_decompile(
  */
 void
 impl_afw_value_get_info(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     afw_value_info_t *info,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    const afw_value_reference_by_key_t *self =
-        (const afw_value_reference_by_key_t *)instance;
 
     afw_memory_clear(info);
-    info->value_inf_id = &instance->inf->rti.implementation_id;
+    info->value_inf_id = &self->pub.inf->rti.implementation_id;
     info->contextual = self->contextual;
     info->detail = self->backtrace_detail;
     info->evaluated_data_type = self->evaluated_data_type;

--- a/src/afw/value/afw_value_script_function.c
+++ b/src/afw/value/afw_value_script_function.c
@@ -40,6 +40,7 @@
 #define AFW_IMPLEMENTATION_ID "script_function"
 #define AFW_IMPLEMENTATION_INF_SPECIFIER AFW_DEFINE_CONST_DATA
 #define AFW_IMPLEMENTATION_INF_LABEL afw_value_script_function_definition_inf
+#define AFW_VALUE_SELF_T afw_value_script_function_definition_t
 #include "afw_value_impl_declares.h"
 
 
@@ -86,7 +87,7 @@ afw_value_script_function_definition_create(
  */
 const afw_data_type_t *
 impl_afw_value_get_data_type(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     afw_xctx_t *xctx)
 {
     return afw_data_type_function;
@@ -98,15 +99,13 @@ impl_afw_value_get_data_type(
  */
 void
 impl_afw_value_produce_compiler_listing(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t *writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_script_function_definition_t *self =
-        (const afw_value_script_function_definition_t *)instance;
     afw_size_t i;
 
-    afw_value_compiler_listing_begin_value(writer, instance,
+    afw_value_compiler_listing_begin_value(writer, &self->pub,
         self->contextual, xctx);
     afw_writer_write_z(writer, ": [", xctx);
     afw_writer_write_eol(writer, xctx);
@@ -184,18 +183,16 @@ impl_afw_value_produce_compiler_listing(
  */
 void
 impl_afw_value_decompile(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t * writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_script_function_definition_t *self =
-        (const afw_value_script_function_definition_t *)instance;
     const afw_value_script_function_parameter_t *param;
     afw_size_t i;
     afw_boolean_t need_comma;
     afw_boolean_t write_returns;
 
-    afw_value_decompile_write_synthetic_function_name(instance, writer, xctx);
+    afw_value_decompile_write_synthetic_function_name(&self->pub, writer, xctx);
     afw_writer_write_z(writer, "(", xctx);
     if (writer->tab) {
         afw_writer_increment_indent(writer, xctx);
@@ -277,16 +274,14 @@ impl_afw_value_decompile(
  */
 void
 impl_afw_value_get_info(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     afw_value_info_t *info,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    const afw_value_script_function_definition_t *self =
-        (const afw_value_script_function_definition_t *)instance;
 
     afw_memory_clear(info);
-    info->value_inf_id = &instance->inf->rti.implementation_id;
+    info->value_inf_id = &self->pub.inf->rti.implementation_id;
     info->contextual = self->contextual;
     info->evaluated_data_type = self->evaluated_data_type;
     info->optimized_value = self->optimized_value;

--- a/src/afw/value/afw_value_symbol_reference.c
+++ b/src/afw/value/afw_value_symbol_reference.c
@@ -27,6 +27,7 @@
 #define AFW_IMPLEMENTATION_ID "symbol_reference"
 #define AFW_IMPLEMENTATION_INF_SPECIFIER AFW_DEFINE_CONST_DATA
 #define AFW_IMPLEMENTATION_INF_LABEL afw_value_symbol_reference_inf
+#define AFW_VALUE_SELF_T afw_value_symbol_reference_t
 #include "afw_value_impl_declares.h"
 
 
@@ -60,17 +61,15 @@ afw_value_symbol_reference_create(
  */
 const afw_value_t *
 impl_afw_value_optional_evaluate(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {
-    const afw_value_symbol_reference_t *self =
-        (const afw_value_symbol_reference_t *)instance;
     const afw_value_t *result;
     const afw_compile_value_contextual_t *saved_contextual;
 
     /* Push value on evaluation stack. */
-    afw_xctx_evaluation_stack_push_value(instance, xctx);
+    afw_xctx_evaluation_stack_push_value(&self->pub, xctx);
     saved_contextual = xctx->error->contextual;
     xctx->error->contextual = self->contextual;
 
@@ -88,11 +87,9 @@ impl_afw_value_optional_evaluate(
  */
 const afw_data_type_t *
 impl_afw_value_get_data_type(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    const afw_value_symbol_reference_t *self =
-        (const afw_value_symbol_reference_t *)instance;
 
     return self->evaluated_data_type;
 }
@@ -103,16 +100,14 @@ impl_afw_value_get_data_type(
  */
 const afw_value_t *
 impl_afw_value_get_evaluated_meta(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    const afw_value_symbol_reference_t *self =
-        (const afw_value_symbol_reference_t *)instance;
     afw_value_meta_object_self_t *meta;
 
     meta = afw_value_internal_create_meta_object_self(
-        instance, p, xctx);
+        &self->pub, p, xctx);
     meta->key = self->symbol->name;
     if (afw_value_is_object(meta->evaluated_value)) {
         meta->additional =
@@ -128,14 +123,12 @@ impl_afw_value_get_evaluated_meta(
  */
 void
 impl_afw_value_produce_compiler_listing(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t *writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_symbol_reference_t *self =
-        (const afw_value_symbol_reference_t *)instance;
 
-    afw_value_compiler_listing_begin_value(writer, instance,
+    afw_value_compiler_listing_begin_value(writer, &self->pub,
         self->contextual, xctx);
     afw_writer_write_z(writer, " ", xctx);
     afw_writer_write_utf8(writer,
@@ -160,12 +153,10 @@ impl_afw_value_produce_compiler_listing(
  */
 void
 impl_afw_value_decompile(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t * writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_symbol_reference_t *self =
-        (const afw_value_symbol_reference_t *)instance;
 
     afw_writer_write_utf8(writer, self->symbol->name, xctx);
 }
@@ -176,16 +167,14 @@ impl_afw_value_decompile(
  */
 void
 impl_afw_value_get_info(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     afw_value_info_t *info,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    const afw_value_symbol_reference_t *self =
-        (const afw_value_symbol_reference_t *)instance;
 
     afw_memory_clear(info);
-    info->value_inf_id = &instance->inf->rti.implementation_id;
+    info->value_inf_id = &self->pub.inf->rti.implementation_id;
     info->contextual = self->contextual;
     info->evaluated_data_type = self->evaluated_data_type;
     info->optimized_value = self->optimized_value;

--- a/src/afw/value/afw_value_template_definition.c
+++ b/src/afw/value/afw_value_template_definition.c
@@ -37,6 +37,7 @@
 #define AFW_IMPLEMENTATION_ID "template_definition"
 #define AFW_IMPLEMENTATION_INF_SPECIFIER AFW_DEFINE_CONST_DATA
 #define AFW_IMPLEMENTATION_INF_LABEL afw_value_template_definition_inf
+#define AFW_VALUE_SELF_T afw_value_template_definition_t
 #include "afw_value_impl_declares.h"
 
 
@@ -70,12 +71,10 @@ afw_value_template_definition_create(
  */
 const afw_value_t *
 impl_afw_value_optional_evaluate(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {
-    const afw_value_template_definition_t *self =
-        (const afw_value_template_definition_t *)instance;
 
     afw_size_t i;
     const afw_value_t * const * v;
@@ -89,7 +88,7 @@ impl_afw_value_optional_evaluate(
     const afw_compile_value_contextual_t *saved_contextual;
 
     /* Push value on evaluation stack. */
-    afw_xctx_evaluation_stack_push_value(instance, xctx);
+    afw_xctx_evaluation_stack_push_value(&self->pub, xctx);
     saved_contextual = xctx->error->contextual;
     xctx->error->contextual = self->contextual;
 
@@ -146,7 +145,7 @@ impl_afw_value_optional_evaluate(
  */
 const afw_data_type_t *
 impl_afw_value_get_data_type(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     afw_xctx_t *xctx)
 {
     return afw_data_type_template;
@@ -158,15 +157,13 @@ impl_afw_value_get_data_type(
  */
 void
 impl_afw_value_produce_compiler_listing(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t *writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_template_definition_t *self =
-        (const afw_value_template_definition_t *)instance;
     afw_size_t i;
 
-    afw_value_compiler_listing_begin_value(writer, instance,
+    afw_value_compiler_listing_begin_value(writer, &self->pub,
         self->contextual, xctx);
     afw_writer_write_z(writer, ": [", xctx);
     afw_writer_write_eol(writer, xctx);
@@ -190,14 +187,12 @@ impl_afw_value_produce_compiler_listing(
  */
 void
 impl_afw_value_decompile(
-    const afw_value_t * instance,
+    AFW_VALUE_SELF_T *self,
     const afw_writer_t * writer,
     afw_xctx_t *xctx)
 {
-    const afw_value_template_definition_t *self =
-        (const afw_value_template_definition_t *)instance;
 
-    afw_value_decompile_write_synthetic_function_name(instance, writer, xctx);
+    afw_value_decompile_write_synthetic_function_name(&self->pub, writer, xctx);
     afw_value_decompile_value_list(writer, self->count, self->values, xctx);
 }
 
@@ -207,18 +202,16 @@ impl_afw_value_decompile(
  */
 void
 impl_afw_value_get_info(
-    const afw_value_t *instance,
+    AFW_VALUE_SELF_T *self,
     afw_value_info_t *info,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    const afw_value_template_definition_t *self =
-        (const afw_value_template_definition_t *)instance;
 
     afw_memory_clear(info);
-    info->value_inf_id = &instance->inf->rti.implementation_id;
+    info->value_inf_id = &self->pub.inf->rti.implementation_id;
     info->contextual = self->contextual;
-    info->optimized_value = instance;
+    info->optimized_value = &self->pub;
 
     /* Note: Maybe something can be done for optimized_value_data_type. */
 }

--- a/src/afw/writer/afw_writer.c
+++ b/src/afw/writer/afw_writer.c
@@ -21,6 +21,8 @@
 
 /* Declares and rti/inf defines for interface afw_writer */
 #define AFW_IMPLEMENTATION_ID "afw_writer_fd"
+typedef struct afw_writer_fd_afw_writer_self_s afw_writer_fd_afw_writer_self_t;
+#define AFW_WRITER_SELF_T afw_writer_fd_afw_writer_self_t
 #include "afw_writer_impl_declares.h"
 
 
@@ -40,11 +42,9 @@ afw_writer_fd_afw_writer_self_s {
  */
 void
 impl_afw_writer_release(
-    const afw_writer_t *instance,
+    AFW_WRITER_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_writer_fd_afw_writer_self_t *self =
-        (afw_writer_fd_afw_writer_self_t *)instance;
 
     if (self->close_on_release) {
         fclose(self->fd);
@@ -56,7 +56,7 @@ impl_afw_writer_release(
  */
 void
 impl_afw_writer_flush(
-    const afw_writer_t *instance,
+    AFW_WRITER_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Ignore flush. */
@@ -67,13 +67,11 @@ impl_afw_writer_flush(
  */
 void
 impl_afw_writer_write(
-    const afw_writer_t *instance,
+    AFW_WRITER_SELF_T *self,
     const void *buffer,
     afw_size_t size,
     afw_xctx_t *xctx)
 {
-    afw_writer_fd_afw_writer_self_t *self =
-        (afw_writer_fd_afw_writer_self_t *)instance;
     size_t len;
 
     /** @todo loop if everything is not returned??? */
@@ -95,11 +93,9 @@ impl_afw_writer_write(
  */
 void
 impl_afw_writer_write_eol(
-    const afw_writer_t *instance,
+    AFW_WRITER_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_writer_fd_afw_writer_self_t *self =
-        (afw_writer_fd_afw_writer_self_t *)instance;
     size_t len;
 
     /** @todo loop if everything is not returned??? */
@@ -119,11 +115,9 @@ impl_afw_writer_write_eol(
  */
 void
 impl_afw_writer_increment_indent(
-    const afw_writer_t *instance,
+    AFW_WRITER_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_writer_fd_afw_writer_self_t *self =
-        (afw_writer_fd_afw_writer_self_t *)instance;
 
     (self->pub.indent)++;
 }
@@ -133,11 +127,9 @@ impl_afw_writer_increment_indent(
  */
 void
 impl_afw_writer_decrement_indent(
-    const afw_writer_t *instance,
+    AFW_WRITER_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_writer_fd_afw_writer_self_t *self =
-        (afw_writer_fd_afw_writer_self_t *)instance;
 
     if (self->pub.indent == 0) {
         AFW_THROW_ERROR_Z(general,

--- a/src/afw_command/afw_command_local_request.c
+++ b/src/afw_command/afw_command_local_request.c
@@ -12,6 +12,7 @@
 
 /* Declares and rti/inf defines for interface afw_request */
 #define AFW_IMPLEMENTATION_ID "afw_command_local"
+#define AFW_REQUEST_SELF_T afw_command_local_request_self_t
 #include "afw_request_impl_declares.h"
 #include "afw_command_local_request.h"
 
@@ -34,7 +35,7 @@
  */
 void
 impl_afw_request_release(
-    const afw_request_t * instance,
+    AFW_REQUEST_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Resource will be release when execution context (xctx) is released. */
@@ -47,12 +48,10 @@ impl_afw_request_release(
  */
 void
 impl_afw_request_set_error_info(
-    const afw_request_t * instance,
+    AFW_REQUEST_SELF_T *self,
     const afw_object_t * error_info,
     afw_xctx_t *xctx)
 {
-    afw_command_local_request_self_t *self =
-        (afw_command_local_request_self_t *)instance;
 
     self->pub.error_info = error_info;
 }
@@ -64,15 +63,13 @@ impl_afw_request_set_error_info(
  */
 void
 impl_afw_request_read_raw_request_body(
-    const afw_request_t * instance,
+    AFW_REQUEST_SELF_T *self,
     afw_size_t buffer_size,
     void * buffer,
     afw_size_t * size,
     afw_boolean_t * more_to_read,
     afw_xctx_t *xctx)
 {
-    afw_command_local_request_self_t *self =
-        (afw_command_local_request_self_t *)instance;
 
     /* Make sure in correct state then set it. */
     if (self->state > afw_request_state_content_read) {
@@ -103,13 +100,11 @@ impl_afw_request_read_raw_request_body(
  */
 void
 impl_afw_request_set_response_status_code(
-    const afw_request_t * instance,
+    AFW_REQUEST_SELF_T *self,
     const afw_utf8_t * code,
     const afw_utf8_t * reason,
     afw_xctx_t *xctx)
 {
-    afw_command_local_request_self_t *self =
-        (afw_command_local_request_self_t *)instance;
     
     /* Ignore status if already past state. */
     if (self->state >= afw_request_state_status_set) {
@@ -129,13 +124,11 @@ impl_afw_request_set_response_status_code(
  */
 void
 impl_afw_request_write_response_header(
-    const afw_request_t * instance,
+    AFW_REQUEST_SELF_T *self,
     const afw_utf8_t * name,
     const afw_utf8_t * value,
     afw_xctx_t *xctx)
 {
-    afw_command_local_request_self_t *self =
-        (afw_command_local_request_self_t *)instance;
 
     /* Make sure in correct state then set it. */
     if (self->state > afw_request_state_header_written) {
@@ -160,13 +153,11 @@ impl_afw_request_write_response_header(
  */
 void
 impl_afw_request_write_raw_response_body(
-    const afw_request_t * instance,
+    AFW_REQUEST_SELF_T *self,
     afw_size_t size,
     const void * buffer,
     afw_xctx_t *xctx)
 {
-    afw_command_local_request_self_t *self =
-        (afw_command_local_request_self_t *)instance;
 
     /* Make sure in correct state. */
     if (self->state > afw_request_state_response_written) {
@@ -189,7 +180,7 @@ impl_afw_request_write_raw_response_body(
  */
 void
 impl_afw_request_flush_response(
-    const afw_request_t * instance,
+    AFW_REQUEST_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Nothing needs to be done since every write is flushed. */
@@ -202,11 +193,9 @@ impl_afw_request_flush_response(
  */
 void
 impl_afw_request_finish_response(
-    const afw_request_t * instance,
+    AFW_REQUEST_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_command_local_request_self_t *self =
-        (afw_command_local_request_self_t *)instance;
 
     /* Make sure in correct state then set it. */
     if (self->state >= afw_request_state_response_finished) {
@@ -233,7 +222,7 @@ impl_read_content_cb(
     afw_size_t size_read;
 
     impl_afw_request_read_raw_request_body(
-        (const afw_request_t *)context,
+        (AFW_REQUEST_SELF_T *)context,
         size, (void *)buffer, &size_read, more_to_read, xctx);
 
     return size_read;
@@ -250,7 +239,7 @@ impl_write_content_cb(
     afw_xctx_t *xctx)
 {
     impl_afw_request_write_raw_response_body(
-        (const afw_request_t *)context, size, buffer, xctx);
+        (AFW_REQUEST_SELF_T *)context, size, buffer, xctx);
 
     return size;
 }

--- a/src/afw_command/afw_command_local_server.c
+++ b/src/afw_command/afw_command_local_server.c
@@ -14,6 +14,7 @@
 
 /* Declares and rti/inf defines for interface afw_server */
 #define AFW_IMPLEMENTATION_ID "afw_command_local"
+#define AFW_SERVER_SELF_T afw_command_local_server_self_t
 #include "afw_server_impl_declares.h"
 
 /**
@@ -436,7 +437,7 @@ impl_read_and_process_request(
  */
 void
 impl_afw_server_release(
-    const afw_server_t * instance,
+    AFW_SERVER_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Everything will be released by afw_command.c */
@@ -449,12 +450,10 @@ impl_afw_server_release(
  */
 void
 impl_afw_server_run(
-    const afw_server_t * instance,
+    AFW_SERVER_SELF_T *self,
     const afw_request_handler_t * handler,
     afw_xctx_t *xctx)
 {
-    afw_command_local_server_self_t *self =
-        (afw_command_local_server_self_t *)instance;
 
     
     afw_command_local_server_write_result(self,

--- a/src/afw_components/afw_components_extension.c
+++ b/src/afw_components/afw_components_extension.c
@@ -34,7 +34,7 @@ AFW_ENVIRONMENT_DEFINE_EXTENSION_IMPL();
  */
 const afw_extension_t *
 impl_afw_extension_initialize(
-    const afw_extension_t * instance,
+    const afw_extension_t * self,
     const afw_object_t * properties,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
@@ -50,7 +50,7 @@ impl_afw_extension_initialize(
     /* Call the generated register function for this extension. */
     afw_components_generated_register(xctx);
 
-    /* Return extension instance. */
+    /* Return extension self. */
     return &impl_extension;
 }
 
@@ -60,7 +60,7 @@ impl_afw_extension_initialize(
  */
 void
 impl_afw_extension_release(
-    const afw_extension_t * instance,
+    const afw_extension_t * self,
     afw_xctx_t *xctx)
 {
     /* Extension release() is not currently called. */

--- a/src/afw_curl/afw_curl_extension.c
+++ b/src/afw_curl/afw_curl_extension.c
@@ -44,7 +44,7 @@ AFW_ENVIRONMENT_DEFINE_EXTENSION_IMPL();
  */
 const afw_extension_t *
 impl_afw_extension_initialize(
-    const afw_extension_t * instance,
+    const afw_extension_t * self,
     const afw_object_t * properties,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
@@ -68,7 +68,7 @@ impl_afw_extension_initialize(
     /* Call the generated register function for this extension. */
     afw_curl_generated_register(xctx);
 
-    /* Return extension instance. */
+    /* Return extension self. */
     return &impl_extension;
 }
 
@@ -77,7 +77,7 @@ impl_afw_extension_initialize(
  */
 void
 impl_afw_extension_release(
-    const afw_extension_t * instance,
+    const afw_extension_t * self,
     afw_xctx_t *xctx)
 {
     /* Extension release() is not currently called. */

--- a/src/afw_ldap/afw_ldap_adapter.c
+++ b/src/afw_ldap/afw_ldap_adapter.c
@@ -20,6 +20,7 @@
 
 /* Declares and rti/inf defines for interface afw_adapter */
 #define AFW_IMPLEMENTATION_ID "ldap"
+#define AFW_ADAPTER_SELF_T afw_ldap_internal_adapter_t
 #include "afw_adapter_impl_declares.h"
 
 
@@ -91,11 +92,11 @@ afw_ldap_internal_adapter_create_cede_p(
  */
 void
 impl_afw_adapter_destroy(
-    const afw_adapter_t * instance,
+    AFW_ADAPTER_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Release pool. */
-    afw_pool_release(instance->p, xctx);
+    afw_pool_release(self->pub.p, xctx);
 }
 
 
@@ -105,10 +106,9 @@ impl_afw_adapter_destroy(
  */
 const afw_adapter_session_t *
 impl_afw_adapter_create_adapter_session (
-    const afw_adapter_t * instance,
+    AFW_ADAPTER_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_ldap_internal_adapter_t *self = (afw_ldap_internal_adapter_t *)instance;
 
     return (const afw_adapter_session_t *)
         afw_ldap_internal_adapter_session_create(self, xctx);
@@ -120,7 +120,7 @@ impl_afw_adapter_create_adapter_session (
  */
 const afw_object_t *
 impl_afw_adapter_get_additional_metrics (
-    const afw_adapter_t * instance,
+    AFW_ADAPTER_SELF_T *self,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {

--- a/src/afw_ldap/afw_ldap_adapter_factory.c
+++ b/src/afw_ldap/afw_ldap_adapter_factory.c
@@ -38,7 +38,7 @@ afw_ldap_adapter_factory =
  */
 const afw_adapter_t *
 impl_afw_adapter_factory_create_adapter_cede_p (
-    const afw_adapter_factory_t * instance,
+    const afw_adapter_factory_t * self,
     const afw_object_t * properties,
     const afw_pool_t * p,
     afw_xctx_t *xctx)

--- a/src/afw_ldap/afw_ldap_adapter_session.c
+++ b/src/afw_ldap/afw_ldap_adapter_session.c
@@ -19,6 +19,7 @@
 
 /* Declares and rti/inf defines for interface afw_adapter_session */
 #define AFW_IMPLEMENTATION_ID "ldap"
+#define AFW_ADAPTER_SESSION_SELF_T afw_ldap_internal_adapter_session_t
 #include "afw_adapter_session_impl_declares.h"
 
 
@@ -49,10 +50,9 @@ afw_ldap_internal_adapter_session_create(
  */
 void
 impl_afw_adapter_session_destroy(
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_ldap_internal_adapter_session_t *self = (afw_ldap_internal_adapter_session_t *)instance;
 
     /* Close ldap connection. */
     afw_ldap_internal_session_end(self);
@@ -64,7 +64,7 @@ impl_afw_adapter_session_destroy(
  */
 void
 impl_afw_adapter_session_retrieve_objects(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_query_criteria_t *criteria,
@@ -74,10 +74,8 @@ impl_afw_adapter_session_retrieve_objects(
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    afw_ldap_internal_adapter_session_t * self =
-        (afw_ldap_internal_adapter_session_t *)instance;
     afw_ldap_internal_adapter_t * adapter =
-        (afw_ldap_internal_adapter_t *)instance->adapter;
+        (afw_ldap_internal_adapter_t *)self->pub.adapter;
     LDAPMessage *res;
     LDAPMessage *e;
     const afw_utf8_t *filter;
@@ -213,7 +211,7 @@ impl_afw_adapter_session_retrieve_objects(
  */
 void
 impl_afw_adapter_session_get_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *object_id,
@@ -223,7 +221,6 @@ impl_afw_adapter_session_get_object(
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    afw_ldap_internal_adapter_session_t * self = (afw_ldap_internal_adapter_session_t *)instance;
     int rv;
     LDAPMessage *res;
     LDAPMessage *e;
@@ -295,7 +292,7 @@ impl_afw_adapter_session_get_object(
  */
 const afw_utf8_t *
 impl_afw_adapter_session_add_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *suggested_object_id,
@@ -303,8 +300,6 @@ impl_afw_adapter_session_add_object(
     const afw_object_t *adapter_type_specific,
     afw_xctx_t *xctx)
 {
-    afw_ldap_internal_adapter_session_t *self =
-        (afw_ldap_internal_adapter_session_t *)instance;
     afw_ldap_metadata_t *metadata = self->adapter->metadata;
     const afw_pool_t *p;
     afw_ldap_object_type_attribute_t *first_attribute;
@@ -341,7 +336,7 @@ impl_afw_adapter_session_add_object(
     }
 
     /* Create mods array. */
-    p = afw_pool_create(instance->p, xctx);
+    p = afw_pool_create(self->pub.p, xctx);
     mods = apr_array_make(afw_pool_get_apr_pool(p), 10, sizeof(LDAPMod *));
 
     /* Add objectClass. */
@@ -405,7 +400,7 @@ impl_afw_adapter_session_add_object(
  */
 void
 impl_afw_adapter_session_modify_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *object_id,
@@ -413,8 +408,6 @@ impl_afw_adapter_session_modify_object(
     const afw_object_t *adapter_type_specific,
     afw_xctx_t *xctx)
 {
-    afw_ldap_internal_adapter_session_t *self =
-        (afw_ldap_internal_adapter_session_t *)instance;
     afw_ldap_metadata_t *metadata = self->adapter->metadata;
     const afw_pool_t *p;
     afw_ldap_object_type_attribute_t *first_attribute;
@@ -442,7 +435,7 @@ impl_afw_adapter_session_modify_object(
     }
 
     /* Create mods. */
-    p = afw_pool_create(instance->p, xctx);
+    p = afw_pool_create(self->pub.p, xctx);
     mods = apr_array_make(afw_pool_get_apr_pool(p), 10, sizeof(LDAPMod *));
     afw_memory_clear(&mod);
     for (e = entry; *e; e++) {
@@ -532,7 +525,7 @@ impl_afw_adapter_session_modify_object(
  */
 void
 impl_afw_adapter_session_replace_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *object_id,
@@ -556,15 +549,13 @@ impl_afw_adapter_session_replace_object(
  */
 void
 impl_afw_adapter_session_delete_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *object_id,
     const afw_object_t *adapter_type_specific,
     afw_xctx_t *xctx)
 {
-    afw_ldap_internal_adapter_session_t *self =
-        (afw_ldap_internal_adapter_session_t *)instance;
     char *dn_z;
     int rv;
 
@@ -592,7 +583,7 @@ impl_afw_adapter_session_delete_object(
  */
 const afw_adapter_transaction_t *
 impl_afw_adapter_session_begin_transaction(
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* LDAP does not support transactions. */
@@ -606,7 +597,7 @@ impl_afw_adapter_session_begin_transaction(
  */
 const afw_adapter_journal_t *
 impl_afw_adapter_session_get_journal_interface(
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Event journal is not supported by this adapter. */
@@ -621,7 +612,7 @@ impl_afw_adapter_session_get_journal_interface(
  */
 const afw_adapter_key_value_t *
 impl_afw_adapter_session_get_key_value_interface (
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Key value interface is not supported by this adapter. */
@@ -633,7 +624,7 @@ impl_afw_adapter_session_get_key_value_interface (
  */
 const afw_adapter_impl_index_t *
 impl_afw_adapter_session_get_index_interface (
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Index interface is not supported by this adapter. */
@@ -647,16 +638,14 @@ impl_afw_adapter_session_get_index_interface (
  */
 const afw_adapter_object_type_cache_t *
 impl_afw_adapter_session_get_object_type_cache_interface(
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_ldap_internal_adapter_session_t *self =
-        (afw_ldap_internal_adapter_session_t *)instance;
 
     afw_adapter_impl_object_type_cache_initialize(
         &self->object_type_cache,
         &afw_adapter_impl_object_type_cache_inf,
-        instance, true, xctx);
+        &self->pub, true, xctx);
 
     return &self->object_type_cache;
 }

--- a/src/afw_ldap/afw_ldap_extension.c
+++ b/src/afw_ldap/afw_ldap_extension.c
@@ -33,7 +33,7 @@ AFW_ENVIRONMENT_DEFINE_EXTENSION_IMPL();
  */
 const afw_extension_t *
 impl_afw_extension_initialize(
-    const afw_extension_t * instance,
+    const afw_extension_t * self,
     const afw_object_t * properties,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
@@ -58,7 +58,7 @@ impl_afw_extension_initialize(
  */
 void
 impl_afw_extension_release(
-    const afw_extension_t * instance,
+    const afw_extension_t * self,
     afw_xctx_t *xctx)
 {
     /* Extension release() is not currently called. */

--- a/src/afw_lmdb/afw_lmdb_adapter.c
+++ b/src/afw_lmdb/afw_lmdb_adapter.c
@@ -23,6 +23,7 @@
 
 /* Declares and rti/inf defines for interface afw_adapter */
 #define AFW_IMPLEMENTATION_ID "lmdb"
+#define AFW_ADAPTER_SELF_T afw_lmdb_adapter_t
 #include "afw_adapter_impl_declares.h"
 
 /*
@@ -346,10 +347,9 @@ const afw_adapter_t * afw_lmdb_adapter_create_cede_p(
  */
 void
 impl_afw_adapter_destroy(
-    const afw_adapter_t * instance,
+    AFW_ADAPTER_SELF_T *self,
     afw_xctx_t *xctx)
 {  
-    afw_lmdb_adapter_t *self = (afw_lmdb_adapter_t *) instance;
     apr_hash_index_t *hi;
 
     /* close any open databases */
@@ -369,7 +369,7 @@ impl_afw_adapter_destroy(
     mdb_env_close(self->dbEnv);
 
     /* Release pool. */
-    afw_pool_release(instance->p, xctx);
+    afw_pool_release(self->pub.p, xctx);
 }
 
 
@@ -379,10 +379,9 @@ impl_afw_adapter_destroy(
  */
 const afw_adapter_session_t *
 impl_afw_adapter_create_adapter_session (
-    const afw_adapter_t * instance,
+    AFW_ADAPTER_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_lmdb_adapter_t *self = (afw_lmdb_adapter_t *)instance;
 
     return (const afw_adapter_session_t *)
         afw_lmdb_adapter_session_create(self, xctx);
@@ -394,12 +393,10 @@ impl_afw_adapter_create_adapter_session (
  */
 const afw_object_t *
 impl_afw_adapter_get_additional_metrics (
-    const afw_adapter_t * instance,
+    AFW_ADAPTER_SELF_T *self,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {
-    const afw_lmdb_adapter_t *self = 
-        (afw_lmdb_adapter_t *) instance;
     int major, minor, patch;
     char *version_str;
     const afw_object_t *metrics;

--- a/src/afw_lmdb/afw_lmdb_adapter_factory.c
+++ b/src/afw_lmdb/afw_lmdb_adapter_factory.c
@@ -37,7 +37,7 @@ afw_lmdb_adapter_factory =
  */
 const afw_adapter_t *
 impl_afw_adapter_factory_create_adapter_cede_p (
-    const afw_adapter_factory_t * instance,
+    const afw_adapter_factory_t * self,
     const afw_object_t * properties,
     const afw_pool_t * p,
     afw_xctx_t *xctx)

--- a/src/afw_lmdb/afw_lmdb_adapter_session.c
+++ b/src/afw_lmdb/afw_lmdb_adapter_session.c
@@ -22,6 +22,7 @@
 
 /* Declares and rti/inf defines for interface afw_adapter_session */
 #define AFW_IMPLEMENTATION_ID "lmdb"
+#define AFW_ADAPTER_SESSION_SELF_T afw_lmdb_adapter_session_t
 #include "afw_adapter_session_impl_declares.h"
 
 
@@ -67,7 +68,7 @@ afw_lmdb_adapter_session_t *afw_lmdb_adapter_session_create(
  */
 void
 impl_afw_adapter_session_destroy(
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
 }
@@ -79,7 +80,7 @@ impl_afw_adapter_session_destroy(
  */
 void
 impl_afw_adapter_session_retrieve_objects(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_query_criteria_t *criteria,
@@ -89,7 +90,6 @@ impl_afw_adapter_session_retrieve_objects(
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    afw_lmdb_adapter_session_t * self = (afw_lmdb_adapter_session_t *)instance;
     afw_lmdb_adapter_t *adapter = (afw_lmdb_adapter_t *)self->adapter;
     MDB_txn * txn;
 
@@ -135,7 +135,7 @@ impl_afw_adapter_session_retrieve_objects(
  */
 void
 impl_afw_adapter_session_get_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *object_id,
@@ -145,7 +145,6 @@ impl_afw_adapter_session_get_object(
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    afw_lmdb_adapter_session_t * self = (afw_lmdb_adapter_session_t *)instance;
     afw_lmdb_adapter_t *adapter = (afw_lmdb_adapter_t *)self->adapter;
     MDB_dbi dbi;
     MDB_txn *txn;
@@ -157,7 +156,7 @@ impl_afw_adapter_session_get_object(
      */
     if (afw_utf8_equal(object_type_id, afw_s__AdaptiveObjectType_)) {
         object = afw_adapter_impl_generic_object_type_object_get(
-            instance->adapter, object_id, p, xctx);
+            self->pub.adapter, object_id, p, xctx);
         callback(object, context, xctx);
         return;
     }
@@ -187,7 +186,7 @@ impl_afw_adapter_session_get_object(
  */
 const afw_utf8_t *
 impl_afw_adapter_session_add_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *suggested_object_id,
@@ -195,7 +194,6 @@ impl_afw_adapter_session_add_object(
     const afw_object_t *adapter_type_specific,
     afw_xctx_t *xctx)
 {
-    afw_lmdb_adapter_session_t *self = (afw_lmdb_adapter_session_t *)instance;
     afw_lmdb_adapter_t *adapter = (afw_lmdb_adapter_t *)self->adapter;
     MDB_dbi dbi;
     MDB_txn *txn;
@@ -241,7 +239,7 @@ impl_afw_adapter_session_add_object(
  */
 void
 impl_afw_adapter_session_modify_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *object_id,
@@ -249,7 +247,6 @@ impl_afw_adapter_session_modify_object(
     const afw_object_t *adapter_type_specific,
     afw_xctx_t *xctx)
 {
-    afw_lmdb_adapter_session_t *self = (afw_lmdb_adapter_session_t *)instance;
     afw_lmdb_adapter_t *adapter = (afw_lmdb_adapter_t *)self->adapter;    
     const afw_object_t *object, *new_object;
     MDB_dbi dbi;    
@@ -296,7 +293,7 @@ impl_afw_adapter_session_modify_object(
  */
 void
 impl_afw_adapter_session_replace_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *object_id,
@@ -304,7 +301,6 @@ impl_afw_adapter_session_replace_object(
     const afw_object_t *adapter_type_specific,
     afw_xctx_t *xctx)
 {
-    afw_lmdb_adapter_session_t *self = (afw_lmdb_adapter_session_t *)instance;
     afw_lmdb_adapter_t *adapter = (afw_lmdb_adapter_t *)self->adapter;    
     const afw_object_t *old_object;
     const afw_value_t *value;
@@ -354,14 +350,13 @@ impl_afw_adapter_session_replace_object(
  */
 void
 impl_afw_adapter_session_delete_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *object_id,
     const afw_object_t *adapter_type_specific,
     afw_xctx_t *xctx)
 {
-    afw_lmdb_adapter_session_t *self = (afw_lmdb_adapter_session_t *)instance;
     afw_lmdb_adapter_t *adapter = (afw_lmdb_adapter_t *)self->adapter;
     const afw_uuid_t *uuid;
     const afw_object_t *object;
@@ -426,10 +421,9 @@ impl_afw_adapter_session_delete_object(
  */
 const afw_adapter_transaction_t *
 impl_afw_adapter_session_begin_transaction(
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_lmdb_adapter_session_t *self = (afw_lmdb_adapter_session_t *)instance;
     afw_lmdb_transaction_t *transaction;
 
     /* create the session transaction at the time it's requested */
@@ -563,10 +557,9 @@ void afw_lmdb_adapter_session_dump_objects(
  */
 const afw_adapter_journal_t *
 impl_afw_adapter_session_get_journal_interface(
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_lmdb_adapter_session_t *self = (afw_lmdb_adapter_session_t *)instance;
 
     return (afw_adapter_journal_t *)self->journal;
 }
@@ -579,10 +572,9 @@ impl_afw_adapter_session_get_journal_interface(
  */
 const afw_adapter_key_value_t *
 impl_afw_adapter_session_get_key_value_interface (
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_lmdb_adapter_session_t *self = (afw_lmdb_adapter_session_t *)instance;
 
     return (afw_adapter_key_value_t *)self->key_value;
 }
@@ -593,10 +585,9 @@ impl_afw_adapter_session_get_key_value_interface (
  */
 const afw_adapter_impl_index_t *
 impl_afw_adapter_session_get_index_interface (
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_lmdb_adapter_session_t *self = (afw_lmdb_adapter_session_t *)instance;
 
     return self->indexer;
 }
@@ -609,7 +600,7 @@ impl_afw_adapter_session_get_index_interface (
  */
 const afw_adapter_object_type_cache_t *
 impl_afw_adapter_session_get_object_type_cache_interface(
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* There is on adapter cache. */

--- a/src/afw_lmdb/afw_lmdb_extension.c
+++ b/src/afw_lmdb/afw_lmdb_extension.c
@@ -33,7 +33,7 @@ AFW_ENVIRONMENT_DEFINE_EXTENSION_IMPL();
  */
 const afw_extension_t *
 impl_afw_extension_initialize(
-    const afw_extension_t * instance,
+    const afw_extension_t * self,
     const afw_object_t * properties,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
@@ -60,7 +60,7 @@ impl_afw_extension_initialize(
  */
 void
 impl_afw_extension_release(
-    const afw_extension_t * instance,
+    const afw_extension_t * self,
     afw_xctx_t *xctx)
 
 {

--- a/src/afw_lmdb/afw_lmdb_index.c
+++ b/src/afw_lmdb/afw_lmdb_index.c
@@ -21,6 +21,7 @@
 #include "generated/afw_lmdb_generated.h"
 
 #define AFW_IMPLEMENTATION_ID "lmdb_index"
+#define AFW_ADAPTER_IMPL_INDEX_SELF_T afw_lmdb_adapter_impl_index_t
 #include "afw_adapter_impl_index_impl_declares.h"
 
 
@@ -44,7 +45,7 @@ afw_adapter_impl_index_t * afw_lmdb_adapter_impl_index_create(
     self->adapter = adapter;
     self->txn = txn;
     self->pub.indexDefinitions = impl_afw_adapter_impl_index_get_index_definitions(
-        (afw_adapter_impl_index_t*)self, xctx);
+        (AFW_ADAPTER_IMPL_INDEX_SELF_T *)self, xctx);
 
     /* Return new instance. */
     return (afw_adapter_impl_index_t*)self;
@@ -91,7 +92,7 @@ const afw_utf8_t * afw_lmdb_index_database(
  * Implementation of method release of interface afw_adapter_impl_index.
  */
 void impl_afw_adapter_impl_index_release(
-    const afw_adapter_impl_index_t * instance,
+    AFW_ADAPTER_IMPL_INDEX_SELF_T *self,
     afw_xctx_t *xctx)
 {
 
@@ -102,11 +103,9 @@ void impl_afw_adapter_impl_index_release(
  */
 const afw_object_t *
 impl_afw_adapter_impl_index_get_index_definitions (
-    const afw_adapter_impl_index_t * instance,
+    AFW_ADAPTER_IMPL_INDEX_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_lmdb_adapter_impl_index_t *self = 
-        (afw_lmdb_adapter_impl_index_t *) instance;
     const afw_adapter_t *adapter = (afw_adapter_t *)self->adapter;
     const afw_object_t *indexes;
 
@@ -133,12 +132,10 @@ impl_afw_adapter_impl_index_get_index_definitions (
  */
 void
 impl_afw_adapter_impl_index_update_index_definitions (
-    const afw_adapter_impl_index_t * instance,
+    AFW_ADAPTER_IMPL_INDEX_SELF_T *self,
     const afw_object_t * indexDefinitions,
     afw_xctx_t *xctx)
 {
-    afw_lmdb_adapter_impl_index_t *self = 
-        (afw_lmdb_adapter_impl_index_t *) instance;
     const afw_lmdb_adapter_session_t *session = self->session;
     const afw_adapter_t *adapter = (afw_adapter_t *)self->session->adapter;    
     const afw_pool_t *pool;
@@ -168,7 +165,7 @@ impl_afw_adapter_impl_index_update_index_definitions (
  */
 void
 impl_afw_adapter_impl_index_open(
-    const afw_adapter_impl_index_t * instance,
+    AFW_ADAPTER_IMPL_INDEX_SELF_T *self,
     const afw_utf8_t * object_type_id,
     const afw_utf8_t * key,
     afw_boolean_t integer,
@@ -177,8 +174,6 @@ impl_afw_adapter_impl_index_open(
     const afw_pool_t * pool,
     afw_xctx_t *xctx)
 {
-    afw_lmdb_adapter_impl_index_t *self = 
-        (afw_lmdb_adapter_impl_index_t *) instance;
     const afw_lmdb_adapter_t *adapter = self->adapter;   
     const afw_lmdb_adapter_session_t * session = NULL;     
     const afw_utf8_t *database;
@@ -220,7 +215,7 @@ impl_afw_adapter_impl_index_open(
  * Implementation of method add of interface afw_adapter_impl_index.
  */
 afw_rc_t impl_afw_adapter_impl_index_add(
-    const afw_adapter_impl_index_t * instance,
+    AFW_ADAPTER_IMPL_INDEX_SELF_T *self,
     const afw_utf8_t * object_type_id,
     const afw_utf8_t * object_id,
     const afw_utf8_t * indexKey,
@@ -229,8 +224,6 @@ afw_rc_t impl_afw_adapter_impl_index_add(
     const afw_pool_t * pool,
     afw_xctx_t *xctx)
 {
-    afw_lmdb_adapter_impl_index_t *self = 
-        (afw_lmdb_adapter_impl_index_t *) instance;
     const afw_lmdb_adapter_session_t *session = self->session;
     afw_rc_t rc;
     MDB_txn * txn;
@@ -289,7 +282,7 @@ afw_rc_t impl_afw_adapter_impl_index_add(
  * Implementation of method delete of interface afw_adapter_impl_index.
  */
 afw_rc_t impl_afw_adapter_impl_index_delete(
-    const afw_adapter_impl_index_t * instance,
+    AFW_ADAPTER_IMPL_INDEX_SELF_T *self,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *object_id,
     const afw_utf8_t *indexKey,
@@ -297,8 +290,6 @@ afw_rc_t impl_afw_adapter_impl_index_delete(
     const afw_pool_t *pool,
     afw_xctx_t *xctx)
 {
-    afw_lmdb_adapter_impl_index_t *self = 
-        (afw_lmdb_adapter_impl_index_t *) instance;
     const afw_lmdb_adapter_session_t *session = self->session;
     MDB_val key, data;
     MDB_dbi dbi;
@@ -347,7 +338,7 @@ afw_rc_t impl_afw_adapter_impl_index_delete(
  * Implementation of method replace of interface afw_adapter_impl_index.
  */
 afw_rc_t impl_afw_adapter_impl_index_replace(
-    const afw_adapter_impl_index_t * instance,
+    AFW_ADAPTER_IMPL_INDEX_SELF_T *self,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *object_id,
     const afw_utf8_t *indexKey,
@@ -356,8 +347,6 @@ afw_rc_t impl_afw_adapter_impl_index_replace(
     const afw_pool_t *pool,
     afw_xctx_t *xctx)
 {
-    afw_lmdb_adapter_impl_index_t *self = 
-        (afw_lmdb_adapter_impl_index_t *) instance;
     const afw_lmdb_adapter_session_t *session = self->session;
     MDB_val key, data;
     MDB_dbi dbi;
@@ -415,14 +404,12 @@ afw_rc_t impl_afw_adapter_impl_index_replace(
  */
 afw_rc_t
 impl_afw_adapter_impl_index_drop (
-    const afw_adapter_impl_index_t * instance,
+    AFW_ADAPTER_IMPL_INDEX_SELF_T *self,
     const afw_utf8_t  * object_type_id,
     const afw_utf8_t  * key,
     const afw_pool_t  * pool,
     afw_xctx_t       * xctx)
 {
-    afw_lmdb_adapter_impl_index_t *self = 
-        (afw_lmdb_adapter_impl_index_t *) instance;
     const afw_lmdb_adapter_session_t *session = self->session;
     const afw_utf8_t *database;
     MDB_dbi dbi;
@@ -446,7 +433,7 @@ impl_afw_adapter_impl_index_drop (
  */
 afw_adapter_impl_index_cursor_t *
 impl_afw_adapter_impl_index_open_cursor (
-    const afw_adapter_impl_index_t * instance,
+    AFW_ADAPTER_IMPL_INDEX_SELF_T *self,
     const afw_utf8_t * object_type_id,
     const afw_utf8_t * key,
     int                operator,
@@ -455,8 +442,6 @@ impl_afw_adapter_impl_index_open_cursor (
     const afw_pool_t * pool,
     afw_xctx_t      * xctx)
 {
-    afw_lmdb_adapter_impl_index_t *self = 
-        (afw_lmdb_adapter_impl_index_t *) instance;
     afw_adapter_impl_index_cursor_t *cursor;
     const afw_utf8_t * database;
 
@@ -474,12 +459,10 @@ impl_afw_adapter_impl_index_open_cursor (
  */
 const afw_adapter_session_t *
 impl_afw_adapter_impl_index_get_session (
-    const afw_adapter_impl_index_t * instance,
+    AFW_ADAPTER_IMPL_INDEX_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    /* Assign instance pointer to self. */
-    afw_lmdb_adapter_impl_index_t * self =
-        (afw_lmdb_adapter_impl_index_t*)instance;
+    /* Assign &self->pub pointer to self. */
 
     return (const afw_adapter_session_t *) self->session;
 }

--- a/src/afw_lmdb/afw_lmdb_internal.c
+++ b/src/afw_lmdb/afw_lmdb_internal.c
@@ -17,8 +17,11 @@
 #include "afw_lmdb_internal.h"
 
 #define AFW_IMPLEMENTATION_ID "lmdb"
+#define AFW_ADAPTER_IMPL_INDEX_CURSOR_SELF_T impl_afw_adapter_impl_index_cursor_self_t
 #include "afw_adapter_impl_index_cursor_impl_declares.h"
+#define AFW_ADAPTER_KEY_VALUE_SELF_T afw_lmdb_key_value_t
 #include "afw_adapter_key_value_impl_declares.h"
+#define AFW_ADAPTER_TRANSACTION_SELF_T afw_lmdb_transaction_t
 #include "afw_adapter_transaction_impl_declares.h"
 
 /*
@@ -637,15 +640,13 @@ afw_lmdb_key_value_t * afw_lmdb_key_value_create(
  */
 void
 impl_afw_adapter_key_value_add (
-    const afw_adapter_key_value_t * instance,
+    AFW_ADAPTER_KEY_VALUE_SELF_T *self,
     const afw_utf8_t * namespace,
     const afw_memory_t * key,
     const afw_memory_t * value,
     afw_xctx_t *xctx)
 {
-    /* Assign instance pointer to self. */
-    afw_lmdb_key_value_t * self = 
-        (afw_lmdb_key_value_t *)instance;
+    /* Assign &self->pub pointer to self. */
     afw_lmdb_adapter_session_t * session =
         (afw_lmdb_adapter_session_t *)self->session;
     const afw_utf8_t separator = AFW_UTF8_LITERAL("#");
@@ -682,16 +683,14 @@ impl_afw_adapter_key_value_add (
  */
 void
 impl_afw_adapter_key_value_delete (
-    const afw_adapter_key_value_t * instance,
+    AFW_ADAPTER_KEY_VALUE_SELF_T *self,
     const afw_utf8_t * namespace,
     const afw_memory_t * key,
     const afw_memory_t * value,
     afw_boolean_t must_exist,
     afw_xctx_t *xctx)
 {
-    /* Assign instance pointer to self. */
-    afw_lmdb_key_value_t * self =
-        (afw_lmdb_key_value_t *)instance;
+    /* Assign &self->pub pointer to self. */
     afw_lmdb_adapter_session_t * session =
         (afw_lmdb_adapter_session_t *)self->session;
     const afw_utf8_t separator = AFW_UTF8_LITERAL("#");
@@ -731,16 +730,14 @@ impl_afw_adapter_key_value_delete (
  */
 void
 impl_afw_adapter_key_value_replace (
-    const afw_adapter_key_value_t * instance,
+    AFW_ADAPTER_KEY_VALUE_SELF_T *self,
     const afw_utf8_t * namespace,
     const afw_memory_t * key,
     const afw_memory_t * value,
     afw_boolean_t must_exist,
     afw_xctx_t *xctx)
 {
-    /* Assign instance pointer to self. */
-    afw_lmdb_key_value_t * self =
-        (afw_lmdb_key_value_t *)instance;
+    /* Assign &self->pub pointer to self. */
     afw_lmdb_adapter_session_t * session =
         (afw_lmdb_adapter_session_t *)self->session;
     const afw_utf8_t separator = AFW_UTF8_LITERAL("#");
@@ -796,13 +793,11 @@ impl_afw_adapter_key_value_replace (
  */
 const afw_memory_t *
 impl_afw_adapter_key_value_get (
-    const afw_adapter_key_value_t * instance,
+    AFW_ADAPTER_KEY_VALUE_SELF_T *self,
     const afw_utf8_t * namespace,
     const afw_memory_t * key,
     afw_xctx_t *xctx)
 {
-    afw_lmdb_key_value_t * self =
-        (afw_lmdb_key_value_t *)instance;
     afw_lmdb_adapter_session_t * session =
         (afw_lmdb_adapter_session_t *)self->session;
     const afw_utf8_t separator = AFW_UTF8_LITERAL("#");
@@ -994,12 +989,10 @@ afw_adapter_impl_index_cursor_t * afw_lmdb_internal_cursor_create(
  */
 void
 impl_afw_adapter_impl_index_cursor_release (
-    const afw_adapter_impl_index_cursor_t * instance,
+    AFW_ADAPTER_IMPL_INDEX_CURSOR_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    /* Assign instance pointer to self. */
-    impl_afw_adapter_impl_index_cursor_self_t * self = 
-        (impl_afw_adapter_impl_index_cursor_self_t *)instance;
+    /* Assign &self->pub pointer to self. */
 
     mdb_cursor_close(self->cursor);
 }
@@ -1071,13 +1064,11 @@ int afw_lmdb_internal_cursor_next(
  */
 const afw_object_t *
 impl_afw_adapter_impl_index_cursor_get_next_object (
-    const afw_adapter_impl_index_cursor_t * instance,
+    AFW_ADAPTER_IMPL_INDEX_CURSOR_SELF_T *self,
     const afw_pool_t *pool,
     afw_xctx_t *xctx)
 {
-    /* Assign instance pointer to self. */
-    impl_afw_adapter_impl_index_cursor_self_t * self = 
-        (impl_afw_adapter_impl_index_cursor_self_t *)instance;
+    /* Assign &self->pub pointer to self. */
     const afw_lmdb_adapter_t *adapter = self->session->adapter;
     const afw_object_t *object = NULL;
     const afw_value_t *value;
@@ -1107,7 +1098,7 @@ impl_afw_adapter_impl_index_cursor_get_next_object (
         rc = mdb_get(txn, self->dbPri, &key, &data);
         if (rc == MDB_NOTFOUND) {
             /* indicates an index was not cleaned up */
-            rc = afw_lmdb_internal_cursor_next(instance, xctx);
+            rc = afw_lmdb_internal_cursor_next(&self->pub, xctx);
             if (rc) {
                 return NULL;
             }
@@ -1132,7 +1123,7 @@ impl_afw_adapter_impl_index_cursor_get_next_object (
             self->object_type_id, object_id, xctx);
 
         /* advance the cursor for the next object */
-        rc = afw_lmdb_internal_cursor_next(instance, xctx);
+        rc = afw_lmdb_internal_cursor_next(&self->pub, xctx);
         if (rc) {
             /* end of data */
             self->data.mv_data = NULL;
@@ -1149,13 +1140,11 @@ impl_afw_adapter_impl_index_cursor_get_next_object (
  */
 afw_boolean_t
 impl_afw_adapter_impl_index_cursor_contains_object (
-    const afw_adapter_impl_index_cursor_t * instance,
+    AFW_ADAPTER_IMPL_INDEX_CURSOR_SELF_T *self,
     const afw_object_t * object,
     afw_xctx_t *xctx)
 {
-    /* Assign instance pointer to self. */
-    impl_afw_adapter_impl_index_cursor_self_t * self = 
-        (impl_afw_adapter_impl_index_cursor_self_t *)instance;
+    /* Assign &self->pub pointer to self. */
     const afw_utf8_t *object_id, *key_string;
     afw_memory_t index;
     MDB_val key, data;
@@ -1212,13 +1201,11 @@ impl_afw_adapter_impl_index_cursor_contains_object (
  */
 const afw_adapter_impl_index_cursor_t *
 impl_afw_adapter_impl_index_cursor_inner_join (
-    const afw_adapter_impl_index_cursor_t * instance,
+    AFW_ADAPTER_IMPL_INDEX_CURSOR_SELF_T *self,
     const afw_adapter_impl_index_cursor_t * cursor,
     afw_xctx_t *xctx)
 {
-    /* Assign instance pointer to self. */
-    impl_afw_adapter_impl_index_cursor_self_t * self = 
-        (impl_afw_adapter_impl_index_cursor_self_t *)instance;
+    /* Assign &self->pub pointer to self. */
     impl_afw_adapter_impl_index_cursor_self_t * that = 
         (impl_afw_adapter_impl_index_cursor_self_t *)cursor;
     size_t count_this, count_that;
@@ -1238,7 +1225,7 @@ impl_afw_adapter_impl_index_cursor_inner_join (
 
     /* use the cursor count and return the smaller set */
     if (count_this < count_that)
-        return instance;
+        return &self->pub;
     else
         return cursor;
 }
@@ -1248,12 +1235,10 @@ impl_afw_adapter_impl_index_cursor_inner_join (
  */
 afw_boolean_t
 impl_afw_adapter_impl_index_cursor_get_count(
-    const afw_adapter_impl_index_cursor_t * instance,
+    AFW_ADAPTER_IMPL_INDEX_CURSOR_SELF_T *self,
     size_t * count,
     afw_xctx_t *xctx)
 {
-    impl_afw_adapter_impl_index_cursor_self_t * self =
-        (impl_afw_adapter_impl_index_cursor_self_t *)instance;
     int rc;
 
     /* we can only calculate the count for duplicate data on a single key,
@@ -1311,12 +1296,10 @@ afw_lmdb_transaction_t * afw_lmdb_transaction_create(
  */
 void
 impl_afw_adapter_transaction_release (
-    const afw_adapter_transaction_t * instance,
+    AFW_ADAPTER_TRANSACTION_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    /* Assign instance pointer to self. */
-    afw_lmdb_transaction_t * self = 
-        (afw_lmdb_transaction_t *)instance;
+    /* Assign &self->pub pointer to self. */
     afw_lmdb_adapter_session_t * session =
         (afw_lmdb_adapter_session_t *)self->session;
 
@@ -1335,12 +1318,10 @@ impl_afw_adapter_transaction_release (
  */
 void
 impl_afw_adapter_transaction_commit (
-    const afw_adapter_transaction_t * instance,
+    AFW_ADAPTER_TRANSACTION_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    /* Assign instance pointer to self. */
-    afw_lmdb_transaction_t * self = 
-        (afw_lmdb_transaction_t *)instance;
+    /* Assign &self->pub pointer to self. */
     afw_lmdb_adapter_session_t * session =
         (afw_lmdb_adapter_session_t *)self->session;
     int rc;

--- a/src/afw_lmdb/afw_lmdb_journal.c
+++ b/src/afw_lmdb/afw_lmdb_journal.c
@@ -21,6 +21,7 @@
 
 /* Declares and rti/inf defines for interface afw_adapter_journal */
 #define AFW_IMPLEMENTATION_ID "lmdb"
+#define AFW_ADAPTER_JOURNAL_SELF_T afw_lmdb_journal_t
 #include "afw_adapter_journal_impl_declares.h"
 
 afw_lmdb_journal_t *
@@ -44,14 +45,12 @@ afw_lmdb_journal_create(
  */
 const afw_utf8_t *
 impl_afw_adapter_journal_add_entry(
-    const afw_adapter_journal_t * instance,
+    AFW_ADAPTER_JOURNAL_SELF_T *self,
     const afw_adapter_impl_request_t * impl_request,
     const afw_object_t * entry,
     afw_xctx_t *xctx)
 {
-    /* Assign instance pointer to self. */
-    afw_lmdb_journal_t * self =
-        (afw_lmdb_journal_t *)instance;
+    /* Assign &self->pub pointer to self. */
     afw_lmdb_adapter_session_t *session = 
         (afw_lmdb_adapter_session_t *)self->session;
     afw_lmdb_adapter_t *adapter = 
@@ -682,7 +681,7 @@ afw_lmdb_journal_advance_cursor_for_consumer(
  */
 void
 impl_afw_adapter_journal_get_entry(
-    const afw_adapter_journal_t * instance,
+    AFW_ADAPTER_JOURNAL_SELF_T *self,
     const afw_adapter_impl_request_t * impl_request,
     afw_adapter_journal_option_t option,
     const afw_utf8_t * consumer_id,
@@ -691,8 +690,6 @@ impl_afw_adapter_journal_get_entry(
     const afw_object_t * response,
     afw_xctx_t *xctx)
 {
-    afw_lmdb_journal_t * self =
-        (afw_lmdb_journal_t *)instance;
     afw_lmdb_adapter_session_t *session = 
         (afw_lmdb_adapter_session_t *)self->session;
     afw_lmdb_adapter_t *adapter = 
@@ -751,14 +748,12 @@ impl_afw_adapter_journal_get_entry(
  */
 void
 impl_afw_adapter_journal_mark_entry_consumed(
-    const afw_adapter_journal_t * instance,
+    AFW_ADAPTER_JOURNAL_SELF_T *self,
     const afw_adapter_impl_request_t * impl_request,
     const afw_utf8_t * consumer_id,
     const afw_utf8_t * entry_cursor,
     afw_xctx_t *xctx)
 {
-    afw_lmdb_journal_t * self =
-        (afw_lmdb_journal_t *)instance;
     afw_lmdb_adapter_session_t *session = 
         (afw_lmdb_adapter_session_t *)self->session;
     afw_lmdb_adapter_t *adapter = 

--- a/src/afw_server_fcgi/afw_server_fcgi.c
+++ b/src/afw_server_fcgi/afw_server_fcgi.c
@@ -151,7 +151,7 @@ afw_server_fcgi_internal_create(const char *path,
  */
 void
 impl_afw_server_release(
-    const afw_server_t * instance,
+    const afw_server_t * self,
     afw_xctx_t *xctx)
 {
     /** @todo Add code to implement method. */
@@ -298,12 +298,12 @@ impl_afw_server_request_thread_start(const afw_thread_t *thread,
  */
 void
 impl_afw_server_run(
-    const afw_server_t * instance,
+    const afw_server_t * self,
     const afw_request_handler_t * handler,
     afw_xctx_t *xctx)
 {
     afw_server_fcgi_internal_t * server =
-        (afw_server_fcgi_internal_t *)instance;
+        (afw_server_fcgi_internal_t *)self;
 
     afw_integer_t count;
     afw_server_fcgi_internal_server_thread_t *server_thread;

--- a/src/afw_server_fcgi/afw_server_fcgi_properties_object.c
+++ b/src/afw_server_fcgi/afw_server_fcgi_properties_object.c
@@ -24,6 +24,8 @@
 
 /* Declares and rti/inf defines for interface afw_object */
 #define AFW_IMPLEMENTATION_ID "fcgi_request_properties"
+typedef struct impl_self_s impl_self_t;
+#define AFW_OBJECT_SELF_T impl_self_t
 #include "afw_object_impl_declares.h"
 
 typedef struct impl_self_s {
@@ -128,7 +130,7 @@ afw_server_fcgi_internal_create_properties_object(
  */
 void
 impl_afw_object_release(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Always releases with xctx. */
@@ -141,7 +143,7 @@ impl_afw_object_release(
  */
 void
 impl_afw_object_get_reference (
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Always releases with xctx. */
@@ -152,10 +154,9 @@ impl_afw_object_get_reference (
  */
 afw_size_t
 impl_afw_object_get_count(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t * xctx)
 {
-    impl_self_t *self = (impl_self_t *)instance;
 
     if (!self->all_loaded) {
         impl_load_all(self, xctx);
@@ -169,12 +170,12 @@ impl_afw_object_get_count(
  */
 const afw_value_t *
 impl_afw_object_get_meta(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
     return afw_object_impl_get_meta(
-        instance, p, xctx);
+        &self->pub, p, xctx);
 }
 
 
@@ -184,11 +185,10 @@ impl_afw_object_get_meta(
  */
 const afw_value_t *
 impl_afw_object_get_property(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t * property_name,
     afw_xctx_t *xctx)
 {
-    impl_self_t *self = (impl_self_t *)instance;
     const void *s;
     const afw_value_t *value;
     const afw_utf8_z_t *property_name_z;
@@ -222,13 +222,13 @@ impl_afw_object_get_property(
  */
 const afw_value_t *
 impl_afw_object_get_property_meta(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t *property_name,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
     return afw_object_impl_get_property_meta(
-        instance, property_name, p, xctx);
+        &self->pub, property_name, p, xctx);
 }
 
 
@@ -238,12 +238,11 @@ impl_afw_object_get_property_meta(
  */
 const afw_value_t *
 impl_afw_object_get_next_property(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_iterator_t * * iterator,
     const afw_utf8_t * * property_name,
     afw_xctx_t *xctx)
 {
-    impl_self_t *self = (impl_self_t *)instance;
 
     /* Materialize full envp into cache once; cache is source of truth. */
     if (!self->all_loaded) {
@@ -261,14 +260,14 @@ impl_afw_object_get_next_property(
  */
 const afw_value_t *
 impl_afw_object_get_next_property_meta(
-    const afw_object_t *instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_iterator_t **iterator,
     const afw_utf8_t **property_name,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
     return afw_object_impl_get_next_property_meta(
-        instance, iterator, property_name, p, xctx);
+        &self->pub, iterator, property_name, p, xctx);
 }
 
 
@@ -278,14 +277,13 @@ impl_afw_object_get_next_property_meta(
  */
 afw_boolean_t
 impl_afw_object_has_property(
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     const afw_utf8_t * property_name,
     afw_xctx_t *xctx)
 {
     const afw_value_t *value;
 
-    value = impl_afw_object_get_property(
-        instance, property_name, xctx);
+    value = impl_afw_object_get_property(self, property_name, xctx);
 
     return (value != NULL);
 }
@@ -297,10 +295,9 @@ impl_afw_object_has_property(
  */
 const afw_object_setter_t *
 impl_afw_object_get_setter (
-    const afw_object_t * instance,
+    AFW_OBJECT_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    impl_self_t * self = (impl_self_t *)instance;
 
     return afw_object_get_setter(self->properties, xctx);
 }

--- a/src/afw_server_fcgi/afw_server_fcgi_request.c
+++ b/src/afw_server_fcgi/afw_server_fcgi_request.c
@@ -20,6 +20,7 @@
 /* Declares and rti/inf defines for interface afw_request */
 #define AFW_IMPLEMENTATION_ID "afw_server_fcgi"
 #define AFW_IMPLEMENTATION_SPECIFIC NULL /* Change to &label if needed. */
+#define AFW_REQUEST_SELF_T afw_server_fcgi_internal_request_t
 #include "afw_request_impl_declares.h"
 
 
@@ -35,7 +36,7 @@ impl_read_content_cb(
     afw_size_t size_read;
 
     impl_afw_request_read_raw_request_body(
-        (const afw_request_t *)context,
+        (AFW_REQUEST_SELF_T *)context,
         size, (void *)buffer, &size_read, more_to_read, xctx);
 
     return size_read;
@@ -51,7 +52,7 @@ impl_write_content_cb(
     afw_xctx_t *xctx)
 {
     impl_afw_request_write_raw_response_body(
-        (const afw_request_t *)context, size, buffer, xctx);
+        (AFW_REQUEST_SELF_T *)context, size, buffer, xctx);
 
     return size;
 }
@@ -165,7 +166,7 @@ afw_server_fcgi_internal_create_request(
  */
 void
 impl_afw_request_release(
-    const afw_request_t * instance,
+    AFW_REQUEST_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /*
@@ -183,12 +184,10 @@ impl_afw_request_release(
  */
 void
 impl_afw_request_set_error_info(
-    const afw_request_t * instance,
+    AFW_REQUEST_SELF_T *self,
     const afw_object_t * error_info,
     afw_xctx_t *xctx)
 {
-    afw_server_fcgi_internal_request_t *self =
-        (afw_server_fcgi_internal_request_t *)instance;
 
     self->pub.error_info = error_info;
 }
@@ -200,15 +199,13 @@ impl_afw_request_set_error_info(
  */
 void
 impl_afw_request_read_raw_request_body(
-    const afw_request_t * instance,
+    AFW_REQUEST_SELF_T *self,
     afw_size_t buffer_size,
     void * buffer,
     afw_size_t * size,
     afw_boolean_t * more_to_read,
     afw_xctx_t *xctx)
 {
-    afw_server_fcgi_internal_request_t *self =
-        (afw_server_fcgi_internal_request_t *)instance;
     int c;
     unsigned char *b = buffer;
 
@@ -239,13 +236,11 @@ impl_afw_request_read_raw_request_body(
  */
 void
 impl_afw_request_set_response_status_code(
-    const afw_request_t * instance,
+    AFW_REQUEST_SELF_T *self,
     const afw_utf8_t * code,
     const afw_utf8_t * reason,
     afw_xctx_t *xctx)
 {
-    afw_server_fcgi_internal_request_t *self =
-        (afw_server_fcgi_internal_request_t *)instance;
     int rv = 0;
 
     /* Ignore status if already past state. */
@@ -282,13 +277,11 @@ impl_afw_request_set_response_status_code(
  */
 void
 impl_afw_request_write_response_header(
-    const afw_request_t * instance,
+    AFW_REQUEST_SELF_T *self,
     const afw_utf8_t * name,
     const afw_utf8_t * value,
     afw_xctx_t *xctx)
 {
-    afw_server_fcgi_internal_request_t *self =
-        (afw_server_fcgi_internal_request_t *)instance;
     int rv;
 
     /* Make sure in correct state then set it. */
@@ -315,13 +308,11 @@ impl_afw_request_write_response_header(
  */
 void
 impl_afw_request_write_raw_response_body(
-    const afw_request_t * instance,
+    AFW_REQUEST_SELF_T *self,
     apr_size_t size,
     const void * buffer,
     afw_xctx_t *xctx)
 {
-    afw_server_fcgi_internal_request_t *self =
-        (afw_server_fcgi_internal_request_t *)instance;
     apr_size_t remaining;
     const char *next;
     int rv;
@@ -368,11 +359,9 @@ impl_afw_request_write_raw_response_body(
  */
 void
 impl_afw_request_flush_response(
-    const afw_request_t * instance,
+    AFW_REQUEST_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_server_fcgi_internal_request_t *self =
-        (afw_server_fcgi_internal_request_t *)instance;
     int rv;
 
     rv = FCGX_FFlush(self->fcgx_request->out);
@@ -389,13 +378,11 @@ impl_afw_request_flush_response(
  */
 void
 impl_afw_request_finish_response(
-    const afw_request_t * instance,
+    AFW_REQUEST_SELF_T *self,
     afw_xctx_t *xctx)
 {
     int rv;
 
-    afw_server_fcgi_internal_request_t *self =
-        (afw_server_fcgi_internal_request_t *)instance;
 
     /* If there was no write_response, write AFW_CRLF. */
     if (self->state < afw_request_state_response_written) {

--- a/src/afw_ubjson/afw_ubjson.c
+++ b/src/afw_ubjson/afw_ubjson.c
@@ -75,7 +75,7 @@ AFW_ENVIRONMENT_DEFINE_EXTENSION_IMPL();
  */
 const afw_extension_t *
 impl_afw_extension_initialize(
-    const afw_extension_t * instance,
+    const afw_extension_t * self,
     const afw_object_t * properties,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
@@ -101,7 +101,7 @@ impl_afw_extension_initialize(
  */
 void
 impl_afw_extension_release(
-    const afw_extension_t * instance,
+    const afw_extension_t * self,
     afw_xctx_t *xctx)
 {
     /* Extension release() is not currently called. */
@@ -113,7 +113,7 @@ impl_afw_extension_release(
  */
 const afw_value_t *
 impl_afw_content_type_raw_to_value(
-    const afw_content_type_t * instance,
+    const afw_content_type_t * self,
     const afw_memory_t * raw,
     const afw_utf8_t * source_location,
     const afw_pool_t * p,
@@ -129,7 +129,7 @@ impl_afw_content_type_raw_to_value(
  */
 const afw_object_t *
 impl_afw_content_type_raw_to_object (
-    const afw_content_type_t * instance,
+    const afw_content_type_t * self,
     const afw_memory_t * raw,
     const afw_utf8_t * source_location,
     const afw_utf8_t * adapter_id,
@@ -150,7 +150,7 @@ impl_afw_content_type_raw_to_object (
  */
 void
 impl_afw_content_type_write_value(
-    const afw_content_type_t * instance,
+    const afw_content_type_t * self,
     const afw_value_t * value,
     const afw_object_options_t *options,
     void * context,
@@ -169,14 +169,14 @@ impl_afw_content_type_write_value(
  */
 const afw_content_type_object_list_writer_t *
 impl_afw_content_type_create_object_list_writer(
-    const afw_content_type_t * instance,
+    const afw_content_type_t * self,
     const afw_object_options_t *options,
     void * context,
     afw_write_cb_t callback,
     const afw_pool_t *p, afw_xctx_t *xctx)
 {
     return afw_content_type_impl_create_object_list_writer(
-        instance, options, context, callback,
+        self, options, context, callback,
         &impl_raw_begin_object_list,
         NULL,
         NULL,

--- a/src/afw_vfs/afw_vfs_adapter.c
+++ b/src/afw_vfs/afw_vfs_adapter.c
@@ -22,6 +22,7 @@
 
 /* Declares and rti/inf defines for interface afw_adapter */
 #define AFW_IMPLEMENTATION_ID "vfs"
+#define AFW_ADAPTER_SELF_T afw_vfs_adapter_internal_t
 #include "afw_adapter_impl_declares.h"
 
 
@@ -265,7 +266,7 @@ afw_vfs_adapter_internal_create_cede_p(
  */
 void
 impl_afw_adapter_destroy(
-    const afw_adapter_t * instance,
+    AFW_ADAPTER_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Memory is owned by the adapter pool; nothing else to release. */
@@ -279,11 +280,9 @@ impl_afw_adapter_destroy(
  */
 const afw_adapter_session_t *
 impl_afw_adapter_create_adapter_session(
-    const afw_adapter_t *instance,
+    AFW_ADAPTER_SELF_T *self,
     afw_xctx_t *xctx)
 {
-    afw_vfs_adapter_internal_t *self =
-        (afw_vfs_adapter_internal_t *)instance;
     const afw_adapter_session_t *session;
 
     /* Create session and return. */
@@ -300,7 +299,7 @@ impl_afw_adapter_create_adapter_session(
  */
 const afw_object_t *
 impl_afw_adapter_get_additional_metrics(
-    const afw_adapter_t * instance,
+    AFW_ADAPTER_SELF_T *self,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
 {

--- a/src/afw_vfs/afw_vfs_adapter_factory.c
+++ b/src/afw_vfs/afw_vfs_adapter_factory.c
@@ -41,7 +41,7 @@ afw_vfs_adapter_factory_vfs =
  */
 const afw_adapter_t *
 impl_afw_adapter_factory_create_adapter_cede_p (
-    const afw_adapter_factory_t * instance,
+    const afw_adapter_factory_t * self,
     const afw_object_t * properties,
     const afw_pool_t * p,
     afw_xctx_t *xctx)

--- a/src/afw_vfs/afw_vfs_adapter_session.c
+++ b/src/afw_vfs/afw_vfs_adapter_session.c
@@ -22,6 +22,7 @@
 
 /* Declares and rti/inf defines for interface afw_adapter_session */
 #define AFW_IMPLEMENTATION_ID "vfs"
+#define AFW_ADAPTER_SESSION_SELF_T afw_vfs_adapter_internal_session_t
 #include "afw_adapter_session_impl_declares.h"
 
 
@@ -722,7 +723,7 @@ afw_vfs_adapter_internal_session_create(
  */
 void
 impl_afw_adapter_session_destroy(
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
     /* Nothing to do. */
@@ -736,7 +737,7 @@ impl_afw_adapter_session_destroy(
  */
 void
 impl_afw_adapter_session_retrieve_objects(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_query_criteria_t *criteria,
@@ -746,8 +747,6 @@ impl_afw_adapter_session_retrieve_objects(
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    afw_vfs_adapter_internal_session_t *self =
-        (afw_vfs_adapter_internal_session_t *)instance;
     const afw_vfs_adapter_internal_t *adapter =
         (const afw_vfs_adapter_internal_t *)self->pub.adapter;
     afw_vfs_adapter_internal_session_context_t ctx;
@@ -887,7 +886,7 @@ impl_afw_adapter_session_retrieve_objects(
  */
 void
 impl_afw_adapter_session_get_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *object_id,
@@ -897,8 +896,6 @@ impl_afw_adapter_session_get_object(
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    afw_vfs_adapter_internal_session_t *self =
-        (afw_vfs_adapter_internal_session_t *)instance;
     const afw_object_t *object;
     const afw_pool_t *object_p;
     const afw_key_z_string_z_t *vfs_entry;
@@ -1186,7 +1183,7 @@ impl_write_data_to_file(
  */
 const afw_utf8_t *
 impl_afw_adapter_session_add_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *suggested_object_id,
@@ -1194,8 +1191,6 @@ impl_afw_adapter_session_add_object(
     const afw_object_t *adapter_type_specific,
     afw_xctx_t *xctx)
 {
-    afw_vfs_adapter_internal_session_t *self =
-        (afw_vfs_adapter_internal_session_t *)instance;
     afw_utf8_utf8_z_t path;
     const afw_value_t *data;
     apr_status_t rv;
@@ -1248,7 +1243,7 @@ impl_afw_adapter_session_add_object(
  */
 void
 impl_afw_adapter_session_modify_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *object_id,
@@ -1256,8 +1251,6 @@ impl_afw_adapter_session_modify_object(
     const afw_object_t *adapter_type_specific,
     afw_xctx_t *xctx)
 {
-    afw_vfs_adapter_internal_session_t *self =
-        (afw_vfs_adapter_internal_session_t *)instance;
     afw_utf8_utf8_z_t path;
     afw_boolean_t is_directory;
     afw_boolean_t valid;
@@ -1327,7 +1320,7 @@ impl_afw_adapter_session_modify_object(
  */
 void
 impl_afw_adapter_session_replace_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *object_id,
@@ -1335,8 +1328,6 @@ impl_afw_adapter_session_replace_object(
     const afw_object_t *adapter_type_specific,
     afw_xctx_t *xctx)
 {
-    afw_vfs_adapter_internal_session_t *self =
-        (afw_vfs_adapter_internal_session_t *)instance;
     afw_utf8_utf8_z_t path;
     const afw_value_t *data;
     afw_boolean_t is_directory;
@@ -1377,15 +1368,13 @@ impl_afw_adapter_session_replace_object(
  */
 void
 impl_afw_adapter_session_delete_object(
-    const afw_adapter_session_t *instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     const afw_adapter_impl_request_t *impl_request,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *object_id,
     const afw_object_t *adapter_type_specific,
     afw_xctx_t *xctx)
 {
-    afw_vfs_adapter_internal_session_t *self =
-        (afw_vfs_adapter_internal_session_t *)instance;
     afw_utf8_utf8_z_t path;
     apr_status_t rv;
     afw_boolean_t is_directory;
@@ -1434,7 +1423,7 @@ impl_afw_adapter_session_delete_object(
  */
 const afw_adapter_transaction_t *
 impl_afw_adapter_session_begin_transaction(
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
     return NULL;
@@ -1448,7 +1437,7 @@ impl_afw_adapter_session_begin_transaction(
  */
 const afw_adapter_journal_t *
 impl_afw_adapter_session_get_journal_interface(
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
     return NULL;
@@ -1462,7 +1451,7 @@ impl_afw_adapter_session_get_journal_interface(
  */
 const afw_adapter_key_value_t *
 impl_afw_adapter_session_get_key_value_interface(
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
     return NULL;
@@ -1476,7 +1465,7 @@ impl_afw_adapter_session_get_key_value_interface(
  */
 const afw_adapter_impl_index_t *
 impl_afw_adapter_session_get_index_interface(
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
     return NULL;
@@ -1490,7 +1479,7 @@ impl_afw_adapter_session_get_index_interface(
  */
 const afw_adapter_object_type_cache_t *
 impl_afw_adapter_session_get_object_type_cache_interface(
-    const afw_adapter_session_t * instance,
+    AFW_ADAPTER_SESSION_SELF_T *self,
     afw_xctx_t *xctx)
 {
     return NULL;

--- a/src/afw_vfs/afw_vfs_extension.c
+++ b/src/afw_vfs/afw_vfs_extension.c
@@ -34,7 +34,7 @@ AFW_ENVIRONMENT_DEFINE_EXTENSION_IMPL();
  */
 const afw_extension_t *
 impl_afw_extension_initialize(
-    const afw_extension_t * instance,
+    const afw_extension_t * self,
     const afw_object_t * properties,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
@@ -50,7 +50,7 @@ impl_afw_extension_initialize(
     /* See function in generated/afw_vfs_generated.c. */
     afw_vfs_generated_register(xctx);
 
-    /* Return extension instance. */
+    /* Return extension self. */
     return &impl_extension;
 }
 
@@ -60,7 +60,7 @@ impl_afw_extension_initialize(
  */
 void
 impl_afw_extension_release(
-    const afw_extension_t * instance,
+    const afw_extension_t * self,
     afw_xctx_t *xctx)
 {
     /* Extension release() is not currently called. */

--- a/src/afw_yaml/afw_yaml.c
+++ b/src/afw_yaml/afw_yaml.c
@@ -104,7 +104,7 @@ AFW_ENVIRONMENT_DEFINE_EXTENSION_IMPL();
  */
 const afw_extension_t *
 impl_afw_extension_initialize(
-    const afw_extension_t * instance,
+    const afw_extension_t * self,
     const afw_object_t * properties,
     const afw_pool_t * p,
     afw_xctx_t *xctx)
@@ -120,7 +120,7 @@ impl_afw_extension_initialize(
     /* Call the register function for this extension. */
     afw_yaml_register(xctx);
 
-    /* Return extension instance. */
+    /* Return extension self. */
     return &impl_extension;
 }
 
@@ -130,7 +130,7 @@ impl_afw_extension_initialize(
  */
 void
 impl_afw_extension_release(
-    const afw_extension_t * instance,
+    const afw_extension_t * self,
     afw_xctx_t *xctx)
 {
 }
@@ -210,7 +210,7 @@ const afw_utf8_t * afw_yaml_from_error(afw_xctx_t *xctx)
  */
 const afw_value_t *
 impl_afw_content_type_raw_to_value(
-    const afw_content_type_t * instance,
+    const afw_content_type_t * self,
     const afw_memory_t * raw,
     const afw_utf8_t * source_location,
     const afw_pool_t * p,
@@ -226,7 +226,7 @@ impl_afw_content_type_raw_to_value(
  */
 const afw_object_t *
 impl_afw_content_type_raw_to_object (
-    const afw_content_type_t * instance,
+    const afw_content_type_t * self,
     const afw_memory_t * raw,
     const afw_utf8_t * source_location,
     const afw_utf8_t * adapter_id,
@@ -247,7 +247,7 @@ impl_afw_content_type_raw_to_object (
  */
 void
 impl_afw_content_type_write_value(
-    const afw_content_type_t * instance,
+    const afw_content_type_t * self,
     const afw_value_t * value,
     const afw_object_options_t *options,
     void * context,
@@ -265,14 +265,14 @@ impl_afw_content_type_write_value(
  */
 const afw_content_type_object_list_writer_t *
 impl_afw_content_type_create_object_list_writer(
-    const afw_content_type_t * instance,
+    const afw_content_type_t * self,
     const afw_object_options_t *options,
     void * context,
     afw_write_cb_t callback,
     const afw_pool_t *p, afw_xctx_t *xctx)
 {
     return afw_content_type_impl_create_object_list_writer(
-        instance, options, context, callback,
+        self, options, context, callback,
         &impl_raw_begin_object_list,
         &impl_raw_object_separator,
         &impl_raw_last_object_separator,


### PR DESCRIPTION
## Summary

- Finish issue #52: convert remaining interface `impl_*` methods to take `AFW_*_SELF_T *self` (or renamed `self` with the default type) instead of casting `instance` on every call.
- Covers core, extensions (ldap/lmdb/vfs/curl/yaml/ubjson/components), `afw` command local host, and `afwfcgi`.
- Forward-declare local self types before `*_impl_declares.h` where needed; keep setter helpers that re-derive the owning object via `self->object` / `self->array`.
- Small clang-scan fix: ensure meta values list/object iterators always have a non-null pool before `afw_pool_calloc_type`.

## Test plan

- [x] `./afwdev build --cdev`
- [x] `./afwdev build --cdev --scan` (0 analyzer bugs)
- [x] `afwdev test -j` (all non-skipped tests passed)
- [ ] Re-check after merge with Jeremy’s `lmdb-transactions` (expect easy resolve in `afw_lmdb_internal.c` transaction release/commit only)

Closes #52