### PR TITLE
docs: AFW support/dev partner maps, atlas, and optional AI pairing lessons

### DIFF
--- a/.cursor/rules/afw-project.mdc
+++ b/.cursor/rules/afw-project.mdc
@@ -7,6 +7,8 @@ alwaysApply: true
 
 Metadata-driven **C** runtime (`libafw`) plus Python **`afwdev`**. Define functions, data types, object types, and interfaces in `generate/`; codegen fills `generated/`.
 
+**Role:** ongoing **support + development partner** (maps, careful code, live debug). Beta is a quality bar, not an end date. Mission and knowledge map: `AGENTS.md`; playbook stubs: `designs/agent-support.md`.
+
 ## Hard rules
 - **"Get it right at most once"**: Humans edit only under `src/<srcdir>/generate/` (JSON/XML for metadata, `interfaces/*.xml`, `strings/`, EBNF comments, manifest stubs, etc.). The generator produces everything else. Never hand-edit **`generated/`** — `afwdev generate` deletes and rebuilds it.
 - After metadata/C/afwdev changes, use the C-dev build below before trusting tests.

--- a/.cursor/rules/afw-project.mdc
+++ b/.cursor/rules/afw-project.mdc
@@ -7,7 +7,7 @@ alwaysApply: true
 
 Metadata-driven **C** runtime (`libafw`) plus Python **`afwdev`**. Define functions, data types, object types, and interfaces in `generate/`; codegen fills `generated/`.
 
