### PR TITLE
feat(#157): experimental advanced-test + afwdev blast

### DIFF
--- a/designs/README.md
+++ b/designs/README.md
@@ -35,7 +35,7 @@ Per-**issue** or per-**theme** working notes: why, options, footguns, parked ide
 | [`array-semantics.md`](array-semantics.md) | **#39** — dense arrays, elision, create_array, out-of-range bracket get |
 | [`conversion-functions.md`](conversion-functions.md) | Type-named converts vs constructors; no null()/function() convert |
 | [`utf8-code-point-sequences.md`](utf8-code-point-sequences.md) | **#153** — utf8-backed values as immutable code-point sequences (index, for-of, array consumers) |
-| [`afwdev-advanced-test.md`](afwdev-advanced-test.md) | **#157** — afwdev `advanced-test` leaves; hermetic `afwfcgi` + FCGI client; feeds **#149** / **#2** stress |
+| [`afwdev-advanced-test.md`](afwdev-advanced-test.md) | **#157** — **experimental** afwdev `advanced-test` leaves; hermetic `afwfcgi` + FCGI client; feeds **#149** / **#2** |
 
 ## Conventions
 

--- a/designs/README.md
+++ b/designs/README.md
@@ -35,6 +35,7 @@ Per-**issue** or per-**theme** working notes: why, options, footguns, parked ide
 | [`array-semantics.md`](array-semantics.md) | **#39** — dense arrays, elision, create_array, out-of-range bracket get |
 | [`conversion-functions.md`](conversion-functions.md) | Type-named converts vs constructors; no null()/function() convert |
 | [`utf8-code-point-sequences.md`](utf8-code-point-sequences.md) | **#153** — utf8-backed values as immutable code-point sequences (index, for-of, array consumers) |
+| [`afwdev-advanced-test.md`](afwdev-advanced-test.md) | **#157** — afwdev `advanced-test` leaves; hermetic `afwfcgi` + FCGI client; feeds **#149** / **#2** stress |
 
 ## Conventions
 

--- a/designs/README.md
+++ b/designs/README.md
@@ -36,6 +36,7 @@ Per-**issue** or per-**theme** working notes: why, options, footguns, parked ide
 | [`conversion-functions.md`](conversion-functions.md) | Type-named converts vs constructors; no null()/function() convert |
 | [`utf8-code-point-sequences.md`](utf8-code-point-sequences.md) | **#153** — utf8-backed values as immutable code-point sequences (index, for-of, array consumers) |
 | [`afwdev-advanced-test.md`](afwdev-advanced-test.md) | **#157** — **experimental** afwdev `advanced-test` leaves; hermetic `afwfcgi` + FCGI client; feeds **#149** / **#2** |
+| [`afwdev-blast.md`](afwdev-blast.md) | **experimental** `afwdev blast` — on-demand random suite firehose at afwfcgi (not `test -j`) |
 
 ## Conventions
 

--- a/designs/afwdev-advanced-test.md
+++ b/designs/afwdev-advanced-test.md
@@ -1,0 +1,417 @@
+# afwdev advanced tests (marker leaves)
+
+**Audience:** maintainers / assistants. **Not** handbook.  
+**Status:** **v1 implemented** on branch `feature-afwfcgi-scenario-tests` (off `mgg-develop`); smoke leaf green; no PR until discussed.  
+**GitHub issue:** [#157](https://github.com/afw-org/afw/issues/157).  
+**Related:** [#2 Memory management](https://github.com/afw-org/afw/issues/2) ([`memory-management.md`](memory-management.md)), [#149 Runtime catalog lifetime](https://github.com/afw-org/afw/issues/149) ([`runtime-catalog-lifetime.md`](runtime-catalog-lifetime.md)).  
+**Depends on:** installed `afwfcgi` / `afw` via `./afwdev build … --install` (e.g. `--cdev` / `--fulldev`).
+
+---
+
+## Product statement
+
+> **Advanced tests** are multi-file, harness-driven tests discovered by a **marker file** in a **leaf directory**.  
+> Under default `afwdev test -j` (`--env-mode afw`), an `afwfcgi` host leaf **starts the installed `afwfcgi`**, drives it with a harness **FastCGI client**, runs ordered **steps**, then **tears down**.  
+> They exercise **process lifetime, conf, adapters, and multi-request** behavior that one-shot `afw` CLI scripts cannot.  
+> They fit Jeremy’s test model: **env-mode** chooses the *environment*; the **marker** is a new *test kind* (like `.py` / `commands_*.txt`), not merely another way to run `.as` files.
+
+---
+
+## Why
+
+| Gap today | Advanced tests |
+|-----------|----------------|
+| `.as` under `afw` | One process per script; weak multi-request / server lifetime |
+| `--env-mode afwfcgi` | Replays `.as` against **already-up** stack; skips custom `afw.conf` |
+| Hand `.py` + `Session("local")` | Flexible but bespoke; not a shared conf+steps fixture pattern |
+
+**Primary consumers after merge:**
+
+1. **#149** — multi-request runtime catalog / registry behavior on a long-lived server process.  
+2. **#2** (umbrella) — long-running value/pool/escape regressions that need repeated eval in one process, optional short concurrency later.  
+3. Conf / extension / service lifecycle that only makes sense with a real `afw_server` host.
+
+**Branch policy:** implement harness on `feature-afwfcgi-scenario-tests` → merge to `mgg-develop` → **rebase** `issue-#149-runtime-catalog-lifetime` and add catalog scenarios there (no afwdev runner work on #149).
+
+---
+
+## Jeremy’s model (do not break)
+
+From `src/afw_dev/_afwdev/test/test.py` and `common.run_test` dispatch:
+
+| Concept | Meaning | Today |
+|---------|---------|--------|
+| **`--env-mode`** | Which **environment** runs compatible tests | `afw`, `valgrind`, `afwfcgi`, `actions` |
+| **Artifact → mode** | Path forces runner; ignores env-mode | `.py` → `python`, `commands_*.txt` → `commands` |
+| **`afwfcgi` env-mode** | Live HTTP stack (`http://localhost:8080/afw`); no spawn; skip custom conf for `.as` | `modes/afwfcgi.py` |
+
+**Advanced tests** join the **artifact** family: marker present → scenario runner.  
+Env-mode still **modulates** how that runner attaches (hermetic vs live vs valgrind).
+
+---
+
+## Decisions (frozen)
+
+### 1. Marker basename and formats
+
+| | |
+|--|--|
+| **Stem** | `advanced-test` |
+| **Files** | `advanced-test.yaml` and/or `advanced-test.json` |
+| **Both present** | **Error** (ambiguous) |
+| **Parser** | YAML via **PyYAML `safe_load`**; JSON via stdlib |
+| **Dependency** | **Require PyYAML** in project Python requirements (do not rely on ambient install alone) |
+
+Prefer **YAML** in examples and smoke leaves (comments, multi-line scripts). JSON is the same object model for authors who want it.
+
+Harness parses markers in **Python**. Do **not** use Adaptive content types / `afw_yaml` to read the marker (different layer). Fixture *data* may still be YAML/JSON Adaptive objects once the server is up.
+
+### 2. Discriminant: `host`
+
+```yaml
+host: afwfcgi    # required in v1
+```
+
+| Rule | Choice |
+|------|--------|
+| Field name | **`host`** |
+| v1 allowed value | **`afwfcgi` only** |
+| Missing `host` | **Error** (self-describing leaves; no silent default) |
+| Unknown `host` | **Error** |
+| Future | `afw-local` (and others) with their own fixture contracts — same marker name |
+
+Optional host-specific block (ignored keys under wrong host = error or warn; v1: only read `afwfcgi:` when `host: afwfcgi`):
+
+```yaml
+host: afwfcgi
+afwfcgi:
+  threads: 1          # maps to afwfcgi -n; default 1
+```
+
+### 3. Env-mode matrix (marker leaves)
+
+| `--env-mode` | Marker leaf behavior |
+|--------------|----------------------|
+| **`afw`** (default) | **Run hermetic:** spawn installed `afwfcgi` + **FCGI client** + leaf conf |
+| **`afwfcgi`** | **Same policy as today’s mode for custom stacks:** do **not** spawn; use live base URL **`http://localhost:8080/afw`** (whatever `modes/afwfcgi.py` uses **now**). If that mode later gains `--server-url` or similar, markers follow it. Leaves that need a **private** conf/process are **skipped** (debug reason), analogous to skipping `.as` with local `afw.conf`. |
+| **`valgrind`** | **Prefer implement if not too hard:** spawn `valgrind` + same suppressions style as CLI valgrind mode + **`afwfcgi`**, traffic via FCGI client; treat valgrind XML/`<error>` as leaf failure. **Hold off in first PR** if it delays the smoke vertical—but keep the hook obvious (`hosts/afwfcgi.py` spawn argv builder) so #2 can rely on it soon. Until then **skip** markers under valgrind with a clear debug reason. |
+| **`actions`** | **Skip** markers (local Session is not this kind). |
+| **Forced** `python` / `commands` | Unchanged; markers never go through those paths. |
+
+Ordinary `.as` / `.py` behavior **unchanged**.
+
+### 4. Live URL / nginx
+
+- **Not** a per-leaf `transport: nginx` for normal commit runs.  
+- Live front door = **`--env-mode afwfcgi`** only for now (hardcoded URL as today).  
+- Custom FCGI client is the **default** path for `afwdev test -j`.  
+- Direct FCGI client replaces **nginx as FastCGI peer only**; **`afwfcgi` + `afw.conf` are the same** either way.  
+- `request::` fidelity vs real nginx params is a **live / later** concern, not v1 blocker.
+
+### 5. Discovery: leaf semantics
+
+```text
+os.walk(tests/)
+  skip environments/, _*
+  if dir contains advanced-test.yaml|json:
+    → exactly ONE test (the marker path)
+    → do NOT discover .as/.py/commands as separate tests inside this tree
+    → do NOT walk children for more test groups / markers
+    → nested advanced-test under a leaf → ERROR
+  else:
+    → existing discovery
+```
+
+Parents may nest freely for organization (`tests/runtime/catalog/multi-request/advanced-test.yaml`).
+
+### 6. Fixture contract (`host: afwfcgi`)
+
+| Path | Role |
+|------|------|
+| **`advanced-test.yaml`** (or `.json`) | Instructions (required) |
+| **`afw.conf`** | Required — server conf (`-f`) |
+| **`config/`**, **`objects/`**, other files | Optional assets; copied into work dir like today’s group copy |
+| Sibling `*.as` | Optional **step scripts**, not independent tests |
+
+Work dir: same pattern as current test environments (copy leaf → temp work dir under runner prefix).  
+Socket: **Unix domain socket under work dir** (parallel-safe for `-j`).  
+Binary: **`afwfcgi` on PATH** from install (`./afwdev build` with `--install`).
+
+### 7. Schema (simple, powerful enough)
+
+Inspired by common integration styles (ordered steps, fixture dir = env, one scenario = one result): **setup is the directory**, **behavior is an ordered list of steps**, **teardown is harness-owned**.
+
+#### Minimal v1 document
+
+```yaml
+# advanced-test.yaml
+host: afwfcgi
+description: Short summary for --list / failure headers
+
+# optional
+timeout_s: 120              # whole leaf; harness default if omitted (e.g. 60)
+
+afwfcgi:
+  threads: 1                # optional; default 1
+
+steps:
+  - name: smoke eval
+    eval: |
+      assert(true);
+      return true;
+
+  - name: script file
+    script: step_catalog.as   # relative to leaf; often #! … --syntax test_script
+```
+
+#### Step kinds (v1)
+
+| Field | Meaning |
+|-------|---------|
+| **`name`** | Required. Used in failure output. |
+| **`eval`** | Inline Adaptive Script source (mutually exclusive with `script`) |
+| **`script`** | Path relative to leaf to a `.as` file (mutually exclusive with `eval`) |
+
+Exactly one of `eval` / `script` per step in v1.
+
+#### Success rules (v1)
+
+| Situation | Pass step? |
+|-----------|------------|
+| FCGI/server error, timeout, non-success transport | **Fail** leaf |
+| `eval` / non–test_script script: completed without thrown error | **Pass** step |
+| `script` with `--syntax test_script`: parse result like CLI mode; **any** embedded test `passed: false` → **Fail** leaf | |
+| First failing step | **Stop** (fail-fast); remaining steps not run |
+
+#### Result grain
+
+- **One leaf → one pass/fail** in suite counts / default summary.  
+- Failure detail **must** name the step and include useful server/harness stderr.  
+- Per-step sub-results in the JSON summary are **optional later** if useful; not required for v1.
+
+#### Explicitly deferred in schema
+
+- `expect:` deep matchers / JSONPath  
+- Variables passed between steps  
+- `parallel` / `stress` step kinds  
+- HTTP method/path REST steps (can add when needed; eval covers most Adaptive API checks)  
+- `before` / `after` hooks beyond process lifecycle  
+
+Grow syntax when a real scenario demands it (#149 / #2 will teach us).
+
+### 8. Process lifecycle
+
+1. Allocate work dir; copy leaf.  
+2. Start: `afwfcgi -f afw.conf -p <work_dir>/afw.sock -n <threads>` (plus any fixed harness needs).  
+3. Health: connect/accept readiness with timeout.  
+4. Run steps in order via **FCGI client** (params sufficient for director / eval path; document minimal param set in implementation).  
+5. Always teardown: signal process group, wait, force kill, remove socket.  
+6. Missing `afwfcgi` on PATH → **fail** with install hint (do not silent-skip on default mode).
+
+### 9. FCGI client
+
+- **In-tree** thin client (stdlib sockets + FastCGI records) preferred over abandoned deps; optional tiny vendor only if justified.  
+- Sets FCGI params + stdin; reads stdout to completion.  
+- Concurrent clients **later** (stress); v1 sequential steps are enough.
+
+#### Default FCGI params (nginx reference parity)
+
+Mirror the **reference** FastCGI front door used with afwfcgi: dev **`/afw/nginx.conf`**, docker **`docker/images/afw-admin/nginx.conf`** / **`docker/images/afw/etc/nginx/nginx.conf`**. The client is not nginx, but **default params should match what we pass today** so `request::` / request-property behavior is close for normal steps. Steps may **override** individual params later if needed.
+
+| Param | Hermetic default (sensible stand-in) | nginx source |
+|-------|--------------------------------------|--------------|
+| `IGNORE_URI_PREFIX` | `/` | fixed in conf |
+| `URI` | request path (e.g. eval/perform path the harness uses) | `$uri` |
+| `QUERY_STRING` | `""` or step query | `$query_string` |
+| `REQUEST_METHOD` | `POST` for eval/body steps; overridable | `$request_method` |
+| `CONTENT_TYPE` | as needed for body (e.g. JSON) | `$content_type` |
+| `CONTENT_LENGTH` | len(body) | `$content_length` |
+| `SCRIPT_FILENAME` | `""` or placeholder | `$document_root$fastcgi_script_name` |
+| `SCRIPT_NAME` | `""` | `$fastcgi_script_name` |
+| `PATH_INFO` | `""` | `$fastcgi_path_info` |
+| `PATH_TRANSLATED` | `""` | `$document_root$fastcgi_path_info` |
+| `REQUEST_URI` | same as path + optional query | `$request_uri` |
+| `DOCUMENT_URI` | path | `$document_uri` |
+| `DOCUMENT_ROOT` | work dir or `""` | `$document_root` |
+| `SERVER_PROTOCOL` | `HTTP/1.1` | `$server_protocol` |
+| `GATEWAY_INTERFACE` | `CGI/1.1` | fixed |
+| `SERVER_SOFTWARE` | `afwdev-fcgi-client/1` (not `nginx/…`) | `$nginx_version` in real nginx |
+| `REMOTE_ADDR` | `127.0.0.1` | `$remote_addr` |
+| `REMOTE_PORT` | `0` or ephemeral stand-in | `$remote_port` |
+| `SERVER_ADDR` | `127.0.0.1` | `$server_addr` |
+| `SERVER_PORT` | `0` or `8080` stand-in | `$server_port` |
+| `SERVER_NAME` | `localhost` | `$server_name` |
+| `HTTPS` | `""` | `$https` |
+| `SCHEME` | `http` | `$scheme` |
+| `TIME_ISO8601` | harness UTC now ISO-8601 | `$time_iso8601` |
+| `REDIRECT_STATUS` | `200` | fixed in conf |
+
+**HTTP_*** headers:** set when a step needs them (e.g. `HTTP_ACCEPT`, `HTTP_CONTENT_TYPE` if used); not all required for smoke eval. Live `--env-mode afwfcgi` still goes through real nginx and real header mapping.
+
+Implementation: one shared dict builder `default_fcgi_params(path, method, body, overrides=)` used by every step.
+
+### 10. v1 implementation cut line
+
+| In first useful merge | Later |
+|-----------------------|--------|
+| Discovery + leaf prune + list | `host: afw-local` |
+| YAML + JSON load; require PyYAML | Rich `expect` language |
+| `host: afwfcgi` + fixture checks | **Stress / parallel steps** (critical for **#2**) |
+| Spawn/stop installed `afwfcgi`, Unix socket | **Observability** under load (#2) — see below |
+| FCGI client + nginx-parity default params | Param override per step (if not free with overrides dict) |
+| Sequential `eval` / `script` steps | `--server-url` (unless env-mode gains it first) |
+| Env-mode matrix above | Full nginx integration as harness-spawned front door |
+| **Valgrind-on-afwfcgi if low cost**; else skip + hook | Valgrind if deferred |
+| At least **one smoke leaf** under `src/afw/tests/` | #149 / #2 real scenarios (on those branches after rebase) |
+| Default `afwdev test -j` runs markers | Heavy soak profiles / tags |
+
+**As much as makes sense in one feature branch:** prefer a **complete thin vertical** (discover → run smoke → teardown) over half of stress/valgrind/local.
+
+### 11. Suite integration
+
+- Part of **normal** `afwdev test` / `afwdev test -j` — no extra flag to enable.  
+- `--test-pattern` matches marker path or leaf dir name.  
+- `--tags` via optional sibling `config.py` **or** optional `tags:` in marker later; v1 can use `config.py` Tags if already loaded for that dir—or skip tags until needed.  
+- Parallel `-j`: one marker leaf = one group unit (one server process), same as today’s group isolation.
+
+### 12. Documentation
+
+| Doc | Role |
+|-----|------|
+| **This pad** | Design + decisions |
+| **Smoke leaf** | Living example |
+| **afwdev help / short developer note** | How to add a leaf (after or with implementation) |
+| **`designs/README.md`** | Index entry |
+
+---
+
+## Example smoke leaf (illustrative)
+
+```text
+src/afw/tests/advanced/smoke/
+  advanced-test.yaml
+  afw.conf
+```
+
+```yaml
+host: afwfcgi
+description: Spawn afwfcgi and eval a trivial script
+
+steps:
+  - name: return true
+    eval: |
+      return true;
+```
+
+`afw.conf` must define enough `requestHandler` / application surface for the harness’s eval (or perform) path—mirror a **minimal** slice of `/afw` conf, not the full dev app.
+
+---
+
+## Future use: #149 and #2
+
+These are **why** the harness exists; scenarios land **after** harness merges (and #149 rebases). Design the runner so #2 stress and observation are **extensions**, not a rewrite.
+
+### #149 — runtime catalog lifetime
+
+Ideas for leaves (not implemented on the harness branch):
+
+- Multiple sequential evals/gets against `/afw/_AdaptiveEnvironmentRegistry_/…` or catalog retrieves in **one** process.  
+- Compare “first request vs Nth request” correctness (and later memory signals).  
+- Leaf-local conf + minimal adapters — not the full live `/afw` admin app.
+
+See [`runtime-catalog-lifetime.md`](runtime-catalog-lifetime.md).
+
+### #2 — memory management (umbrella) — stress + observe
+
+**Stress will be a large part of #2 validation.** v1 only needs sequential multi-request; the schema and process model must leave room for:
+
+| Direction | Notes |
+|-----------|--------|
+| **Parallel / burst steps** | `concurrency`, `repeat`, hard `max_seconds`; client fan-out + `afwfcgi.threads` |
+| **Soak profiles** | Longer runs opt-in (tags / flag) so default `afwdev test -j` stays a commit gate |
+| **Valgrind on `afwfcgi`** | Catch definite leaks/invalid access across many requests in one process |
+| **Observability** | See below — “are we screwing up memory management?” needs more than pass/fail |
+
+#### Observability (design intent — evolve with #2)
+
+We should figure out **what is worth observing** so advanced leaves can fail or warn when lifetime/pools go wrong—not only when Adaptive returns a wrong value. Candidates (research during #2; not all v1):
+
+| Signal | Possible source | Use |
+|--------|-----------------|-----|
+| Valgrind errors | `--env-mode valgrind` + XML | Hard fail |
+| Process RSS / growth over N requests | `/proc`, `resource`, or sampling around steps | Soft bound in stress leaves (“RSS must not grow unbounded”) |
+| Request/pool metrics already exposed | Adaptive runtime / admin / debug objects if any | Assert stable or non-increasing where product defines |
+| afwfcgi stderr patterns | harness capture | Unexpected fatal / assert |
+| Step latency distribution | harness timers under stress | Catch pathological slowdown (often allocation thrash) |
+| Graceful teardown | process exit code after SIGTERM | Pools released; no hang |
+
+**Principle:** prefer **signals the product already exposes** or **standard process tools** over inventing a second memory debugger inside Adaptive. When #2 defines invariants (“after M evals, metric X ≤ bound”), advanced-test is the place to encode them as steps or leaf-level checks.
+
+Harness may later support optional leaf fields like `observe: { rss_max_mb, … }` or post-step hooks—**do not invent the full language in v1**; keep stderr, timing, and exit status available first.
+
+See [`memory-management.md`](memory-management.md).
+
+### Stress (parked detail, high priority after vertical)
+
+- Step kind or leaf profile: `concurrency` / `repeat` / time cap.  
+- Default `-j`: tiny bursts only if any; intensive soaks behind tags/flags.  
+- Always one server process per leaf (isolation); stress is **in-process request concurrency**, not cross-leaf.
+
+---
+
+## Non-goals
+
+- Replacing all `.as` tests or generated function suites with advanced leaves  
+- Harness starting full `/afw` nginx+apps for every test  
+- Parsing markers with running AFW  
+- Implementing #149/#2 product fixes on the harness branch  
+
+---
+
+## Implementation sketch (for implementers)
+
+```text
+_afwdev/test/
+  common.py          # discovery: advanced-test leaf; prune; dispatch
+  advanced/          # or scenario/
+    load.py          # yaml/json → dict; validate schema
+    runner.py        # lifecycle + step loop
+    fcgi_client.py   # thin FastCGI client
+    hosts/
+      afwfcgi.py     # spawn args, health, env-mode variants
+  modes/
+    afw.py           # unchanged for .as; markers not routed here if dispatch is earlier
+    afwfcgi.py       # live URL shared helper for .as + live-ok markers
+    valgrind.py      # skip or wrap afwfcgi
+```
+
+Dispatch should treat marker paths **before** env-mode module selection (same pattern as `.py`), then pass `options['mode']` into the advanced runner for attach policy.
+
+---
+
+## Open only if implementation forces it
+
+- Exact **URI / body envelope** for eval/perform—**match what already works** against live afwfcgi for `.as` (`eval_script` / Session). Default **FCGI params** are specified above from nginx reference.  
+- Default `timeout_s` number (start with 60–120s; adjust for CI).  
+- Valgrind in first PR vs skip-with-hook (prefer implement if small; do not block smoke).  
+- Which #2 metrics are stable enough to assert (decide on #2 work, not guess here).
+
+---
+
+## Checklist
+
+- [x] Marker name `advanced-test`  
+- [x] `host` discriminant; v1 `afwfcgi`  
+- [x] Env-mode matrix  
+- [x] Live = current `afwfcgi` mode URL behavior  
+- [x] Schema sketch + one pass/fail per leaf  
+- [x] Installed binary; Unix socket; work dir copy  
+- [x] PyYAML required  
+- [x] Part of normal `afwdev test -j`  
+- [x] #149 / #2 + stress/observability called out  
+- [x] Nginx-parity FCGI default params  
+- [x] GitHub issue [#157](https://github.com/afw-org/afw/issues/157)  
+- [x] Implement vertical + smoke leaf (`src/afw/tests/advanced/smoke/`)  
+- [x] Valgrind-on-afwfcgi (spawn hook + works under `--env-mode valgrind`)  
+- [ ] Merge → rebase #149 → catalog scenarios  
+- [ ] #2 stress + observe extensions  

--- a/designs/afwdev-advanced-test.md
+++ b/designs/afwdev-advanced-test.md
@@ -50,6 +50,13 @@ When the shape settles, drop the experimental banner and promote invariants into
 
 **Branch policy:** implement harness on `feature-afwfcgi-scenario-tests` → merge to `mgg-develop` → **rebase** `issue-#149-runtime-catalog-lifetime` and add catalog scenarios there (no afwdev runner work on #149).
 
+### Handoff / sibling sessions (2026-08)
+
+- This work was **intentionally split** from the **#149 runtime catalog** Grok session so that branch’s context (live afwfcgi poking, env/registry mental model) stayed unpolluted.
+- **#149 session** owns product/reliability for catalogs/accessors; **this branch** owns experimental **afwdev test advanced-test** + **`afwdev blast`**.
+- After PR merges: on `issue-#149-runtime-catalog-lifetime`, rebase onto updated `mgg-develop`, then add **purpose-built advanced-test leaves** for multi-request catalog behavior; use **`afwdev blast`** for load/crash hunts (not as the #149 correctness suite).
+- On-demand load design pad: [`afwdev-blast.md`](afwdev-blast.md). afwfcgi SIGTERM: **#158**.
+
 ---
 
 ## Jeremy’s model (do not break)

--- a/designs/afwdev-advanced-test.md
+++ b/designs/afwdev-advanced-test.md
@@ -1,10 +1,27 @@
 # afwdev advanced tests (marker leaves)
 
 **Audience:** maintainers / assistants. **Not** handbook.  
-**Status:** **v1 implemented** on branch `feature-afwfcgi-scenario-tests` (off `mgg-develop`); smoke leaf green; no PR until discussed.  
+**Status:** **\*\*\* Experimental \*\*\*** — implemented and usable for comment; **not** a frozen green contract.  
 **GitHub issue:** [#157](https://github.com/afw-org/afw/issues/157).  
+**Branch:** `feature-afwfcgi-scenario-tests` (off `mgg-develop`).  
 **Related:** [#2 Memory management](https://github.com/afw-org/afw/issues/2) ([`memory-management.md`](memory-management.md)), [#149 Runtime catalog lifetime](https://github.com/afw-org/afw/issues/149) ([`runtime-catalog-lifetime.md`](runtime-catalog-lifetime.md)).  
 **Depends on:** installed `afwfcgi` / `afw` via `./afwdev build … --install` (e.g. `--cdev` / `--fulldev`).
+
+---
+
+## \*\*\* Experimental \*\*\*
+
+This feature is **out for comment and real use**, not a promise of long-term stability of names, schema, or behavior.
+
+| Expect | Do not expect (yet) |
+|--------|---------------------|
+| Useful hermetic multi-request / `afwfcgi` regression leaves today | Marker name, YAML fields, or runner semantics frozen forever |
+| Many early decisions to **stick** (leaf discovery, `host`, FCGI client default, env-mode split) | No breaking tweaks over the next few months |
+| Growth driven by **#149**, **#2**, and whoever tries it | “Green” handbook-grade API and support story |
+
+**Feedback welcome** on issue **#157** and PRs. If you invest in many leaves, prefer the *ideas* (hermetic server, multi-step, fixture dir) over coupling to every field name—we may reshape surfaces as we learn.
+
+When the shape settles, drop the experimental banner and promote invariants into afwdev help / developer notes.
 
 ---
 

--- a/designs/afwdev-advanced-test.md
+++ b/designs/afwdev-advanced-test.md
@@ -295,9 +295,9 @@ Implementation: one shared dict builder `default_fcgi_params(path, method, body,
 
 | Doc | Role |
 |-----|------|
-| **This pad** | Design + decisions |
-| **Smoke leaf** | Living example |
-| **afwdev help / short developer note** | How to add a leaf (after or with implementation) |
+| **This pad** | Design + decisions (experimental) |
+| **Smoke / showcase leaves** | Living examples under `src/afw/tests/advanced/` |
+| **`src/afw/doc/developer/writing-tests.md`** | Builder-facing how-to (test_script first; advanced-test section experimental) |
 | **`designs/README.md`** | Index entry |
 
 ---

--- a/designs/afwdev-blast.md
+++ b/designs/afwdev-blast.md
@@ -1,0 +1,72 @@
+# afwdev blast (experimental)
+
+**Status:** **\*\*\* Experimental \*\*\***  
+**Audience:** maintainers debugging runtime / afwfcgi under load.  
+**Related:** [#157](https://github.com/afw-org/afw/issues/157) advanced-test, [#158](https://github.com/afw-org/afw/issues/158) afwfcgi signals.
+
+## Product split
+
+| Command | Job | Default `-j` gate? |
+|---------|-----|--------------------|
+| **`afwdev test`** | Jeremy language/package suite + tiny advanced-test multi-request | **Yes** |
+| **`afwdev blast`** | On-demand random suite firehose at **afwfcgi** | **No** |
+
+## Usage
+
+```bash
+# Typical docker/dev: nginx + afwfcgi already up — all defaults
+afwdev blast
+
+# Same idea, short aliases
+afwdev blast -d 30m -c 16
+afwdev blast -u http://localhost:8080/afw -d 1h
+
+# Managed — spawn installed afwfcgi from conf (-f like afw)
+afwdev blast -f path/to/afw.conf -m 500
+
+# Focus corpus (same filters as test)
+afwdev blast -d 10m -p afw --test-pattern 'file_adapter/|rql/'
+```
+
+### Defaults (plain `afwdev blast`)
+
+| Option | Default |
+|--------|---------|
+| Target | **attach** `http://localhost:8080/afw` (unless `-f`/`--conf`) |
+| `--duration` / `-d` | **5m** (`0` = no time limit; then need `-m`) |
+| `--concurrency` / `-c` | **CPU count** (`0` = auto) |
+| `--threads` / `-n` | **CPU count** when managed (`0` = auto) |
+| Corpus filters | same as `test` (all matching srcdirs / `.*` tags) |
+
+### Short aliases
+
+| Long | Short |
+|------|-------|
+| `--url` | `-u` |
+| `--conf` | `-f` |
+| `--duration` | `-d` |
+| `--max-requests` | `-m` |
+| `--concurrency` | `-c` |
+| `--threads` | `-n` |
+| `--srcdir-pattern` | `-p` (shared with other subcommands) |
+
+Optional: personal shortcuts via **`afwdev task`** (`tasks` in afwdev-settings.json) if you want named recipes beyond defaults.
+
+## Behavior
+
+- Corpus: `.as` test_scripts from package `tests/` (not advanced-test markers, not `.py`)
+- Attach: skip tests whose directory has local `afw.conf` (same spirit as live test mode)
+- Pick: **random** with replacement
+- Adaptive fail: **continue**; count fail
+- Server dead / unreachable: **stop**; exit 2
+- Any fails at end: exit 1
+- Console progress lines + recent failures summary
+- Ctrl+C: stop sending; managed mode tears down spawn; attach does **not** kill your afwfcgi
+
+## Implementation
+
+- CLI: `cli/info.py` `_info_blast`, handler `subcommand_blast`, registry
+- Logic: `_afwdev/blast/blast.py`
+- Reuse: test discovery/tags, advanced FCGI client + afwfcgi host spawn
+
+afwfcgi graceful SIGTERM: track **#158**.

--- a/designs/afwdev-blast.md
+++ b/designs/afwdev-blast.md
@@ -18,8 +18,8 @@
 afwdev blast
 
 # Same idea, short aliases
-afwdev blast -d 30m -c 16
-afwdev blast -u http://localhost:8080/afw -d 1h
+afwdev blast -d 30m              # still 2×CPU concurrency by default
+afwdev blast -d 1h -c 16         # override concurrency
 
 # Managed — spawn installed afwfcgi from conf (-f like afw)
 afwdev blast -f path/to/afw.conf -m 500
@@ -34,9 +34,24 @@ afwdev blast -d 10m -p afw --test-pattern 'file_adapter/|rql/'
 |--------|---------|
 | Target | **attach** `http://localhost:8080/afw` (unless `-f`/`--conf`) |
 | `--duration` / `-d` | **5m** (`0` = no time limit; then need `-m`) |
-| `--concurrency` / `-c` | **CPU count** (`0` = auto) |
-| `--threads` / `-n` | **CPU count** when managed (`0` = auto) |
-| Corpus filters | same as `test` (all matching srcdirs / `.*` tags) |
+| `--concurrency` / `-c` | **2×CPU count** (`0` = auto; historical gobench-style) |
+| `--threads` / `-n` | **CPU count** when managed (`0` = auto); attach: set afwfcgi `-n` yourself |
+| Corpus filters | same as `test`; **skip fixture groups** by default |
+| Fixtures | skip `Environment=` / `afw.conf` unless `--include-fixtures` |
+
+### Load diagnosis (later — avoid wheel-spinning)
+
+Distinguish **too fast / overloaded** vs **real product failure**:
+
+| Signal | Suggests |
+|--------|----------|
+| Timeouts rise with `-c`, vanish at low `-c` | Capacity / client timeout, not wrong expects |
+| test_script fails at low `-c` too | Functional bug (suite usually already caught) |
+| `err` / process death | Hard server bug |
+| Latency p50/p99 climb over a long run | Queueing, leak, or progressive slowdown (#2 interest) |
+| afwfcgi accept/active/in-flight gauges | Server-side overload vs client impatience |
+
+Possible additions (not required for first PR): separate **timeout** vs **expect** counters; optional latency histogram on progress line; blast `--fail-log path`; Adaptive/runtime **request metrics** on afwfcgi for in-flight and queue depth.
 
 ### Short aliases
 
@@ -55,12 +70,15 @@ Optional: personal shortcuts via **`afwdev task`** (`tasks` in afwdev-settings.j
 ## Behavior
 
 - Corpus: `.as` test_scripts from package `tests/` (not advanced-test markers, not `.py`)
-- Attach: skip tests whose directory has local `afw.conf` (same spirit as live test mode)
+- **Default skip fixtures** so a normal blast is “server healthy under load,” not “suite expects private conf”:
+  - group `config.py` with **`Environment = "..."`** (shared `tests/environments/`)
+  - group-level or nearby **`afw.conf`**
+  - opt in with **`--include-fixtures`** when you intentionally blast adapter/env tests
 - Pick: **random** with replacement
-- Adaptive fail: **continue**; count fail
+- Adaptive fail: **continue**; count fail (expect **near-zero** without `--include-fixtures`)
 - Server dead / unreachable: **stop**; exit 2
 - Any fails at end: exit 1
-- Console progress lines + recent failures summary
+- Console progress lines + recent failures summary; reports `skipped_fixture=N`
 - Ctrl+C: stop sending; managed mode tears down spawn; attach does **not** kill your afwfcgi
 
 ## Implementation

--- a/designs/afwdev-blast.md
+++ b/designs/afwdev-blast.md
@@ -2,7 +2,9 @@
 
 **Status:** **\*\*\* Experimental \*\*\***  
 **Audience:** maintainers debugging runtime / afwfcgi under load.  
-**Related:** [#157](https://github.com/afw-org/afw/issues/157) advanced-test, [#158](https://github.com/afw-org/afw/issues/158) afwfcgi signals.
+**Related:** [#157](https://github.com/afw-org/afw/issues/157) advanced-test, [#158](https://github.com/afw-org/afw/issues/158) afwfcgi signals.  
+**Branch:** `feature-afwfcgi-scenario-tests` (with advanced-test).  
+**Sibling:** #149 catalog work was explored in a **separate Grok session** on `issue-#149-runtime-catalog-lifetime`; merge this harness first, then use blast + advanced leaves there.
 
 ## Product split
 

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -3,5 +3,6 @@ inflection
 jsonschema
 lxml
 marko
+PyYAML
 requests
 watchdog

--- a/src/afw/doc/developer/extending.md
+++ b/src/afw/doc/developer/extending.md
@@ -58,6 +58,7 @@ impls from `add-adapter-type` skeletons.
 ## Related
 
 - @ref afw_dev_implementing  
+- @ref afw_dev_writing_tests  
 - @ref afw_included_extensions  
 - Extension layout notes in `.cursor/rules/afw-extensions.mdc`  
 - Public map header: `src/afw_curl/afw_curl.h`  

--- a/src/afw/doc/developer/overview.md
+++ b/src/afw/doc/developer/overview.md
@@ -55,6 +55,7 @@ HTML look (light/dark slate skin): `src/afw/doc/doxygen-extra.css` — see
 - @ref afw_dev_interfaces — macros, XML, generation  
 - @ref afw_dev_implementing — afwdev make/add, skeletons, impl_declares  
 - @ref afw_dev_extending — end-to-end extension sketch  
+- @ref afw_dev_writing_tests — adding regressions for `afwdev test`  
 - @ref afw_dev_runtime — pool, value, xctx, environment pointers  
 - @ref afw_dev_types_opaques — `afw_*_t` vs multi-layout values  
 - @ref afw_dev_compiler_ebnf — grammar comments / EBNF harvest (compiler only)  

--- a/src/afw/doc/developer/writing-tests.md
+++ b/src/afw/doc/developer/writing-tests.md
@@ -1,0 +1,216 @@
+Writing tests {#afw_dev_writing_tests}
+=============
+
+@brief How a developer adds tests that `afwdev test` will run.
+
+## Audience
+
+Package, extension, and core authors who need a **regression** for behavior
+they care about. This is not a full Adaptive Script tutorial.
+
+## Where tests live
+
+Under each source directory:
+
+```text
+src/<srcdir>/tests/
+  some_group/           # ordinary test group (one or more files)
+    foo.as
+    bar.as
+    afw.conf            # optional; used when the group needs conf
+    objects/            # optional fixtures
+    config.py           # optional Tags, Environment, before/after hooks
+  environments/         # optional shared fixtures (named; see config.py)
+    models/
+      afw.conf
+      …
+```
+
+`afwdev test` walks `src/*/tests/` (filtered by `--srcdir-pattern` /
+`--test-pattern`). A **group** is usually a directory of related files that
+should not be split across parallel workers when they share conf or data.
+
+## Day-to-day loop
+
+```bash
+# From package root — after code/generate changes
+./afwdev build --cdev -j
+
+# Run tests (installed afw / afwfcgi on PATH)
+afwdev test -j
+afwdev test --srcdir-pattern afw --test-pattern 'rql/.*'
+afwdev test --list --test-pattern smoke
+```
+
+Use `./afwdev` when the build must refresh `afwdev` itself; use `afwdev` on
+PATH afterward for `test`, `validate`, and similar.
+
+## Choose a test kind
+
+| Kind | When to use |
+|------|-------------|
+| **Adaptive test script** (`.as`, `--syntax test_script`) | Default. Language, functions, adapters under optional `afw.conf`. |
+| **Python** (`.py` with `run()`) | Need host process control, raw env octets, bindings that are awkward in script. |
+| **`commands_*.txt`** | Drive shell-ish command sequences (special runner). |
+| **Advanced-test leaf** | Multi-request / long-lived **`afwfcgi`** process with leaf conf. **Experimental** — see below. |
+
+Prefer a **test_script** unless you need process lifetime, a private server, or
+host-only APIs.
+
+## Adaptive test scripts
+
+### Skeleton
+
+```adaptive
+#!/usr/bin/env -S afw --syntax test_script
+//? testScript: example.as
+//? description: What this file covers
+//? sourceType: script
+//?
+//? test: case-1
+//? description: short case title
+//? expect: true
+//? source: ...
+
+return true;
+
+//?
+//? test: case-2
+//? description: another case
+//? expect: 0
+//? source: ...
+
+// body …
+return 0;
+```
+
+Notes:
+
+- Shebang must mention **`afw`** and **`test_script`** (as above or
+  `afw --syntax test_script`).  
+- Metadata lines start with **`//?`**. Keys such as `test`, `description`,
+  `expect`, `source`, `skip` are the common ones.  
+- After `//? source: ...`, the body runs until the next `//?` block or EOF.  
+- The runner compares the evaluation result to **`expect`** (Adaptive value
+  syntax). Failures are reported per `test:` case.  
+- Study working files under `src/afw/tests/` (for example
+  `src/afw/tests/language/script/try.as`).
+
+Exact line grammar for test scripts lives in the compiler
+(`afw_compile_parse_script.c` EBNF comments). Prefer copying a nearby test
+over inventing a new metadata dialect.
+
+### Conf and fixtures
+
+If the script needs adapters or other conf:
+
+- Put **`afw.conf`** in the same directory (or use a shared
+  `tests/environments/<name>/` and set `Environment` in `config.py`).  
+- Default **`--env-mode afw`** runs `afw` with that conf when the group
+  provides it.  
+- Keep fixtures small and hermetic; `afwdev test` copies group files into a
+  temp work directory.
+
+### Optional `config.py`
+
+A group may define:
+
+- **`Tags`** — list of strings; `afwdev test --tags <regex>` filters groups.  
+- **`Environment`** — name of a directory under `tests/environments/`.  
+- **`before_all` / `after_all` / `before_each` / `after_each`** — hooks.
+
+See existing `config.py` files under `src/afw/tests/` for patterns.
+
+## How `afwdev test` runs things (`--env-mode`)
+
+| Mode | Typical use |
+|------|-------------|
+| **`afw`** (default) | Subprocess **`afw`** for `.as`; hermetic **advanced-test** leaves (spawn `afwfcgi`). |
+| **`valgrind`** | `.as` under valgrind; advanced leaves wrap **`afwfcgi`** when supported. |
+| **`afwfcgi`** | Replays compatible `.as` against a **live** stack (default URL
+  `http://localhost:8080/afw`). Skips tests with a private `afw.conf`.
+  Advanced leaves are skipped (hermetic conf does not apply to the live process). |
+| **`actions`** | Local Python `Session` + `eval_script` for `.as`. |
+
+File type still wins for some paths: `.py` → Python runner;
+`commands_*.txt` → commands runner.
+
+## \*\*\* Experimental \*\*\* advanced-test leaves
+
+**Status: experimental.** Marker names, schema, and runner details may change.
+Many early choices (leaf discovery, hermetic `afwfcgi`, FCGI client) are
+expected to stay in spirit. Feedback: GitHub issue **#157** and
+`designs/afwdev-advanced-test.md`.
+
+Use an advanced-test leaf when you need:
+
+- One long-lived **`afwfcgi`** for several requests  
+- Leaf-local conf / objects that must not depend on a pre-started stack  
+- Multi-step process-lifetime checks (catalog, adapters, later stress for #2)
+
+### Shape
+
+```text
+src/<srcdir>/tests/…/my_leaf/     # any depth under tests/
+  advanced-test.yaml              # or advanced-test.json (not both)
+  afw.conf                        # required for host afwfcgi
+  objects/                        # optional
+  step_something.as               # optional; referenced from steps
+```
+
+The directory with the marker is a **leaf**: one test unit; children are
+assets only (not nested tests).
+
+Minimal YAML:
+
+```yaml
+# Experimental — see designs/afwdev-advanced-test.md
+host: afwfcgi
+description: Short summary for listing / failures
+
+afwfcgi:
+  threads: 1
+
+timeout_s: 60
+
+steps:
+  - name: first request
+    eval: |
+      return true;
+
+  - name: script file
+    script: step_two.as
+```
+
+- **`host`** — v1 supports **`afwfcgi`** only.  
+- **`eval`** — inline Adaptive Script (one FCGI perform / request).  
+- **`script`** — path relative to the leaf; keep a `test_script` shebang if you
+  want per-case `expect` checking.  
+- One leaf → one pass/fail (fail-fast on first bad step).  
+- Requires **PyYAML** (see package `python-requirements.txt`) and **`afwfcgi`**
+  on PATH from an install build.
+
+Examples: `src/afw/tests/advanced/` (smoke, multi-request file adapter,
+multi-eval lifetime, JSON marker sample).
+
+## Practical tips
+
+1. **Start from a neighbor** — copy a test in the same area and edit.  
+2. **Name for `--test-pattern`** — patterns match file path / basename / leaf
+   directory name (advanced markers).  
+3. **Keep groups small** — shared conf is fine; do not hide unrelated suites
+   in one directory if you want fine-grained parallel runs.  
+4. **Default gate** — `afwdev test -j` after meaningful changes; valgrind mode
+   is slower and optional for day-to-day.  
+5. **Generated tests** — many function/datatype scripts under
+   `tests/generated/` are generated; prefer hand tests under clear group
+   names for new product behavior.
+
+## Related
+
+- @ref afw_dev_overview — builder docs map  
+- @ref afw_dev_extending — extension sketch (includes `afwdev test -j`)  
+- @ref afw_dev_compiler_ebnf — compiler EBNF harvest (not test authoring)  
+- Maintainer design: `designs/afwdev-advanced-test.md` (experimental)  
+- Issue [#157](https://github.com/afw-org/afw/issues/157)  
+- CLI help: `afw --help` (`-s test_script`), `afwdev test --help`  

--- a/src/afw/doc/developer/writing-tests.md
+++ b/src/afw/doc/developer/writing-tests.md
@@ -211,8 +211,11 @@ afwdev blast -f /path/to/afw.conf -m 200
 ```
 
 Same discovery filters as `test` (`--srcdir-pattern`, `--test-pattern`,
-`--tags`). Continues on Adaptive failures; stops if the server dies.
-Design: `designs/afwdev-blast.md`. afwfcgi signal shutdown: issue **#158**.
+`--tags`). By default **skips fixture-heavy groups** (`Environment=` /
+`afw.conf`) so failures usually mean a real problem; use
+`--include-fixtures` to blast adapter/env tests too. Continues on Adaptive
+failures; stops if the server dies. Design: `designs/afwdev-blast.md`.
+afwfcgi signal shutdown: issue **#158**.
 
 ## Practical tips
 

--- a/src/afw/doc/developer/writing-tests.md
+++ b/src/afw/doc/developer/writing-tests.md
@@ -53,6 +53,7 @@ PATH afterward for `test`, `validate`, and similar.
 | **Python** (`.py` with `run()`) | Need host process control, raw env octets, bindings that are awkward in script. |
 | **`commands_*.txt`** | Drive shell-ish command sequences (special runner). |
 | **Advanced-test leaf** | Multi-request / long-lived **`afwfcgi`** process with leaf conf. **Experimental** — see below. |
+| **`afwdev blast`** | On-demand **random** suite firehose at afwfcgi for a period. **Not** part of `test -j`. See below. |
 
 Prefer a **test_script** unless you need process lifetime, a private server, or
 host-only APIs.
@@ -192,6 +193,26 @@ steps:
 
 Examples: `src/afw/tests/advanced/` (smoke, multi-request file adapter,
 multi-eval lifetime, JSON marker sample).
+
+## \*\*\* Experimental \*\*\* afwdev blast
+
+**Not part of the normal gate.** On-demand load: randomly eval suite
+`.as` sources against afwfcgi for a duration or request count.
+
+```bash
+# Typical docker/dev (defaults: url :8080/afw, 5m, concurrency=CPUs)
+afwdev blast
+
+# Longer / more parallel / adapter-focused
+afwdev blast -d 30m -c 16 --test-pattern 'file_adapter/|model_adapter/|rql/'
+
+# Harness-owned afwfcgi
+afwdev blast -f /path/to/afw.conf -m 200
+```
+
+Same discovery filters as `test` (`--srcdir-pattern`, `--test-pattern`,
+`--tags`). Continues on Adaptive failures; stops if the server dies.
+Design: `designs/afwdev-blast.md`. afwfcgi signal shutdown: issue **#158**.
 
 ## Practical tips
 

--- a/src/afw/tests/advanced/multi-eval-lifetime/advanced-test.yaml
+++ b/src/afw/tests/advanced/multi-eval-lifetime/advanced-test.yaml
@@ -1,0 +1,70 @@
+# =============================================================================
+# advanced-test: multi-eval process lifetime (issue #157; feeds #149 / #2)
+# =============================================================================
+# What this shows:
+#   - Many sequential evals on ONE afwfcgi (not N CLI processes)
+#   - Same process registry / runtime catalog can be read on every request
+#   - A simple "warmup then N requests" pattern useful for lifetime work
+#
+# This is intentionally light (no custom adapters). Use it as a template for
+# #149 catalog scenarios and #2 stress loops once those land.
+#
+# Run:
+#   ./afwdev test --test-pattern multi-eval-lifetime --show-all
+# =============================================================================
+
+host: afwfcgi
+
+description: >
+  Multi-eval on one afwfcgi: repeated registry/catalog reads stay healthy
+
+afwfcgi:
+  threads: 1
+
+timeout_s: 120
+
+steps:
+  # First request: touch the live afw adapter catalog (runtime object types)
+  - name: first catalog retrieve
+    eval: |
+      // maxObjects is the 6th arg (see #49); 0 = unlimited catalog retrieve
+      const types = retrieve_objects(
+          "afw", "_AdaptiveObjectType_",
+          undefined, undefined, undefined, 0);
+      assert(length(types) > 0, "expected at least one object type");
+      return length(types);
+
+  # Second request: same process — count should still be positive (and stable
+  # enough for a smoke assert; exact count may vary with extensions).
+  - name: second catalog retrieve
+    eval: |
+      const types = retrieve_objects(
+          "afw", "_AdaptiveObjectType_",
+          undefined, undefined, undefined, 0);
+      assert(length(types) > 0);
+      return length(types);
+
+  # Burst of cheap evals: still one server, many request xctx create/release
+  # cycles (template for #2 memory loops — not a soak yet).
+  - name: eval burst 1
+    eval: |
+      let i: integer = 0;
+      let sum: integer = 0;
+      for (i = 0; i < 50; i = i + 1)
+          sum = sum + i;
+      assert(sum == 1225);
+      return sum;
+
+  - name: eval burst 2
+    eval: |
+      // Second burst after prior request fully finished
+      let i: integer = 0;
+      let sum: integer = 0;
+      for (i = 0; i < 50; i = i + 1)
+          sum = sum + i;
+      assert(sum == 1225);
+      return sum;
+
+  # Optional hybrid: test_script syntax over FCGI (shebang kept by harness)
+  - name: test_script sanity
+    script: step_registry_sane.as

--- a/src/afw/tests/advanced/multi-eval-lifetime/advanced-test.yaml
+++ b/src/afw/tests/advanced/multi-eval-lifetime/advanced-test.yaml
@@ -1,5 +1,7 @@
 # =============================================================================
-# advanced-test: multi-eval process lifetime (issue #157; feeds #149 / #2)
+# *** Experimental *** advanced-test (issue #157) — may change; see
+# designs/afwdev-advanced-test.md
+# multi-eval process lifetime (feeds #149 / #2)
 # =============================================================================
 # What this shows:
 #   - Many sequential evals on ONE afwfcgi (not N CLI processes)

--- a/src/afw/tests/advanced/multi-eval-lifetime/afw.conf
+++ b/src/afw/tests/advanced/multi-eval-lifetime/afw.conf
@@ -1,0 +1,8 @@
+/* Minimal server: perform/eval only — enough for multi-eval process lifetime. */
+[
+    {
+        type                : "requestHandler",
+        uriPrefix           : "/",
+        requestHandlerType  : "adapter"
+    }
+]

--- a/src/afw/tests/advanced/multi-eval-lifetime/step_registry_sane.as
+++ b/src/afw/tests/advanced/multi-eval-lifetime/step_registry_sane.as
@@ -1,0 +1,16 @@
+#!/usr/bin/env afw --syntax test_script
+//?
+//? testScript: step_registry_sane.as
+//? description: Lightweight registry sanity after multi-eval bursts
+//? sourceType: script
+//?
+//? test: object_types_nonempty
+//? description: afw adapter still serves object type catalog
+//? expect: true
+//? source: ...
+
+const types = retrieve_objects(
+    "afw", "_AdaptiveObjectType_",
+    undefined, undefined, undefined, 0);
+assert(length(types) > 0);
+return true;

--- a/src/afw/tests/advanced/multi-request-file/advanced-test.yaml
+++ b/src/afw/tests/advanced/multi-request-file/advanced-test.yaml
@@ -1,5 +1,7 @@
 # =============================================================================
-# advanced-test: multi-request file adapter (issue #157)
+# *** Experimental *** advanced-test (issue #157) — may change; see
+# designs/afwdev-advanced-test.md
+# multi-request file adapter
 # =============================================================================
 # What this shows that a one-shot `afw` CLI .as cannot (easily):
 #   - One long-lived afwfcgi process for the whole leaf

--- a/src/afw/tests/advanced/multi-request-file/advanced-test.yaml
+++ b/src/afw/tests/advanced/multi-request-file/advanced-test.yaml
@@ -1,0 +1,74 @@
+# =============================================================================
+# advanced-test: multi-request file adapter (issue #157)
+# =============================================================================
+# What this shows that a one-shot `afw` CLI .as cannot (easily):
+#   - One long-lived afwfcgi process for the whole leaf
+#   - Several independent HTTP/FCGI requests (steps) against that process
+#   - State that survives across requests: file adapter data on disk under
+#     the harness work dir (not script-local variables)
+#   - Leaf-local conf + objects/ fixtures (hermetic; not the live /afw stack)
+#
+# How to run (from package root, after install):
+#   ./afwdev test --test-pattern multi-request-file --show-all
+# =============================================================================
+
+host: afwfcgi
+
+description: >
+  Multi-request: add via file adapter in request 1, get/modify in later
+  requests on the same afwfcgi process
+
+# Optional host tuning (maps to afwfcgi -n)
+afwfcgi:
+  threads: 1
+
+# Whole-leaf wall clock (start + all steps + teardown)
+timeout_s: 90
+
+steps:
+  # --- Request 1: write through file adapter ---------------------------------
+  - name: add Demo object
+    # Inline Adaptive Script (no shebang needed). Each step is a separate
+    # perform/eval<script> over FCGI — new request xctx every time.
+    eval: |
+      // Persist an object the next requests must see
+      add_object(
+          "file",
+          "Demo",
+          {
+              "msg": "from-request-1",
+              "n": 1
+          },
+          "alpha"
+      );
+      return true;
+
+  # --- Request 2: read back (proves process + adapter still up) --------------
+  - name: get object from prior request
+    eval: |
+      const o = get_object("file", "Demo", "alpha");
+      assert(o.msg == "from-request-1", "msg not persisted across requests");
+      assert(o.n == 1, "n not persisted across requests");
+      return o.msg;
+
+  # --- Request 3: mutate, still same server ----------------------------------
+  - name: replace and re-get
+    eval: |
+      replace_object(
+          "file",
+          "Demo",
+          "alpha",
+          {
+              "msg": "from-request-3",
+              "n": 3
+          }
+      );
+      const o = get_object("file", "Demo", "alpha");
+      assert(o.msg == "from-request-3");
+      assert(o.n == 3);
+      return o.n;
+
+  # --- Request 4: sibling test_script file (same FCGI path) ------------------
+  - name: cleanup via test_script file
+    # script: path is relative to this leaf (copied into the work dir)
+    script: step_cleanup.as

--- a/src/afw/tests/advanced/multi-request-file/afw.conf
+++ b/src/afw/tests/advanced/multi-request-file/afw.conf
@@ -1,0 +1,20 @@
+/* Hermetic afwfcgi conf for multi-request file adapter demo (#157). */
+[
+    // REST + perform actions (POST /afw)
+    {
+        type                : "requestHandler",
+        uriPrefix           : "/",
+        requestHandlerType  : "adapter"
+    },
+
+    // Per-leaf file adapter; root is relative to the test work dir
+    {
+        type                : "adapter",
+        adapterType         : "file",
+        adapterId           : "file",
+        description         : "demo file adapter for multi-request persistence",
+        root                : "objects/",
+        filenameSuffix      : ".json",
+        contentType         : "json"
+    }
+]

--- a/src/afw/tests/advanced/multi-request-file/objects/_AdaptiveObjectType_/Demo.json
+++ b/src/afw/tests/advanced/multi-request-file/objects/_AdaptiveObjectType_/Demo.json
@@ -1,0 +1,15 @@
+{
+    "objectType": "Demo",
+    "allowAdd": true,
+    "allowChange": true,
+    "allowDelete": true,
+    "allowEntity": true,
+    "propertyTypes": {
+        "msg": {
+            "dataType": "string"
+        },
+        "n": {
+            "dataType": "integer"
+        }
+    }
+}

--- a/src/afw/tests/advanced/multi-request-file/step_cleanup.as
+++ b/src/afw/tests/advanced/multi-request-file/step_cleanup.as
@@ -1,0 +1,13 @@
+#!/usr/bin/env afw --syntax test_script
+//?
+//? testScript: step_cleanup.as
+//? description: Delete Demo/alpha left by prior multi-request steps
+//? sourceType: script
+//?
+//? test: delete_alpha
+//? description: remove the multi-request demo object
+//? expect: null
+//? source: ...
+
+delete_object("file", "Demo", "alpha");
+return null;

--- a/src/afw/tests/advanced/smoke-json/advanced-test.json
+++ b/src/afw/tests/advanced/smoke-json/advanced-test.json
@@ -1,6 +1,6 @@
 {
   "host": "afwfcgi",
-  "description": "JSON marker form of advanced-test (same schema as .yaml); hermetic afwfcgi + FCGI eval smoke",
+  "description": "*** Experimental *** JSON marker form of advanced-test (#157); same schema as .yaml \u2014 may change",
   "afwfcgi": {
     "threads": 1
   },

--- a/src/afw/tests/advanced/smoke-json/advanced-test.json
+++ b/src/afw/tests/advanced/smoke-json/advanced-test.json
@@ -1,0 +1,18 @@
+{
+  "host": "afwfcgi",
+  "description": "JSON marker form of advanced-test (same schema as .yaml); hermetic afwfcgi + FCGI eval smoke",
+  "afwfcgi": {
+    "threads": 1
+  },
+  "timeout_s": 60,
+  "steps": [
+    {
+      "name": "return true",
+      "eval": "return true;\n"
+    },
+    {
+      "name": "simple arithmetic",
+      "eval": "assert((1 + 2) == 3);\nreturn 3;\n"
+    }
+  ]
+}

--- a/src/afw/tests/advanced/smoke-json/afw.conf
+++ b/src/afw/tests/advanced/smoke-json/afw.conf
@@ -1,0 +1,8 @@
+/* Minimal conf for advanced-test.json smoke (#157). */
+[
+    {
+        type                : "requestHandler",
+        uriPrefix           : "/",
+        requestHandlerType  : "adapter"
+    }
+]

--- a/src/afw/tests/advanced/smoke/advanced-test.yaml
+++ b/src/afw/tests/advanced/smoke/advanced-test.yaml
@@ -1,0 +1,17 @@
+# Hermetic afwfcgi smoke — designs/afwdev-advanced-test.md / issue #157
+host: afwfcgi
+description: Spawn afwfcgi and eval a trivial script via FCGI client
+
+afwfcgi:
+  threads: 1
+
+timeout_s: 60
+
+steps:
+  - name: return true
+    eval: |
+      return true;
+
+  - name: script file test_script
+    script: step_two.as
+

--- a/src/afw/tests/advanced/smoke/advanced-test.yaml
+++ b/src/afw/tests/advanced/smoke/advanced-test.yaml
@@ -1,4 +1,6 @@
-# Hermetic afwfcgi smoke — designs/afwdev-advanced-test.md / issue #157
+# *** Experimental *** advanced-test (issue #157) — may change; see
+# designs/afwdev-advanced-test.md
+# Hermetic afwfcgi smoke
 host: afwfcgi
 description: Spawn afwfcgi and eval a trivial script via FCGI client
 

--- a/src/afw/tests/advanced/smoke/afw.conf
+++ b/src/afw/tests/advanced/smoke/afw.conf
@@ -1,0 +1,8 @@
+/* Minimal conf for advanced-test smoke: adapter request handler only. */
+[
+    {
+        type                : "requestHandler",
+        uriPrefix           : "/",
+        requestHandlerType  : "adapter"
+    }
+]

--- a/src/afw/tests/advanced/smoke/step_two.as
+++ b/src/afw/tests/advanced/smoke/step_two.as
@@ -1,0 +1,11 @@
+#!/usr/bin/env afw --syntax test_script
+//?
+//? testScript: step_two.as
+//? description: second step via script file
+//? sourceType: script
+//?
+//? test: truth
+//? description: return true
+//? expect: true
+//? source: ...
+return true;

--- a/src/afw_dev/_afwdev/blast/__init__.py
+++ b/src/afw_dev/_afwdev/blast/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+"""
+afwdev blast — on-demand firehose of suite Adaptive tests at afwfcgi.
+
+*** Experimental *** — not part of afwdev test -j. See designs/afwdev-blast.md.
+"""
+
+from _afwdev.blast.blast import run
+
+__all__ = ["run"]

--- a/src/afw_dev/_afwdev/blast/blast.py
+++ b/src/afw_dev/_afwdev/blast/blast.py
@@ -1,0 +1,542 @@
+# -*- coding: utf-8 -*-
+"""
+On-demand blast: randomly fire Adaptive test_script sources at afwfcgi.
+
+Attach (--url) or managed spawn (--conf). Continues on Adaptive failures;
+stops if the server dies or duration / max-requests is hit.
+"""
+
+from __future__ import print_function
+
+import fnmatch
+import json
+import os
+import random
+import sys
+import threading
+import time
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
+
+import requests
+
+from _afwdev.common import msg, package
+from _afwdev.test.common import (
+    find_test_groups,
+    load_test_group_config,
+    test_group_matches_tags,
+)
+
+
+# Default attach target: docker/dev nginx front door (modes/afwfcgi.py)
+_DEFAULT_URL = "http://localhost:8080/afw"
+_DEFAULT_DURATION = "5m"
+
+
+def _cpu_count():
+    n = os.cpu_count()
+    if n is None or n < 1:
+        return 4
+    return n
+
+
+def run(options):
+    """Entry point for the blast subcommand."""
+    url = options.get("url") or options.get("server_url")
+    conf = options.get("conf")
+    if url and conf:
+        msg.error_exit(
+            "afwdev blast: use only one of --url/-u (attach) or "
+            "--conf/-f (managed spawn)")
+    if not url and not conf:
+        # Typical afw docker/dev: nginx always up, afwfcgi when you need it
+        url = _DEFAULT_URL
+
+    duration_raw = options.get("duration")
+    if duration_raw is None or duration_raw == "":
+        duration_raw = _DEFAULT_DURATION
+    # duration 0 / 0s / 0m means "no time limit" (use max-requests only)
+    duration_s = _parse_duration(duration_raw)
+    if duration_s is not None and duration_s <= 0:
+        duration_s = None
+
+    max_requests = options.get("max_requests")
+    if max_requests is not None and max_requests != "":
+        try:
+            max_requests = int(max_requests)
+        except (TypeError, ValueError):
+            msg.error_exit("--max-requests must be an integer")
+        if max_requests < 1:
+            msg.error_exit("--max-requests must be >= 1")
+    else:
+        max_requests = None
+
+    if duration_s is None and max_requests is None:
+        msg.error_exit(
+            "afwdev blast needs a stop condition: --duration/-d "
+            "(default 5m) and/or --max-requests/-m")
+
+    cpus = _cpu_count()
+    try:
+        concurrency = int(options.get("concurrency") or 0)
+    except (TypeError, ValueError):
+        msg.error_exit("--concurrency must be an integer")
+    if concurrency <= 0:
+        concurrency = cpus
+    if concurrency < 1:
+        msg.error_exit("--concurrency must be >= 1")
+
+    try:
+        threads = int(options.get("threads") or 0)
+    except (TypeError, ValueError):
+        msg.error_exit("--threads must be an integer")
+    if threads <= 0:
+        threads = cpus
+    if threads < 1:
+        msg.error_exit("--threads must be >= 1")
+
+    timeout_s = float(options.get("request_timeout") or 30.0)
+    progress_every_s = float(options.get("progress_every") or 2.0)
+
+    srcdirs = _collect_srcdirs(options)
+    attach = bool(url)
+    corpus = _collect_corpus(options, srcdirs, skip_conf=attach)
+    if not corpus:
+        msg.error_exit(
+            "No .as tests in blast corpus "
+            "(check --srcdir-pattern / --test-pattern / --tags; "
+            "attach mode skips tests next to afw.conf)")
+
+    msg.highlighted_info(
+        "*** Experimental *** afwdev blast — not part of test -j")
+    dur_show = duration_raw if duration_s is not None else "-"
+    msg.highlighted_info(
+        "corpus={}  mode={}  concurrency={} (cpus={})  "
+        "duration={}  max_requests={}".format(
+            len(corpus),
+            "attach " + url if attach else "managed conf=" + conf,
+            concurrency,
+            cpus,
+            dur_show if duration_s is not None else "-",
+            max_requests if max_requests is not None else "-",
+        ))
+    if attach:
+        msg.highlighted_info(
+            "attach: ensure afwfcgi is up behind that URL "
+            "(nginx often already running in dev containers)")
+
+    handle = None
+    socket_path = None
+    session = None
+    stats = _Stats()
+    stop = threading.Event()
+
+    try:
+        if attach:
+            session = requests.Session()
+            session.headers.update({
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            })
+            transport = _HttpTransport(session, url, timeout_s)
+            # cheap health: empty eval
+            try:
+                transport.send("return true;")
+            except Exception as e:
+                msg.error_exit(
+                    "Cannot reach afwfcgi at {!r}: {}".format(url, e))
+        else:
+            from _afwdev.test.advanced.hosts import afwfcgi as afwfcgi_host
+            from _afwdev.test.advanced.fcgi_client import fcgi_request
+
+            work_dir = os.path.dirname(os.path.abspath(conf))
+            conf_name = os.path.basename(conf)
+            if conf_name != "afw.conf":
+                # host helper expects afw.conf in work_dir
+                import shutil
+                tmp = os.path.join(work_dir, ".afwdev_blast_work")
+                if os.path.isdir(tmp):
+                    shutil.rmtree(tmp)
+                os.makedirs(tmp)
+                shutil.copy2(conf, os.path.join(tmp, "afw.conf"))
+                work_dir = tmp
+            elif not os.path.isfile(os.path.join(work_dir, "afw.conf")):
+                msg.error_exit("afw.conf not found: " + conf)
+
+            under_valgrind = (options.get("mode") == "valgrind")
+            handle = afwfcgi_host.start_afwfcgi(
+                work_dir,
+                threads=threads,
+                under_valgrind=under_valgrind,
+                options=options,
+                ready_timeout_s=30.0,
+            )
+            socket_path = handle["socket_path"]
+            transport = _FcgiTransport(socket_path, timeout_s)
+
+        t0 = time.time()
+        deadline = (t0 + duration_s) if duration_s is not None else None
+        last_progress = t0
+
+        def one_shot():
+            if stop.is_set():
+                return
+            if deadline is not None and time.time() >= deadline:
+                stop.set()
+                return
+            if max_requests is not None and stats.total >= max_requests:
+                stop.set()
+                return
+
+            path = random.choice(corpus)
+            try:
+                with open(path, "r", encoding="utf-8", errors="replace") as fd:
+                    source = fd.read()
+            except OSError as e:
+                stats.record_fail(path, "read: " + str(e))
+                return
+
+            try:
+                transport.send(source)
+                stats.record_ok(path)
+            except _ServerDead as e:
+                stats.record_err(path, str(e))
+                stop.set()
+                stats.server_dead = True
+            except Exception as e:
+                stats.record_fail(path, str(e))
+
+        try:
+            with ThreadPoolExecutor(max_workers=concurrency) as pool:
+                futures = set()
+                while not stop.is_set():
+                    if deadline is not None and time.time() >= deadline:
+                        break
+                    if max_requests is not None and stats.total >= max_requests:
+                        break
+
+                    while (len(futures) < concurrency and not stop.is_set()):
+                        if max_requests is not None and (
+                                stats.total + len(futures) >= max_requests):
+                            break
+                        if deadline is not None and time.time() >= deadline:
+                            break
+                        futures.add(pool.submit(one_shot))
+
+                    if not futures:
+                        break
+
+                    done, futures = wait(
+                        futures, timeout=0.5, return_when=FIRST_COMPLETED)
+                    for fut in done:
+                        try:
+                            fut.result()
+                        except Exception as e:
+                            msg.debug("worker: " + str(e))
+
+                    now = time.time()
+                    if now - last_progress >= progress_every_s:
+                        _print_progress(stats, t0)
+                        last_progress = now
+
+                if futures:
+                    done, _ = wait(futures)
+                    for fut in done:
+                        try:
+                            fut.result()
+                        except Exception:
+                            pass
+        except KeyboardInterrupt:
+            msg.highlighted_info("\nInterrupted — stopping blast.")
+            stop.set()
+
+        _print_progress(stats, t0, final=True)
+        elapsed = time.time() - t0
+        msg.highlighted_info("")
+        msg.highlighted_info(
+            "blast done in {:.1f}s  ok={}  fail={}  err={}  total={}".format(
+                elapsed, stats.ok, stats.fail, stats.err, stats.total))
+        if stats.recent_fails:
+            msg.error("Recent failures:")
+            for path, detail in stats.recent_fails[-10:]:
+                msg.error("  {}  {}".format(
+                    os.path.relpath(path) if os.path.exists(path) else path,
+                    detail[:120]))
+
+        if stats.server_dead:
+            msg.error("Server died or became unreachable during blast.")
+            sys.exit(2)
+        if stats.fail or stats.err:
+            sys.exit(1)
+        sys.exit(0)
+
+    finally:
+        if handle is not None:
+            from _afwdev.test.advanced.hosts import afwfcgi as afwfcgi_host
+            afwfcgi_host.stop_afwfcgi(handle)
+        if session is not None:
+            try:
+                session.close()
+            except Exception:
+                pass
+
+
+class _ServerDead(Exception):
+    pass
+
+
+class _HttpTransport(object):
+    def __init__(self, session, url, timeout_s):
+        self._session = session
+        self._url = url
+        self._timeout = timeout_s
+
+    def send(self, source):
+        payload = {
+            "actions": [
+                {"function": "eval<script>", "source": source}
+            ]
+        }
+        try:
+            r = self._session.post(
+                self._url,
+                data=json.dumps(payload),
+                timeout=self._timeout,
+            )
+        except requests.exceptions.ConnectionError as e:
+            raise _ServerDead("connection failed: " + str(e)) from e
+        except requests.exceptions.Timeout as e:
+            raise RuntimeError("request timeout: " + str(e)) from e
+
+        if r.status_code >= 500:
+            raise _ServerDead(
+                "HTTP {} from server".format(r.status_code))
+
+        try:
+            body = r.json()
+        except ValueError as e:
+            raise RuntimeError(
+                "non-JSON response HTTP {}: {}".format(
+                    r.status_code, r.text[:200])) from e
+
+        status = body.get("status")
+        if status and status != "success":
+            raise RuntimeError(
+                "status={!r}: {}".format(status, json.dumps(body)[:300]))
+
+        actions = body.get("actions") or []
+        for act in actions:
+            if isinstance(act, dict) and act.get("status") == "error":
+                raise RuntimeError(
+                    "action error: {}".format(
+                        json.dumps(act.get("error") or act)[:300]))
+            _raise_if_test_script_failures(act.get("result") if isinstance(act, dict) else None)
+        return body
+
+
+class _FcgiTransport(object):
+    def __init__(self, socket_path, timeout_s):
+        self._socket_path = socket_path
+        self._timeout = timeout_s
+
+    def send(self, source):
+        from _afwdev.common import nfc
+        from _afwdev.test.advanced.fcgi_client import (
+            FcgiClientError,
+            fcgi_request,
+        )
+
+        payload = nfc.json_dumps({
+            "actions": [
+                {"function": "eval<script>", "source": source}
+            ]
+        })
+        try:
+            result = fcgi_request(
+                self._socket_path,
+                path="/afw",
+                method="POST",
+                body=payload,
+                timeout=self._timeout,
+            )
+        except FcgiClientError as e:
+            err = str(e).lower()
+            if "connect" in err or "closed" in err or "timeout" in err:
+                # distinguish hard death vs slow: connection refused = dead
+                if "connect" in err or "closed" in err:
+                    raise _ServerDead(str(e)) from e
+            raise RuntimeError(str(e)) from e
+
+        body_text = (result.get("body") or b"").decode(
+            "utf-8", errors="replace")
+        try:
+            body = nfc.json_loads(body_text) if body_text.strip() else {}
+        except Exception as e:
+            raise RuntimeError(
+                "non-JSON FCGI body: {}".format(body_text[:200])) from e
+
+        status = body.get("status")
+        if status and status != "success":
+            raise RuntimeError(
+                "status={!r}: {}".format(status, body_text[:300]))
+        actions = body.get("actions") or []
+        for act in actions:
+            if isinstance(act, dict) and act.get("status") == "error":
+                raise RuntimeError(
+                    "action error: {}".format(
+                        nfc.json_dumps(act.get("error") or act)[:300]))
+            _raise_if_test_script_failures(
+                act.get("result") if isinstance(act, dict) else None)
+        return body
+
+
+def _raise_if_test_script_failures(result_obj):
+    """If eval returned a test_script result with failed cases, raise."""
+    if not isinstance(result_obj, dict) or "tests" not in result_obj:
+        return
+    for tc in result_obj.get("tests") or []:
+        if tc.get("skip"):
+            continue
+        if tc.get("passed", False) is False:
+            raise RuntimeError(
+                "test_script failure: {}".format(
+                    tc.get("test") or tc.get("description") or tc))
+
+
+class _Stats(object):
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.ok = 0
+        self.fail = 0
+        self.err = 0
+        self.total = 0
+        self.last_path = ""
+        self.recent_fails = []
+        self.server_dead = False
+
+    def record_ok(self, path):
+        with self._lock:
+            self.ok += 1
+            self.total += 1
+            self.last_path = path
+
+    def record_fail(self, path, detail):
+        with self._lock:
+            self.fail += 1
+            self.total += 1
+            self.last_path = path
+            self.recent_fails.append((path, detail))
+            if len(self.recent_fails) > 50:
+                self.recent_fails = self.recent_fails[-50:]
+
+    def record_err(self, path, detail):
+        with self._lock:
+            self.err += 1
+            self.total += 1
+            self.last_path = path
+            self.recent_fails.append((path, detail))
+
+
+def _print_progress(stats, t0, final=False):
+    elapsed = max(0.001, time.time() - t0)
+    rps = stats.total / elapsed
+    last = stats.last_path
+    if last:
+        try:
+            last = os.path.relpath(last)
+        except ValueError:
+            pass
+    line = (
+        "blast  {elapsed}  req={total}  ok={ok}  fail={fail}  err={err}  "
+        "rps≈{rps:.1f}  last={last}"
+    ).format(
+        elapsed=_fmt_hms(elapsed),
+        total=stats.total,
+        ok=stats.ok,
+        fail=stats.fail,
+        err=stats.err,
+        rps=rps,
+        last=last or "-",
+    )
+    if final:
+        msg.highlighted_info(line)
+    else:
+        # single updating-friendly line
+        print(line, flush=True)
+
+
+def _fmt_hms(seconds):
+    seconds = int(seconds)
+    h = seconds // 3600
+    m = (seconds % 3600) // 60
+    s = seconds % 60
+    if h:
+        return "{:d}:{:02d}:{:02d}".format(h, m, s)
+    return "{:d}:{:02d}".format(m, s)
+
+
+def _parse_duration(text):
+    if text is None or text == "":
+        return None
+    text = str(text).strip().lower()
+    if not text:
+        return None
+    mult = 1.0
+    if text.endswith("ms"):
+        mult = 0.001
+        text = text[:-2]
+    elif text.endswith("s"):
+        mult = 1.0
+        text = text[:-1]
+    elif text.endswith("m"):
+        mult = 60.0
+        text = text[:-1]
+    elif text.endswith("h"):
+        mult = 3600.0
+        text = text[:-1]
+    try:
+        return float(text) * mult
+    except ValueError:
+        msg.error_exit(
+            "Invalid --duration {!r} (use 30s, 5m, 1h, or seconds)".format(
+                text))
+
+
+def _collect_srcdirs(options):
+    pattern = options.get("srcdir_pattern") or "*"
+    pattern = pattern.replace("\\", "")
+    srcdirs = []
+    for srcdir in package.get_afw_package(options)["srcdirs"]:
+        if not fnmatch.fnmatch(srcdir, pattern):
+            continue
+        package.set_options_from_existing_package_srcdir(
+            options, srcdir, set_all=True)
+        srcdir_path = options["srcdir_path"]
+        manual_tests = srcdir_path + "tests"
+        srcdirs.append((srcdir, srcdir_path, None, manual_tests))
+    return srcdirs
+
+
+def _collect_corpus(options, srcdirs, skip_conf=True):
+    corpus = []
+    for srcdir, srcdir_path, _, manual_tests in srcdirs:
+        if not os.path.isdir(manual_tests):
+            continue
+        groups = find_test_groups(options, srcdir, manual_tests)
+        for _sd, root, tests in groups:
+            config = load_test_group_config(root)
+            if not test_group_matches_tags(options, config):
+                continue
+            for path in tests:
+                if not path.endswith(".as"):
+                    continue
+                base = os.path.basename(path)
+                if base.startswith("_"):
+                    continue
+                if skip_conf:
+                    conf = os.path.join(os.path.dirname(path), "afw.conf")
+                    if os.path.isfile(conf):
+                        msg.debug(
+                            "blast skip (local afw.conf): " + path)
+                        continue
+                corpus.append(path)
+    return corpus

--- a/src/afw_dev/_afwdev/blast/blast.py
+++ b/src/afw_dev/_afwdev/blast/blast.py
@@ -76,12 +76,13 @@ def run(options):
             "(default 5m) and/or --max-requests/-m")
 
     cpus = _cpu_count()
+    # Historical gobench-style load: threads ≈ CPUs, in-flight ≈ 2×CPUs
     try:
         concurrency = int(options.get("concurrency") or 0)
     except (TypeError, ValueError):
         msg.error_exit("--concurrency must be an integer")
     if concurrency <= 0:
-        concurrency = cpus
+        concurrency = max(1, 2 * cpus)
     if concurrency < 1:
         msg.error_exit("--concurrency must be >= 1")
 
@@ -99,20 +100,24 @@ def run(options):
 
     srcdirs = _collect_srcdirs(options)
     attach = bool(url)
-    corpus = _collect_corpus(options, srcdirs, skip_conf=attach)
+    # Default: skip fixture-heavy groups so fail≈0 unless something is wrong
+    include_fixtures = bool(options.get("include_fixtures"))
+    corpus, skipped_fixture = _collect_corpus(
+        options, srcdirs, skip_fixtures=not include_fixtures)
     if not corpus:
         msg.error_exit(
             "No .as tests in blast corpus "
             "(check --srcdir-pattern / --test-pattern / --tags; "
-            "attach mode skips tests next to afw.conf)")
+            "fixture groups skipped by default — see --include-fixtures)")
 
     msg.highlighted_info(
         "*** Experimental *** afwdev blast — not part of test -j")
     dur_show = duration_raw if duration_s is not None else "-"
     msg.highlighted_info(
-        "corpus={}  mode={}  concurrency={} (cpus={})  "
+        "corpus={}  skipped_fixture={}  mode={}  concurrency={} (cpus={})  "
         "duration={}  max_requests={}".format(
             len(corpus),
+            skipped_fixture,
             "attach " + url if attach else "managed conf=" + conf,
             concurrency,
             cpus,
@@ -123,6 +128,10 @@ def run(options):
         msg.highlighted_info(
             "attach: ensure afwfcgi is up behind that URL "
             "(nginx often already running in dev containers)")
+    if not include_fixtures and skipped_fixture:
+        msg.highlighted_info(
+            "skipping groups with Environment= / afw.conf "
+            "(use --include-fixtures to blast those too)")
 
     handle = None
     socket_path = None
@@ -195,13 +204,16 @@ def run(options):
                 stats.record_fail(path, "read: " + str(e))
                 return
 
+            t_req = time.time()
             try:
                 transport.send(source)
-                stats.record_ok(path)
+                stats.record_ok(path, (time.time() - t_req) * 1000.0)
             except _ServerDead as e:
                 stats.record_err(path, str(e))
                 stop.set()
                 stats.server_dead = True
+            except _Timeout as e:
+                stats.record_timeout(path, str(e))
             except Exception as e:
                 stats.record_fail(path, str(e))
 
@@ -253,19 +265,33 @@ def run(options):
         elapsed = time.time() - t0
         msg.highlighted_info("")
         msg.highlighted_info(
-            "blast done in {:.1f}s  ok={}  fail={}  err={}  total={}".format(
-                elapsed, stats.ok, stats.fail, stats.err, stats.total))
+            "blast done in {:.1f}s  ok={}  fail={}  timeout={}  err={}  "
+            "total={}  latency_ms avg={:.0f} max={:.0f}".format(
+                elapsed,
+                stats.ok,
+                stats.fail,
+                stats.timeout,
+                stats.err,
+                stats.total,
+                stats.avg_latency_ms(),
+                stats.max_latency_ms,
+            ))
+        if stats.timeout and not stats.fail and not stats.err:
+            msg.highlighted_info(
+                "note: only client timeouts (no expect fails) — often load/"
+                "queue; try lower -c or higher --request-timeout")
         if stats.recent_fails:
-            msg.error("Recent failures:")
-            for path, detail in stats.recent_fails[-10:]:
-                msg.error("  {}  {}".format(
+            msg.error("Recent problems:")
+            for kind, path, detail in stats.recent_fails[-10:]:
+                msg.error("  [{}] {}  {}".format(
+                    kind,
                     os.path.relpath(path) if os.path.exists(path) else path,
                     detail[:120]))
 
         if stats.server_dead:
             msg.error("Server died or became unreachable during blast.")
             sys.exit(2)
-        if stats.fail or stats.err:
+        if stats.fail or stats.err or stats.timeout:
             sys.exit(1)
         sys.exit(0)
 
@@ -281,6 +307,11 @@ def run(options):
 
 
 class _ServerDead(Exception):
+    pass
+
+
+class _Timeout(Exception):
+    """Client-side request timeout (load/queue), not an Adaptive expect fail."""
     pass
 
 
@@ -305,7 +336,7 @@ class _HttpTransport(object):
         except requests.exceptions.ConnectionError as e:
             raise _ServerDead("connection failed: " + str(e)) from e
         except requests.exceptions.Timeout as e:
-            raise RuntimeError("request timeout: " + str(e)) from e
+            raise _Timeout("request timeout: " + str(e)) from e
 
         if r.status_code >= 500:
             raise _ServerDead(
@@ -360,10 +391,10 @@ class _FcgiTransport(object):
             )
         except FcgiClientError as e:
             err = str(e).lower()
-            if "connect" in err or "closed" in err or "timeout" in err:
-                # distinguish hard death vs slow: connection refused = dead
-                if "connect" in err or "closed" in err:
-                    raise _ServerDead(str(e)) from e
+            if "timeout" in err:
+                raise _Timeout(str(e)) from e
+            if "connect" in err or "closed" in err:
+                raise _ServerDead(str(e)) from e
             raise RuntimeError(str(e)) from e
 
         body_text = (result.get("body") or b"").decode(
@@ -406,25 +437,43 @@ class _Stats(object):
     def __init__(self):
         self._lock = threading.Lock()
         self.ok = 0
-        self.fail = 0
-        self.err = 0
+        self.fail = 0          # Adaptive expect / action errors
+        self.timeout = 0       # client read/connect timeout (load)
+        self.err = 0           # server dead / 5xx class
         self.total = 0
         self.last_path = ""
-        self.recent_fails = []
+        self.recent_fails = []  # (kind, path, detail)
         self.server_dead = False
+        self.latency_sum_ms = 0.0
+        self.latency_n = 0
+        self.max_latency_ms = 0.0
 
-    def record_ok(self, path):
+    def record_ok(self, path, latency_ms=0.0):
         with self._lock:
             self.ok += 1
             self.total += 1
             self.last_path = path
+            if latency_ms > 0:
+                self.latency_sum_ms += latency_ms
+                self.latency_n += 1
+                if latency_ms > self.max_latency_ms:
+                    self.max_latency_ms = latency_ms
 
     def record_fail(self, path, detail):
         with self._lock:
             self.fail += 1
             self.total += 1
             self.last_path = path
-            self.recent_fails.append((path, detail))
+            self.recent_fails.append(("fail", path, detail))
+            if len(self.recent_fails) > 50:
+                self.recent_fails = self.recent_fails[-50:]
+
+    def record_timeout(self, path, detail):
+        with self._lock:
+            self.timeout += 1
+            self.total += 1
+            self.last_path = path
+            self.recent_fails.append(("timeout", path, detail))
             if len(self.recent_fails) > 50:
                 self.recent_fails = self.recent_fails[-50:]
 
@@ -433,7 +482,12 @@ class _Stats(object):
             self.err += 1
             self.total += 1
             self.last_path = path
-            self.recent_fails.append((path, detail))
+            self.recent_fails.append(("err", path, detail))
+
+    def avg_latency_ms(self):
+        if self.latency_n < 1:
+            return 0.0
+        return self.latency_sum_ms / float(self.latency_n)
 
 
 def _print_progress(stats, t0, final=False):
@@ -446,21 +500,24 @@ def _print_progress(stats, t0, final=False):
         except ValueError:
             pass
     line = (
-        "blast  {elapsed}  req={total}  ok={ok}  fail={fail}  err={err}  "
-        "rps≈{rps:.1f}  last={last}"
+        "blast  {elapsed}  req={total}  ok={ok}  fail={fail}  "
+        "timeout={timeout}  err={err}  rps≈{rps:.1f}  "
+        "lat_ms≈{lat:.0f}/{mx:.0f}  last={last}"
     ).format(
         elapsed=_fmt_hms(elapsed),
         total=stats.total,
         ok=stats.ok,
         fail=stats.fail,
+        timeout=stats.timeout,
         err=stats.err,
         rps=rps,
+        lat=stats.avg_latency_ms(),
+        mx=stats.max_latency_ms,
         last=last or "-",
     )
     if final:
         msg.highlighted_info(line)
     else:
-        # single updating-friendly line
         print(line, flush=True)
 
 
@@ -516,8 +573,44 @@ def _collect_srcdirs(options):
     return srcdirs
 
 
-def _collect_corpus(options, srcdirs, skip_conf=True):
+def _group_needs_fixture(root, config):
+    """
+    True if this test group needs a private conf, shared environment, or
+    work-dir setup that a bare live /afw (or single --conf) does not provide.
+
+    Matches Jeremy's live afwfcgi mode spirit: skip custom stacks; default
+    blast should fail only when something is actually wrong.
+    """
+    if config and config.get("environment"):
+        return True, "Environment=" + str(config.get("environment"))
+    if os.path.isfile(os.path.join(root, "afw.conf")):
+        return True, "group afw.conf"
+    return False, None
+
+
+def _path_has_afw_conf_nearby(path, stop_dir_name="tests"):
+    """Walk parents of the test file for afw.conf (subdir tests under a conf)."""
+    d = os.path.dirname(os.path.abspath(path))
+    for _ in range(12):
+        if os.path.isfile(os.path.join(d, "afw.conf")):
+            return True
+        base = os.path.basename(d)
+        if base == stop_dir_name or d == os.path.dirname(d):
+            break
+        d = os.path.dirname(d)
+    return False
+
+
+def _collect_corpus(options, srcdirs, skip_fixtures=True):
+    """
+    Build list of .as paths for blasting.
+
+    When skip_fixtures (default): omit groups with config.py Environment,
+    group-level afw.conf, or afw.conf next to / above the script. Those need
+    afwdev test work dirs / environments, not a random eval on /afw.
+    """
     corpus = []
+    skipped_fixture = 0
     for srcdir, srcdir_path, _, manual_tests in srcdirs:
         if not os.path.isdir(manual_tests):
             continue
@@ -526,17 +619,27 @@ def _collect_corpus(options, srcdirs, skip_conf=True):
             config = load_test_group_config(root)
             if not test_group_matches_tags(options, config):
                 continue
+
+            if skip_fixtures:
+                needs, reason = _group_needs_fixture(root, config)
+                if needs:
+                    n_as = sum(1 for p in tests if p.endswith(".as"))
+                    skipped_fixture += n_as
+                    msg.debug(
+                        "blast skip group ({}) {}: {} script(s)".format(
+                            reason, root, n_as))
+                    continue
+
             for path in tests:
                 if not path.endswith(".as"):
                     continue
                 base = os.path.basename(path)
                 if base.startswith("_"):
                     continue
-                if skip_conf:
-                    conf = os.path.join(os.path.dirname(path), "afw.conf")
-                    if os.path.isfile(conf):
-                        msg.debug(
-                            "blast skip (local afw.conf): " + path)
-                        continue
+                if skip_fixtures and _path_has_afw_conf_nearby(path):
+                    skipped_fixture += 1
+                    msg.debug(
+                        "blast skip (afw.conf nearby): " + path)
+                    continue
                 corpus.append(path)
-    return corpus
+    return corpus, skipped_fixture

--- a/src/afw_dev/_afwdev/cli/handlers/test_validate.py
+++ b/src/afw_dev/_afwdev/cli/handlers/test_validate.py
@@ -8,6 +8,7 @@
 import sys
 from _afwdev.test import test
 from _afwdev.validate import validate
+from _afwdev import blast as blast_mod
 
 
 ##
@@ -24,6 +25,20 @@ def subcommand_test(args, options):
         'srcdir_pattern', '\\*').replace('\\', '')
     options['subcommand'] = "test"
     test.run(options)
+
+
+##
+# @defgroup afwdev_blast blast
+# @ingroup afwdev
+# @brief On-demand suite firehose at afwfcgi (experimental)
+# @details Not part of test -j. Random Adaptive test_scripts for a duration
+#          or request count; attach (--url) or managed spawn (--conf).
+#
+def subcommand_blast(args, options):
+    options['srcdir_pattern'] = options.get(
+        'srcdir_pattern', '\\*').replace('\\', '')
+    options['subcommand'] = "blast"
+    blast_mod.run(options)
 
 
 ##

--- a/src/afw_dev/_afwdev/cli/info.py
+++ b/src/afw_dev/_afwdev/cli/info.py
@@ -1009,8 +1009,8 @@ _info_blast_concurrency = {
     "default": "0",
     "noprompt": True,
     "help":
-        "In-flight requests at once. Default 0 = number of CPUs "
-        "(at least 1)."
+        "In-flight requests at once. Default 0 = 2×CPU count "
+        "(classic gobench-style load)."
 }
 
 _info_blast_threads = {
@@ -1021,8 +1021,8 @@ _info_blast_threads = {
     "default": "0",
     "noprompt": True,
     "help":
-        "afwfcgi -n when using --conf. Default 0 = number of CPUs. "
-        "Ignored for --url attach."
+        "afwfcgi -n when using --conf. Default 0 = CPU count. "
+        "Ignored for --url attach (use afwfcgi -n when you start it)."
 }
 
 _info_blast_request_timeout = {
@@ -1033,6 +1033,18 @@ _info_blast_request_timeout = {
     "help": "Per-request timeout in seconds (default 30)."
 }
 
+_info_blast_include_fixtures = {
+    "optionName": "include_fixtures",
+    "arg": "--include-fixtures",
+    "action": "store_true",
+    "default": False,
+    "noprompt": True,
+    "help":
+        "Include tests that need private afw.conf, tests/environments "
+        "(config.py Environment), or nearby conf. Default is to skip "
+        "those so fail counts stay near zero unless something is wrong."
+}
+
 _info_blast = {
     "subcommand": "blast",
     "help": "On-demand load blast at afwfcgi (experimental)",
@@ -1041,8 +1053,11 @@ _info_blast = {
         "sources at afwfcgi for a period of time. Not part of "
         "'afwdev test -j'. Defaults target a typical docker/dev stack: "
         "attach to http://localhost:8080/afw for 5m with concurrency "
-        "(and managed -n) at CPU count — so plain 'afwdev blast' often "
+        "2×CPUs (and managed afwfcgi -n = CPUs) — plain 'afwdev blast' often "
         "suffices when nginx+afwfcgi are up. Override with -u/-f/-d/-c/-n. "
+        "By default skips fixture-heavy groups (Environment= / afw.conf) "
+        "so failures usually mean a real problem; "
+        "--include-fixtures to load them too. "
         "Filters: --srcdir-pattern, --test-pattern, --tags. "
         "Continues on Adaptive failures; stops if the server dies. "
         "See designs/afwdev-blast.md.",
@@ -1055,6 +1070,7 @@ _info_blast = {
         _info_blast_concurrency,
         _info_blast_threads,
         _info_blast_request_timeout,
+        _info_blast_include_fixtures,
         _info_srcdir_pattern,
         _info_test_pattern,
         _info_test_tags,

--- a/src/afw_dev/_afwdev/cli/info.py
+++ b/src/afw_dev/_afwdev/cli/info.py
@@ -958,6 +958,109 @@ _info_test = {
     ]
 }
 
+# subcommand blast (experimental on-demand afwfcgi firehose)
+
+_info_blast_url = {
+    "optionName": "url",
+    "arg": "--url",
+    "short": "-u",
+    "noprompt": True,
+    "help":
+        "Attach mode: base URL of live AFW HTTP front door. "
+        "Default when --conf is omitted: http://localhost:8080/afw "
+        "(docker/dev nginx). Mutually exclusive with --conf."
+}
+
+_info_blast_conf = {
+    "optionName": "conf",
+    "arg": "--conf",
+    "short": "-f",
+    "noprompt": True,
+    "help":
+        "Managed mode: path to afw.conf; spawn installed afwfcgi "
+        "(-f like afw/afwfcgi). Mutually exclusive with --url."
+}
+
+_info_blast_duration = {
+    "optionName": "duration",
+    "arg": "--duration",
+    "short": "-d",
+    "default": "5m",
+    "noprompt": True,
+    "help":
+        "How long to blast (30s, 5m, 1h, or seconds). Default 5m. "
+        "Use 0 with --max-requests only to disable the time limit."
+}
+
+_info_blast_max_requests = {
+    "optionName": "max_requests",
+    "arg": "--max-requests",
+    "short": "-m",
+    "int": True,
+    "noprompt": True,
+    "help": "Stop after approximately this many requests (optional)."
+}
+
+_info_blast_concurrency = {
+    "optionName": "concurrency",
+    "arg": "--concurrency",
+    "short": "-c",
+    "int": True,
+    "default": "0",
+    "noprompt": True,
+    "help":
+        "In-flight requests at once. Default 0 = number of CPUs "
+        "(at least 1)."
+}
+
+_info_blast_threads = {
+    "optionName": "threads",
+    "arg": "--threads",
+    "short": "-n",
+    "int": True,
+    "default": "0",
+    "noprompt": True,
+    "help":
+        "afwfcgi -n when using --conf. Default 0 = number of CPUs. "
+        "Ignored for --url attach."
+}
+
+_info_blast_request_timeout = {
+    "optionName": "request_timeout",
+    "arg": "--request-timeout",
+    "default": "30",
+    "noprompt": True,
+    "help": "Per-request timeout in seconds (default 30)."
+}
+
+_info_blast = {
+    "subcommand": "blast",
+    "help": "On-demand load blast at afwfcgi (experimental)",
+    "description":
+        "*** Experimental *** Fire randomly chosen Adaptive test_script "
+        "sources at afwfcgi for a period of time. Not part of "
+        "'afwdev test -j'. Defaults target a typical docker/dev stack: "
+        "attach to http://localhost:8080/afw for 5m with concurrency "
+        "(and managed -n) at CPU count — so plain 'afwdev blast' often "
+        "suffices when nginx+afwfcgi are up. Override with -u/-f/-d/-c/-n. "
+        "Filters: --srcdir-pattern, --test-pattern, --tags. "
+        "Continues on Adaptive failures; stops if the server dies. "
+        "See designs/afwdev-blast.md.",
+    "thing": "blast",
+    "args": [
+        _info_blast_url,
+        _info_blast_conf,
+        _info_blast_duration,
+        _info_blast_max_requests,
+        _info_blast_concurrency,
+        _info_blast_threads,
+        _info_blast_request_timeout,
+        _info_srcdir_pattern,
+        _info_test_pattern,
+        _info_test_tags,
+    ]
+}
+
 
 
 _info_pattern = {
@@ -1040,6 +1143,7 @@ _subcommand_infos = [
     _info_settings,
     _info_task,
     _info_test,
+    _info_blast,
     _info_validate
 ]
 

--- a/src/afw_dev/_afwdev/cli/registry.py
+++ b/src/afw_dev/_afwdev/cli/registry.py
@@ -42,6 +42,7 @@ SUBCOMMAND_HANDLERS = {
     'settings': misc_handlers.subcommand_settings,
     'task': misc_handlers.subcommand_task,
     'test': test_validate_handlers.subcommand_test,
+    'blast': test_validate_handlers.subcommand_blast,
     'validate': test_validate_handlers.subcommand_validate,
 }
 

--- a/src/afw_dev/_afwdev/test/advanced/__init__.py
+++ b/src/afw_dev/_afwdev/test/advanced/__init__.py
@@ -1,5 +1,11 @@
 # -*- coding: utf-8 -*-
-"""Advanced test leaves (advanced-test.yaml|json) — see designs/afwdev-advanced-test.md."""
+"""
+Advanced test leaves (advanced-test.yaml|json).
+
+*** Experimental *** — usable for comment and real regression work; schema and
+behavior may change over the next months. See designs/afwdev-advanced-test.md
+and GitHub issue #157.
+"""
 
 from _afwdev.test.advanced.discovery import (
     MARKER_STEM,

--- a/src/afw_dev/_afwdev/test/advanced/__init__.py
+++ b/src/afw_dev/_afwdev/test/advanced/__init__.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+"""Advanced test leaves (advanced-test.yaml|json) — see designs/afwdev-advanced-test.md."""
+
+from _afwdev.test.advanced.discovery import (
+    MARKER_STEM,
+    find_advanced_marker,
+    is_advanced_marker_path,
+)
+from _afwdev.test.advanced.runner import run_advanced_test
+
+__all__ = [
+    "MARKER_STEM",
+    "find_advanced_marker",
+    "is_advanced_marker_path",
+    "run_advanced_test",
+]

--- a/src/afw_dev/_afwdev/test/advanced/discovery.py
+++ b/src/afw_dev/_afwdev/test/advanced/discovery.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""Discovery helpers for advanced-test marker leaves."""
+
+import os
+
+MARKER_STEM = "advanced-test"
+MARKER_YAML = MARKER_STEM + ".yaml"
+MARKER_JSON = MARKER_STEM + ".json"
+
+
+def find_advanced_marker(directory):
+    """
+    If directory is an advanced-test leaf, return absolute path to the marker.
+
+    Both .yaml and .json present → ValueError (ambiguous).
+    """
+    yaml_path = os.path.join(directory, MARKER_YAML)
+    json_path = os.path.join(directory, MARKER_JSON)
+    has_yaml = os.path.isfile(yaml_path)
+    has_json = os.path.isfile(json_path)
+    if has_yaml and has_json:
+        raise ValueError(
+            "Ambiguous advanced-test leaf (both .yaml and .json): " + directory)
+    if has_yaml:
+        return yaml_path
+    if has_json:
+        return json_path
+    return None
+
+
+def is_advanced_marker_path(path):
+    """True if path is advanced-test.yaml or advanced-test.json."""
+    if not path:
+        return False
+    base = os.path.basename(path)
+    return base == MARKER_YAML or base == MARKER_JSON

--- a/src/afw_dev/_afwdev/test/advanced/fcgi_client.py
+++ b/src/afw_dev/_afwdev/test/advanced/fcgi_client.py
@@ -1,0 +1,282 @@
+# -*- coding: utf-8 -*-
+"""
+Thin FastCGI responder client for talking to afwfcgi over a Unix socket.
+
+Record framing follows the FastCGI 1.0 spec (responder role only).
+Default params mirror the AFW reference nginx fastcgi_param set
+(see designs/afwdev-advanced-test.md and /afw/nginx.conf).
+"""
+
+import datetime
+import socket
+import struct
+
+# FastCGI constants
+FCGI_VERSION = 1
+FCGI_BEGIN_REQUEST = 1
+FCGI_ABORT_REQUEST = 2
+FCGI_END_REQUEST = 3
+FCGI_PARAMS = 4
+FCGI_STDIN = 5
+FCGI_STDOUT = 6
+FCGI_STDERR = 7
+FCGI_RESPONDER = 1
+FCGI_KEEP_CONN = 1
+
+
+def _name_value_pair(name, value):
+    name_b = name.encode("utf-8") if isinstance(name, str) else name
+    value_b = value.encode("utf-8") if isinstance(value, str) else value
+    nlen = len(name_b)
+    vlen = len(value_b)
+
+    def enc_len(n):
+        if n < 128:
+            return struct.pack("B", n)
+        return struct.pack(">I", n | 0x80000000)
+
+    return enc_len(nlen) + enc_len(vlen) + name_b + value_b
+
+
+def _record(rec_type, request_id, content):
+    clen = len(content)
+    padding = (8 - (clen % 8)) % 8
+    header = struct.pack(
+        ">BBHHBx",
+        FCGI_VERSION,
+        rec_type,
+        request_id,
+        clen,
+        padding,
+    )
+    return header + content + (b"\x00" * padding)
+
+
+def default_fcgi_params(path, method="POST", body=b"", overrides=None):
+    """
+    Build nginx-parity default FastCGI params for a request.
+
+    path: request path (e.g. /afw)
+    method: HTTP method string
+    body: request body bytes (for CONTENT_LENGTH)
+    overrides: optional dict of param name -> string to merge last
+    """
+    if isinstance(body, str):
+        body = body.encode("utf-8")
+    if path is None:
+        path = "/"
+    if not path.startswith("/"):
+        path = "/" + path
+
+    now = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    params = {
+        "IGNORE_URI_PREFIX": "/",
+        "URI": path,
+        "QUERY_STRING": "",
+        "REQUEST_METHOD": method,
+        "CONTENT_TYPE": "application/json",
+        "CONTENT_LENGTH": str(len(body)),
+        "SCRIPT_FILENAME": "",
+        "SCRIPT_NAME": "",
+        "PATH_INFO": "",
+        "PATH_TRANSLATED": "",
+        "REQUEST_URI": path,
+        "DOCUMENT_URI": path,
+        "DOCUMENT_ROOT": "",
+        "SERVER_PROTOCOL": "HTTP/1.1",
+        "GATEWAY_INTERFACE": "CGI/1.1",
+        "SERVER_SOFTWARE": "afwdev-fcgi-client/1",
+        "REMOTE_ADDR": "127.0.0.1",
+        "REMOTE_PORT": "0",
+        "SERVER_ADDR": "127.0.0.1",
+        "SERVER_PORT": "8080",
+        "SERVER_NAME": "localhost",
+        "HTTPS": "",
+        "SCHEME": "http",
+        "TIME_ISO8601": now,
+        "REDIRECT_STATUS": "200",
+        "HTTP_ACCEPT": "application/json",
+        "HTTP_CONTENT_TYPE": "application/json",
+    }
+    if overrides:
+        for k, v in overrides.items():
+            if v is None:
+                params.pop(k, None)
+            else:
+                params[k] = str(v)
+    return params
+
+
+def _encode_params(params):
+    chunks = []
+    for name, value in params.items():
+        if value is None:
+            continue
+        chunks.append(_name_value_pair(name, value))
+    return b"".join(chunks)
+
+
+def _read_record(sock):
+    header = _recv_exact(sock, 8)
+    if not header:
+        return None
+    version, rec_type, request_id, clen, padding, _ = struct.unpack(
+        ">BBHHBB", header)
+    content = _recv_exact(sock, clen) if clen else b""
+    if padding:
+        _recv_exact(sock, padding)
+    return version, rec_type, request_id, content
+
+
+def _recv_exact(sock, n):
+    buf = bytearray()
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            if not buf:
+                return b""
+            raise EOFError(
+                "FCGI socket closed early (wanted {} got {})".format(
+                    n, len(buf)))
+        buf.extend(chunk)
+    return bytes(buf)
+
+
+def _parse_cgi_response(stdout_bytes):
+    """
+    Parse CGI/1.1 style stdout from a FastCGI responder.
+
+    Returns (status_code, headers_dict, body_bytes).
+    """
+    # Headers end at blank line (CRLFCRLF or LFLF)
+    sep = b"\r\n\r\n"
+    idx = stdout_bytes.find(sep)
+    if idx < 0:
+        sep = b"\n\n"
+        idx = stdout_bytes.find(sep)
+    if idx < 0:
+        # No headers — treat all as body
+        return 200, {}, stdout_bytes
+
+    header_blob = stdout_bytes[:idx]
+    body = stdout_bytes[idx + len(sep):]
+    headers = {}
+    status_code = 200
+    for line in header_blob.replace(b"\r\n", b"\n").split(b"\n"):
+        if not line:
+            continue
+        if b":" not in line:
+            continue
+        name, _, value = line.partition(b":")
+        name_s = name.decode("latin-1").strip()
+        value_s = value.decode("latin-1").strip()
+        headers[name_s.lower()] = value_s
+        if name_s.lower() == "status":
+            # "200 OK" or "Status: 200 OK"
+            parts = value_s.split()
+            if parts and parts[0].isdigit():
+                status_code = int(parts[0])
+
+    return status_code, headers, body
+
+
+class FcgiClientError(Exception):
+    """Transport or protocol error talking to afwfcgi."""
+
+
+def fcgi_request(
+        socket_path,
+        path="/afw",
+        method="POST",
+        body=b"",
+        param_overrides=None,
+        timeout=30.0):
+    """
+    Send one FastCGI responder request to afwfcgi on a Unix socket.
+
+    Returns dict:
+      status_code, headers, body (bytes), stderr (bytes), app_status
+    """
+    if isinstance(body, str):
+        body = body.encode("utf-8")
+
+    params = default_fcgi_params(path, method=method, body=body,
+                                 overrides=param_overrides)
+    request_id = 1
+
+    # FCGI_BEGIN_REQUEST body: role(2) flags(1) reserved(5)
+    begin = struct.pack(">HB5s", FCGI_RESPONDER, 0, b"\x00" * 5)
+
+    records = []
+    records.append(_record(FCGI_BEGIN_REQUEST, request_id, begin))
+
+    params_bytes = _encode_params(params)
+    # Stream params in chunks if large
+    offset = 0
+    while offset < len(params_bytes):
+        chunk = params_bytes[offset:offset + 65535]
+        records.append(_record(FCGI_PARAMS, request_id, chunk))
+        offset += len(chunk)
+    records.append(_record(FCGI_PARAMS, request_id, b""))
+
+    offset = 0
+    while offset < len(body):
+        chunk = body[offset:offset + 65535]
+        records.append(_record(FCGI_STDIN, request_id, chunk))
+        offset += len(chunk)
+    records.append(_record(FCGI_STDIN, request_id, b""))
+
+    payload = b"".join(records)
+
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        sock.settimeout(timeout)
+        try:
+            sock.connect(socket_path)
+        except OSError as e:
+            raise FcgiClientError(
+                "Cannot connect to afwfcgi socket {!r}: {}".format(
+                    socket_path, e)) from e
+        sock.sendall(payload)
+
+        stdout = bytearray()
+        stderr = bytearray()
+        app_status = None
+
+        while True:
+            rec = _read_record(sock)
+            if rec is None:
+                break
+            _, rec_type, rid, content = rec
+            if rid != request_id and rid != 0:
+                continue
+            if rec_type == FCGI_STDOUT:
+                if content:
+                    stdout.extend(content)
+            elif rec_type == FCGI_STDERR:
+                if content:
+                    stderr.extend(content)
+            elif rec_type == FCGI_END_REQUEST:
+                if len(content) >= 8:
+                    app_status, protocol_status = struct.unpack(
+                        ">IB3x", content[:8])
+                    _ = protocol_status
+                break
+    except socket.timeout as e:
+        raise FcgiClientError(
+            "Timeout waiting for afwfcgi on {!r}".format(socket_path)) from e
+    finally:
+        try:
+            sock.close()
+        except Exception:
+            pass
+
+    status_code, headers, body_out = _parse_cgi_response(bytes(stdout))
+    return {
+        "status_code": status_code,
+        "headers": headers,
+        "body": body_out,
+        "stderr": bytes(stderr),
+        "app_status": app_status,
+        "stdout_raw": bytes(stdout),
+    }

--- a/src/afw_dev/_afwdev/test/advanced/hosts/__init__.py
+++ b/src/afw_dev/_afwdev/test/advanced/hosts/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Host backends for advanced-test leaves."""

--- a/src/afw_dev/_afwdev/test/advanced/hosts/afwfcgi.py
+++ b/src/afw_dev/_afwdev/test/advanced/hosts/afwfcgi.py
@@ -1,0 +1,215 @@
+# -*- coding: utf-8 -*-
+"""
+Spawn / stop installed afwfcgi for hermetic advanced-test leaves.
+
+Binary is expected on PATH from `./afwdev build … --install`.
+"""
+
+import os
+import signal
+import subprocess
+import time
+
+from _afwdev.common import msg, resources
+
+
+class AfwfcgiHostError(Exception):
+    """Failed to start or manage afwfcgi."""
+
+
+def build_afwfcgi_argv(
+        conf_path,
+        socket_path,
+        threads=1,
+        under_valgrind=False,
+        valgrind_suppressions=None):
+    """
+    Build argv to start afwfcgi (optionally under valgrind).
+
+    Hook point for --env-mode valgrind and future flags.
+    """
+    afwfcgi = "afwfcgi"
+    server = [
+        afwfcgi,
+        "-f", conf_path,
+        "-p", socket_path,
+        "-n", str(threads),
+    ]
+    if not under_valgrind:
+        return server
+
+    vg = [
+        "valgrind",
+        "--xml=yes",
+        "--xml-fd=2",
+        "--show-possibly-lost=no",
+    ]
+    if valgrind_suppressions and os.path.isfile(valgrind_suppressions):
+        vg.append("--suppressions=" + valgrind_suppressions)
+    return vg + server
+
+
+def start_afwfcgi(
+        work_dir,
+        threads=1,
+        under_valgrind=False,
+        options=None,
+        ready_timeout_s=15.0):
+    """
+    Start afwfcgi in work_dir with afw.conf and Unix socket afw.sock.
+
+    Returns a handle dict: process, socket_path, conf_path, log_path, argv
+    """
+    conf_path = os.path.join(work_dir, "afw.conf")
+    if not os.path.isfile(conf_path):
+        raise AfwfcgiHostError(
+            "advanced-test leaf requires afw.conf in work dir: " + work_dir)
+
+    socket_path = os.path.join(work_dir, "afw.sock")
+    if os.path.exists(socket_path):
+        try:
+            os.unlink(socket_path)
+        except OSError:
+            pass
+
+    suppressions = None
+    if under_valgrind and options is not None:
+        # Copy test resources (valgrind.suppress) into work_dir like modes/valgrind.py
+        try:
+            resources.copy_resources(options, "test/", todir=work_dir)
+            cand = os.path.join(work_dir, "valgrind.suppress")
+            if os.path.isfile(cand):
+                suppressions = cand
+        except Exception as e:
+            msg.debug("valgrind suppressions copy failed: {}".format(e))
+
+    argv = build_afwfcgi_argv(
+        conf_path,
+        socket_path,
+        threads=threads,
+        under_valgrind=under_valgrind,
+        valgrind_suppressions=suppressions,
+    )
+
+    log_path = os.path.join(work_dir, "afwfcgi.stderr.log")
+    log_fd = open(log_path, "wb")
+
+    msg.debug("Starting afwfcgi: " + " ".join(argv))
+    try:
+        proc = subprocess.Popen(
+            argv,
+            cwd=work_dir,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=log_fd,
+            start_new_session=True,
+        )
+    except FileNotFoundError as e:
+        log_fd.close()
+        raise AfwfcgiHostError(
+            "afwfcgi not found on PATH (install with "
+            "./afwdev build --cdev or --fulldev --install): {}".format(e)
+        ) from e
+    except Exception as e:
+        log_fd.close()
+        raise AfwfcgiHostError(
+            "Failed to spawn afwfcgi: {}".format(e)) from e
+
+    handle = {
+        "process": proc,
+        "socket_path": socket_path,
+        "conf_path": conf_path,
+        "log_path": log_path,
+        "log_fd": log_fd,
+        "argv": argv,
+        "under_valgrind": under_valgrind,
+    }
+
+    deadline = time.time() + ready_timeout_s
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            log_fd.flush()
+            err = _read_log_tail(log_path)
+            stop_afwfcgi(handle)
+            raise AfwfcgiHostError(
+                "afwfcgi exited during startup (code {}): {}".format(
+                    proc.returncode, err or "(no stderr)"))
+        if os.path.exists(socket_path):
+            # brief settle so accept loop is up
+            time.sleep(0.05)
+            return handle
+        time.sleep(0.05)
+
+    stop_afwfcgi(handle)
+    raise AfwfcgiHostError(
+        "Timeout waiting for afwfcgi socket {!r} ({}s). stderr: {}".format(
+            socket_path, ready_timeout_s, _read_log_tail(log_path)))
+
+
+def stop_afwfcgi(handle, grace_s=5.0):
+    """Terminate afwfcgi process group and remove socket."""
+    if not handle:
+        return
+    proc = handle.get("process")
+    log_fd = handle.get("log_fd")
+    socket_path = handle.get("socket_path")
+
+    if proc is not None and proc.poll() is None:
+        try:
+            os.killpg(proc.pid, signal.SIGTERM)
+        except (ProcessLookupError, PermissionError, OSError):
+            try:
+                proc.terminate()
+            except Exception:
+                pass
+        deadline = time.time() + grace_s
+        while time.time() < deadline and proc.poll() is None:
+            time.sleep(0.05)
+        if proc.poll() is None:
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError, OSError):
+                try:
+                    proc.kill()
+                except Exception:
+                    pass
+            try:
+                proc.wait(timeout=2.0)
+            except Exception:
+                pass
+
+    if log_fd is not None:
+        try:
+            log_fd.close()
+        except Exception:
+            pass
+        handle["log_fd"] = None
+
+    if socket_path and os.path.exists(socket_path):
+        try:
+            os.unlink(socket_path)
+        except OSError:
+            pass
+
+
+def valgrind_errors_in_log(log_path):
+    """True if valgrind XML in stderr log reports an <error>."""
+    if not log_path or not os.path.isfile(log_path):
+        return False
+    try:
+        with open(log_path, "rb") as fd:
+            data = fd.read()
+        return b"<error>" in data
+    except OSError:
+        return False
+
+
+def _read_log_tail(log_path, max_bytes=8000):
+    try:
+        with open(log_path, "rb") as fd:
+            data = fd.read()
+        if len(data) > max_bytes:
+            data = data[-max_bytes:]
+        return data.decode("utf-8", errors="replace")
+    except OSError:
+        return ""

--- a/src/afw_dev/_afwdev/test/advanced/load.py
+++ b/src/afw_dev/_afwdev/test/advanced/load.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+"""Load and validate advanced-test marker documents."""
+
+import os
+
+from _afwdev.common import nfc
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    yaml = None
+
+
+class AdvancedTestLoadError(Exception):
+    """Invalid or unreadable advanced-test marker."""
+
+
+def load_advanced_test_document(marker_path):
+    """
+    Load advanced-test.yaml or .json into a dict and validate v1 schema.
+
+    Returns the document dict (mutated only for normalization of defaults).
+    """
+    if not os.path.isfile(marker_path):
+        raise AdvancedTestLoadError("Marker not found: " + marker_path)
+
+    raw = None
+    with nfc.open(marker_path, "r") as fd:
+        text = fd.read()
+
+    if marker_path.endswith(".yaml") or marker_path.endswith(".yml"):
+        if yaml is None:
+            raise AdvancedTestLoadError(
+                "PyYAML is required to load advanced-test.yaml "
+                "(install PyYAML / project python-requirements)")
+        try:
+            raw = yaml.safe_load(text)
+        except Exception as e:
+            raise AdvancedTestLoadError(
+                "Failed to parse YAML {}: {}".format(marker_path, e)) from e
+    elif marker_path.endswith(".json"):
+        try:
+            raw = nfc.json_loads(text)
+        except Exception as e:
+            raise AdvancedTestLoadError(
+                "Failed to parse JSON {}: {}".format(marker_path, e)) from e
+    else:
+        raise AdvancedTestLoadError(
+            "Marker must be advanced-test.yaml or advanced-test.json: "
+            + marker_path)
+
+    if not isinstance(raw, dict):
+        raise AdvancedTestLoadError(
+            "advanced-test document must be a mapping/object: " + marker_path)
+
+    host = raw.get("host")
+    if not host:
+        raise AdvancedTestLoadError(
+            "advanced-test requires 'host' field: " + marker_path)
+    if host != "afwfcgi":
+        raise AdvancedTestLoadError(
+            "advanced-test host {!r} not supported in v1 (only 'afwfcgi'): "
+            "{}".format(host, marker_path))
+
+    steps = raw.get("steps")
+    if not isinstance(steps, list) or len(steps) == 0:
+        raise AdvancedTestLoadError(
+            "advanced-test requires non-empty 'steps' list: " + marker_path)
+
+    for i, step in enumerate(steps):
+        if not isinstance(step, dict):
+            raise AdvancedTestLoadError(
+                "steps[{}] must be a mapping: {}".format(i, marker_path))
+        name = step.get("name")
+        if not name or not isinstance(name, str):
+            raise AdvancedTestLoadError(
+                "steps[{}] requires string 'name': {}".format(i, marker_path))
+        has_eval = "eval" in step and step.get("eval") is not None
+        has_script = "script" in step and step.get("script") is not None
+        if has_eval and has_script:
+            raise AdvancedTestLoadError(
+                "steps[{}] ({!r}) must not set both 'eval' and 'script': "
+                "{}".format(i, name, marker_path))
+        if not has_eval and not has_script:
+            raise AdvancedTestLoadError(
+                "steps[{}] ({!r}) requires 'eval' or 'script': {}".format(
+                    i, name, marker_path))
+        if has_script and not isinstance(step.get("script"), str):
+            raise AdvancedTestLoadError(
+                "steps[{}] ({!r}) 'script' must be a string path: {}".format(
+                    i, name, marker_path))
+        if has_eval and not isinstance(step.get("eval"), str):
+            raise AdvancedTestLoadError(
+                "steps[{}] ({!r}) 'eval' must be a string: {}".format(
+                    i, name, marker_path))
+
+    if "timeout_s" in raw and raw["timeout_s"] is not None:
+        try:
+            raw["timeout_s"] = float(raw["timeout_s"])
+        except (TypeError, ValueError) as e:
+            raise AdvancedTestLoadError(
+                "timeout_s must be a number: " + marker_path) from e
+    else:
+        raw["timeout_s"] = 120.0
+
+    afwfcgi = raw.get("afwfcgi")
+    if afwfcgi is None:
+        raw["afwfcgi"] = {"threads": 1}
+    elif not isinstance(afwfcgi, dict):
+        raise AdvancedTestLoadError(
+            "afwfcgi block must be a mapping: " + marker_path)
+    else:
+        threads = afwfcgi.get("threads", 1)
+        try:
+            threads = int(threads)
+        except (TypeError, ValueError) as e:
+            raise AdvancedTestLoadError(
+                "afwfcgi.threads must be an integer: " + marker_path) from e
+        if threads < 1:
+            raise AdvancedTestLoadError(
+                "afwfcgi.threads must be >= 1: " + marker_path)
+        afwfcgi["threads"] = threads
+
+    if not raw.get("description"):
+        raw["description"] = os.path.basename(os.path.dirname(marker_path))
+
+    return raw

--- a/src/afw_dev/_afwdev/test/advanced/runner.py
+++ b/src/afw_dev/_afwdev/test/advanced/runner.py
@@ -1,0 +1,290 @@
+# -*- coding: utf-8 -*-
+"""
+Run one advanced-test leaf (marker path).
+
+Returns (response, error, debug) compatible with afwdev test parse_test_run:
+  - one synthetic test case for one leaf pass/fail
+  - response None + error None => skipped
+"""
+
+import os
+import time
+
+from _afwdev.common import msg, nfc
+from _afwdev.test.advanced.load import (
+    AdvancedTestLoadError,
+    load_advanced_test_document,
+)
+from _afwdev.test.advanced.fcgi_client import FcgiClientError, fcgi_request
+from _afwdev.test.advanced.hosts import afwfcgi as afwfcgi_host
+
+
+def run_advanced_test(marker_path, options, testEnvironment=None,
+                      testGroupConfig=None):
+    """
+    Entry point from common.run_test for advanced-test markers.
+    """
+    mode = (options or {}).get("mode") or "afw"
+    debug_parts = []
+
+    if mode == "actions":
+        msg.debug("Skipping advanced-test under --env-mode actions: " +
+                  marker_path)
+        return None, None, None
+
+    if mode == "afwfcgi":
+        # Private conf / hermetic leaf — skip (same spirit as .as + afw.conf)
+        msg.debug(
+            "Skipping advanced-test under --env-mode afwfcgi "
+            "(live stack; use default env-mode for hermetic leaves): "
+            + marker_path)
+        return None, None, None
+
+    under_valgrind = (mode == "valgrind")
+
+    try:
+        doc = load_advanced_test_document(marker_path)
+    except AdvancedTestLoadError as e:
+        # Assertion-style fail (no separate error) so counts stay 1:1
+        return _fail_response(str(marker_path), str(e)), None, None
+
+    work_dir = None
+    if testEnvironment and testEnvironment.get("work_dir"):
+        work_dir = testEnvironment["work_dir"]
+    else:
+        work_dir = os.path.dirname(marker_path)
+
+    conf_path = os.path.join(work_dir, "afw.conf")
+    if not os.path.isfile(conf_path):
+        err = "advanced-test requires afw.conf in leaf/work dir: " + work_dir
+        return _fail_response("advanced-test", err), None, None
+
+    description = doc.get("description") or os.path.basename(work_dir)
+    timeout_s = float(doc.get("timeout_s") or 120.0)
+    threads = int(doc.get("afwfcgi", {}).get("threads") or 1)
+    steps = doc["steps"]
+
+    handle = None
+    t0 = time.time()
+    try:
+        handle = afwfcgi_host.start_afwfcgi(
+            work_dir,
+            threads=threads,
+            under_valgrind=under_valgrind,
+            options=options,
+            ready_timeout_s=min(30.0, timeout_s),
+        )
+        debug_parts.append("started: " + " ".join(handle["argv"]))
+        debug_parts.append("socket: " + handle["socket_path"])
+
+        for step in steps:
+            if time.time() - t0 > timeout_s:
+                err = "advanced-test timed out after {}s (step {!r})".format(
+                    timeout_s, step.get("name"))
+                return (
+                    _fail_response(description, err),
+                    None,
+                    _debug_blob(debug_parts, handle),
+                )
+
+            step_name = step["name"]
+            msg.debug("advanced-test step: " + step_name)
+            remaining = max(1.0, timeout_s - (time.time() - t0))
+            try:
+                _run_step(
+                    step,
+                    work_dir=work_dir,
+                    socket_path=handle["socket_path"],
+                    timeout=remaining,
+                    debug_parts=debug_parts,
+                )
+            except Exception as e:
+                err = "step {!r} failed: {}".format(step_name, e)
+                debug_parts.append(err)
+                return (
+                    _fail_response(description, err),
+                    None,
+                    _debug_blob(debug_parts, handle),
+                )
+
+        if under_valgrind and afwfcgi_host.valgrind_errors_in_log(
+                handle.get("log_path")):
+            err = "Valgrind error(s) detected in afwfcgi stderr"
+            return (
+                _fail_response(description, err),
+                None,
+                _debug_blob(debug_parts, handle),
+            )
+
+        return (
+            _pass_response(description),
+            None,
+            _debug_blob(debug_parts, handle),
+        )
+
+    except afwfcgi_host.AfwfcgiHostError as e:
+        # Host spawn failures: surface as error for digest path identity
+        return (
+            _fail_response(description, str(e)),
+            str(e),
+            _debug_blob(debug_parts, handle),
+        )
+    except Exception as e:
+        return (
+            _fail_response(description, str(e)),
+            str(e),
+            _debug_blob(debug_parts, handle),
+        )
+    finally:
+        if handle is not None:
+            afwfcgi_host.stop_afwfcgi(handle)
+
+
+def _run_step(step, work_dir, socket_path, timeout, debug_parts):
+    source = step.get("eval")
+    if source is None:
+        script_rel = step["script"]
+        script_path = os.path.join(work_dir, script_rel)
+        if not os.path.isfile(script_path):
+            raise RuntimeError("script not found: " + script_path)
+        with nfc.open(script_path, "r") as fd:
+            source = fd.read()
+
+    # Keep shebang in source: eval<script> honors --syntax test_script when
+    # present (same as modes/afwfcgi.py). Still parse syntax for checks.
+    syntax = None
+    lines = source.splitlines()
+    if lines and lines[0].startswith("#!") and "--syntax" in lines[0]:
+        parts = lines[0].split()
+        try:
+            syntax = parts[parts.index("--syntax") + 1]
+        except (ValueError, IndexError):
+            syntax = None
+
+    body_obj = {
+        "actions": [
+            {
+                "function": "eval<script>",
+                "source": source,
+            }
+        ]
+    }
+    body = nfc.json_dumps(body_obj)
+
+    try:
+        result = fcgi_request(
+            socket_path,
+            path="/afw",
+            method="POST",
+            body=body,
+            timeout=timeout,
+        )
+    except FcgiClientError as e:
+        raise RuntimeError(str(e)) from e
+
+    debug_parts.append(
+        "step {!r} status={} body_len={}".format(
+            step.get("name"),
+            result.get("status_code"),
+            len(result.get("body") or b""),
+        )
+    )
+    if result.get("stderr"):
+        debug_parts.append(
+            "fcgi stderr: " +
+            result["stderr"].decode("utf-8", errors="replace")[:2000])
+
+    body_text = (result.get("body") or b"").decode("utf-8", errors="replace")
+    try:
+        response = nfc.json_loads(body_text) if body_text.strip() else {}
+    except Exception as e:
+        raise RuntimeError(
+            "non-JSON response from afwfcgi (HTTP-ish status {}): {}".format(
+                result.get("status_code"), body_text[:500])) from e
+
+    status = response.get("status")
+    if status and status != "success":
+        raise RuntimeError(
+            "perform status {!r}: {}".format(
+                status, body_text[:1500]))
+
+    if response.get("status") == "error":
+        raise RuntimeError(
+            "action error: {}".format(
+                nfc.json_dumps(response.get("error") or response)[:1500]))
+
+    actions = response.get("actions")
+    if "result" in response and isinstance(response["result"], dict):
+        inner = response["result"]
+        if inner.get("status") == "error":
+            raise RuntimeError(
+                "action error: {}".format(
+                    nfc.json_dumps(inner.get("error") or inner)[:1500]))
+        if inner.get("actions") is not None:
+            actions = inner.get("actions")
+
+    # Collect test_script result objects from action results
+    def _fail_if_test_script_failures(obj):
+        if not isinstance(obj, dict) or "tests" not in obj:
+            return
+        for tc in obj.get("tests") or []:
+            if tc.get("skip"):
+                continue
+            if tc.get("passed", False) is False:
+                raise RuntimeError(
+                    "test_script failure: {}".format(
+                        tc.get("test") or tc.get("description") or tc))
+
+    if actions:
+        for act in actions:
+            if not isinstance(act, dict):
+                continue
+            if act.get("status") == "error":
+                raise RuntimeError(
+                    "action error: {}".format(
+                        nfc.json_dumps(act.get("error") or act)[:1500]))
+            ar = act.get("result")
+            # Always inspect for tests[] (eval of test_script source)
+            _fail_if_test_script_failures(ar)
+            if syntax == "test_script" and ar is not None:
+                _fail_if_test_script_failures(ar)
+
+
+def _pass_response(description):
+    return {
+        "description": description,
+        "tests": [
+            {
+                "test": description,
+                "description": description,
+                "passed": True,
+            }
+        ],
+    }
+
+
+def _fail_response(description, detail):
+    return {
+        "description": description or "advanced-test",
+        "tests": [
+            {
+                "test": description or "advanced-test",
+                "description": detail,
+                "passed": False,
+                "error": detail,
+            }
+        ],
+    }
+
+
+def _debug_blob(debug_parts, handle):
+    parts = list(debug_parts or [])
+    if handle and handle.get("log_path"):
+        try:
+            with open(handle["log_path"], "rb") as fd:
+                log = fd.read().decode("utf-8", errors="replace")
+            if log:
+                parts.append("--- afwfcgi stderr ---\n" + log[-12000:])
+        except OSError:
+            pass
+    return "\n".join(parts) if parts else None

--- a/src/afw_dev/_afwdev/test/common.py
+++ b/src/afw_dev/_afwdev/test/common.py
@@ -143,7 +143,10 @@ def after_all(root, testGroupConfig, testEnvironment):
 #
 def is_test_file(file):    
     skip = [        
-        "config.py"
+        "config.py",
+        # advanced-test markers are discovered as leaf units, not as scripts
+        "advanced-test.yaml",
+        "advanced-test.json",
     ]
 
     if (file.endswith(".as") or
@@ -153,6 +156,25 @@ def is_test_file(file):
         if file in skip or file.startswith("_"):
             return False        
         return True
+    return False
+
+
+def _test_pattern_matches(pattern, path_or_name):
+    """True if --test-pattern matches basename or full path string."""
+    if not pattern or pattern == ".*":
+        return True
+    try:
+        if re.search(pattern, path_or_name):
+            return True
+        base = os.path.basename(path_or_name)
+        if base != path_or_name and re.search(pattern, base):
+            return True
+        # leaf directory name (for advanced-test.yaml under smoke/)
+        parent = os.path.basename(os.path.dirname(path_or_name))
+        if parent and re.search(pattern, parent):
+            return True
+    except re.error:
+        return False
     return False
 
 ##
@@ -296,11 +318,14 @@ def load_test_group_config(root):
 # For a given folder, find all tests 
 def find_tests(options, root, files):
     tests = []
+    pattern = options.get("test-pattern")
 
     for f in files:
         # check options to filter out tests
-        if options.get("test-pattern"):
-            if not re.match(options.get("test-pattern"), f):
+        if pattern and pattern != ".*":
+            full = os.path.join(root, f)
+            if not _test_pattern_matches(pattern, full) and \
+                    not _test_pattern_matches(pattern, f):
                 msg.debug("Skipping test (does not match): " + f)
                 continue
 
@@ -319,6 +344,30 @@ def find_test_groups(options, srcdir, tests_dir):
         # exclude subdirectory environments and any directories that start with an underscore
         dirs[:] = [d for d in dirs if d != 'environments' and not d.startswith('_')]
 
+        # advanced-test leaf: marker directory is one test; do not walk children
+        try:
+            from _afwdev.test.advanced.discovery import find_advanced_marker
+            marker = find_advanced_marker(root)
+        except ValueError as e:
+            msg.error(str(e))
+            dirs[:] = []
+            testGroups.append((srcdir, root, []))
+            continue
+        except ImportError:
+            marker = None
+
+        if marker:
+            dirs[:] = []  # prune — assets only under leaf
+            pattern = options.get("test-pattern")
+            if pattern and pattern != ".*" and \
+                    not _test_pattern_matches(pattern, marker):
+                msg.debug(
+                    "Skipping advanced-test (does not match pattern): " +
+                    marker)
+                continue
+            testGroups.append((srcdir, root, [marker]))
+            continue
+
         if is_test_group(root):
             pass
 
@@ -334,6 +383,20 @@ def find_test_groups(options, srcdir, tests_dir):
 # group. After running the test, it returns a tuple containing the test
 # response, any errors, and the stderr output.
 def run_test(test, options, testEnvironment=None, testGroupConfig=None):
+
+    # advanced-test.yaml|json — harness runner (env-mode modulates attach)
+    try:
+        from _afwdev.test.advanced.discovery import is_advanced_marker_path
+        from _afwdev.test.advanced.runner import run_advanced_test
+        if is_advanced_marker_path(test):
+            return run_advanced_test(
+                test, options, testEnvironment, testGroupConfig)
+    except ImportError as e:
+        if test and (
+                test.endswith("advanced-test.yaml") or
+                test.endswith("advanced-test.json")):
+            msg.error("Unable to load advanced-test runner: " + str(e))
+            return (None, str(e), None)
 
     # look at the test file extension to determine how to run it
     # some files, such as .py files have to be run in 'python' mode

--- a/whats-new.md
+++ b/whats-new.md
@@ -86,12 +86,12 @@ Not a replacement for ordinary `.as` test scripts. Live `--env-mode afwfcgi` sti
 Randomly sends suite Adaptive `test_script` sources at **afwfcgi** for a duration and/or request count (language gate stays Jeremy’s `test`).
 
 ```bash
-afwdev blast                    # defaults: :8080/afw, 5m, concurrency=CPUs
-afwdev blast -d 30m -c 16       # short aliases
-afwdev blast -f path/to/afw.conf -m 500   # managed spawn
+afwdev blast                    # :8080/afw, 5m, concurrency=2×CPUs
+afwdev blast -d 30m             # short aliases; -c/-n override auto
+afwdev blast -f path/to/afw.conf -m 500   # managed spawn (-n defaults to CPUs)
 ```
 
-Defaults favor a typical docker/dev stack (nginx + afwfcgi). Filters match `test`: `-p` / `--srcdir-pattern`, `--test-pattern`, `--tags`. Continues on Adaptive failures; stops if the server dies. Design: [`designs/afwdev-blast.md`](designs/afwdev-blast.md). Graceful afwfcgi signals: [#158](https://github.com/afw-org/afw/issues/158).
+Defaults favor docker/dev + classic load (threads≈CPUs, in-flight≈2×CPUs). Fixture-heavy tests skipped unless `--include-fixtures`. Design: [`designs/afwdev-blast.md`](designs/afwdev-blast.md). Signals: [#158](https://github.com/afw-org/afw/issues/158).
 
 **[↑ Highlights](#highlights)**
 

--- a/whats-new.md
+++ b/whats-new.md
@@ -57,6 +57,7 @@ sections end with **[↑ Highlights](#highlights)** to return here.
 | [**Conversion functions**](#conversion-functions-type-named) | Type-named converts; no `null()` / `function()` converts; `array` is constructor; source types hold text for `compile` |
 | [**UTF-8 code-point sequences (#153)**](#utf-8-code-point-sequences-issue-153) | Utf8-backed values as **immutable code-point sequences**: `s[i]`, for-of, array formals / HOFs; C **`afw_iterator`** redesign (**recompile** out-of-tree; rename legacy cursor to **`afw_iterator_old`**) |
 | [**afwdev advanced-test (#157)**](#experimental-afwdev-advanced-test-issue-157) | **\*\*\* Experimental \*\*\***: hermetic `afwfcgi` multi-step tests via `advanced-test.yaml` / `.json` — for comment; may change |
+| [**afwdev blast**](#experimental-afwdev-blast) | **\*\*\* Experimental \*\*\***: on-demand random suite firehose at afwfcgi — not part of `test -j` |
 
 ---
 
@@ -73,6 +74,24 @@ sections end with **[↑ Highlights](#highlights)** to return here.
 | **Design / feedback** | [`designs/afwdev-advanced-test.md`](designs/afwdev-advanced-test.md), GitHub **[#157](https://github.com/afw-org/afw/issues/157)**. |
 
 Not a replacement for ordinary `.as` test scripts. Live `--env-mode afwfcgi` still means “shared stack”; advanced leaves stay **hermetic** under default mode.
+
+**[↑ Highlights](#highlights)**
+
+---
+
+## \*\*\* Experimental \*\*\* afwdev blast
+
+**Status: experimental** — on-demand only; **not** part of `afwdev test -j`.
+
+Randomly sends suite Adaptive `test_script` sources at **afwfcgi** for a duration and/or request count (language gate stays Jeremy’s `test`).
+
+```bash
+afwdev blast                    # defaults: :8080/afw, 5m, concurrency=CPUs
+afwdev blast -d 30m -c 16       # short aliases
+afwdev blast -f path/to/afw.conf -m 500   # managed spawn
+```
+
+Defaults favor a typical docker/dev stack (nginx + afwfcgi). Filters match `test`: `-p` / `--srcdir-pattern`, `--test-pattern`, `--tags`. Continues on Adaptive failures; stops if the server dies. Design: [`designs/afwdev-blast.md`](designs/afwdev-blast.md). Graceful afwfcgi signals: [#158](https://github.com/afw-org/afw/issues/158).
 
 **[↑ Highlights](#highlights)**
 

--- a/whats-new.md
+++ b/whats-new.md
@@ -69,6 +69,7 @@ sections end with **[↑ Highlights](#highlights)** to return here.
 | **What** | Under `src/*/tests/`, a directory with **`advanced-test.yaml`** or **`advanced-test.json`** is one **leaf** test: harness starts installed **`afwfcgi`**, drives it with a FastCGI client, runs ordered **`eval` / `script`** steps, tears down. |
 | **When it runs** | Normal **`afwdev test` / `afwdev test -j`** (default `--env-mode afw`). Requires **PyYAML** and **`afwfcgi` on PATH** (build with install). |
 | **Examples** | `src/afw/tests/advanced/` (smoke, multi-request file adapter, multi-eval lifetime, JSON marker sample). |
+| **How to write tests** | Builder page [`src/afw/doc/developer/writing-tests.md`](src/afw/doc/developer/writing-tests.md) (Doxygen related page **Writing tests** after docs build). |
 | **Design / feedback** | [`designs/afwdev-advanced-test.md`](designs/afwdev-advanced-test.md), GitHub **[#157](https://github.com/afw-org/afw/issues/157)**. |
 
 Not a replacement for ordinary `.as` test scripts. Live `--env-mode afwfcgi` still means “shared stack”; advanced leaves stay **hermetic** under default mode.

--- a/whats-new.md
+++ b/whats-new.md
@@ -56,6 +56,24 @@ sections end with **[↑ Highlights](#highlights)** to return here.
 | [**Array semantics (#39)**](#array-semantics-issue-39) | Literal elision → undefined; assign-append at `length`; **`create_array(n)`**; dense arrays only (no sparse / no `in`/`delete`) |
 | [**Conversion functions**](#conversion-functions-type-named) | Type-named converts; no `null()` / `function()` converts; `array` is constructor; source types hold text for `compile` |
 | [**UTF-8 code-point sequences (#153)**](#utf-8-code-point-sequences-issue-153) | Utf8-backed values as **immutable code-point sequences**: `s[i]`, for-of, array formals / HOFs; C **`afw_iterator`** redesign (**recompile** out-of-tree; rename legacy cursor to **`afw_iterator_old`**) |
+| [**afwdev advanced-test (#157)**](#experimental-afwdev-advanced-test-issue-157) | **\*\*\* Experimental \*\*\***: hermetic `afwfcgi` multi-step tests via `advanced-test.yaml` / `.json` — for comment; may change |
+
+---
+
+## \*\*\* Experimental \*\*\* afwdev advanced-test (issue #157)
+
+**Status: experimental** — ship for **comment and use**, not a frozen green contract. Marker names, schema, and runner behavior may change over the next months as maintainers exercise multi-request / process-lifetime tests (including work toward **#149** and **#2**). Many early design choices are expected to stick; treat the *capability* (hermetic server + multi-step fixtures) as durable, not every field name.
+
+| | |
+|--|--|
+| **What** | Under `src/*/tests/`, a directory with **`advanced-test.yaml`** or **`advanced-test.json`** is one **leaf** test: harness starts installed **`afwfcgi`**, drives it with a FastCGI client, runs ordered **`eval` / `script`** steps, tears down. |
+| **When it runs** | Normal **`afwdev test` / `afwdev test -j`** (default `--env-mode afw`). Requires **PyYAML** and **`afwfcgi` on PATH** (build with install). |
+| **Examples** | `src/afw/tests/advanced/` (smoke, multi-request file adapter, multi-eval lifetime, JSON marker sample). |
+| **Design / feedback** | [`designs/afwdev-advanced-test.md`](designs/afwdev-advanced-test.md), GitHub **[#157](https://github.com/afw-org/afw/issues/157)**. |
+
+Not a replacement for ordinary `.as` test scripts. Live `--env-mode afwfcgi` still means “shared stack”; advanced leaves stay **hermetic** under default mode.
+
+**[↑ Highlights](#highlights)**
 
 ---
 


### PR DESCRIPTION
## Summary

**Experimental** afwdev testing support for real `afwfcgi` multi-request work and on-demand load — without changing Jeremy’s language-suite focus for normal `afwdev test -j`.

1. **`advanced-test` leaves** (`advanced-test.yaml` / `.json`) — hermetic spawn of installed `afwfcgi`, FCGI client (nginx-parity params), ordered `eval` / `script` steps. Runs under default `test -j`; skipped under `--env-mode afwfcgi` (private conf). Showcase leaves under `src/afw/tests/advanced/`.
2. **`afwdev blast`** — on-demand random suite firehose at afwfcgi (attach `:8080/afw` or managed `--conf`). Defaults: 5m, concurrency 2×CPU, fixture groups skipped. Not part of the gate.
3. **Docs** — `designs/afwdev-advanced-test.md`, `designs/afwdev-blast.md`, `src/afw/doc/developer/writing-tests.md`, experimental notes in `whats-new.md`.

**After merge:** rebase `issue-#149-runtime-catalog-lifetime` onto `mgg-develop` and add catalog multi-request leaves; use blast for load/crash hunts. Related: **#158** (afwfcgi signal shutdown).

## Test plan

- [x] `afwdev test -j` green (includes advanced-test leaves)
- [x] `afwdev test -j --env-mode afwfcgi` green (advanced-test skipped; conf-free scripts)
- [x] `afwdev blast -d 1m` attach: fail≈0 expect, occasional timeouts under high concurrency, err=0
- [ ] CI / reviewer: rebuild with install so PATH `afwdev` has blast + advanced-test

## Experimental

Schema, marker names, and blast knobs may change. Core ideas (leaf discovery, hermetic multi-request, gate vs on-demand load) expected to stick. Feedback welcome on #157.