### PR TITLE
fix(#149): pooled propertyTypes for rich objectOptions on permanent shells

### DIFF
--- a/beta-backlog.md
+++ b/beta-backlog.md
@@ -97,7 +97,7 @@ Update this section if the plan changes.
   - Tests: always-on `tests/advanced/catalog-value-accessors/`; opt-in `tests_special/` lifecycle + blast corpus.
 - **afwdev follow-ons** on same PR (after **#159** advanced-test/blast): `--tests-path`/`-T`, `--output`/`--output-format`, recipe polish, **#61** structured exceptions (closed).
 - **#13** stress: comment to Jeremy (blast ≠ his `--rounds`/`--continuous` on `test`); left open.
-- **Active branch:** `issue-#149-catalog-phase2` off `mgg-develop` for phase 2 (more accessors only if proven; EnvironmentRegistry/`current` + rich objectOptions pool bug).
+- **Active branch:** `issue-#149-catalog-phase2` — phase 2 **EnvironmentRegistry/`current` objectOptions pool fix** landed (meta propertyTypes materialize on view pool); remaining: more accessors only if proven; metrics R vs snapshot.
 
 ### Session wrap-up — 2026-08-06 (#17 merged)
 

--- a/beta-backlog.md
+++ b/beta-backlog.md
@@ -91,13 +91,13 @@ Update this section if the plan changes.
 
 ### Session wrap-up — 2026-08-09 (#149 phase 1 + afwdev harness)
 
-- **#149 phase 1** on branch `issue-#149-runtime-catalog-lifetime` → PR to `mgg-develop` (see issue for ship notes). **Does not close #149.**
+- **#149 phase 1** merged to **`mgg-develop`** via [PR #160](https://github.com/afw-org/afw/pull/160) (`32ff0706`). Issue comment has ship notes. **Does not close #149.**
   - Architecture: [`designs/runtime-objects-and-environment.md`](designs/runtime-objects-and-environment.md), snapshot [`runtime-value-accessors.md`](designs/runtime-value-accessors.md), discovery [`runtime-catalog-lifetime.md`](designs/runtime-catalog-lifetime.md).
   - Product C: first-class `_AdaptiveRuntimeValueAccessor_` registry objects; lock+copy **`referenceCount`** for adapter + auth handler; metrics/properties stay live-while-active (documented).
   - Tests: always-on `tests/advanced/catalog-value-accessors/`; opt-in `tests_special/` lifecycle + blast corpus.
-- **afwdev follow-ons** on same branch (after PR **#159** advanced-test/blast): `--tests-path`/`-T`, `--output`/`--output-format`, recipe polish, **#61** structured exceptions (closed).
+- **afwdev follow-ons** on same PR (after **#159** advanced-test/blast): `--tests-path`/`-T`, `--output`/`--output-format`, recipe polish, **#61** structured exceptions (closed).
 - **#13** stress: comment to Jeremy (blast ≠ his `--rounds`/`--continuous` on `test`); left open.
-- **Next:** new branch off `mgg-develop` for #149 phase 2 (more accessors only if proven; EnvironmentRegistry/`current` + rich objectOptions pool bug; issue comments as work lands).
+- **Active branch:** `issue-#149-catalog-phase2` off `mgg-develop` for phase 2 (more accessors only if proven; EnvironmentRegistry/`current` + rich objectOptions pool bug).
 
 ### Session wrap-up — 2026-08-06 (#17 merged)
 

--- a/designs/runtime-objects-and-environment.md
+++ b/designs/runtime-objects-and-environment.md
@@ -498,7 +498,8 @@ High signal for #149 (adjust as inventory proceeds):
 2. ~~Inventory risk types with §10 checklist~~ (core named accessors + P0 adapter/auth — §14).  
 3. ~~Surgical P0: lock+copy `referenceCount` (adapter + auth); first-class `_AdaptiveRuntimeValueAccessor_` registry.~~  
 4. ~~Phase 1 PR to `mgg-develop`~~ — [PR #160](https://github.com/afw-org/afw/pull/160) merged 2026-08-09 (`32ff0706`).  
-5. **Phase 2+ (open on `issue-#149-catalog-phase2`):** more lock/copy only where inventory proves need; EnvironmentRegistry/`current` + rich objectOptions “must have a pool” (§14.7); optional metrics snapshot vs document-R; services/logs; issue comments as slices land.
+5. ~~EnvironmentRegistry/`current` + rich objectOptions “must have a pool” (§14.7).~~ **fixed** on `issue-#149-catalog-phase2`.  
+6. **Still open:** more lock/copy only where inventory proves need; optional metrics snapshot vs document-R; services/logs; issue comments as slices land.
 
 When decisions stabilize, promote invariants into `.cursor/rules` or developer docs and thin the pads.
 
@@ -651,31 +652,30 @@ Plus **18** `onGetValueCFunctionName` model `current::` callbacks (xctx model st
 - Prefer live **OT get** or instance get with options (`metaFull`, `objectTypes`, …) for property meta including `runtime.valueAccessor`.  
 - For **lifetime**, the **generated map + accessor** is authoritative.
 
-### 14.7 Bug: rich objectOptions on EnvironmentRegistry/`current` (2026-08-08)
+### 14.7 Bug: rich objectOptions on EnvironmentRegistry/`current` (2026-08-08) — **fixed phase 2**
 
-**Symptom:** `get_object(afw, _AdaptiveEnvironmentRegistry_, current, options: …)` with certain option sets fails; afwfcgi stays up.
+**Symptom (before fix):** `get_object(afw, _AdaptiveEnvironmentRegistry_, current, options: …)` with certain option sets failed; afwfcgi stayed up.
 
-| Options | Error |
-|---------|--------|
-| bare / `metaFull` alone / identity flags | **success** (~1.3–1.4 MiB) |
-| `metaFull` + `normalize` + path/ids | **`Object must have a pool`** |
-| `metaFull` + `objectTypes` + … | **`Object must have a pool`** |
-| kitchen sink incl. `composite` + `inheritedFrom` + defaults | **`Object immutable`** |
+| Options | Before | After (phase 2) |
+|---------|--------|-----------------|
+| bare / `metaFull` alone / identity flags | success | success |
+| `metaFull` + `normalize` (+ path/ids) | **`Object must have a pool`** | **success** |
+| `metaFull` + `objectTypes` | fail (same class) | **success** |
+| `composite` + `inheritedFrom` + metaFull + normalize | mixed | **success** (smoke) |
 
-**Root cause (backtrace):**
+**Root cause:**
 
-1. `afw_object_view_create` → `impl_additional_object_option_processing` / normalize path.  
-2. Tries to annotate meta (`impl_meta_set_property_type_property`, or on catch `afw_object_meta_add_property_error` → `afw_object_set_property_as_array`).  
-3. **`EnvironmentRegistry/current` is a static const object with `p == NULL`** (`afw_environment_registry_object.c`: `impl_current_object.p = NULL`). Nested values include other permanent/immutable runtime/const objects.  
-4. `afw_object_set_property_as_array` / `afw_object_set_property` require a **pool** and/or **mutable** meta — permanent objects throw.
+1. View create runs `impl_additional_object_option_processing` / normalize.  
+2. With **`metaFull`**, `afw_object_meta_set_object_type` attaches the OT; meta `get_property` then falls through to the **permanent** `object_type_object` for `propertyTypes`.  
+3. `afw_object_meta_get_property_type` returned those OT property type objects with **`p == NULL`**.  
+4. Normalize tried to set / record errors on them → `afw_object_set_property_as_*` → **Object must have a pool**.  
+5. Catch path `afw_object_meta_add_property_error` masked the first error with the same pool throw.
 
-**Why it may feel new:** #2-era tightening of managed/unmanaged create paths and stricter “must have a pool” checks on `set_property_as_*` (generated data-type bindings) make meta mutation fail loudly; older code may have been laxer or admin may have stopped passing these options on the big get.
+**Fix (landed):** `afw_object_meta_get_property_type` materializes **pooled clones** of permanent `propertyTypes` / property-type entries onto `instance->p` (view pool); refuses when `!instance->p`. `add_property_error` soft no-ops if it still cannot get a mutable property type (do not replace the original error with pool noise).
 
-**Product note:** Jeremy’s app loads `current` with **`modelOptions.adaptiveObject: false` and no objectOptions** — so UI avoids this. Object viewer uses rich options on **individual** objects (composite/normalize/…), which often have pooled views. Fixing meta annotation for permanent objects would still be correct for API completeness.
+**Product note:** Jeremy’s app loads `current` without objectOptions; object viewer uses rich options on individual objects. Fix still needed for API completeness and any client that passes metaFull+normalize on permanent shells via views.
 
-**Fix direction (not implemented yet):** ensure option processing only mutates **view-owned pooled meta** (never the underlying permanent object’s meta); when recording property errors, use `view->p` / meta objects created in the view pool; skip or soft-fail meta mutation for `!object->p` / immutable bases. Related to #149 only insofar as views + immutable runtime bases interact.
-
-**Tests to add when fixing:** get `current` with normalize+metaFull+path; with composite+inheritedFrom; expect success (or documented subset of options), not throw.
+**Regression:** `src/afw/tests/objects/object_options.as` — `envreg current metaFull normalize` / `objectTypes`.
 
 ### 14.8 Decade-old problem: `object->p` for “stuff that dies with the object”
 

--- a/designs/runtime-objects-and-environment.md
+++ b/designs/runtime-objects-and-environment.md
@@ -497,8 +497,8 @@ High signal for #149 (adjust as inventory proceeds):
 1. ~~Deep dive / architecture MD (this file).~~  
 2. ~~Inventory risk types with §10 checklist~~ (core named accessors + P0 adapter/auth — §14).  
 3. ~~Surgical P0: lock+copy `referenceCount` (adapter + auth); first-class `_AdaptiveRuntimeValueAccessor_` registry.~~  
-4. ~~Phase 1 PR to `mgg-develop`~~ (architecture + P0 + multi-request tests + harness follow-ons).  
-5. **Phase 2+ (open):** more lock/copy only where inventory proves need; EnvironmentRegistry/`current` + rich objectOptions “must have a pool” (§14.7); optional metrics snapshot vs document-R; services/logs; issue comments as slices land.
+4. ~~Phase 1 PR to `mgg-develop`~~ — [PR #160](https://github.com/afw-org/afw/pull/160) merged 2026-08-09 (`32ff0706`).  
+5. **Phase 2+ (open on `issue-#149-catalog-phase2`):** more lock/copy only where inventory proves need; EnvironmentRegistry/`current` + rich objectOptions “must have a pool” (§14.7); optional metrics snapshot vs document-R; services/logs; issue comments as slices land.
 
 When decisions stabilize, promote invariants into `.cursor/rules` or developer docs and thin the pads.
 

--- a/src/afw/object/afw_object_meta.c
+++ b/src/afw/object/afw_object_meta.c
@@ -264,7 +264,12 @@ afw_object_meta_get_path(
 
 /*
  * Get the property type object for an object's property from the meta
- * of an object, creating it if needed
+ * of an object, creating it if needed.
+ *
+ * With metaFull, meta get can surface propertyTypes from a permanent object
+ * type graph (p == NULL). Option/normalize processing must only mutate
+ * instance-owned meta on instance->p (views always have a pool). Materialize
+ * clones when the resolved bag or entry is permanent.
  */
 AFW_DEFINE(const afw_object_t *)
 afw_object_meta_get_property_type(
@@ -276,8 +281,17 @@ afw_object_meta_get_property_type(
     const afw_object_t *property_types;
     const afw_object_t *property_type;
 
-    /* This is here for const objects for now. */
+    /* Const objects with no meta and no pool: cannot build mutable types. */
     if (!instance->meta.meta_object && !instance->p) {
+        return NULL;
+    }
+
+    /*
+     * Need a pool to own materializations. Permanent shells (p == NULL)
+     * cannot host option-driven propertyTypes writes — callers should be
+     * views or other pooled wrappers.
+     */
+    if (!instance->p) {
         return NULL;
     }
 
@@ -291,6 +305,15 @@ afw_object_meta_get_property_type(
             meta, afw_s_propertyTypes, xctx);
         ((afw_object_t *)property_types)->meta.object_type_uri =
             afw_s__AdaptiveMetaPropertyTypes_;
+    }
+    else if (!property_types->p) {
+        /* Permanent OT propertyTypes — clone onto instance pool / delta. */
+        property_types = afw_object_create_clone(
+            property_types, instance->p, xctx);
+        ((afw_object_t *)property_types)->meta.object_type_uri =
+            afw_s__AdaptiveMetaPropertyTypes_;
+        afw_object_set_property_as_object(meta,
+            afw_s_propertyTypes, property_types, xctx);
     }
 
     property_type = afw_object_old_get_property_as_object(property_types,
@@ -311,6 +334,18 @@ afw_object_meta_get_property_type(
         }
         ((afw_object_t *)property_type)->meta.object_type_uri =
             afw_s__AdaptiveMetaPropertyType_;
+    }
+    else if (!property_type->p) {
+        /*
+         * Bag was cloned but entries can still be permanent (shallow
+         * nested object values). Replace with a pooled clone.
+         */
+        property_type = afw_object_create_clone(property_type,
+            instance->p, xctx);
+        ((afw_object_t *)property_type)->meta.object_type_uri =
+            afw_s__AdaptiveMetaPropertyType_;
+        afw_object_set_property_as_object(property_types,
+            property_name, property_type, xctx);
     }
 
     return property_type;
@@ -766,9 +801,22 @@ afw_object_meta_add_property_error(
     const afw_object_t *property_type;
     const afw_value_t *value;
     const afw_array_t *errors;
- 
+
+    /*
+     * Cannot record property errors on permanent objects (no pool) or when
+     * property type materialization fails. Soft no-op so option processing
+     * does not replace the original failure with "Object must have a pool".
+     */
+    if (!instance->p) {
+        return;
+    }
+
     property_type = afw_object_meta_get_property_type(instance,
         property_name, xctx);
+    if (!property_type || !property_type->p) {
+        return;
+    }
+
     errors = afw_object_old_get_property_as_array(property_type,
         afw_s_errors, xctx);
     if (!errors) {

--- a/src/afw/tests/objects/object_options.as
+++ b/src/afw/tests/objects/object_options.as
@@ -169,7 +169,7 @@ return meta(obj).dataType;
 
 //? test: everything everywhere all at once
 //? description: Tests all the options together
-//? expect: error:Object immutable
+//? expect: string("object")
 //? source: ...
 
 const obj = get_object("afw", "_AdaptiveObjectType_", "_AdaptiveObjectType_", { 
@@ -197,7 +197,7 @@ return meta(obj).dataType;
 
 //? test: no checkRequired
 //? description: Tests all the options except checkRequired
-//? expect: error:Object immutable
+//? expect: string("object")
 //? source: ...
 
 const obj = get_object("afw", "_AdaptiveObjectType_", "_AdaptiveObjectType_", {     
@@ -224,7 +224,7 @@ return meta(obj).dataType;
 
 //? test: no composite
 //? description: Tests all the options except composite
-//? expect: error:Object immutable
+//? expect: string("object")
 //? source: ...
 
 const obj = get_object("afw", "_AdaptiveObjectType_", "_AdaptiveObjectType_", {     
@@ -251,7 +251,7 @@ return meta(obj).dataType;
 
 //? test: no includeDefaultValues
 //? description: Tests all the options except includeDefaultValues
-//? expect: error:Object must have a pool
+//? expect: string("object")
 //? source: ...
 
 const obj = get_object("afw", "_AdaptiveObjectType_", "_AdaptiveObjectType_", {     
@@ -278,7 +278,7 @@ return meta(obj).dataType;
 
 //? test: no includeDescendentObjectTypes
 //? description: Tests all the options except includeDescendentObjectTypes
-//? expect: error:Object immutable
+//? expect: string("object")
 //? source: ...
 
 const obj = get_object("afw", "_AdaptiveObjectType_", "_AdaptiveObjectType_", {     
@@ -305,7 +305,7 @@ return meta(obj).dataType;
 
 //? test: no inheritedFrom
 //? description: Tests all the options except inheritedFrom
-//? expect: error:Object immutable
+//? expect: string("object")
 //? source: ...
 
 const obj = get_object("afw", "_AdaptiveObjectType_", "_AdaptiveObjectType_", {     
@@ -353,3 +353,27 @@ const obj = get_object("file", "_AdaptiveObjectType_", "TestObjectType2", {
     resolvedParentPaths: true
 });
 return meta(obj).dataType;
+
+//? test: envreg current metaFull normalize
+//? description: #149 permanent OT propertyTypes must materialize under metaFull+normalize on EnvironmentRegistry/current (no pool throw)
+//? expect: true
+//? source: ...
+
+const obj = get_object("afw", "_AdaptiveEnvironmentRegistry_", "current", {
+    metaFull: true,
+    normalize: true,
+    path: true,
+    objectId: true
+});
+return obj != null && meta(obj).objectId == "current";
+
+//? test: envreg current metaFull objectTypes
+//? description: #149 metaFull+objectTypes on EnvironmentRegistry/current
+//? expect: true
+//? source: ...
+
+const obj = get_object("afw", "_AdaptiveEnvironmentRegistry_", "current", {
+    metaFull: true,
+    objectTypes: true
+});
+return obj != null && meta(obj).objectTypes != null;

--- a/whats-new.md
+++ b/whats-new.md
@@ -59,7 +59,7 @@ sections end with **[↑ Highlights](#highlights)** to return here.
 | [**afwdev advanced-test (#157)**](#experimental-afwdev-advanced-test-issue-157) | **\*\*\* Experimental \*\*\***: hermetic `afwfcgi` multi-step tests via `advanced-test.yaml` / `.json` — for comment; may change |
 | [**afwdev blast**](#experimental-afwdev-blast) | **\*\*\* Experimental \*\*\***: on-demand random suite firehose at afwfcgi — not part of `test -j` |
 | [**afwdev test/blast recipe flags**](#afwdev-testblast-recipe-flags) | **\*\*\* Experimental \*\*\***: `--tests-path`/`-T`, `--output` / `--output-format` for machine summaries |
-| [**Runtime catalog / accessors (#149 phase 1)**](#runtime-catalog-accessors-issue-149-phase-1) | Lock+copy adapter/auth **`referenceCount`**; first-class **`_AdaptiveRuntimeValueAccessor_`** registry objects — more #149 work still open |
+| [**Runtime catalog / accessors (#149)**](#runtime-catalog-accessors-issue-149-phase-1) | Phase 1: lock+copy adapter/auth **`referenceCount`**; accessor registry. Phase 2: rich **objectOptions** on permanent shells (e.g. EnvironmentRegistry/`current` + metaFull+normalize) no longer throw “must have a pool” |
 
 ---
 
@@ -114,15 +114,16 @@ Recipes: [`designs/afwdev-test-recipe.md`](designs/afwdev-test-recipe.md).
 
 ---
 
-## Runtime catalog / accessors (issue #149 phase 1)
+## Runtime catalog / accessors (issue #149)
 
-Child of **#2** memory work. **Phase 1 only** — issue **#149** stays open.
+Child of **#2** memory work. Issue **#149** stays open for further accessor work.
 
 | | |
 |--|--|
-| **`referenceCount` on catalog adapter / auth handler objects** | Snapshot under the existing anchor lock (no longer a racy live integer read on get) |
-| **`_AdaptiveRuntimeValueAccessor_`** | First-class registry objects describing each named runtime value accessor (including whether it copies under lock / returns a live reference) |
-| **Still open** | Further per-type accessor safety, full-registry materialize cost, rich options on permanent shells — see issue and [`designs/runtime-objects-and-environment.md`](designs/runtime-objects-and-environment.md) |
+| **`referenceCount` on catalog adapter / auth handler objects** (phase 1) | Snapshot under the existing anchor lock (no longer a racy live integer read on get) |
+| **`_AdaptiveRuntimeValueAccessor_`** (phase 1) | First-class registry objects describing each named runtime value accessor (including whether it copies under lock / returns a live reference) |
+| **Rich objectOptions on permanent / const shells** (phase 2) | `get_object` with **metaFull+normalize** (and similar) on large permanent views such as **`/afw/_AdaptiveEnvironmentRegistry_/current`** no longer fails with **Object must have a pool**. Option processing materializes mutable propertyTypes onto the **view pool** instead of writing permanent OT meta. |
+| **Still open** | Further per-type accessor safety, full-registry materialize cost — see issue and [`designs/runtime-objects-and-environment.md`](designs/runtime-objects-and-environment.md) |
 
 If you hold Adaptive values from `/afw/…` adapter/auth objects across **service stop**, treat **metrics** / **properties** as valid only while the instance is active (or you hold a session ref); **`referenceCount`** is a safe integer snapshot.
 


### PR DESCRIPTION
## Summary

Phase 2 of **#149**: fix rich `objectOptions` (especially **metaFull + normalize**) on permanent / const shells such as **`/afw/_AdaptiveEnvironmentRegistry_/current`**.

### Cause
With **metaFull**, meta falls through to the permanent object type graph for `propertyTypes`. Those entries have **`p == NULL`**. Normalize tried to annotate them and threw **Object must have a pool**; the catch path often masked the first error with the same message.

### Fix
- `afw_object_meta_get_property_type`: materialize **pooled clones** of permanent `propertyTypes` / property-type entries onto **`instance->p`** (view pool); return NULL when `!instance->p`
- `afw_object_meta_add_property_error`: soft no-op if no mutable property type (do not replace original failures with pool noise)

### Tests / docs
- EnvironmentRegistry regressions in `object_options.as`
- Kitchen-sink option combos that previously expected pool/immutable errors now expect success
- Design pad §14.7, whats-new, beta-backlog

Does **not** close #149 (further accessor work still open).

## Test plan
- [x] `afwdev test --test-pattern object_options` (36 pass)
- [x] `afwdev test -j` — 3731 pass / 117 skip
- [x] Manual: `get_object(..., current, { metaFull, normalize, path, objectId })` succeeds