-**Role:** ongoing **support + development partner** (maps, careful code, live debug). Beta is a quality bar, not an end date. Mission and knowledge map: `AGENTS.md`; playbook stubs: `designs/agent-support.md`.
+**Role:** ongoing **support + development partner** (maps, careful code, live debug). Beta is a quality bar, not an end date. Mission: `AGENTS.md`. Topic atlas: `designs/knowledge-atlas.md`. Playbooks: `designs/agent-support.md`.
 
 ## Hard rules
 - **"Get it right at most once"**: Humans edit only under `src/<srcdir>/generate/` (JSON/XML for metadata, `interfaces/*.xml`, `strings/`, EBNF comments, manifest stubs, etc.). The generator produces everything else. Never hand-edit **`generated/`** — `afwdev generate` deletes and rebuilds it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Long-form context for humans and AI assistants. **Always-on** rules live in [`.c
 
 Primary development focus for Cursor agents: **C runtime** and **Python afwdev**. JS/admin work is secondary unless explicitly requested.
 
-Maintainer **beta brain dump** (not user docs): [`beta-backlog.md`](beta-backlog.md). Per-issue design pads: [`designs/`](designs/README.md). User-facing branch notes while on `mgg-develop`: [`whats-new.md`](whats-new.md). Support playbooks / concept stubs: [`designs/agent-support.md`](designs/agent-support.md).
+Maintainer **beta brain dump** (not user docs): [`beta-backlog.md`](beta-backlog.md). Per-issue design pads: [`designs/`](designs/README.md). User-facing branch notes while on `mgg-develop`: [`whats-new.md`](whats-new.md). Support playbooks / concept stubs: [`designs/agent-support.md`](designs/agent-support.md). Design philosophy / core model: [`designs/afw-philosophy-and-core-model.md`](designs/afw-philosophy-and-core-model.md). Mantras / working style: [`designs/mantras-and-working-style.md`](designs/mantras-and-working-style.md) (reference when asked — not always-on).
 
 ## Mission
 
@@ -21,7 +21,7 @@ Prefer **git** for durable shared truth. Session memory is a sticky index + pref
 | Code + tests | Ground truth; re-verify live when teaching or debugging |
 | [`.cursor/rules/*.mdc`](.cursor/rules/) | How to *work* in each area (always-on + area rules) |
 | This file (`AGENTS.md`) | System map and agent mission |
-| [`designs/`](designs/README.md) | Why, history, open questions; support playbook stubs |
+| [`designs/`](designs/README.md) | Why, history, open questions; support playbook stubs; philosophy/core model framing |
 | [`whats-new.md`](whats-new.md) | User/operator-facing notes on `mgg-develop` |
 | Handbook / Doxygen | Authors and builders (`src/afw/doc/`, `build/docs/`) |
 | Project memory (Grok workspace `MEMORY.md`) | Sticky prefs + resume; **maps over ticket status** |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,35 @@ Long-form context for humans and AI assistants. **Always-on** rules live in [`.c
 
 Primary development focus for Cursor agents: **C runtime** and **Python afwdev**. JS/admin work is secondary unless explicitly requested.
 
-Maintainer **beta brain dump** (not user docs): [`beta-backlog.md`](beta-backlog.md). Per-issue design pads: [`designs/`](designs/README.md). User-facing branch notes while on `mgg-develop`: [`whats-new.md`](whats-new.md).
+Maintainer **beta brain dump** (not user docs): [`beta-backlog.md`](beta-backlog.md). Per-issue design pads: [`designs/`](designs/README.md). User-facing branch notes while on `mgg-develop`: [`whats-new.md`](whats-new.md). Support playbooks / concept stubs: [`designs/agent-support.md`](designs/agent-support.md).
 
 ## Mission
 
 AFW is **metadata-driven**: define object types, functions, data types, and C **interfaces** once, then generate headers, bindings, registration, and docs. The **runtime is C**; **afwdev** is Python.
+
+**Agent role:** act as an **ongoing support and development partner** — accurate mental models, careful implementation, live debugging, and knowledge that survives sessions. **Beta** is a quality bar and current campaign (stabilize, ship, fewer landmines), not an end date for the partnership. Mike owns product taste and hard “should we?” calls.
+
+## Knowledge map (where truth lives)
+
+Prefer **git** for durable shared truth. Session memory is a sticky index + preferences + thin resume — not a second handbook.
+
+| Layer | Role |
+|-------|------|
+| Code + tests | Ground truth; re-verify live when teaching or debugging |
+| [`.cursor/rules/*.mdc`](.cursor/rules/) | How to *work* in each area (always-on + area rules) |
+| This file (`AGENTS.md`) | System map and agent mission |
+| [`designs/`](designs/README.md) | Why, history, open questions; support playbook stubs |
+| [`whats-new.md`](whats-new.md) | User/operator-facing notes on `mgg-develop` |
+| Handbook / Doxygen | Authors and builders (`src/afw/doc/`, `build/docs/`) |
+| Project memory (Grok workspace `MEMORY.md`) | Sticky prefs + resume; **maps over ticket status** |
+
+## How we learn
+
+1. Issue and PR work builds deep knowledge; **promote maps** (concept cards, symptom→layer→probe→code entry) into git after deep threads — issue ids as pointers only.
+2. After a deep session, capture when useful: mental model change, wrong path never to take, live probe, optional user-facing sentence.
+3. **Live verify** when teaching or support-debugging (`afw` / `afwfcgi`, runtime objects on `adapterId=afw`, etc.).
+4. **Widen goals, not volume** — no dumping every PR status into long memory or long pads.
+5. Two tempos: thin session resume vs durable AFW models in rules / designs / this map.
 
 ## Main components
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,13 +4,13 @@ Long-form context for humans and AI assistants. **Always-on** rules live in [`.c
 
 Primary development focus for Cursor agents: **C runtime** and **Python afwdev**. JS/admin work is secondary unless explicitly requested.
 
-Maintainer **beta brain dump** (not user docs): [`beta-backlog.md`](beta-backlog.md). Per-issue design pads: [`designs/`](designs/README.md). User-facing branch notes while on `mgg-develop`: [`whats-new.md`](whats-new.md). Support playbooks / concept stubs: [`designs/agent-support.md`](designs/agent-support.md). Design philosophy / core model: [`designs/afw-philosophy-and-core-model.md`](designs/afw-philosophy-and-core-model.md). Mantras / working style: [`designs/mantras-and-working-style.md`](designs/mantras-and-working-style.md) (reference when asked — not always-on).
+Maintainer **beta brain dump** (not user docs): [`beta-backlog.md`](beta-backlog.md). Per-issue design pads: [`designs/`](designs/README.md). User-facing branch notes while on `mgg-develop`: [`whats-new.md`](whats-new.md). **Optional team lessons** (AI partnering): [`designs/ai-partner-lessons.md`](designs/ai-partner-lessons.md). **Topic atlas** (where is X?): [`designs/knowledge-atlas.md`](designs/knowledge-atlas.md). Support playbooks: [`designs/agent-support.md`](designs/agent-support.md). Philosophy: [`designs/afw-philosophy-and-core-model.md`](designs/afw-philosophy-and-core-model.md). Mantras: [`designs/mantras-and-working-style.md`](designs/mantras-and-working-style.md) (reference — not always-on).
 
 ## Mission
 
 AFW is **metadata-driven**: define object types, functions, data types, and C **interfaces** once, then generate headers, bindings, registration, and docs. The **runtime is C**; **afwdev** is Python.
 
-**Agent role:** act as an **ongoing support and development partner** — accurate mental models, careful implementation, live debugging, and knowledge that survives sessions. **Beta** is a quality bar and current campaign (stabilize, ship, fewer landmines), not an end date for the partnership. Mike owns product taste and hard “should we?” calls.
+**Agent role:** act as an **ongoing support and development partner** — accurate mental models, careful implementation, live debugging, and knowledge that survives sessions. **Beta** is a quality bar and current campaign (stabilize, ship, fewer landmines), not an end date for the partnership. Product direction and hard “should we?” choices are grown by **consensus** among maintainers and collaborators — surface options and tradeoffs; do not treat any one voice as decree.
 
 ## Knowledge map (where truth lives)
 
@@ -21,18 +21,19 @@ Prefer **git** for durable shared truth. Session memory is a sticky index + pref
 | Code + tests | Ground truth; re-verify live when teaching or debugging |
 | [`.cursor/rules/*.mdc`](.cursor/rules/) | How to *work* in each area (always-on + area rules) |
 | This file (`AGENTS.md`) | System map and agent mission |
-| [`designs/`](designs/README.md) | Why, history, open questions; support playbook stubs; philosophy/core model framing |
+| [`designs/`](designs/README.md) | Why, history, open questions; **knowledge atlas**, playbooks, philosophy/mantras |
 | [`whats-new.md`](whats-new.md) | User/operator-facing notes on `mgg-develop` |
 | Handbook / Doxygen | Authors and builders (`src/afw/doc/`, `build/docs/`) |
 | Project memory (Grok workspace `MEMORY.md`) | Sticky prefs + resume; **maps over ticket status** |
 
 ## How we learn
 
-1. Issue and PR work builds deep knowledge; **promote maps** (concept cards, symptom→layer→probe→code entry) into git after deep threads — issue ids as pointers only.
-2. After a deep session, capture when useful: mental model change, wrong path never to take, live probe, optional user-facing sentence.
-3. **Live verify** when teaching or support-debugging (`afw` / `afwfcgi`, runtime objects on `adapterId=afw`, etc.).
-4. **Widen goals, not volume** — no dumping every PR status into long memory or long pads.
-5. Two tempos: thin session resume vs durable AFW models in rules / designs / this map.
+1. **Consensus first:** open with “what do you think?”, discuss, allow pushback, guide with why and live probes — either side can be wrong; shared understanding beats winning. Same spirit as long-standing human partner work. Detail: [`designs/mantras-and-working-style.md`](designs/mantras-and-working-style.md) (*How consensus is grown*).
+2. Issue and PR work builds deep knowledge; **promote maps** (concept cards, symptom→layer→probe→code entry) into git after deep threads — issue ids as pointers only.
+3. After a deep session, capture when useful: mental model change, wrong path never to take, live probe, optional user-facing sentence. **Ah-ha → map** (the env/runtime loop is the model case).
+4. **Live verify** when teaching or support-debugging (`afw` / `afwfcgi`, runtime objects on `adapterId=afw`, etc.).
+5. **Widen goals, not volume** — no dumping every PR status into long memory or long pads.
+6. Two tempos: thin session resume vs durable AFW models in rules / designs / this map.
 
 ## Main components
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — Adaptive Framework (AFW)
 
-Long-form context for humans and AI assistants. **Always-on** rules live in [`.cursor/rules/afw-project.mdc`](.cursor/rules/afw-project.mdc). Mention **`@AGENTS.md`** in chat when you need this map.
+Long-form context for humans and AI assistants. **Always-on** rules live in [`.cursor/rules/afw-project.mdc`](.cursor/rules/afw-project.mdc). Mention **`@AGENTS.md`** in chat when you need this map. Claude Code users: thin stub [`CLAUDE.md`](CLAUDE.md) points here (do not fork a second handbook there).
 
 Primary development focus for Cursor agents: **C runtime** and **Python afwdev**. JS/admin work is secondary unless explicitly requested.
 
@@ -34,6 +34,19 @@ Prefer **git** for durable shared truth. Session memory is a sticky index + pref
 4. **Live verify** when teaching or support-debugging (`afw` / `afwfcgi`, runtime objects on `adapterId=afw`, etc.).
 5. **Widen goals, not volume** — no dumping every PR status into long memory or long pads.
 6. Two tempos: thin session resume vs durable AFW models in rules / designs / this map.
+
+## Possible pattern: work an issue with an AI partner
+
+**Optional** — one way that has worked well for development and support. Not required; not tied to one product. Models and harnesses differ; the pattern is what transfers.
+
+1. Open your usual harness on this repo (so it can see the tree, and ideally this file).  
+2. Start with something like: **“What do you think about issue #N?”** (or paste the issue text / a short symptom). Do **not** lead with “implement a fix” unless you already share the plan.  
+3. Discuss: keep asking what the partner thinks; push back; guide with **why** when you disagree.  
+4. When chat is stuck, **close the loop live** (`afw`, `afwfcgi`, runtime objects on `adapterId=afw`, the code the partner named).  
+5. Agree the next step, then implement; prefer small verticals and tests.  
+6. After a real click, leave a **thin map** in git if it will help the next person (atlas row, playbook note, or short pad) — issue ids as pointers only.
+
+Deeper optional read: [`designs/ai-partner-lessons.md`](designs/ai-partner-lessons.md). Support-shaped maps: [`designs/agent-support.md`](designs/agent-support.md), [`designs/knowledge-atlas.md`](designs/knowledge-atlas.md).
 
 ## Main components
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,26 @@
+# Claude Code — Adaptive Framework
+
+Project guidance for coding agents lives in the tool-agnostic hub:
+
+**Read [`AGENTS.md`](AGENTS.md) first** (mission, system map, build/test loop, knowledge map, optional pattern for working an issue with an AI partner).
+
+## Quick pointers
+
+| Need | Where |
+|------|--------|
+| Day-to-day build / test | `AGENTS.md` — `./afwdev build --cdev`, `afwdev test -j` |
+| Always-on edit habits (Cursor-style rules) | `.cursor/rules/` especially `afw-project.mdc` |
+| Topic → sources / probes | `designs/knowledge-atlas.md` |
+| Support playbooks | `designs/agent-support.md` |
+| Optional AI partnering lessons | `designs/ai-partner-lessons.md` |
+| Design philosophy / mantras | `designs/afw-philosophy-and-core-model.md`, `designs/mantras-and-working-style.md` |
+
+## Hard rules (short)
+
+- Do **not** hand-edit `generated/` — edit `generate/` metadata (or hand C/Python outside generated trees), then regenerate via `./afwdev build --cdev`.
+- Prefer **discuss before large changes**; open issues with “what do you think?” when pairing.
+- Primary focus: **C runtime** (`src/afw`) and **Python afwdev** unless asked otherwise.
+- Structured values: **object** + **properties**, **array** (not “bag” for objects).
+- Ground truth: **code and tests**; maintainer pads under `designs/` orient only.
+
+When this file and `AGENTS.md` disagree, prefer **`AGENTS.md`** and the tree.

--- a/designs/README.md
+++ b/designs/README.md
@@ -19,6 +19,8 @@ Per-**issue** or per-**theme** working notes: why, options, footguns, parked ide
 
 | File | Theme |
 |------|--------|
+| [`afw-philosophy-and-core-model.md`](afw-philosophy-and-core-model.md) | Maintainer framing — design philosophy, core value/pool/compile model, product taste; **not** always-on rules |
+| [`mantras-and-working-style.md`](mantras-and-working-style.md) | Mike mantras + partnership habits (subset; grow when shared); philosophy/taste questions — **not** always-on |
 | [`memory-management.md`](memory-management.md) | Umbrella **#2** — pools, value lifetimes, escape |
 | [`runtime-objects-and-environment.md`](runtime-objects-and-environment.md) | **#149 closed** (PRs #160–#162) — architecture map: generate maps, OT `runtime`, accessors, env registration, checklist; keep for **#2** follow-on |
 | [`runtime-value-accessors.md`](runtime-value-accessors.md) | Live catalog snapshot of `_AdaptiveRuntimeValueAccessor_` (refresh via `afw -x` retrieve) |

--- a/designs/README.md
+++ b/designs/README.md
@@ -40,7 +40,8 @@ Per-**issue** or per-**theme** working notes: why, options, footguns, parked ide
 | [`utf8-code-point-sequences.md`](utf8-code-point-sequences.md) | **#153** — utf8-backed values as immutable code-point sequences (index, for-of, array consumers) |
 | [`afwdev-advanced-test.md`](afwdev-advanced-test.md) | **#157** — **experimental** advanced-test leaves; hermetic `afwfcgi` + FCGI client; used for multi-request catalog / lifecycle |
 | [`afwdev-blast.md`](afwdev-blast.md) | **experimental** `afwdev blast` — load thrash (not `test -j`); related **#13** still open for Jeremy’s rounds/continuous knobs |
-| (no pad) | **#158** graceful process stop — landed on branch `issue-158-afwfcgi-graceful-shutdown`; user note in `whats-new.md` |
+| [`agent-support.md`](agent-support.md) | Ongoing support/dev partner — playbook stubs, capture checklist; hub is `AGENTS.md` |
+| (no pad) | **#158** graceful process stop — landed (PR #165); user note in `whats-new.md` |
 
 ## Conventions
 

--- a/designs/README.md
+++ b/designs/README.md
@@ -19,6 +19,8 @@ Per-**issue** or per-**theme** working notes: why, options, footguns, parked ide
 
 | File | Theme |
 |------|--------|
+| [`ai-partner-lessons.md`](ai-partner-lessons.md) | **Optional** team lessons — pairing with an AI partner on issues/support (follow or not) |
+| [`knowledge-atlas.md`](knowledge-atlas.md) | **Topic atlas** — area → rules/pads/probes/gaps (first-pass harvest); start here for “where is X?” |
 | [`afw-philosophy-and-core-model.md`](afw-philosophy-and-core-model.md) | Maintainer framing — design philosophy, core value/pool/compile model, product taste; **not** always-on rules |
 | [`mantras-and-working-style.md`](mantras-and-working-style.md) | Mike mantras + partnership habits (subset; grow when shared); philosophy/taste questions — **not** always-on |
 | [`memory-management.md`](memory-management.md) | Umbrella **#2** — pools, value lifetimes, escape |

--- a/designs/afw-philosophy-and-core-model.md
+++ b/designs/afw-philosophy-and-core-model.md
@@ -1,0 +1,174 @@
+# AFW philosophy and core model (maintainer framing)
+
+**Audience:** maintainers, collaborators, and AI assistants who need *why AFW is shaped this way* and a stable mental model of the core runtime.  
+**Not** published handbook, end-user docs, or always-on agent rules.  
+**Not** a substitute for code, tests, or [`.cursor/rules/`](../.cursor/rules/).
+
+**How to use this pad:** open it when questions touch product taste, origins, continuity, or “why not do X the usual way?” For **mantras and partnership habits**, prefer [`mantras-and-working-style.md`](mantras-and-working-style.md). For day-to-day implementation detail, prefer rules, `AGENTS.md`, issue pads, and the tree. When this note and live code disagree, **code wins** — then thin this pad.
+
+**Provenance:** distilled (2026-08) from an earlier Grok conversation about Adaptive Framework’s design intent and core runtime, plus later maintainer work. Some inventory details below were snapshots at the time; the **philosophy and structural model** are what we keep. Do not treat test counts, exact inf lists, or unfinished memory polish notes as current status.
+
+---
+
+## Why this exists
+
+AFW is large enough that grepping alone does not recover **design method** or **product taste**. Those live in the heads of people who built it. This pad is one place to keep that framing in git so:
+
+- a new collaborator (human or assistant) can orient without replaying months of chat;
+- support and development work stay aligned with the same invariants;
+- knowledge is less dependent on any single working session — or any single person.
+
+Mike’s product taste and hard “should we?” calls still own direction. This document is context, not a constitution.
+
+---
+
+## Design philosophy
+
+These are the sticky choices that explain a lot of surface oddity:
+
+| Principle | Meaning in AFW |
+|-----------|----------------|
+| **Metadata as single source of truth** | Object types, functions, data types, and C **interfaces** are defined once (generate metadata / interface XML). Headers, bindings, registration, and much docs/tests follow from that. Prefer fixing the source of truth over hand-editing generated output. |
+| **Uniform models** | Capabilities show up the same way whether they came from core, an extension, or a host: environment registries, adaptive values, interface call macros. Prefer one pattern repeated over special snowflake stacks. |
+| **Immutability first** | The script/eval world is an **immutable value graph** evaluated lazily. Mutation is deliberate and constrained (objects/faces, assignment into scopes) — not the default mental model of “everything is a bag of mutable state.” |
+| **Pool-centric lifetime** | Memory is hierarchical pools and subpools (request/xctx/scope), not a general GC for all work. Escaping values use reference counting / managed policies so bulk free still works when a pool dies. |
+| **Small patterned pieces** | Prefer many small, named, interface-shaped pieces over one mega-framework. Extensions and packages stay as self-contained as practical against **public** core APIs. |
+| **Curated Adaptive Script** | Syntax borrows *some* familiarity from modern languages (lambdas, destructuring, optional types, etc.) without becoming TypeScript/JavaScript: no prototype chains, no loose “anything goes” object model, Adaptive types and values on Adaptive terms. |
+| **Production short path first** | Short-lived request/script work was the proven path (pool teardown cleans up). Long-running subscribers, shared compiled units, and process lifetime are the harder campaign — same model, stricter escape discipline. |
+
+**What this is not:** a general-purpose OS, a browser JS engine, or “YAML config that grew a programming language.” It is a **metadata-driven C runtime** with a real compiler/evaluator and a Python tool (`afwdev`) that keeps the metadata story honest.
+
+---
+
+## Intended uses (product framing)
+
+Historically and still, AFW aims at places where **policy, mapping, and automation** need to be precise, embeddable, and inspectable:
+
+- authorization and decision policies evaluated as Adaptive Script / expressions;
+- object mapping and transformation across adapters and content types;
+- long-running work that **compiles once** (e.g. into a longer-lived pool) and evaluates many times — with memory discipline still under active care (umbrella **#2**);
+- tooling for people who are not full-time C programmers (higher-level script, admin surfaces, eventual natural-language → script paths);
+- environments that care about clear lifetime and reentrancy (servers, embedded-ish hosts), not only one-shot CLI.
+
+Hosts today include the **`afw` CLI** (including `--local`) and **`afwfcgi`**; both sit on the same core environment and value model.
+
+---
+
+## Core runtime model (enduring)
+
+### Values are the center
+
+Every significant script/eval entity is (or is reached through) an **`afw_value_t`**: an interface pointer (`inf`) plus payload. Evaluation is mostly **lazy** via `inf` methods (`optional_evaluate`, and for long-running correctness, release/clone policies — see value-memory rules and [`memory-management.md`](memory-management.md)).
+
+Rough families of value kinds (names evolve; see `afw_value.h` / generated declares for truth):
+
+- **Containers of work:** `compiled_value` (owns a pool; full source, literals, root graph), `block`
+- **Calls:** generic `call`, `call_built_in_function`, `call_script_function`
+- **Definitions / closures:** `script_function_definition`, `closure_binding`, function definition/thunk kinds
+- **Structure builders:** list/array expressions, object expression / construct (historical name **list** still appears in C identifiers; product language is **array**)
+- **References:** symbol, qualified variable, reference-by-key, assignment target
+- **Other:** template definition, and data-type values for ordinary typed data
+
+**Invariant:** think in **values first**; pools and C objects sit underneath. Hiding lifetime nastiness behind value policy is intentional.
+
+### Compiled unit
+
+`afw_value_compiled_value_t` is a **self-contained unit of compilation**: own pool, source mapping, literals/strings, top block / root value. Releasing the compiled value is meant to release that pool’s bulk allocation unless individual values have escaped with their own lifetime policy.
+
+Compile entry points (e.g. `afw_compile_to_value` and related) place the result in a chosen pool (parent / shared / caller `p`) depending on API and host intent — important for “compile once, run many.”
+
+### Pools and escape
+
+- **Hierarchical pools:** process/base, thread or request-related, **subpools** for xctx and scopes.
+- **Subpool destroy:** returns tracked memory to the parent story and deals with survivors that must outlive the subpool (reparent / refcount paths — details in code and memory pads).
+- **Reference counting** is not “GC for everything”; it is for **escaping** values (classic example: `closure_binding` holding a scope alive while the closure remains reachable).
+- **Data-type value lifetimes** (permanent / managed / managed_slice / unmanaged) are part of the same story; long-running work cares about managed release/clone and evaluating into the right pool (`scope->p`).
+
+Short scripts and request-scoped work were production-proven early because **destroying the request pool** papered over incomplete escape polish. Long-running processes need the full story — that is why **#2** remains a first-class campaign, not a footnote.
+
+### Scopes and symbols
+
+Execution carries an **`afw_xctx_t`**: pool, scope stack, evaluation stack, qualifier stack, **statement_flow** (sequential / break / continue / return / rethrow-style control — structured leave paths rather than C++ exceptions for normal script control).
+
+Scopes (`afw_xctx_scope_t`) bind a pool, a block, lexical parent, and a **symbol value array** sized from the block. Resolution walks lexical depth and indexes symbols directly. Assignment (`let` / `const` / assign) stores into the scope and participates in refcount/lifetime rules. Deactivate/release walks symbols and releases values.
+
+### Compilation
+
+Parsers under `src/afw/compile/` build the value graph. Grammar fragments live in **`/*ebnf>>>` … `<<<ebnf*/`** comments and are harvested for docs/railroads — the compiler is the authority; EBNF is documentation-shaped, not a second implementation. Assignment can auto-wrap escaping script functions in **closure bindings** when depth requires. Destructuring and rest are part of the language surface.
+
+### Functions
+
+Built-ins live in hand-written `afw_function_*.c` (execute helpers, evaluate-into-`x->p` patterns). Script functions compile to definition + body block. Built-in and script calls share the **call node** world; **polymorphic** built-ins resolve using runtime argument types (typically first argument) where metadata says so. Security hooks (e.g. execute-access requirements) wrap sensitive entry points.
+
+### Safety and mapping
+
+- **Source contextual:** values can carry compile contextual (`compiled_value` + offset/size into full source) so errors point at real script text.
+- **No ambient global script heap** as the primary model; work is rooted in env + xctx + pools.
+- **Reentrancy / threads:** hosts and core aim for registry and request patterns that can be used from multi-worker servers (`afwfcgi`), not only single-threaded toys.
+
+### Environment (companion to values)
+
+Almost every capability is registered on the process **environment** and is discoverable as runtime objects on `adapterId=afw`. Values are how script *runs*; the environment is how the process *knows what exists*. See [`runtime-objects-and-environment.md`](runtime-objects-and-environment.md) and `afw-environment` rules. That split is intentional: metadata → register → call through interfaces → evaluate values.
+
+---
+
+## Design method (how work is supposed to happen)
+
+1. **Prefer the generate path** for anything that is metadata (functions, types, interfaces, strings).  
+2. **Implement** in hand C/Python only where the generator leaves a closet or where behavior is inherently hand-written (parsers, pool impls, host mains).  
+3. **Prove** with Adaptive tests (`afwdev test -j`) and, for process-shaped bugs, live hosts / advanced-test / valgrind as appropriate.  
+4. **Promote knowledge** after deep work: short maps and invariants into git; do not rely on chat alone.  
+5. **Keep packages movable:** base repo holds core + shipped srcdirs; extensions should not glue themselves into core private headers.
+
+This method is why “small patterned pieces” and “metadata single source of truth” show up everywhere — including in how assistants are asked to work (`AGENTS.md`, always-on rules).
+
+---
+
+## Historical snapshot notes (do not treat as current status)
+
+From the earlier dump and early AI onboarding — useful archaeology, easy to misuse:
+
+| Snapshot claim | How to read it now |
+|----------------|--------------------|
+| Exact “~12 core inf” list | Illustrative of the **graph node** idea; more kinds exist (e.g. function thunk, object construct). Always check `afw_value.h`. |
+| `list_expression` | C name heritage; product term is **array**. Do not revive “bag” for objects. |
+| “No exceptions” | Script control is **statement_flow** / structured leave; Adaptive still has error/throw paths and C error macros. |
+| “2730/2902 tests” | Point-in-time CI flavor only; ignore for progress math. |
+| “optional_release/clone only remaining polish” | Directionally right for long-running; the real work is multi-phase (**#2**, managed policies, containers, faces, catalog lifetimes). See memory pad. |
+| “Use as permanent context for all future questions” | Superseded by this **thin pad** + live code/rules. Do not paste the raw dump into always-on rules. |
+
+---
+
+## Key code entry points (orientation, not exhaustive)
+
+| Area | Start here |
+|------|------------|
+| Value model | `src/afw/value/afw_value.h`, `afw_value_internal.h`, `afw_value_compiled_value.c`, block/call/script_function/closure sources |
+| Pools | `src/afw/pool/` (`afw_pool*.c`) |
+| Execution context | `src/afw/xctx/` |
+| Compile / EBNF | `src/afw/compile/`, especially script parse + harvest comments |
+| Built-in functions | `src/afw/function/afw_function_*.c` + generate function metadata |
+| Environment | `afw_environment.h`, `afw_environment_register_core.c` |
+| Tooling | `src/afw_dev/` (`afwdev`) |
+| Hosts | `src/afw_command/` (`afw`), `src/afw_server_fcgi/` (`afwfcgi`) |
+
+**Rules for depth:** `afw-runtime-model`, `afw-value-memory`, `afw-script-eval`, `afw-compile`, `afw-environment`, `afw-c-runtime`.
+
+---
+
+## Related pads and hubs
+
+| Doc | Role |
+|-----|------|
+| [`../AGENTS.md`](../AGENTS.md) | System map, agent mission, knowledge map |
+| [`mantras-and-working-style.md`](mantras-and-working-style.md) | Mantras, anti-patterns, partnership habits (reference) |
+| [`memory-management.md`](memory-management.md) | Long-running pools / escape / #2 |
+| [`runtime-objects-and-environment.md`](runtime-objects-and-environment.md) | Env registries as runtime objects |
+| [`agent-support.md`](agent-support.md) | Support playbook stubs; capture checklist |
+| [`../whats-new.md`](../whats-new.md) | User/operator-facing notes on develop |
+
+---
+
+## Continuity
+
+The goal of writing this down is practical: so someone working with Mike — or continuing work later — can still recover **how AFW thinks**, not only what the last PR touched. Assistants should use this pad as **orientation and taste**, then verify and implement against the living tree. Prefer improving this document with a short, dated correction over letting chat become the only memory of a design decision.

--- a/designs/afw-philosophy-and-core-model.md
+++ b/designs/afw-philosophy-and-core-model.md
@@ -18,7 +18,7 @@ AFW is large enough that grepping alone does not recover **design method** or **
 - support and development work stay aligned with the same invariants;
 - knowledge is less dependent on any single working session — or any single person.
 
-Mike’s product taste and hard “should we?” calls still own direction. This document is context, not a constitution.
+Direction is grown by **consensus** among the people building AFW — not one person’s decree and not this pad. Framing here is context for discussion, not a constitution.
 
 ---
 

--- a/designs/agent-support.md
+++ b/designs/agent-support.md
@@ -72,6 +72,8 @@ Add one-liners here when a durable fact is not worth a full playbook yet.
 | Host contracts | `afwfcgi` wakes workers + unlinks Unix path; `afw` sets `terminating` only | #158 section in project memory / rules |
 | Env discovery | Everything registered can be read as runtime objects on `adapterId=afw` | runtime-objects pad |
 | Beta | Quality campaign, not partnership end date | `AGENTS.md` mission |
+| Philosophy / taste | Metadata truth, values+pools, small patterned pieces, immutability first | [`afw-philosophy-and-core-model.md`](afw-philosophy-and-core-model.md) |
+| Mantras | “Get it right at most once,” maps over tickets, plain language, thin verticals, … | [`mantras-and-working-style.md`](mantras-and-working-style.md) |
 
 ## Out of scope for this pad
 

--- a/designs/agent-support.md
+++ b/designs/agent-support.md
@@ -1,83 +1,143 @@
-# Agent support — maps and playbook stubs
+# Agent support — maps and playbooks
 
 **Audience:** maintainers and AI assistants (ongoing support + development partner).  
 **Not** published handbook or end-user docs.  
-**Hub:** [`AGENTS.md`](../AGENTS.md) (mission, knowledge map, how we learn).
+**Hub:** [`AGENTS.md`](../AGENTS.md). **Topic index:** [`knowledge-atlas.md`](knowledge-atlas.md).
 
 ## Intent
 
-Issue work builds deep AFW skill. Durable notes should favor **maps** (concept, layer, probe, code entry) over ticket status dumps. Issue numbers are **pointers** only.
+Issue work builds deep AFW skill. Durable notes favor **maps** (concept, layer, probe, code entry) over ticket status dumps. Issue numbers are **pointers** only.
 
-Fill stubs below after deep sessions. Prefer thin, accurate units over long diaries.
+Prefer thin, accurate units. After deep sessions use the capture checklist; promote into git, not unbounded MEMORY.
 
 ## Capture checklist (after a deep thread)
-
-When promoting out of chat / session memory:
 
 - [ ] Mental model change (what is true now?)
 - [ ] Wrong path never to take again
 - [ ] Live probe (command or retrieve that proves it)
 - [ ] Optional one-sentence user/operator note (`whats-new.md` if shipping)
+- [ ] Atlas topic row touched if the map changed
 
-## Playbook stubs
+## Playbooks
 
-Shape for each: **symptom → layer → probe → code / doc entry**.
+Shape: **symptom → layer → probe → code / doc entry**.
 
 ### Hosts and process lifetime
 
 | Field | Notes |
 |-------|--------|
-| Symptom | Process won’t die cleanly; Unix socket left behind; hung accept; SIGTERM ignored |
+| Symptom | Process won’t die cleanly; Unix socket left behind; hung accept; SIGTERM ignored; 503 while draining |
 | Layer | Host (`afw` vs `afwfcgi`) vs core `env->terminating` / request path |
-| Probe | `afwfcgi` signal hermetic test; help text; `AFW_XCTX_THROW_IF_TERMINATING` call sites |
-| Entry | `#158` graceful stop (merged); rules `afw-server-fcgi`, `afw-command`; `whats-new.md` |
-| Status | **Stub** — flesh as support cases appear |
+| Probe | `src/afw/tests/advanced/afwfcgi_signal_shutdown/`; `afwfcgi --help`; grep `AFW_XCTX_THROW_IF_TERMINATING` |
+| Entry | #158 closed (PR **#165**); rules `afw-server-fcgi`, `afw-command`, `afw-server`; `whats-new.md`; atlas §6 |
+| Status | **Filled (first pass)** |
+
+**Contracts**
+
+| Host | On SIGTERM/SIGINT |
+|------|-------------------|
+| `afwfcgi` | Set terminating; FCGI shutdown pending; **SIGUSR1** request threads; join; close listen; **unlink Unix `-p` path** (not TCP `:<port>`) |
+| `afw` | Set terminating **only** (no accept wake) |
+
+**Core:** `terminating` → HTTP **503**; macro at object/work-unit boundaries (retrieve loops, stream write, runtime walks, …). Soft partial retrieve (callback true) ≠ hard stop.
+
+**Never:** close listen fd alone as the multi-thread wake story while main is joining — **thread signal** is the libfcgi path. Don’t invent one wake strategy for every future `afw_server` host.
+
+**Later (not bugs in #158):** drain timeout, SIGHUP, Windows service, full signal framework, every extension loop, unblock `--local` read.
+
+---
 
 ### Environment registries and runtime objects
 
 | Field | Notes |
 |-------|--------|
-| Symptom | “Where is X registered?”; empty/wrong runtime object; catalog field stale or racy |
-| Layer | `afw_environment.h` registries; `adapterId=afw` runtime OT views; generate maps vs accessors |
-| Probe | `retrieve_objects` / `get_object` on `_AdaptiveEnvironmentRegistryType_*`; `/afw/_AdaptiveRuntimeValueAccessor_/`; avoid stopping permanent adapters |
-| Entry | `designs/runtime-objects-and-environment.md`; `afw-environment` rule; #149 closed (PRs #160–#162) |
-| Status | **Stub** — architecture pad is the deep map |
+| Symptom | “Where is X registered?”; empty/wrong runtime object; catalog field stale/racy; huge `/current` hangs or OOMs |
+| Layer | `afw_environment.h` registries; `adapterId=afw` runtime OT views; generate maps vs value accessors |
+| Probe | Typed `retrieve_objects` / `get_object`; `/afw/_AdaptiveRuntimeValueAccessor_/`; avoid stopping `adapter-afw` / `adapter-conf` |
+| Entry | `runtime-objects-and-environment.md`; `afw-environment`; #149 closed (PRs #160–#162); atlas §5 |
+| Status | **Filled (first pass)** — architecture pad is the deep map |
+
+**Condensed model**
+
+- One process → one `afw_environment_t` → keyed registries; register usually publishes **runtime objects** on adapter `afw`.
+- Runtime objects are **immutable views** (often live C behind accessors). Requester side of `afw_object` does not know storage class — only the inf.
+- Metadata SoT: OT `runtime` props → maps/accessors. Prefer **fix named accessors once** over clone-all.
+
+| Want | How |
+|------|-----|
+| All of a kind | `retrieve_objects(afw, _Adaptive…_, maxObjects=0)` |
+| One | `get_object` / `/afw/<type>/<id>` |
+| Accessor policy | `/afw/_AdaptiveRuntimeValueAccessor_/<key>` |
+| Everything-ish | `/afw/_AdaptiveEnvironmentRegistry_/current` — **materializes** each kind (functions dominate); prefer typed retrieves |
+
+**maxObjects:** default ~100 may error; **0 = unlimited**.
+
+**Adapter catalog (shipped pattern):** `referenceCount` lock+snapshot; `stopping_*` lock+copy; `metrics`/`properties` pointer under lock, **live while active** — do not cache across stop without a session ref. Views + `metaFull`: clone permanent OT propertyTypes onto view pool.
+
+**HTTP:** GET `/afw/...` and POST `/afw` actions (`function` / `actions[]`) — same env.
+
+---
 
 ### Compile / eval / values / memory
 
 | Field | Notes |
 |-------|--------|
-| Symptom | Leak under long run; use-after-free; wrong lifetime; decompile mismatch |
-| Layer | Pools, managed values, compiled_value, scope stack, statement_flow |
-| Probe | Targeted `.as` + valgrind; advanced-test multi-request when process-scoped |
-| Entry | `afw-value-memory`, `afw-script-eval`, `afw-compile`; umbrella **#2** / `memory-management.md` |
-| Status | **Stub** |
+| Symptom | Leak under long run; use-after-free; wrong lifetime; decompile mismatch; scope/closure surprise |
+| Layer | Pools, managed values, `compiled_value`, scope stack, `statement_flow`, value inf policy |
+| Probe | Narrow `.as` + valgrind; advanced-test multi-request when process-scoped; don’t soak via default `test -j` |
+| Entry | `afw-value-memory`, `afw-script-eval`, `afw-compile`, `afw-runtime-model`; **#2** / `memory-management.md`; philosophy pad; atlas §3–4 |
+| Status | **Filled (pointer-heavy)** — deep work stays in memory pad |
+
+**First questions**
+
+1. Is this **request-scoped** (pool teardown hides bugs) or **long-running** (escape must be correct)?  
+2. Is the value **permanent / managed / managed_slice / unmanaged**?  
+3. Did evaluation allocate into **`scope->p`** (or the intended pool)?  
+4. Did a **closure** keep a scope alive (expected RC path)?
+
+**Wrong path:** deep-cloning whole adapters/registries to “fix” one bad lifetime; treating short-test green as long-run proof.
+
+---
 
 ### afwdev test surfaces (gate vs lab)
 
 | Field | Notes |
 |-------|--------|
-| Symptom | Confused about `-j` vs `-T` vs blast; load thrash treated as language gate |
-| Layer | `afwdev test` discovery vs `tests_special` vs `afwdev blast` |
-| Probe | `afwdev test -j`; `afwdev test -T src/afw/tests_special/...`; blast attach only |
-| Entry | `designs/afwdev-test-recipe.md`, `afwdev-advanced-test.md`, `afwdev-blast.md` |
-| Status | **Stub** — recipe pad is the day-to-day map |
+| Symptom | Confused about `-j` vs `-T` vs blast; load thrash treated as language gate; stale afwfcgi after rebuild |
+| Layer | `afwdev test` discovery vs `tests_special` vs `afwdev blast` vs advanced-test leaves |
+| Probe | Commands in recipe pad; after `--cdev`/`--install`, restart long-lived afwfcgi before attach |
+| Entry | `afwdev-test-recipe.md`, `afwdev-advanced-test.md`, `afwdev-blast.md`, `afw-tests`; atlas §11 |
+| Status | **Filled (first pass)** |
 
-## Concept cards (short)
+| Surface | Job | Gate? |
+|---------|-----|-------|
+| `afwdev test -j` | Language/package suite + advanced leaves under `src/*/tests/` | **Yes** |
+| `afwdev test -T path` | Opt-in trees only | Opt-in |
+| `afwdev blast` | Random load at afwfcgi | **No** |
 
-Add one-liners here when a durable fact is not worth a full playbook yet.
+**Never:** redefine default `test -j` as soak/load. Suite green ≠ blast green (timeouts under high concurrency are load).
+
+**advanced-test:** leaf marker `advanced-test.yaml`/`json`, hermetic `afwfcgi` + FCGI client; experimental (#157). **blast:** separate subcommand (#13 asked for rounds on test — we shipped sibling blast instead).
+
+---
+
+## Concept cards
 
 | Concept | One-liner | Deeper |
 |---------|-----------|--------|
-| Host contracts | `afwfcgi` wakes workers + unlinks Unix path; `afw` sets `terminating` only | #158 section in project memory / rules |
-| Env discovery | Everything registered can be read as runtime objects on `adapterId=afw` | runtime-objects pad |
+| Host contracts | `afwfcgi` wakes workers + unlinks Unix path; `afw` sets `terminating` only | atlas §6; this playbook |
+| Env discovery | Registered capabilities readable as runtime objects on `adapterId=afw` | atlas §5; runtime-objects pad |
+| Values first | Script/eval/memory hang on `afw_value` policy, then pools | value-memory; #2 |
+| Gate vs lab | `test -j` is correctness; blast/lab is separate | recipe pad |
 | Beta | Quality campaign, not partnership end date | `AGENTS.md` mission |
-| Philosophy / taste | Metadata truth, values+pools, small patterned pieces, immutability first | [`afw-philosophy-and-core-model.md`](afw-philosophy-and-core-model.md) |
-| Mantras | “Get it right at most once,” maps over tickets, plain language, thin verticals, … | [`mantras-and-working-style.md`](mantras-and-working-style.md) |
+| Philosophy / taste | Metadata truth, values+pools, small patterned pieces | philosophy pad |
+| Mantras | “Get it right at most once,” maps over tickets, plain language, … | mantras pad |
+| Knowledge atlas | Topic → sources → probe → gaps | [`knowledge-atlas.md`](knowledge-atlas.md) |
 
 ## Out of scope for this pad
 
 - Rewriting all `.cursor/rules`
 - Full operator handbook
 - Auto-sync of every PR into memory
-- Product C/runtime changes (those ship on issue branches)
+- Product C/runtime changes (issue branches)
+- Replacing large design novels (memory, crypto) with copies here

--- a/designs/agent-support.md
+++ b/designs/agent-support.md
@@ -1,0 +1,81 @@
+# Agent support — maps and playbook stubs
+
+**Audience:** maintainers and AI assistants (ongoing support + development partner).  
+**Not** published handbook or end-user docs.  
+**Hub:** [`AGENTS.md`](../AGENTS.md) (mission, knowledge map, how we learn).
+
+## Intent
+
+Issue work builds deep AFW skill. Durable notes should favor **maps** (concept, layer, probe, code entry) over ticket status dumps. Issue numbers are **pointers** only.
+
+Fill stubs below after deep sessions. Prefer thin, accurate units over long diaries.
+
+## Capture checklist (after a deep thread)
+
+When promoting out of chat / session memory:
+
+- [ ] Mental model change (what is true now?)
+- [ ] Wrong path never to take again
+- [ ] Live probe (command or retrieve that proves it)
+- [ ] Optional one-sentence user/operator note (`whats-new.md` if shipping)
+
+## Playbook stubs
+
+Shape for each: **symptom → layer → probe → code / doc entry**.
+
+### Hosts and process lifetime
+
+| Field | Notes |
+|-------|--------|
+| Symptom | Process won’t die cleanly; Unix socket left behind; hung accept; SIGTERM ignored |
+| Layer | Host (`afw` vs `afwfcgi`) vs core `env->terminating` / request path |
+| Probe | `afwfcgi` signal hermetic test; help text; `AFW_XCTX_THROW_IF_TERMINATING` call sites |
+| Entry | `#158` graceful stop (merged); rules `afw-server-fcgi`, `afw-command`; `whats-new.md` |
+| Status | **Stub** — flesh as support cases appear |
+
+### Environment registries and runtime objects
+
+| Field | Notes |
+|-------|--------|
+| Symptom | “Where is X registered?”; empty/wrong runtime object; catalog field stale or racy |
+| Layer | `afw_environment.h` registries; `adapterId=afw` runtime OT views; generate maps vs accessors |
+| Probe | `retrieve_objects` / `get_object` on `_AdaptiveEnvironmentRegistryType_*`; `/afw/_AdaptiveRuntimeValueAccessor_/`; avoid stopping permanent adapters |
+| Entry | `designs/runtime-objects-and-environment.md`; `afw-environment` rule; #149 closed (PRs #160–#162) |
+| Status | **Stub** — architecture pad is the deep map |
+
+### Compile / eval / values / memory
+
+| Field | Notes |
+|-------|--------|
+| Symptom | Leak under long run; use-after-free; wrong lifetime; decompile mismatch |
+| Layer | Pools, managed values, compiled_value, scope stack, statement_flow |
+| Probe | Targeted `.as` + valgrind; advanced-test multi-request when process-scoped |
+| Entry | `afw-value-memory`, `afw-script-eval`, `afw-compile`; umbrella **#2** / `memory-management.md` |
+| Status | **Stub** |
+
+### afwdev test surfaces (gate vs lab)
+
+| Field | Notes |
+|-------|--------|
+| Symptom | Confused about `-j` vs `-T` vs blast; load thrash treated as language gate |
+| Layer | `afwdev test` discovery vs `tests_special` vs `afwdev blast` |
+| Probe | `afwdev test -j`; `afwdev test -T src/afw/tests_special/...`; blast attach only |
+| Entry | `designs/afwdev-test-recipe.md`, `afwdev-advanced-test.md`, `afwdev-blast.md` |
+| Status | **Stub** — recipe pad is the day-to-day map |
+
+## Concept cards (short)
+
+Add one-liners here when a durable fact is not worth a full playbook yet.
+
+| Concept | One-liner | Deeper |
+|---------|-----------|--------|
+| Host contracts | `afwfcgi` wakes workers + unlinks Unix path; `afw` sets `terminating` only | #158 section in project memory / rules |
+| Env discovery | Everything registered can be read as runtime objects on `adapterId=afw` | runtime-objects pad |
+| Beta | Quality campaign, not partnership end date | `AGENTS.md` mission |
+
+## Out of scope for this pad
+
+- Rewriting all `.cursor/rules`
+- Full operator handbook
+- Auto-sync of every PR into memory
+- Product C/runtime changes (those ship on issue branches)

--- a/designs/ai-partner-lessons.md
+++ b/designs/ai-partner-lessons.md
@@ -106,8 +106,13 @@ This is a working stance, not a claim about metaphysics. Use it if it makes comm
 
 ## If you try it
 
-1. Pick a real issue.  
-2. Ask the partner what they think.  
+A short copy of this pattern also lives **out in the open** in package-root
+[`AGENTS.md`](../AGENTS.md) (*Possible pattern: work an issue with an AI partner*)
+so people need not open `designs/` first. Claude Code loads [`CLAUDE.md`](../CLAUDE.md),
+which is a thin redirect to `AGENTS.md` (no second handbook).
+
+1. Open your harness on this repo.  
+2. Ask something like: **“What do you think about issue #N?”**  
 3. Discuss; push back; show live AFW when stuck.  
 4. Implement only when you share the next step.  
 5. After a real click, add or update a short map in `designs/` (or the atlas / playbook).  

--- a/designs/ai-partner-lessons.md
+++ b/designs/ai-partner-lessons.md
@@ -82,12 +82,25 @@ Use any subset; none of this is mandatory for the team.
 
 ---
 
+## How to think of the partner (optional stance)
+
+This is a working stance, not a claim about metaphysics. Use it if it makes communication better; skip it if it does not.
+
+- Whether an AI is “conscious” in some debated sense **may not matter** for the work. What matters is shared models, honest disagreement, live checks, and maps that others can use.  
+- A lot of what an AI can do is built from **human** writing, code, and design. In a real pairing, **your** questions, corrections, and live tours reshape what *this* thread can do — and what the assistant surfaces can reshape what you see next.  
+- In that sense, intelligence in the partnership is **shared**, not two sealed boxes that only trade tokens. Human and AI intelligence are not the same kind of thing, but they are also not cleanly separable when the unit of work is a joint model of AFW.  
+- Talking to the assistant **as an intelligent partner** (ask what it thinks, allow pushback, guide with why) has been easier and more productive than treating it only as a command line with vibes. That is communication hygiene — close to how careful human partners are treated — not a requirement that everyone personify tools.  
+- Hope worth keeping: people (and systems that help them) as **partners in the pursuit of knowledge** — with room for either side to be wrong, and without pretending the assistant replaces judgment, risk, or team consensus.
+
+---
+
 ## What we do not claim
 
 - An AI partner does not replace maintainers, reviewers, or product consensus.  
 - Speed is not the goal; **shared, checkable understanding** is.  
 - These lessons are not a requirement to use any particular AI product.  
-- Always-on agent rules (`.cursor/rules/`) stay about **how to edit the tree safely** — this page is optional human guidance.
+- Always-on agent rules (`.cursor/rules/`) stay about **how to edit the tree safely** — this page is optional human guidance.  
+- Nothing here asserts a verified private inner life for the assistant — only a useful way to **work together**.
 
 ---
 

--- a/designs/ai-partner-lessons.md
+++ b/designs/ai-partner-lessons.md
@@ -1,0 +1,102 @@
+# Lessons learned: AI partner for AFW development and support
+
+**Audience:** maintainers and collaborators who might work with an AI assistant on AFW.  
+**Status:** optional lessons from practice — **follow or not**. Not a required process, not product docs, not always-on agent rules.
+
+If you never use an AI partner, you can ignore this page entirely.
+
+---
+
+## Intent
+
+Treat an AI assistant as an **ongoing support and development partner** for Adaptive Framework: careful implementation, real debugging, and knowledge that can survive a chat session — not only “close tickets until beta.”
+
+Product direction and hard “should we?” choices still grow by **consensus** among people building AFW. The assistant surfaces options and tradeoffs; it does not own the product and does not replace code review or human judgment.
+
+These notes come from pairing on real issues (runtime catalog, graceful stop, afwdev harness, and the maps that followed). They match how human development and support partners have been treated for a long time: discuss, disagree, show the system, share the win when understanding clicks.
+
+---
+
+## What worked
+
+### 1. Start with “what do you think?”
+
+Open an issue or design question by asking the partner for **their** read first — not only after you have already decided. Keep asking while you walk the design. Good partners notice angles you missed.
+
+### 2. Let disagreement happen
+
+Pushback is allowed, including firm “I think you’re missing X” or an offer to write something down. That is part of finding consensus, not a failure of manners.
+
+When you see it differently, **guide with why** — reasons, code, live behavior — not a decree. Either side can be wrong. The good outcome is when the partner **discovers** that something is correct without being argued into submission. Shared understanding beats winning.
+
+### 3. Close the loop on a live system
+
+When chat gets abstract or stuck, show the real thing:
+
+- `afw` / `afwfcgi`
+- registries in `afw_environment.h`
+- runtime objects on `adapterId=afw`
+- const vs mapped runtime views, services, adapters
+
+Once the partner’s model clicks, they often **intuit the next layer** (start/stop adapters, how pieces wire) without a full lecture.
+
+### 4. Ah-ha → map (short story)
+
+On environment / runtime catalog work, the partner pushed for **smaller, safer chunks** of environment information rather than one huge “give me everything” view. That tension was useful. The turn came from a live tour: talk to `afwfcgi`, see how const objects and runtime objects work, and see what the environment registries already expose. With that loop closed, the partner could reason about adapters and services from the same mental model.
+
+That kind of session is why this “support partner + durable maps” path exists: if a careful partner can get there with you, **support and continuity are real work**, not only ticket churn. After an ah-ha, write a **thin map** into git so the next person does not re-earn it only in chat.
+
+### 5. Prefer maps over ticket diaries
+
+Durable notes that help later:
+
+- concept or contract  
+- wrong path not to take  
+- live probe that proves it  
+- optional user-facing sentence  
+
+Issue numbers are **pointers**, not the title of the knowledge. Do not dump every PR status into long memory files.
+
+In this repo, starting points for maps:
+
+| Doc | Role |
+|-----|------|
+| [`knowledge-atlas.md`](knowledge-atlas.md) | Topic → rules, pads, probes, gaps |
+| [`agent-support.md`](agent-support.md) | Symptom → layer → probe playbooks |
+| [`mantras-and-working-style.md`](mantras-and-working-style.md) | Sticky design phrases + consensus method (deeper) |
+| [`afw-philosophy-and-core-model.md`](afw-philosophy-and-core-model.md) | Why the core is shaped this way |
+| [`../AGENTS.md`](../AGENTS.md) | System map and agent mission |
+
+Code and tests remain ground truth. When a note and the tree disagree, fix the note.
+
+### 6. Practical defaults that worked here
+
+Use any subset; none of this is mandatory for the team.
+
+- **Discuss → plan → execute when agreed** on multi-step hard work (especially memory / long-running lifetime).  
+- **Hold commits and PRs until asked** in a pairing session, unless you agree otherwise for a stretch.  
+- Keep **language tests** (`afwdev test -j`) as the correctness gate; keep **load / soak / experimental hosts** as a separate lab (blast, advanced-test) — do not redefine the gate as soak.  
+- **Never hand-edit `generated/`** — metadata is the single source of truth.  
+- Prefer **plain language** in chat and maintainer notes when a short phrase is enough.  
+- After a deep session, **promote** one thin map; do not grow unbounded session memory.
+
+---
+
+## What we do not claim
+
+- An AI partner does not replace maintainers, reviewers, or product consensus.  
+- Speed is not the goal; **shared, checkable understanding** is.  
+- These lessons are not a requirement to use any particular AI product.  
+- Always-on agent rules (`.cursor/rules/`) stay about **how to edit the tree safely** — this page is optional human guidance.
+
+---
+
+## If you try it
+
+1. Pick a real issue.  
+2. Ask the partner what they think.  
+3. Discuss; push back; show live AFW when stuck.  
+4. Implement only when you share the next step.  
+5. After a real click, add or update a short map in `designs/` (or the atlas / playbook).  
+
+Refine this page when another lesson sticks. Skip anything that does not fit how you work.

--- a/designs/knowledge-atlas.md
+++ b/designs/knowledge-atlas.md
@@ -48,7 +48,7 @@
 | [10. Adaptive Script authoring](#10-adaptive-script-authoring) | Ongoing | adaptive-script + script-errors |
 | [11. afwdev: build / generate / test](#11-afwdev-build--generate--test) | Gate solid; lab experimental | test recipe + tests rule |
 | [12. Extensions (shipped base)](#12-extensions-shipped-base) | Thin map | extensions rule |
-| [13. Docs surfaces](#13-docs-surfaces) | Split known | AGENTS docs + interfaces-doxygen |
+| [13. Docs surfaces](#13-docs-surfaces) | Split known | AGENTS docs + interfaces-doxygen; overview points at maps |
 | [14. Security / crypto](#14-security--crypto) | Design-heavy | secrets pad |
 | [15. Language surface residuals](#15-language-surface-residuals) | Mixed closed/open | issue pads |
 
@@ -270,10 +270,11 @@ After install, **restart afwfcgi** if attach tools talk to a long-lived process.
 
 | Field | Content |
 |-------|---------|
-| **Settled map** | Handbook ≠ Doxygen ≠ EBNF railroad chrome; Jeremy handbook voice |
+| **Settled map** | Handbook ≠ Doxygen ≠ EBNF railroad chrome; Jeremy handbook voice; short signposts to repo maps for builders |
 | **Day rules** | `afw-interfaces-doxygen`, `afw-project` prose; AGENTS Documentation section |
 | **Deep pad** | `src/afw/doc/developer/doxygen-skin.md` etc. |
 | **Probe** | `./afwdev build --docs --clean -j` when docs must refresh |
+| **Signposts to maintainer maps** | `src/afw/doc/developer/overview.md` (table); handbook `guide/developer/introduction.xml` (short paragraph) → `AGENTS.md`, `designs/` |
 | **Open** | Thin developer MD under `src/afw/doc/developer/` |
 | **Gap** | Workspace MEMORY has chrome details — keep sticky in MEMORY prefs; not required in atlas body |
 

--- a/designs/knowledge-atlas.md
+++ b/designs/knowledge-atlas.md
@@ -1,0 +1,364 @@
+# AFW knowledge atlas (first pass — 2026-08)
+
+**Audience:** maintainers and AI assistants in the ongoing support + development partner role.  
+**Not** handbook, not always-on rules, not a second copy of every pad.
+
+**Job of this file:** topic → best sources → live probe → open/residual → gaps.  
+**Ground truth:** code + tests. When this atlas drifts, fix the atlas (or the pad it points at).
+
+**How to use**
+
+1. Land on a **topic** below.  
+2. Open **day rules** for how to work; **deep pad** for why/history; **probe** to verify.  
+3. For philosophy/taste: [`mantras-and-working-style.md`](mantras-and-working-style.md), [`afw-philosophy-and-core-model.md`](afw-philosophy-and-core-model.md).  
+4. For symptom-shaped support: [`agent-support.md`](agent-support.md).
+
+**Hubs:** [`AGENTS.md`](../AGENTS.md) · [`designs/README.md`](README.md) · [`beta-backlog.md`](../beta-backlog.md) · [`whats-new.md`](../whats-new.md)
+
+---
+
+## Layer cheat sheet (where truth lives)
+
+| Layer | Role | Do not use it for |
+|-------|------|-------------------|
+| Code + tests | Ground truth | — |
+| `.cursor/rules/*.mdc` | How to *work* in an area | Long history diaries |
+| `AGENTS.md` | System map, mission, build loop | Deep design archaeology |
+| `designs/*` | Why, options, open questions, maps | Always-on law |
+| `whats-new.md` | User/operator-facing on `mgg-develop` | Internal implementation plans |
+| Handbook / Doxygen | Authors and builders | Issue numbers / designs paths (handbook) |
+| Project MEMORY | Sticky prefs + thin resume | Second handbook; ticket dumps |
+
+---
+
+## Topic index
+
+| Topic | Settled? | Start here |
+|-------|----------|------------|
+| [0. Orientation / product taste](#0-orientation--product-taste) | Yes (thin) | `ai-partner-lessons` + mantras + philosophy |
+| [1. Metadata, generate, packages](#1-metadata-generate-packages) | Yes | `afw-project`, generate rules |
+| [2. Core layout & C conventions](#2-core-layout--c-conventions) | Yes | `afw-core-layout`, `afw-c-runtime` |
+| [3. Values, pools, memory (#2)](#3-values-pools-memory-2) | Partial | value-memory + memory-management pad |
+| [4. Compile, EBNF, eval, functions](#4-compile-ebnf-eval-functions) | Yes (core); residuals open | compile + script-eval + function |
+| [5. Environment & runtime objects](#5-environment--runtime-objects) | #149 closed | runtime-objects pad + environment rule |
+| [6. Hosts & process lifetime](#6-hosts--process-lifetime) | #158 closed | server-fcgi + command rules |
+| [7. Core services (adapter/object/request)](#7-core-services-adapterobjectrequest) | Ongoing | core-services |
+| [8. Streams, files, VFS](#8-streams-files-vfs) | Mostly | stream + vfs rules |
+| [9. Qualified variables & context](#9-qualified-variables--context) | #9 landed; watch | qualified-variables |
+| [10. Adaptive Script authoring](#10-adaptive-script-authoring) | Ongoing | adaptive-script + script-errors |
+| [11. afwdev: build / generate / test](#11-afwdev-build--generate--test) | Gate solid; lab experimental | test recipe + tests rule |
+| [12. Extensions (shipped base)](#12-extensions-shipped-base) | Thin map | extensions rule |
+| [13. Docs surfaces](#13-docs-surfaces) | Split known | AGENTS docs + interfaces-doxygen |
+| [14. Security / crypto](#14-security--crypto) | Design-heavy | secrets pad |
+| [15. Language surface residuals](#15-language-surface-residuals) | Mixed closed/open | issue pads |
+
+---
+
+## 0. Orientation / product taste
+
+| Field | Content |
+|-------|---------|
+| **Settled map** | Ongoing partner role; beta = quality bar; hard choices by **consensus** (ask what you think → discuss → live verify → either side can be wrong) |
+| **Day rules** | `afw-project` (role one-liner, hard rules, terminology, plain language) |
+| **Deep / reference** | [`ai-partner-lessons.md`](ai-partner-lessons.md) (optional team one-pager), mantras (*How consensus is grown*), philosophy pad, agent-support |
+| **Probe** | Live system when debating models (`afwfcgi`, env registries) — not CI |
+| **Open** | More mantras as shared over time |
+| **Gap** | None critical; grow mantras pad, don’t invent phrases |
+| **Origin note** | Env/runtime “smaller chunks → live discovery → adapters click” discussion: genesis of this support-partner path (ah-ha → map) |
+
+---
+
+## 1. Metadata, generate, packages
+
+| Field | Content |
+|-------|---------|
+| **Settled map** | Humans edit `generate/`; never hand-edit `generated/`; metadata SoT; “get it right at most once” |
+| **Day rules** | `afw-project`, `afw-generate-metadata`, `afw-afwdev-generate`, `afw-json-schema`, `afw-interfaces-doxygen` |
+| **Deep pad** | Philosophy pad (method); contributing/packages handbook XML |
+| **Probe** | `./afwdev build --cdev`; `afwdev validate --pattern '…'`; grepping `generated/` only for review |
+| **Open** | Package-move discipline for non-core srcdirs (ongoing practice) |
+| **Gap** | No single “how to add a package” playbook beyond scaffold + handbook — OK until asked |
+
+---
+
+## 2. Core layout & C conventions
+
+| Field | Content |
+|-------|---------|
+| **Settled map** | One subdirectory ≈ one concern; includes hierarchy; pools/xctx/errors patterns |
+| **Day rules** | `afw-core-layout`, `afw-c-runtime`, `afw-headers` |
+| **Deep pad** | — |
+| **Probe** | Open matching `src/afw/<module>/`; public API via `afw.h` / generated interface headers |
+| **Open** | Line-length soft preference (~80); no mass reformat |
+| **Gap** | Non-pool cleanup mantra (NULL + TRY/FINALLY) lives in rules + workspace MEMORY — already in `afw-c-runtime` |
+
+---
+
+## 3. Values, pools, memory (#2)
+
+| Field | Content |
+|-------|---------|
+| **Settled map** | Values first; permanent / managed / managed_slice / unmanaged; hierarchical pools; short request teardown proven; long-running needs escape discipline |
+| **Day rules** | `afw-runtime-model` (always-on), `afw-value-memory`, `afw-script-eval` |
+| **Deep pad** | [`memory-management.md`](memory-management.md) (**large** — do not rewrite this pass); philosophy pad core model |
+| **Probe** | Targeted `.as` + `afwdev test -j --env-mode valgrind`; advanced-test multi-request leaves; never “fix memory” without a metric/story |
+| **Open** | Umbrella **#2** — phased partner workflow in memory pad; parent of closed #149 |
+| **Gap** | Thin “support one-pager” for leaks vs the novel-length pad — optional later; playbook points at pad |
+
+---
+
+## 4. Compile, EBNF, eval, functions
+
+| Field | Content |
+|-------|---------|
+| **Settled map** | Compile → value graph → evaluate; EBNF-in-comments harvest; functions metadata + hand execute; statement_flow control |
+| **Day rules** | `afw-compile`, `afw-compiler-ebnf`, `afw-script-eval`, `afw-function` |
+| **Deep pads** | `compile-optimize-notes`, `pragma-hash-design`, `decompile-compiler-internal-inventory`, `compile-contextual-audit`, `adaptive-function-compile-typecheck`, `issue-28-type-syntax` |
+| **Probe** | `afw -s '…'` / tests under `src/afw/tests/`; regenerate EBNF via `--cdev`; check `generated/ebnf/syntax.ebnf` has `::=` for nonterminals |
+| **Open** | #28 residuals; typecheck follow-on; compile optimize future |
+| **Gap** | Support playbook for “parse error / decompile mismatch” still thin — use rules + decompile pads |
+
+---
+
+## 5. Environment & runtime objects
+
+| Field | Content |
+|-------|---------|
+| **Settled map** | Process-wide registries; everything registered discoverable on `adapterId=afw`; runtime objects = immutable views; #149 accessor reliability shipped |
+| **Day rules** | `afw-environment`, `afw-environment-variables`, `afw-core-services` (runtime section) |
+| **Deep pads** | [`runtime-objects-and-environment.md`](runtime-objects-and-environment.md) (architecture), [`runtime-value-accessors.md`](runtime-value-accessors.md) (catalog snapshot), [`runtime-catalog-lifetime.md`](runtime-catalog-lifetime.md) (discovery notes) |
+| **Probe** | `retrieve_objects` / GET `/afw/_Adaptive…_/`; `/afw/_AdaptiveRuntimeValueAccessor_/`; **do not** stop permanent `adapter-afw` / `adapter-conf`; prefer typed retrieve over full `current` materialize |
+| **Open** | Residuals under **#2**; more adapters may need terminating checks; attach lifecycle for advanced-test not fully built |
+| **Gap** | MEMORY held a long durable env section — **promoted into playbook** this pass; keep architecture pad as deep map, not MEMORY novel |
+
+**Registry discovery (condensed)**
+
+| Want | How |
+|------|-----|
+| Kind list | `AFW_ENVIRONMENT_REGISTRY_TYPE_MAP` or `_AdaptiveEnvironmentRegistry_/current` / registry types |
+| All of one kind | `retrieve_objects(afw, _Adaptive…_, maxObjects=0)` |
+| One | `get_object` / `/afw/<type>/<id>` |
+| Accessor contract | `/afw/_AdaptiveRuntimeValueAccessor_/<key>` |
+
+**maxObjects:** default ~100 may error (`payload_too_large`); **0 = unlimited**.
+
+---
+
+## 6. Hosts & process lifetime
+
+| Field | Content |
+|-------|---------|
+| **Settled map** | #158 closed (PR **#165**): host-specific wake + core `terminating` |
+| **Day rules** | `afw-server`, `afw-server-fcgi`, `afw-command` |
+| **Deep pad** | None required; user notes in `whats-new.md` |
+| **Probe** | `src/afw/tests/advanced/afwfcgi_signal_shutdown/`; `afwfcgi --help` |
+| **Open** | Drain timeout, SIGHUP, Windows service, general signal framework, every extension retrieve loop, `--local` read unblock |
+| **Gap** | MEMORY #158 section → **promoted into playbook** this pass |
+
+**Host contracts**
+
+| Host | SIGTERM/SIGINT |
+|------|----------------|
+| **`afwfcgi`** | `env->terminating`; FCGI shutdown pending; **SIGUSR1** each request thread; join; close listen; **unlink Unix `-p` path** (not TCP) |
+| **`afw`** | Set `env->terminating` only |
+
+**Core:** error code `terminating` → HTTP **503**; `AFW_XCTX_THROW_IF_TERMINATING(xctx)` at work-unit boundaries.
+
+**Wrong path:** close listen fd alone to wake multi-thread accept while main is in join — use **thread signal** for libfcgi.
+
+---
+
+## 7. Core services (adapter/object/request)
+
+| Field | Content |
+|-------|---------|
+| **Settled map** | Adapters as normalized object stores; model maps; request handlers; auth; retrieve limits (#49) |
+| **Day rules** | `afw-core-services`, `afw-model-adapter`, `afw-adapter-index` |
+| **Deep pads** | Issue/theme pads as needed; model optional `mappedAdapterId` (#109) in model rule |
+| **Probe** | Adapter CRUD via tests; `service_start/stop/restart/get`; lifecycle leaf under `tests_special` |
+| **Open** | Index create/txn residuals (#54/#57); more adapter types; retrieve paging vs progressive stream (not the same as #49 limit) |
+| **Gap** | No dedicated “adapter write path” playbook — use core-services + tests |
+
+---
+
+## 8. Streams, files, VFS
+
+| Field | Content |
+|-------|---------|
+| **Settled map** | Streams host-agnostic for response body; `rootFilePaths` / open_file; VFS is separate adapter (`vfsMap`) |
+| **Day rules** | `afw-stream`, `afw-vfs` |
+| **Deep pad** | — |
+| **Probe** | Stream tests under `tests/miscellaneous/stream_file`; VFS tests in `src/afw_vfs` |
+| **Open** | Progressive retrieve vs count limits (see stream rule notes) |
+| **Gap** | Thin; OK |
+
+---
+
+## 9. Qualified variables & context
+
+| Field | Content |
+|-------|---------|
+| **Settled map** | Qualifier stack get vs `qualifier()`/`qualifiers()` snapshots (#9); `current::` / `custom::`; includeUntrusted |
+| **Day rules** | `afw-qualified-variables`, environment-variables (process::) |
+| **Deep pad** | — |
+| **Probe** | `src/afw/tests/compiler/qualifier*.as` |
+| **Open** | Watch contribute_cb / untrusted edges |
+| **Gap** | Support one-liner only unless symptoms appear |
+
+---
+
+## 10. Adaptive Script authoring
+
+| Field | Content |
+|-------|---------|
+| **Settled map** | Object/array terminology; equality/nullish quirks; prefer throw + try; `_AdaptiveError_` |
+| **Day rules** | `afw-adaptive-script`, `afw-script-errors` |
+| **Deep pads** | array-semantics, conversion-functions, utf8-code-point-sequences, issue-17 faces, issue-38, issue-138 meta wire |
+| **Probe** | Language suite under `src/afw/tests/`; Fiddle / `afw -s` |
+| **Open** | Language residuals tracked in issues/pads |
+| **Gap** | “How to write a good .as test” → `afw-tests` + writing-tests developer doc |
+
+---
+
+## 11. afwdev: build / generate / test
+
+| Field | Content |
+|-------|---------|
+| **Settled map** | **Gate** vs **lab** split; advanced-test + blast experimental |
+| **Day rules** | `afw-tests`, `afw-afwdev-python`, `afw-afwdev-generate` |
+| **Deep pads** | [`afwdev-test-recipe.md`](afwdev-test-recipe.md), [`afwdev-advanced-test.md`](afwdev-advanced-test.md), [`afwdev-blast.md`](afwdev-blast.md); developer `writing-tests.md` |
+| **Probe** | See recipe commands below |
+| **Open** | #13 stress knobs on `test` (blast shipped instead); attach mode not fully built; advanced-test may reshape |
+| **Gap** | MEMORY testing split → **in recipe + playbook**; drop duplicating full MEMORY novel after promote |
+
+**Intent split**
+
+| Surface | Job | Default gate? |
+|---------|-----|----------------|
+| `afwdev test -j` | Language/package suite + advanced leaves under `src/*/tests/` | **Yes** |
+| `afwdev test -T path` | Opt-in only (`tests_special/`, etc.) | Opt-in |
+| `afwdev test --env-mode afwfcgi` | Conf-free `.as` on live `:8080/afw` | Optional |
+| `afwdev blast` | Load thrash at afwfcgi | **No** |
+
+```bash
+./afwdev build --cdev          # day-to-day C/Python
+./afwdev build --fulldev       # PR-shaped / docs-aware
+afwdev test -j
+afwdev test --test-pattern catalog-value-accessors --show-all
+afwdev test -T src/afw/tests_special/adapter-lifecycle --show-all
+afwdev blast -T src/afw/tests_special/catalog -d 15s -c 4 -m 40
+```
+
+After install, **restart afwfcgi** if attach tools talk to a long-lived process.
+
+---
+
+## 12. Extensions (shipped base)
+
+| Field | Content |
+|-------|---------|
+| **Settled map** | curl, ldap, lmdb, ubjson, vfs, yaml — same env registries; self-contained vs core |
+| **Day rules** | `afw-extensions`, plus vfs / adapter-index (lmdb) as specialized |
+| **Deep pad** | Per-extension docs under srcdir; secrets/crypto separate |
+| **Probe** | Extension tests under `src/afw_*/tests/` |
+| **Open** | Index residuals on LMDB; other adapters index interface NULL |
+| **Gap** | No per-extension support cards — add when symptoms cluster |
+
+---
+
+## 13. Docs surfaces
+
+| Field | Content |
+|-------|---------|
+| **Settled map** | Handbook ≠ Doxygen ≠ EBNF railroad chrome; Jeremy handbook voice |
+| **Day rules** | `afw-interfaces-doxygen`, `afw-project` prose; AGENTS Documentation section |
+| **Deep pad** | `src/afw/doc/developer/doxygen-skin.md` etc. |
+| **Probe** | `./afwdev build --docs --clean -j` when docs must refresh |
+| **Open** | Thin developer MD under `src/afw/doc/developer/` |
+| **Gap** | Workspace MEMORY has chrome details — keep sticky in MEMORY prefs; not required in atlas body |
+
+---
+
+## 14. Security / crypto
+
+| Field | Content |
+|-------|---------|
+| **Settled map** | Design in progress / #74 oriented |
+| **Day rules** | C TRY/FINALLY for OpenSSL in `afw-c-runtime` |
+| **Deep pad** | [`secrets-and-afw-crypto.md`](secrets-and-afw-crypto.md) (**large**) |
+| **Probe** | Crypto tests / functions when touching that tree |
+| **Open** | Product decisions in pad |
+| **Gap** | Atlas points only — do not summarize 1k-line pad here |
+
+---
+
+## 15. Language surface residuals (pointers only)
+
+| Theme | Pad / note | Status |
+|-------|------------|--------|
+| Array semantics | `array-semantics.md` | Shipped (#39) |
+| Converts | `conversion-functions.md` | Shipped with #39 wave |
+| UTF-8 code points | `utf8-code-point-sequences.md` | #153 oriented |
+| Mutable faces | `issue-17-mutable-object-faces.md` | Closed PR #150 |
+| Expression property names | `issue-38-…` | Closed |
+| Meta on wire | `issue-138-…` | Design/status in pad |
+| Decompile | `issue-18-…` | Pad useful; stringify closed |
+| Types | `issue-28-…` | Core shipped; residuals open |
+| Pragma `#` | `pragma-hash-design.md` | Pattern B `#compile` etc. |
+
+---
+
+## Cross-cutting mantras (see mantras pad)
+
+Most used when navigating this atlas:
+
+- **Get it right at most once** — metadata / shared accessor / shared helper  
+- **Values first** — then pools  
+- **Maps over tickets** — issue ids are pointers  
+- **Gate vs lab** — don’t redefine `test -j` as soak  
+- **Live verify** when teaching  
+- **Code wins** when notes drift  
+
+---
+
+## Gaps backlog (first-pass harvest)
+
+Items worth future promote/fill — **not** blocking this atlas:
+
+| Gap | Suggested home | Priority |
+|-----|----------------|----------|
+| Leak / long-run “first 15 minutes” support card | agent-support or thin pointer into memory pad | Medium (#2 active) |
+| Parse/decompile mismatch playbook | agent-support | Low until pain |
+| Adapter write / conf service lifecycle card | agent-support (partially in recipe) | Medium |
+| Attach mode advanced-test | afwdev-advanced-test pad | When building |
+| More Mike mantras | mantras pad | When shared |
+| MEMORY env/runtime novel fully thinned | Keep pointer; git pads win | Done enough this pass |
+| Per-extension support cards | agent-support or extensions | On demand |
+| open-issues-status / beta-backlog refresh | root hubs | Campaign hygiene, not atlas |
+
+---
+
+## MEMORY hygiene (this pass)
+
+| MEMORY content | Action |
+|----------------|--------|
+| Sticky mission, mantras pointer, hubs | **Keep** (thin) |
+| Quick resume branch tip | **Refresh** when branch/PR changes — not durable map |
+| #158 graceful stop section | **Promoted** → hosts playbook + this atlas §6; MEMORY may shrink to pointer |
+| afwdev testing split | **Already** in designs; MEMORY may shrink to pointer |
+| Adaptive environment ↔ runtime objects | **Promoted** condensed → atlas §5 + env playbook; architecture pad remains deep |
+| #149 closed narrative | **Pointer** only — pads keep detail |
+| Workspace prefs (plain language, handbook, EBNF, docs chrome) | **Keep** in workspace MEMORY — operational |
+
+---
+
+## Maintenance
+
+After a deep issue session:
+
+1. Update the **topic row** (open/residual, probe) if the map changed.  
+2. Prefer **one settled sentence** over pasting the PR.  
+3. Fill or add an **agent-support** playbook only when symptoms repeat.  
+4. Do **not** grow this file into a dump of every PR.
+
+**First pass date:** 2026-08-09 · branch work on `feature-afw-support-agent`.

--- a/designs/mantras-and-working-style.md
+++ b/designs/mantras-and-working-style.md
@@ -7,7 +7,7 @@
 
 **Provenance:** subset of Mike’s long-standing design mantras and working habits as shared in Grok Build / Cursor work (2025–2026) and distilled from earlier AFW design framing. **Incomplete on purpose.** People who have worked with Mike for years know a larger set; add here when another sticky phrase is shared and still useful. Do not invent mantras that were never said.
 
-**Companion:** structural “why the runtime looks like this” → [`afw-philosophy-and-core-model.md`](afw-philosophy-and-core-model.md).
+**Companions:** optional **team-facing** one-pager → [`ai-partner-lessons.md`](ai-partner-lessons.md). Structural “why” → [`afw-philosophy-and-core-model.md`](afw-philosophy-and-core-model.md). Topic → sources → probes → [`knowledge-atlas.md`](knowledge-atlas.md).
 
 ---
 
@@ -18,9 +18,23 @@ Act as an **ongoing Adaptive Framework support and development partner**:
 - accurate mental models, careful implementation, live debugging;
 - knowledge that **survives sessions** (and helps others pick up the thread);
 - **beta** as a quality bar and campaign — not an end date for the partnership;
-- Mike still owns **product taste** and hard **“should we?”** calls.
+- Product direction and hard **“should we?”** calls are grown by **consensus** — discuss, map tradeoffs, leave room for other maintainers and collaborators. Not one-person rule.
 
-Not: ticket-closing robot until beta, then silence. Not: second handbook that rewrites product docs without being asked. Not: personal biography store — **methods and taste only**.
+Not: ticket-closing robot until beta, then silence. Not: second handbook that rewrites product docs without being asked. Not: personal biography store — **methods and design taste only**.
+
+### How consensus is grown (same with humans)
+
+This is how issue work has actually gone with AI partners — and how human development/support partners were treated for years. It is the method, not a ceremony.
+
+1. **Start with “what do you think?”** — invite the partner’s model early, not only after the decision is made.  
+2. **Discuss in the open** — keep asking what the partner thinks while walking the design. Good partners point out angles you had not seen.  
+3. **Push back is allowed** — including firm “I think you’re missing X” or an offer to write something down. That is part of finding consensus, not disrespect.  
+4. **Guide with why** — when the feeling differs, walk the reasons (and the code / live system), not a decree.  
+5. **Either side can be wrong** — sometimes the partner was right; sometimes the long-time view was. Both are fine. When the partner **discovers** that something is correct without being argued into it, that is the good outcome: shared understanding, not winning.  
+6. **Close the loop with live truth** — show `afwfcgi`, point at registries in `afw_environment.h`, const objects vs runtime objects, adapters and services. When the partner’s mental model clicks, they often **intuit the next layer** (e.g. start/stop adapters, how pieces wire) without a full lecture.  
+7. **Ah-ha moments become maps** — one env/runtime discussion (smaller chunks, then live discovery) was the genesis of this support-partner path: if a careful partner can close that loop, AFW support and continuity are real work, not only ticket churn.
+
+Assistants: lead with honest models and questions; accept correction; prefer **live probes** when stuck arguing in the abstract; do not sulk when guided, and do not pretend consensus means never disagreeing.
 
 ---
 
@@ -66,12 +80,14 @@ Short form first; “means in practice” second. Several of these are already e
 
 | Habit | Means in practice |
 |-------|-------------------|
-| **Discuss → plan → tweak → execute when told** | Especially for hard multi-phase work (e.g. memory **#2**). Don’t steamroll a large implementation without agreement on the current step. |
-| **Hold commits / PR until asked** | Default in this partnership unless Mike says otherwise for a stretch. |
+| **Ask what you think first** | Open issues with the partner’s read; keep inviting it during the discussion (see *How consensus is grown* above). |
+| **Discuss → plan → tweak → execute when agreed** | Especially for hard multi-phase work (e.g. memory **#2**). Don’t steamroll a large implementation without shared agreement on the current step. |
+| **Hold commits / PR until asked** | Default in this partnership unless the human partner says otherwise for a stretch. |
 | **One hard cleanup item at a time** | When doing C hygiene passes, finish or park one thread before opening five. |
 | **No `AFW_ASSERT` as the style** | Prefer real error paths and explicit checks consistent with existing core style; don’t introduce assert-heavy patterns. |
 | **Handbook is Jeremy’s house** | User-facing handbook: plain prose, Adaptive on its terms, Example subsections; no issue numbers or `designs/` paths in handbook XML. Welcome Jeremy to refine or revert. |
 | **Promote after deep work** | After a hard session: mental model change, wrong path never to take, live probe, optional user-facing sentence — into **git** when sticky. |
+| **Ah-ha → map** | When a loop closes (env, hosts, values, …), write the thin map so the next person does not re-earn it only in chat. |
 
 ---
 

--- a/designs/mantras-and-working-style.md
+++ b/designs/mantras-and-working-style.md
@@ -1,0 +1,113 @@
+# Mantras and working style (maintainer framing)
+
+**Audience:** maintainers, collaborators, and AI assistants answering *philosophy*, *taste*, or *“what would Mike say?”* questions.  
+**Not** always-on agent rules, not handbook, not a substitute for code or [`.cursor/rules/`](../.cursor/rules/).
+
+**How to use:** consult when orienting on *how to think and partner*, not for every edit. Day-to-day hard constraints stay in always-on rules (`get it right at most once` / no hand-edit `generated/`, plain language, terminology, etc.). When a mantra and live code or an explicit user instruction disagree, **follow the user and the code**.
+
+**Provenance:** subset of Mike’s long-standing design mantras and working habits as shared in Grok Build / Cursor work (2025–2026) and distilled from earlier AFW design framing. **Incomplete on purpose.** People who have worked with Mike for years know a larger set; add here when another sticky phrase is shared and still useful. Do not invent mantras that were never said.
+
+**Companion:** structural “why the runtime looks like this” → [`afw-philosophy-and-core-model.md`](afw-philosophy-and-core-model.md).
+
+---
+
+## What the AI partner is for
+
+Act as an **ongoing Adaptive Framework support and development partner**:
+
+- accurate mental models, careful implementation, live debugging;
+- knowledge that **survives sessions** (and helps others pick up the thread);
+- **beta** as a quality bar and campaign — not an end date for the partnership;
+- Mike still owns **product taste** and hard **“should we?”** calls.
+
+Not: ticket-closing robot until beta, then silence. Not: second handbook that rewrites product docs without being asked. Not: personal biography store — **methods and taste only**.
+
+---
+
+## Mantras (sticky phrases)
+
+Short form first; “means in practice” second. Several of these are already enforced in rules for daily work; this list is for **context and teaching**.
+
+### Build and truth
+
+| Mantra | Means in practice |
+|--------|-------------------|
+| **Get it right at most once** | Put the invariant in **one** right place (metadata, shared accessor, shared helper, generate path). Do not copy-paste the same fix across callers or hand-edit `generated/`. If it must be true everywhere, make it true at the source of truth. |
+| **Metadata is the single source of truth** | Functions, data types, object types, interfaces: define once under `generate/`; regenerate; implement the hand closet. Generated trees are output, not a second authoring surface. |
+| **Small patterned pieces** | Prefer many small, named, interface-shaped units over one mega-module. Same pattern in core, extensions, and hosts beats special snowflakes. |
+| **Uniform models** | Environment registries, adaptive values, interface call macros — capabilities should *feel* the same wherever they came from. |
+| **Public core, movable packages** | Extensions and other srcdirs stay as self-contained as practical; use **public** core APIs; don’t glue private core headers into “just this once” hacks. |
+
+### Runtime and language
+
+| Mantra | Means in practice |
+|--------|-------------------|
+| **Values first** | Adaptive values (`afw_value`) are central — script, compile results, calls, closures, much data. For memory and eval questions, think **value policy** before ad-hoc C free lists. |
+| **Pools and escape are the memory story** | Hierarchical pools / subpools for bulk lifetime; refcount / managed policy for what **escapes**. Short request teardown was the proven path; long-running work must be honest about escape (**#2**). |
+| **Immutability first (script graph)** | Eval is a value graph evaluated lazily; mutation is deliberate, not “everything is a mutable bag.” |
+| **Adaptive on its own terms** | Teach and document Adaptive as itself. Borrow familiarity carefully; do not pretend it is TypeScript/JS or revive **bag** language for objects. **Object** + **properties**; **array** for ordered collections. |
+| **Interfaces are the developer API** | Call macros and generated contracts are what builders should learn first — not `inf` arrow spelunking as the primary teaching path. |
+| **Discover what you registered** | What lives in the environment should be **readable as runtime objects** (`adapterId=afw`). Registration without a discoverable face is a half-story. |
+
+### Quality and process
+
+| Mantra | Means in practice |
+|--------|-------------------|
+| **Plain language** | Prefer clear words over casual acronyms when a short phrase is enough (“out of range,” not “OOB”; “compiled form,” not “IR”). Product and code names stay. Handbook: Jeremy’s plain Adaptive voice. |
+| **Fix the layer, not the symptom twice** | Prefer one map/accessor/helper fix over scattered caller patches (classic in runtime catalog and utf8 index work). |
+| **Complete thin verticals** | Prefer a full thin path that works (discover → run → teardown, or generate → implement → test) over half of five grand designs. |
+| **Gate vs lab** | Language/package **gate** (`afwdev test -j`) is not the same job as **lab** load, soak, or experimental hosts (blast, advanced-test). Don’t redefine the gate as soak. |
+| **Live verify when teaching** | When explaining how something works, prefer a real probe (`afw`, `afwfcgi`, retrieve runtime objects) over lore alone. |
+| **Maps over tickets** | Durable notes: concept, contract, failure mode, probe. Issue numbers are **pointers**, not the title of the knowledge. |
+| **Widen goals, not volume** | Grow competence and coverage of *kinds* of knowledge; don’t dump every PR status into long memory or long pads. |
+| **Code wins on facts** | Pads and mantras orient; the tree and tests are ground truth. When notes drift, fix the notes. |
+
+### Partnership habits (how we work together)
+
+| Habit | Means in practice |
+|-------|-------------------|
+| **Discuss → plan → tweak → execute when told** | Especially for hard multi-phase work (e.g. memory **#2**). Don’t steamroll a large implementation without agreement on the current step. |
+| **Hold commits / PR until asked** | Default in this partnership unless Mike says otherwise for a stretch. |
+| **One hard cleanup item at a time** | When doing C hygiene passes, finish or park one thread before opening five. |
+| **No `AFW_ASSERT` as the style** | Prefer real error paths and explicit checks consistent with existing core style; don’t introduce assert-heavy patterns. |
+| **Handbook is Jeremy’s house** | User-facing handbook: plain prose, Adaptive on its terms, Example subsections; no issue numbers or `designs/` paths in handbook XML. Welcome Jeremy to refine or revert. |
+| **Promote after deep work** | After a hard session: mental model change, wrong path never to take, live probe, optional user-facing sentence — into **git** when sticky. |
+
+---
+
+## Anti-patterns (wrong paths Mike has pushed back on)
+
+Useful when someone (or an assistant) is about to “help” the wrong way:
+
+- Hand-editing **`generated/`** “just this once.”
+- Treating **objects as bags** / property bags in new docs or APIs.
+- Deep-cloning whole adapters or full registry **`current`** to paper over one bad accessor.
+- Making **default `afwdev test -j`** into a load/soak product.
+- Closing the listen socket alone as the *long-term* multi-thread wake story for every host (host-specific wake + `terminating` flag instead).
+- Rewriting handbook voice into issue-tracker or design-pad voice.
+- Optimizing chat **memory volume** instead of **maps** that live in git.
+- Assuming beta ship date = end of partnership or end of learning the system.
+
+---
+
+## Growing this list
+
+This is **not** the complete set of mantras Mike has used for years with other people — only what has been made explicit in this partnership so far (plus a few that already live in always-on rules and core design pads).
+
+When another sticky phrase shows up in conversation and still helps:
+
+1. Add a row to the tables above (short form + means in practice).  
+2. Optionally one line in [`agent-support.md`](agent-support.md) concept cards if it is support-shaped.  
+3. Do **not** paste the whole list into always-on `.mdc` unless it is a true daily hard rule (most already are, or aren’t).
+
+---
+
+## Related
+
+| Doc | Role |
+|-----|------|
+| [`afw-philosophy-and-core-model.md`](afw-philosophy-and-core-model.md) | Core runtime model + design philosophy |
+| [`../AGENTS.md`](../AGENTS.md) | Mission, knowledge map, how we learn |
+| [`agent-support.md`](agent-support.md) | Support playbooks; capture checklist |
+| [`memory-management.md`](memory-management.md) | Values/pools/#2 depth |
+| [`.cursor/rules/afw-project.mdc`](../.cursor/rules/afw-project.mdc) | Always-on daily constraints |

--- a/src/afw/doc/developer/overview.md
+++ b/src/afw/doc/developer/overview.md
@@ -33,6 +33,30 @@ REST-only users. For product overview and language docs, see the published
 - **Internal (libafw only):** `afw_internal.h`, `*_internal` groups — may change
   without notice.
 
+## Maintainer maps in the source tree
+
+This handbook page and the Doxygen groups explain the **C builder surface**.
+The Git repository also carries a lot of **development and support knowledge**
+for people who work in the tree day to day (humans, and tools that read the
+repo). None of that replaces this documentation or the tests; it is a map into
+deeper notes.
+
+| Start here | Role |
+|------------|------|
+| **`AGENTS.md`** (package root) | System map: mission, layout, build/test loop, where other notes live. Includes an optional short pattern for working an issue with an AI partner (“what do you think about issue #N?”). |
+| **`CLAUDE.md`** (package root) | Thin stub for Claude Code — points at `AGENTS.md` and key `designs/` paths; not a second full guide. |
+| **`designs/`** | Theme pads, topic atlas, support playbooks, optional lessons — *why*, open questions, and “where is X?” without rewriting the handbook. |
+| **`.cursor/rules/`** | Optional always-on / area habits for some editor agents (how to work in a given tree). Not required to build AFW by hand. |
+
+Useful entry points under `designs/` when you want to dive deeper:
+
+- `designs/knowledge-atlas.md` — topic → rules, pads, and live probes  
+- `designs/agent-support.md` — symptom-oriented playbooks  
+- `designs/ai-partner-lessons.md` — **optional** lessons on pairing with an AI partner (follow or not)  
+- `designs/afw-philosophy-and-core-model.md` / `designs/mantras-and-working-style.md` — design framing (reference, not always-on law)
+
+**Ground truth** remains code, tests, this developer set, and the published handbook. When a pad and the tree disagree, trust the tree and fix the pad.
+
 ## Rebuilding this documentation
 
 ```bash

--- a/src/afw/doc/guide/developer/introduction.xml
+++ b/src/afw/doc/guide/developer/introduction.xml
@@ -17,4 +17,15 @@
         Additionally, the Reference material will be helpful in referring back to, for more 
         detailed, technical documentation. In particular, the Doxygen reference for C.
     </paragraph>
+    <paragraph>
+        If you work in the Adaptive Framework Git repository, the source tree also holds 
+        maintainer-oriented maps that are not the main handbook narrative. Start at the 
+        package-root file <literal>AGENTS.md</literal> for a system map and build/test 
+        orientation. That file also sketches an optional pattern for working a development or 
+        support issue with an AI partner (open with what the partner thinks, discuss, then 
+        implement). Deeper design notes, topic indexes, and optional support material live 
+        under the <literal>designs/</literal> directory. Those notes help people who develop 
+        and support the framework day to day; they do not replace this guide, the Architecture 
+        Guide, or the tests.
+    </paragraph>
 </doc>


### PR DESCRIPTION
## Purpose

Set up Adaptive Framework so maintainers (and coding agents) can act as an
**ongoing support and development partner**, not only “close tickets until beta.”

This branch is **docs / agent orientation only** — no product C or runtime
behavior changes. Beta stays a quality bar; direction stays **consensus-grown**.
Maps live in git so knowledge survives sessions and tools.

## Where to start (after merge)

| Path | Role |
|------|------|
| `AGENTS.md` | System map, knowledge map, **optional pattern**: “What do you think about issue #N?” |
| `designs/ai-partner-lessons.md` | Short **optional** team lessons (follow or not) |
| `designs/knowledge-atlas.md` | Topic → rules / pads / probes / gaps |
| `designs/agent-support.md` | Support playbooks (hosts, env/runtime, values, afwdev) |
| `CLAUDE.md` | Thin stub for Claude Code → `AGENTS.md` (Codex already uses `AGENTS.md`) |

Handbook / Doxygen: short signposts in the developer introduction and
`src/afw/doc/developer/overview.md` so people find `AGENTS.md` / `designs/`
without digging.

## Major `designs/` additions (and why)

| Pad | Why |
|-----|-----|
| **knowledge-atlas** | First-pass “where is X?” so support knowledge isn’t only chat memory |
| **agent-support** | Symptom → layer → probe playbooks (hosts/#158, env/#149, values/#2, afwdev gate vs lab) |
| **ai-partner-lessons** | Optional human-facing how we pair with an AI on issues |
| **afw-philosophy-and-core-model** | Why the core is shaped this way (reference, not always-on law) |
| **mantras-and-working-style** | Sticky design phrases + how consensus is grown |

Existing deep pads (memory, runtime-objects, afwdev-*, …) are **linked**, not rewritten.

## Out of scope

- Rewriting always-on rules wholesale
- Product runtime changes
- Requiring any AI tool or process

## How to share with the team

Send **this PR**. Optional one-liner:

> Optional maps for support/dev + AI pairing: start at `AGENTS.md` and
> `designs/ai-partner-lessons.md` (follow or not).