### PR TITLE
afwfcgi/afw: graceful SIGTERM/SIGINT and terminating (503) (#158)

### DIFF
--- a/.cursor/rules/afw-command.mdc
+++ b/.cursor/rules/afw-command.mdc
@@ -12,11 +12,14 @@ Thin **libafw host** executable (`produces: afw`). Compiles/evaluates Adaptive s
 
 ```text
 AFW_ENVIRONMENT_CREATE          → full core registries
+SIGTERM/SIGINT → set env->terminating only (issue #158; no accept wake)
 afw_command_generated_register  → version info + strings only (minimal generate/)
 optional -e  → afw_environment_load_extension
 optional -f  → configure_with_object_list (content type -t, default json)
 then one execution path (below)
 ```
+
+**Signals:** thin flag only for one-shot, interactive, and `--local`. Long I/O may hit `AFW_XCTX_THROW_IF_TERMINATING` (HTTP 503 `terminating`). Unlike `afwfcgi`, no thread wake / socket unlink story here.
 
 Includes **`afw.h`** (consumer pattern), never `afw_internal.h`. See `afw-environment` for registry semantics.
 

--- a/.cursor/rules/afw-server-fcgi.mdc
+++ b/.cursor/rules/afw-server-fcgi.mdc
@@ -85,7 +85,8 @@ No interfaces/manifest/functions in this `generate/` — capabilities come from 
 
 ## Known incompletes / drift
 
-- `impl_afw_server_release` stub; SIGTERM/`FCGX_ShutdownPending` path commented out.
+- `impl_afw_server_release` stub.
+- SIGTERM/SIGINT: after request threads exist in `run`, set `env->terminating` + `FCGX_ShutdownPending()` + `pthread_kill(SIGUSR1)` each APR request thread so accept gets EINTR under `FCGI_FAIL_ACCEPT_ON_INTR` (issue **#158**). No listen-fd close; no in-process drain timer; cooperative mid-request polls later.
 - Admin docs may mention `-d`; CLI does not.
 - No srcdir FCGI `.as` tests; exercise request/env rules via `afw --local` (`local_test_3`) and process-env suites. `afwdev test --env-mode afwfcgi` needs nginx+`afwfcgi` (often `:8080`).
 

--- a/.cursor/rules/afw-server-fcgi.mdc
+++ b/.cursor/rules/afw-server-fcgi.mdc
@@ -86,7 +86,7 @@ No interfaces/manifest/functions in this `generate/` — capabilities come from 
 ## Known incompletes / drift
 
 - `impl_afw_server_release` stub.
-- SIGTERM/SIGINT: after request threads exist in `run`, set `env->terminating` + `FCGX_ShutdownPending()` + `pthread_kill(SIGUSR1)` each APR request thread so accept gets EINTR under `FCGI_FAIL_ACCEPT_ON_INTR` (issue **#158**). No listen-fd close; no in-process drain timer; cooperative mid-request polls later.
+- SIGTERM/SIGINT: after request threads exist in `run`, set `env->terminating` + `FCGX_ShutdownPending()` + `pthread_kill(SIGUSR1)` each APR request thread so accept gets EINTR under `FCGI_FAIL_ACCEPT_ON_INTR` (issue **#158**). After join: close listen fd; **unlink Unix `-p` path** (not TCP `:<port>`). No in-process drain timer.
 - Admin docs may mention `-d`; CLI does not.
 - No srcdir FCGI `.as` tests; exercise request/env rules via `afw --local` (`local_test_3`) and process-env suites. `afwdev test --env-mode afwfcgi` needs nginx+`afwfcgi` (often `:8080`).
 

--- a/designs/README.md
+++ b/designs/README.md
@@ -40,6 +40,7 @@ Per-**issue** or per-**theme** working notes: why, options, footguns, parked ide
 | [`utf8-code-point-sequences.md`](utf8-code-point-sequences.md) | **#153** — utf8-backed values as immutable code-point sequences (index, for-of, array consumers) |
 | [`afwdev-advanced-test.md`](afwdev-advanced-test.md) | **#157** — **experimental** advanced-test leaves; hermetic `afwfcgi` + FCGI client; used for multi-request catalog / lifecycle |
 | [`afwdev-blast.md`](afwdev-blast.md) | **experimental** `afwdev blast` — load thrash (not `test -j`); related **#13** still open for Jeremy’s rounds/continuous knobs |
+| (no pad) | **#158** graceful process stop — landed on branch `issue-158-afwfcgi-graceful-shutdown`; user note in `whats-new.md` |
 
 ## Conventions
 

--- a/designs/afwdev-advanced-test.md
+++ b/designs/afwdev-advanced-test.md
@@ -55,7 +55,7 @@ When the shape settles, drop the experimental banner and promote invariants into
 - This work was **intentionally split** from the **#149 runtime catalog** Grok session so that branch’s context (live afwfcgi poking, env/registry mental model) stayed unpolluted.
 - **#149 session** owns product/reliability for catalogs/accessors; **this branch** owns experimental **afwdev test advanced-test** + **`afwdev blast`**.
 - After PR merges: on `issue-#149-runtime-catalog-lifetime`, rebase onto updated `mgg-develop`, then add **purpose-built advanced-test leaves** for multi-request catalog behavior; use **`afwdev blast`** for load/crash hunts (not as the #149 correctness suite).
-- On-demand load design pad: [`afwdev-blast.md`](afwdev-blast.md). afwfcgi SIGTERM: **#158**.
+- On-demand load design pad: [`afwdev-blast.md`](afwdev-blast.md). afwfcgi SIGTERM/SIGINT graceful stop: **#158** (done).
 
 ---
 

--- a/designs/afwdev-blast.md
+++ b/designs/afwdev-blast.md
@@ -127,4 +127,4 @@ Optional: personal shortcuts via **`afwdev task`** (`tasks` in afwdev-settings.j
 - Reuse: test discovery/tags, advanced FCGI client + afwfcgi host spawn
 - Errors: `_afwdev.common.errors` (issue **#61**) where applicable
 
-afwfcgi graceful SIGTERM: track **#158**.
+afwfcgi graceful SIGTERM/SIGINT: **#158** (landed on `issue-158-afwfcgi-graceful-shutdown` / `mgg-develop` when merged).

--- a/src/afw/adapter/afw_adapter_impl.c
+++ b/src/afw/adapter/afw_adapter_impl.c
@@ -1007,6 +1007,9 @@ impl_afw_adapter_session_retrieve_objects(
         AFW_UTF8_FMT_Q,
         AFW_UTF8_FMT_ARG(ctx.resource_id));
 
+    /* Do not start a large retrieve if the server is shutting down. */
+    AFW_XCTX_THROW_IF_TERMINATING(xctx);
+
     /** @fixme Add common prologue code. */
     afw_atomic_integer_increment(&impl->retrieve_objects_count);
 
@@ -1033,6 +1036,7 @@ impl_afw_adapter_session_retrieve_objects(
             hi;
             hi = apr_hash_next(hi))
         {
+            AFW_XCTX_THROW_IF_TERMINATING(xctx);
             apr_hash_this(hi,
                 (const void **)& object_id.s, (apr_ssize_t *)& object_id.len,
                 (void **)& e);
@@ -1142,6 +1146,9 @@ impl_afw_adapter_session_get_object(
         "begin get_object "
         AFW_UTF8_FMT_Q,
         AFW_UTF8_FMT_ARG(ctx.resource_id));
+
+    /* Do not start get if the server is shutting down. */
+    AFW_XCTX_THROW_IF_TERMINATING(xctx);
 
     /** @fixme Add common prologue code. */
     afw_atomic_integer_increment(&impl->get_object_count);

--- a/src/afw/doc/developer/writing-tests.md
+++ b/src/afw/doc/developer/writing-tests.md
@@ -215,7 +215,8 @@ Same discovery filters as `test` (`--srcdir-pattern`, `--test-pattern`,
 `afw.conf`) so failures usually mean a real problem; use
 `--include-fixtures` to blast adapter/env tests too. Continues on Adaptive
 failures; stops if the server dies. Design: `designs/afwdev-blast.md`.
-afwfcgi signal shutdown: issue **#158**.
+afwfcgi SIGTERM/SIGINT graceful stop: issue **#158** (done; hermetic
+check under `tests/advanced/afwfcgi_signal_shutdown/`).
 
 ## Practical tips
 

--- a/src/afw/file/afw_file.c
+++ b/src/afw/file/afw_file.c
@@ -505,6 +505,9 @@ impl_afw_adapter_session_retrieve_objects(
     /* Process each JSON object in directory. */
     while (1) {
 
+        /* Stop starting more I/O if the server is shutting down. */
+        AFW_XCTX_THROW_IF_TERMINATING(xctx);
+
         /* Read next directory entry until there are no more.*/
         rv = apr_dir_read(&finfo, APR_FINFO_SIZE + APR_FINFO_NAME, dir);
         if (rv == APR_ENOENT ||

--- a/src/afw/include/afw_common.h
+++ b/src/afw/include/afw_common.h
@@ -906,6 +906,9 @@ typedef struct afw_object_meta_s {
  *
  * client_closed            - Client closed connection.
  *
+ * terminating              - Server is terminating; stop starting more work
+ *                           (e.g. mid retrieve at an object boundary).
+ *
  *
  * Map has id, error_allow_in_response, http_response_code, and description.
  * 
@@ -947,6 +950,7 @@ typedef struct afw_object_meta_s {
     XX(evaluate,               true,  400, "Evaluation error"                  )\
     XX(undefined,              true,  400, "Undefined value"                   )\
     XX(code,                   true,  500, "Clearly an internal coding error"  )\
+    XX(terminating,            true,  503, "Server Terminating"                )\
 
 /** Adaptive Framework error codes enum. */
 typedef enum afw_error_code_e {

--- a/src/afw/runtime/afw_runtime.c
+++ b/src/afw/runtime/afw_runtime.c
@@ -743,6 +743,7 @@ impl_afw_adapter_session_retrieve_objects(
     /* Call callback with all applicable set runtime objects. */
     apr_p = afw_pool_get_apr_pool(p);
     for (c = xctx; c; c = c->parent) {
+        AFW_XCTX_THROW_IF_TERMINATING(xctx);
         if (c->runtime_objects && c->runtime_objects->types_ht) {
             ht = apr_hash_get(c->runtime_objects->types_ht,
                 object_type_id->s, object_type_id->len);
@@ -750,6 +751,7 @@ impl_afw_adapter_session_retrieve_objects(
                 for (hi = apr_hash_first(apr_p, ht); hi;
                     hi = apr_hash_next(hi))
                 {
+                    AFW_XCTX_THROW_IF_TERMINATING(xctx);
                     apr_hash_this(hi, NULL, NULL, (void **)&entry);
                     obj = impl_entry_to_object(entry, xctx);
                     if (afw_query_criteria_test_object(obj,

--- a/src/afw/stream/afw_stream_fd.c
+++ b/src/afw/stream/afw_stream_fd.c
@@ -85,6 +85,7 @@ impl_afw_stream_fd_write_cb(
     ptr = (const afw_octet_t *)buffer;
     remaining = size;
     while (remaining > 0) {
+        AFW_XCTX_THROW_IF_TERMINATING(xctx);
         n = fwrite(ptr, 1, remaining, self->fd);
         if (n == 0) {
             err = errno;

--- a/src/afw/tests/advanced/afwfcgi_signal_shutdown/afwfcgi_signal_shutdown.py
+++ b/src/afw/tests/advanced/afwfcgi_signal_shutdown/afwfcgi_signal_shutdown.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Hermetic check: afwfcgi exits on SIGTERM/SIGINT without needing SIGKILL (#158).
+
+Spawns installed afwfcgi (-n 2), waits for the Unix socket, signals the
+process group, and requires process exit within a short grace period.
+Not an advanced-test marker leaf (no multi-step FCGI client); process
+lifecycle only.
+"""
+
+from __future__ import print_function
+
+import os
+import signal
+import subprocess
+import tempfile
+import time
+
+
+MINIMAL_CONF = """\
+[
+  {
+    "type": "application",
+    "applicationId": "signal_shutdown_smoke"
+  }
+]
+"""
+
+
+def _case(name, description, passed, error=None, skip=False):
+    return {
+        "test": name,
+        "description": description,
+        "passed": bool(passed),
+        "skip": bool(skip),
+        "error": error,
+    }
+
+
+def _spawn_afwfcgi(work_dir, threads=2):
+    conf_path = os.path.join(work_dir, "afw.conf")
+    with open(conf_path, "w", encoding="utf-8") as fd:
+        fd.write(MINIMAL_CONF)
+
+    socket_path = os.path.join(work_dir, "afw.sock")
+    if os.path.exists(socket_path):
+        try:
+            os.unlink(socket_path)
+        except OSError:
+            pass
+
+    log_path = os.path.join(work_dir, "afwfcgi.stderr.log")
+    log_fd = open(log_path, "wb")
+    argv = [
+        "afwfcgi",
+        "-f", conf_path,
+        "-p", socket_path,
+        "-n", str(threads),
+    ]
+    try:
+        proc = subprocess.Popen(
+            argv,
+            cwd=work_dir,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=log_fd,
+            start_new_session=True,
+        )
+    except FileNotFoundError as e:
+        log_fd.close()
+        raise RuntimeError(
+            "afwfcgi not on PATH (./afwdev build --cdev --install): "
+            + str(e)
+        ) from e
+
+    return {
+        "process": proc,
+        "socket_path": socket_path,
+        "log_path": log_path,
+        "log_fd": log_fd,
+    }
+
+
+def _wait_socket(handle, timeout_s=15.0):
+    proc = handle["process"]
+    socket_path = handle["socket_path"]
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(
+                "afwfcgi exited during startup (code {}): {}".format(
+                    proc.returncode, _log_tail(handle))
+            )
+        if os.path.exists(socket_path):
+            time.sleep(0.05)
+            return
+        time.sleep(0.05)
+    raise RuntimeError(
+        "Timeout waiting for socket {!r}: {}".format(
+            socket_path, _log_tail(handle))
+    )
+
+
+def _log_tail(handle, max_bytes=4000):
+    path = handle.get("log_path")
+    if not path or not os.path.isfile(path):
+        return "(no log)"
+    try:
+        with open(path, "rb") as fd:
+            data = fd.read()
+        if len(data) > max_bytes:
+            data = data[-max_bytes:]
+        return data.decode("utf-8", errors="replace")
+    except OSError:
+        return "(log unreadable)"
+
+
+def _signal_and_wait(handle, sig, grace_s=5.0):
+    """
+    Send sig to process group. Return dict:
+      exited (bool), used_sigkill (bool), returncode, elapsed_s
+    """
+    proc = handle["process"]
+    t0 = time.time()
+    used_sigkill = False
+
+    if proc.poll() is None:
+        try:
+            os.killpg(proc.pid, sig)
+        except (ProcessLookupError, PermissionError, OSError):
+            try:
+                proc.send_signal(sig)
+            except Exception:
+                pass
+
+        deadline = time.time() + grace_s
+        while time.time() < deadline and proc.poll() is None:
+            time.sleep(0.05)
+
+        if proc.poll() is None:
+            used_sigkill = True
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError, OSError):
+                try:
+                    proc.kill()
+                except Exception:
+                    pass
+            try:
+                proc.wait(timeout=2.0)
+            except Exception:
+                pass
+
+    elapsed = time.time() - t0
+    return {
+        "exited": proc.poll() is not None,
+        "used_sigkill": used_sigkill,
+        "returncode": proc.returncode,
+        "elapsed_s": elapsed,
+    }
+
+
+def _cleanup(handle):
+    if not handle:
+        return
+    proc = handle.get("process")
+    log_fd = handle.get("log_fd")
+    socket_path = handle.get("socket_path")
+    if proc is not None and proc.poll() is None:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+        try:
+            proc.wait(timeout=2.0)
+        except Exception:
+            pass
+    if log_fd is not None:
+        try:
+            log_fd.close()
+        except Exception:
+            pass
+    if socket_path and os.path.exists(socket_path):
+        try:
+            os.unlink(socket_path)
+        except OSError:
+            pass
+
+
+def _run_signal_case(sig, sig_name, threads=2, grace_s=5.0):
+    work = tempfile.mkdtemp(prefix="afwfcgi_sig_")
+    handle = None
+    try:
+        handle = _spawn_afwfcgi(work, threads=threads)
+        _wait_socket(handle)
+        result = _signal_and_wait(handle, sig, grace_s=grace_s)
+        if result["used_sigkill"] or not result["exited"]:
+            return False, (
+                "{} did not stop afwfcgi within {}s without SIGKILL "
+                "(returncode={}, elapsed={:.2f}s). stderr: {}".format(
+                    sig_name,
+                    grace_s,
+                    result["returncode"],
+                    result["elapsed_s"],
+                    _log_tail(handle),
+                )
+            )
+        # Success: process gone without SIGKILL. Exit code is typically 0.
+        return True, None
+    except Exception as e:
+        return False, str(e)
+    finally:
+        _cleanup(handle)
+
+
+def run():
+    description = (
+        "afwfcgi graceful stop on SIGTERM/SIGINT without SIGKILL (#158)"
+    )
+    tests = []
+
+    for sig, name in (
+        (signal.SIGTERM, "SIGTERM"),
+        (signal.SIGINT, "SIGINT"),
+    ):
+        ok, err = _run_signal_case(sig, name, threads=2, grace_s=5.0)
+        tests.append(
+            _case(
+                "afwfcgi_{}_n2".format(name.lower()),
+                "afwfcgi -n 2 exits on {} within 5s without SIGKILL".format(
+                    name),
+                passed=ok,
+                error=err,
+            )
+        )
+
+    return {
+        "description": description,
+        "tests": tests,
+    }

--- a/src/afw/tests/advanced/afwfcgi_signal_shutdown/afwfcgi_signal_shutdown.py
+++ b/src/afw/tests/advanced/afwfcgi_signal_shutdown/afwfcgi_signal_shutdown.py
@@ -197,6 +197,7 @@ def _run_signal_case(sig, sig_name, threads=2, grace_s=5.0):
     try:
         handle = _spawn_afwfcgi(work, threads=threads)
         _wait_socket(handle)
+        socket_path = handle["socket_path"]
         result = _signal_and_wait(handle, sig, grace_s=grace_s)
         if result["used_sigkill"] or not result["exited"]:
             return False, (
@@ -209,7 +210,12 @@ def _run_signal_case(sig, sig_name, threads=2, grace_s=5.0):
                     _log_tail(handle),
                 )
             )
-        # Success: process gone without SIGKILL. Exit code is typically 0.
+        # Unix listen path should be unlinked on clean exit (#158).
+        if os.path.exists(socket_path):
+            return False, (
+                "{}: process exited but Unix socket path still exists: "
+                "{!r}".format(sig_name, socket_path)
+            )
         return True, None
     except Exception as e:
         return False, str(e)

--- a/src/afw/xctx/afw_xctx.h
+++ b/src/afw/xctx/afw_xctx.h
@@ -102,6 +102,23 @@ afw_xctx_environment_is_terminating(afw_xctx_t *xctx)
 
 
 /**
+ * @brief If the environment is terminating, throw terminating (HTTP 503).
+ * @param xctx of caller.
+ *
+ * Use at object / work-unit boundaries in long I/O loops so in-flight work
+ * stops starting more work during graceful shutdown. Requires AFW throw
+ * macros (e.g. via afw_error.h / afw_minimal.h).
+ */
+#define AFW_XCTX_THROW_IF_TERMINATING(xctx) \
+    do { \
+        if (afw_xctx_environment_is_terminating(xctx)) { \
+            AFW_THROW_ERROR_Z(terminating, \
+                "Server is terminating", (xctx)); \
+        } \
+    } while (0)
+
+
+/**
  * @brief Macro to allocate cleared memory in xctx's lifetime pool.
  * @param size of memory to allocate.
  * @param xctx of caller.

--- a/src/afw_command/afw_command.c
+++ b/src/afw_command/afw_command.c
@@ -11,6 +11,7 @@
 #include "afw_command_local_server.h"
 #include <apr_file_io.h>
 #include <apr_getopt.h>
+#include <apr_signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -37,6 +38,34 @@
 /* Default number of history entries kept for interactive sessions. */
 #define AFW_COMMAND_HISTORY_SIZE 500
 #endif
+
+/*
+ * Base xctx for SIGTERM/SIGINT. Handler only sets env->terminating so
+ * long I/O / retrieve paths can AFW_XCTX_THROW_IF_TERMINATING. No accept
+ * wake (unlike afwfcgi); one-shot, interactive, and --local stay simple.
+ */
+static afw_xctx_t *impl_signal_xctx;
+
+static void
+impl_handle_terminating_signal(int signum)
+{
+    afw_environment_t *env;
+
+    (void)signum;
+    if (impl_signal_xctx && impl_signal_xctx->env) {
+        env = (afw_environment_t *)impl_signal_xctx->env;
+        env->terminating = true;
+    }
+}
+
+static void
+impl_install_terminating_signal_handlers(afw_xctx_t *xctx)
+{
+    impl_signal_xctx = xctx;
+    apr_signal(SIGTERM, impl_handle_terminating_signal);
+    apr_signal(SIGINT, impl_handle_terminating_signal);
+}
+
 
 static void
 impl_print_result(afw_command_self_t *self, const char *format, ...);
@@ -917,6 +946,12 @@ main(int argc, const char * const *argv) {
         afw_error_print(stderr, create_error);
         return EXIT_FAILURE;
     }
+
+    /*
+     * SIGTERM/SIGINT: set env->terminating only (one-shot, interactive, and
+     * --local). Cooperative I/O uses AFW_XCTX_THROW_IF_TERMINATING.
+     */
+    impl_install_terminating_signal_handlers(xctx);
 
     /* stdout except for result goes to stderr.*/
     afw_environment_set_stdout_fd(stderr, xctx);

--- a/src/afw_server_fcgi/afw_server_fcgi.c
+++ b/src/afw_server_fcgi/afw_server_fcgi.c
@@ -20,6 +20,9 @@
 #include "afw_request_impl.h"
 #include <fcgiapp.h>
 #include <apr_signal.h>
+#include <apr_portable.h>
+#include <signal.h>
+#include <pthread.h>
 
 /* Declares and rti/inf defines for interface afw_server */
 #define AFW_IMPLEMENTATION_ID "fcgi"
@@ -27,27 +30,100 @@
 #include "afw_server_fcgi_strings.h"
 #include "generated/afw_server_fcgi_version_info.h"
 
-/* Global to hold base xctx pointer. */
+/*
+ * Base xctx for the process. Used by the shutdown signal handler to set
+ * env->terminating. Published before handlers are installed in run().
+ */
 static afw_xctx_t *impl_server_xctx;
+
+/*
+ * Server instance while run() is active (request thread table). Set after
+ * all request threads are created, before handlers are installed.
+ */
+static afw_server_fcgi_internal_t *impl_server;
+
+/*
+ * Avoid a pthread_kill storm if the handler runs again (e.g. second signal
+ * or SIGTERM delivered to a worker that re-enters the handler).
+ */
+static volatile sig_atomic_t impl_shutdown_waking;
 
 /* Compiled afw version. */
 static const afw_utf8_t impl_compiled_afw_version =
 AFW_UTF8_LITERAL(AFW_VERSION_STRING);
 
-#ifdef __FIXME__
-/** @fixme Replace this when afw_signal is implemented. */
-static void impl_handle_sigterm(int signum)
+/*
+ * SIGTERM / SIGINT: stop accepting new FastCGI requests and let in-flight
+ * work finish.
+ *
+ * 1. Set env->terminating so request loops stop taking new work.
+ * 2. FCGX_ShutdownPending() (libfcgi; signal-handler safe).
+ * 3. pthread_kill each request thread with SIGUSR1 so a blocking accept()
+ *    returns EINTR; FCGI_FAIL_ACCEPT_ON_INTR then ends FCGX_Accept_r.
+ *
+ * Main is usually in join, so the process signal alone does not interrupt
+ * workers in accept. Waking APR/request threads matches multi-thread
+ * afw_server hosts; we do not close the libfcgi listen fd.
+ *
+ * SIGUSR1 is used to wake so we do not re-enter this SIGTERM/SIGINT handler
+ * on every worker. libfcgi already treats SIGUSR1 as ShutdownPending.
+ *
+ * Keep the handler minimal. Parent SIGKILL remains the backstop.
+ * POSIX process model; no Windows service path.
+ */
+static void
+impl_handle_shutdown_signal(int signum)
 {
     afw_environment_t *env;
+    afw_integer_t count;
+    afw_server_fcgi_internal_server_thread_t *server_thread;
+    const afw_thread_t *thread;
+    apr_os_thread_t *osthd;
+    apr_status_t rv;
 
-    /* Set flag in environment. */
-    env = (afw_environment_t *)impl_server_xctx->env;
-    env->terminating = true;
+    (void)signum;
 
-    /* Tell FCGI shutdown is pending. */
+    if (impl_server_xctx && impl_server_xctx->env) {
+        env = (afw_environment_t *)impl_server_xctx->env;
+        env->terminating = true;
+    }
+
     FCGX_ShutdownPending();
+
+    if (impl_shutdown_waking) {
+        return;
+    }
+    impl_shutdown_waking = 1;
+
+    if (!impl_server || !impl_server->threads) {
+        return;
+    }
+
+    for (count = 1, server_thread = impl_server->threads;
+        count <= impl_server->pub.thread_count;
+        count++, server_thread++)
+    {
+        thread = server_thread->thread;
+        if (!thread || !thread->apr_thread) {
+            continue;
+        }
+        rv = apr_os_thread_get(&osthd, thread->apr_thread);
+        if (rv != APR_SUCCESS || !osthd) {
+            continue;
+        }
+        (void)pthread_kill(*osthd, SIGUSR1);
+    }
 }
-#endif
+
+
+/* Install SIGTERM/SIGINT after request threads exist (impl_server set). */
+static void
+impl_install_shutdown_signal_handlers(afw_xctx_t *xctx)
+{
+    impl_server_xctx = xctx;
+    apr_signal(SIGTERM, impl_handle_shutdown_signal);
+    apr_signal(SIGINT, impl_handle_shutdown_signal);
+}
 
 
 /* Internal server create. */
@@ -67,15 +143,6 @@ afw_server_fcgi_internal_create(const char *path,
 
     /* Call FCGI_Finish on exit. */
     atexit(&FCGX_Finish);
-
-
-    /* Set signal handler function for sigterm. */
-    impl_server_xctx = xctx;
-
-    /** @fixme Removed for now because not working fully
-    apr_signal(SIGTERM, impl_handle_sigterm);
-     */
-
 
     /* Allocate and initialize self. */
     self = afw_xctx_calloc_type(afw_server_fcgi_internal_t, xctx);
@@ -316,8 +383,6 @@ impl_afw_server_run(
         (afw_size_t)server->pub.thread_count,
         xctx);
 
-    /** @fixme Put in signal handling */
-
     /* The default thread attribute: detachable */
     thread_attr = afw_thread_attr_create(xctx->p, xctx);
 
@@ -335,7 +400,16 @@ impl_afw_server_run(
             count, xctx);
     }
 
-    /* Wait for request threads to die. */
+    /*
+     * Publish thread table, then install SIGTERM/SIGINT. Handler sets
+     * terminating + FCGX_ShutdownPending and pthread_kill(SIGUSR1) each
+     * request thread so Accept_r leaves; join below then returns.
+     */
+    impl_server = server;
+    impl_shutdown_waking = 0;
+    impl_install_shutdown_signal_handlers(xctx);
+
+    /* Wait for request threads to die (after terminating / accept returns). */
     for (count = 1, server_thread = server->threads;
         count <= server->pub.thread_count;
         count++, server_thread++)
@@ -343,6 +417,7 @@ impl_afw_server_run(
         afw_thread_join(server_thread->thread, xctx);
     }
 
+    impl_server = NULL;
 
     /* Run is finished. */
 }

--- a/src/afw_server_fcgi/afw_server_fcgi.c
+++ b/src/afw_server_fcgi/afw_server_fcgi.c
@@ -23,6 +23,7 @@
 #include <apr_portable.h>
 #include <signal.h>
 #include <pthread.h>
+#include <unistd.h>
 
 /* Declares and rti/inf defines for interface afw_server */
 #define AFW_IMPLEMENTATION_ID "fcgi"
@@ -166,6 +167,15 @@ afw_server_fcgi_internal_create(const char *path,
     if (self->sock < 0) {
         AFW_THROW_ERROR_Z(general,
             "FCGX_OpenSocket() error", xctx);
+    }
+
+    /*
+     * Remember Unix listen path for unlink after run(). TCP paths are
+     * ":<port>" (or empty default); libfcgi treats those as inet.
+     */
+    if (path && path[0] != '\0' && path[0] != ':') {
+        self->unix_socket_path_z = apr_pstrdup(
+            afw_pool_get_apr_pool(xctx->p), path);
     }
 
     /* Make sure this is not a CGI.
@@ -418,6 +428,16 @@ impl_afw_server_run(
     }
 
     impl_server = NULL;
+
+    /* Close listen fd and remove Unix socket file we created. */
+    if (server->sock >= 0) {
+        (void)close(server->sock);
+        server->sock = -1;
+    }
+    if (server->unix_socket_path_z) {
+        (void)unlink(server->unix_socket_path_z);
+        server->unix_socket_path_z = NULL;
+    }
 
     /* Run is finished. */
 }

--- a/src/afw_server_fcgi/afw_server_fcgi.md
+++ b/src/afw_server_fcgi/afw_server_fcgi.md
@@ -12,6 +12,8 @@ Adaptive Frame FastCGI Support (`afwfcgi` command).
   with SIGUSR1) so a blocking FastCGI `accept` returns (with
   `FCGI_FAIL_ACCEPT_ON_INTR`). Threads finish the current request if any,
   leave the accept loop, main joins them and exits.
+* After join, the listen fd is closed; if `-p` was a **Unix domain path**
+  (not TCP `:<port>`), that path is **unlinked**.
 * No in-process drain timer; the parent (systemd, Docker, afwdev, etc.)
   may still SIGKILL if needed.
 

--- a/src/afw_server_fcgi/afw_server_fcgi.md
+++ b/src/afw_server_fcgi/afw_server_fcgi.md
@@ -3,9 +3,27 @@ afw_server_fcgi
 
 ## Synopsis
 
-Adaptive Frame FastCGI Support
+Adaptive Frame FastCGI Support (`afwfcgi` command).
 
-## Visual Studio Command Arguments
+## Signals (POSIX)
+
+* **SIGTERM** / **SIGINT** — set `env->terminating`, call
+  `FCGX_ShutdownPending()`, then wake each request thread (`pthread_kill`
+  with SIGUSR1) so a blocking FastCGI `accept` returns (with
+  `FCGI_FAIL_ACCEPT_ON_INTR`). Threads finish the current request if any,
+  leave the accept loop, main joins them and exits.
+* No in-process drain timer; the parent (systemd, Docker, afwdev, etc.)
+  may still SIGKILL if needed.
+
+## CLI
+
+* `-p` path — Unix socket path or TCP `:port` (default `:9345`)
+* `-f` configuration file (default `afw.conf`)
+* `-n` request thread count
+* `-e` extension, `-t` conf content type
+* `--help`, `--version`
+
+## Visual Studio Command Arguments (historical)
 
 * -p = port (default is :9345)
 * -f = configuration file (default is: afw.conf)

--- a/src/afw_server_fcgi/afw_server_fcgi_internal.h
+++ b/src/afw_server_fcgi/afw_server_fcgi_internal.h
@@ -51,6 +51,12 @@ struct afw_server_fcgi_internal_s {
 
     /* Socket */
     int sock;
+
+    /*
+     * Listen path from -p / FCGX_OpenSocket. Non-NULL when a Unix domain path
+     * should be unlinked on clean exit (not used for TCP ":port").
+     */
+    const char *unix_socket_path_z;
  
     /* threads. */
     afw_server_fcgi_internal_server_thread_t *threads;

--- a/src/afw_server_fcgi/afw_server_fcgi_main.c
+++ b/src/afw_server_fcgi/afw_server_fcgi_main.c
@@ -49,8 +49,9 @@ static void print_usage(void)
         "\n"
         "Signals: SIGTERM and SIGINT set the environment terminating flag,\n"
         "stop accepting new FastCGI requests, wake request threads, and\n"
-        "exit after they finish the current request if any (no in-process\n"
-        "drain timer; the parent may still SIGKILL).\n");
+        "exit after they finish the current request if any. Unix listen\n"
+        "socket paths are removed on clean exit (no in-process drain\n"
+        "timer; the parent may still SIGKILL).\n");
 }
 
 

--- a/src/afw_server_fcgi/afw_server_fcgi_main.c
+++ b/src/afw_server_fcgi/afw_server_fcgi_main.c
@@ -44,8 +44,13 @@ typedef struct self_args_s {
 static void print_usage(void)
 {
     fprintf(stderr,
-        "Usage: afw_server_fcgi_main [-f filename] [-p path] [-n threads] [-e extension] "
-        "[-t content-type] [--help] [--version]\n");
+        "Usage: afwfcgi [-f filename] [-p path] [-n threads] [-e extension] "
+        "[-t content-type] [--help] [--version]\n"
+        "\n"
+        "Signals: SIGTERM and SIGINT set the environment terminating flag,\n"
+        "stop accepting new FastCGI requests (FCGX_ShutdownPending), wake\n"
+        "request threads, and exit after they finish the current request\n"
+        "if any (no in-process drain timer; the parent may still SIGKILL).\n");
 }
 
 

--- a/src/afw_server_fcgi/afw_server_fcgi_main.c
+++ b/src/afw_server_fcgi/afw_server_fcgi_main.c
@@ -48,9 +48,9 @@ static void print_usage(void)
         "[-t content-type] [--help] [--version]\n"
         "\n"
         "Signals: SIGTERM and SIGINT set the environment terminating flag,\n"
-        "stop accepting new FastCGI requests (FCGX_ShutdownPending), wake\n"
-        "request threads, and exit after they finish the current request\n"
-        "if any (no in-process drain timer; the parent may still SIGKILL).\n");
+        "stop accepting new FastCGI requests, wake request threads, and\n"
+        "exit after they finish the current request if any (no in-process\n"
+        "drain timer; the parent may still SIGKILL).\n");
 }
 
 

--- a/whats-new.md
+++ b/whats-new.md
@@ -59,6 +59,7 @@ sections end with **[↑ Highlights](#highlights)** to return here.
 | [**afwdev advanced-test (#157)**](#experimental-afwdev-advanced-test-issue-157) | **\*\*\* Experimental \*\*\***: hermetic `afwfcgi` multi-step tests via `advanced-test.yaml` / `.json` — for comment; may change |
 | [**afwdev blast**](#experimental-afwdev-blast) | **\*\*\* Experimental \*\*\***: on-demand random suite firehose at afwfcgi — not part of `test -j` |
 | [**afwdev test/blast recipe flags**](#afwdev-testblast-recipe-flags) | **\*\*\* Experimental \*\*\***: `--tests-path`/`-T`, `--output` / `--output-format` for machine summaries |
+| [**Graceful process stop (#158)**](#graceful-process-stop-sigtermsigint-issue-158) | **`afwfcgi`** honors **SIGTERM/SIGINT** (stop accept, drain workers, unlink Unix listen path); **`afw`** sets **`terminating`**; mid-request I/O can throw **503 Server Terminating** |
 | [**Runtime catalog / accessors (#149)**](#runtime-catalog-accessors-issue-149-phase-1) | Lock+copy **`referenceCount`**; accessor registry; rich objectOptions on permanent shells fixed; **metrics/properties** live-while-active with lock-safe pointer load |
 
 ---
@@ -93,7 +94,23 @@ afwdev blast -d 30m             # short aliases; -c/-n override auto
 afwdev blast -f path/to/afw.conf -m 500   # managed spawn (-n defaults to CPUs)
 ```
 
-Defaults favor docker/dev + classic load (threads≈CPUs, in-flight≈2×CPUs). Fixture-heavy tests skipped unless `--include-fixtures`. Design: [`designs/afwdev-blast.md`](designs/afwdev-blast.md). Signals: [#158](https://github.com/afw-org/afw/issues/158).
+Defaults favor docker/dev + classic load (threads≈CPUs, in-flight≈2×CPUs). Fixture-heavy tests skipped unless `--include-fixtures`. Design: [`designs/afwdev-blast.md`](designs/afwdev-blast.md). Managed teardown uses SIGTERM; **`afwfcgi` graceful stop** is [#158](https://github.com/afw-org/afw/issues/158) (see below).
+
+**[↑ Highlights](#highlights)**
+
+---
+
+## Graceful process stop (SIGTERM/SIGINT, issue #158)
+
+Operators and tooling can stop long-lived hosts without relying on SIGKILL under normal load.
+
+| Host | Behavior |
+|------|----------|
+| **`afwfcgi`** | **SIGTERM** / **SIGINT**: set environment **`terminating`**, stop accepting FastCGI requests, wake request threads, join, close listen fd, **unlink Unix** `-p` path (not TCP `:<port>`). Brief note in `afwfcgi --help`. |
+| **`afw`** (one-shot, interactive, **`--local`**) | Same signals set **`terminating` only** (no accept-loop wake). |
+| **In-flight Adaptive work** | Long I/O / retrieve paths may throw error **`terminating`** → HTTP **503** (“Server Terminating”) via **`AFW_XCTX_THROW_IF_TERMINATING`**. |
+
+Hermetic suite check: `src/afw/tests/advanced/afwfcgi_signal_shutdown/`. Parent still may SIGKILL after a grace period (systemd/Docker/`stop_afwfcgi`). No configurable drain timer; no SIGHUP reload.
 
 **[↑ Highlights](#highlights)**
 


### PR DESCRIPTION
## Summary

Closes graceful process stop for long-lived hosts and cooperative mid-request I/O (**#158**).

- **`afwfcgi`:** SIGTERM/SIGINT sets `env->terminating`, `FCGX_ShutdownPending`, wakes request threads (`pthread_kill` SIGUSR1 + `FCGI_FAIL_ACCEPT_ON_INTR`), joins, closes listen fd, **unlinks Unix** `-p` paths.
- **`afw`:** same signals set **`terminating` only** (one-shot, interactive, `--local`).
- **Core:** error code **`terminating`** (HTTP **503** “Server Terminating”); **`AFW_XCTX_THROW_IF_TERMINATING`** at file retrieve, adapter_impl get/retrieve, runtime retrieve walks, stream write loops.
- **Test:** `src/afw/tests/advanced/afwfcgi_signal_shutdown/` (exit without SIGKILL; socket path gone).
- **Docs:** `whats-new.md`, help/`afw_server_fcgi.md`, design/writing-tests pointers.

## Test plan

- [x] `./afwdev build --cdev` / maintainer fulldev
- [x] `afwdev test -j` (and valgrind as maintainer default)
- [x] Hermetic `afwfcgi_signal_shutdown` (SIGTERM + SIGINT)

Closes #158