### PR TITLE
#106: test262 FIXME sweep and compiler literals

### DIFF
--- a/.cursor/rules/afw-tests.mdc
+++ b/.cursor/rules/afw-tests.mdc
@@ -47,12 +47,10 @@ agree:
 
 | Prefix | Meaning |
 |--------|---------|
-| **`Incompatible:`** | Never plan to convert |
 | **`FIXME:`** | Adaptive should fix or decide |
-| **`Deferred:`** | Later, not current priority |
-| **`Harness:`** | Runner/adaptation limit (rare) |
+| **`Never:`** | We do not plan to support this |
 
-Examples: `Incompatible: ES generators / function*`; `FIXME: for-of member LHS (x.y)`; `Deferred: deep TCO`. Long `skipReason` (or any key): use `//? skipReason: ...` then body lines until the next `//?` for ~80-column editing. Full notes: `src/afw/tests/test262/README.md`.
+Examples: `Never: no String.fromCharCode`; `FIXME: for-of const + closure (#35 / #2)`. Long `skipReason` (or any key): use `//? skipReason: ...` then body lines until the next `//?` for ~80-column editing. Full notes: `src/afw/tests/test262/README.md`.
 
 Typical case skeleton:
 
@@ -62,7 +60,7 @@ Typical case skeleton:
 //? description: What this case checks
 //? differences: Optional ES vs Adaptive language note
 //? skip: false
-//? skipReason: Incompatible: … / FIXME: … / Deferred: …
+//? skipReason: Never: … / FIXME: …
 //? expect: 0
 //? source: ...
 

--- a/.cursor/rules/afw-tests.mdc
+++ b/.cursor/rules/afw-tests.mdc
@@ -35,7 +35,7 @@ agree:
 | Key | Role |
 |-----|------|
 | **`test`** | Case id |
-| **`description`** | What the case checks (test262: stay close to TC39 text) |
+| **`description`** | Stay close to TC39 text. Skip notes → `skipReason`. `expect: error` → source `//` comment, not a rewritten description |
 | **`differences`** | Optional ES vs Adaptive **language** delta for the construct under test (not harness) |
 | **`expect`** | Outcome: Adaptive value (`0`, `true`, `undefined`, …), **`success`** (ran, ignore result), or **`error`** / **`error:…`** |
 | **`skip`** | `true` / `false` |

--- a/designs/decompile-compiler-internal-inventory.md
+++ b/designs/decompile-compiler-internal-inventory.md
@@ -5,6 +5,9 @@
 **Tests:** `src/afw/tests/compiler/decompile_accept/`; broad round-trips — `decompile_fidelity.as`, samples — `decompile.as` / `pragma.as`.
 
 Author-facing `#compile` is **not** in this inventory (policy pragma).  
+**Compiler literals** (`#doubleMax`, `#pi`, `#infinity`, …) are author-facing
+values that fold at compile; they are **not** decompile IR. See
+`afw_value.h` and `src/afw/tests/compiler/compiler_literals.as`.  
 Compiler-private forms are **toolchain only** (decompile → recompile).
 
 ## Dispatch positions
@@ -30,6 +33,7 @@ Lex token: `pound_identifier` (`#Name`). Unknown names → parse error (statemen
 | `#closure_binding` | Yes (live closure) | Known **reject** | No | Runtime enclosing scope not reconstructible from text |
 | `#function_thunk` | Yes (C thunk label) | Known **reject** | No | C-side only (e.g. model hooks) |
 | `#compile` | Never (policy pragma) | Pragma path only | n/a | Not compiler-internal |
+| `#doubleMax` and other **compiler literals** | Never (fold to the number) | Value | n/a | Author-facing; not IR |
 | other `#Name` | — | Unknown error | No | |
 
 ## Emit helpers

--- a/designs/pragma-hash-design.md
+++ b/designs/pragma-hash-design.md
@@ -9,6 +9,7 @@
 | Kind | Parse | Audience | Role |
 |------|--------|----------|------|
 | **Pragma** | `afw_compile_parse_pragma.c` | Script authors | Per-compile **policy** |
+| **Compiler literal** | `afw_compile_parse_compiler_internal.c` | Script authors | `#` name that folds to a permanent value (`#doubleMax`, `#pi`, …) |
 | **Compiler-internal** | `afw_compile_parse_compiler_internal.c` | Toolchain only | **decompile → recompile** (`#block`, `#script_function`, …) |
 
 Lex: `pound_identifier` for any `#Name`. Product docs should not teach compiler-internal forms as normal script.

--- a/open-issues-status.md
+++ b/open-issues-status.md
@@ -2,7 +2,7 @@
 
 **Repo:** [afw-org/afw](https://github.com/afw-org/afw)  
 **Branch context:** `mgg-develop` (beta readiness)  
-**Generated / refreshed:** 2026-08-13 (evening; GitHub assignees and dates)  
+**Generated / refreshed:** 2026-08-14 (#106 wrap)  
 **Source:** live GitHub open issues (`gh issue list --state open`) + maintainer notes from recent `mgg-develop` work.
 
 This is a **working tracker**, not a substitute for issue bodies or PRs. “How it stands” mixes GitHub metadata with known landings on `mgg-develop`; re-verify before closing anything.
@@ -19,10 +19,10 @@ Assignees are from GitHub. Dual assignees mean both are listed, not necessarily 
 
 ## Summary counts
 
-- **Open issues:** 39
+- **Open issues:** 38
 - **Jeremy:** 27 issues (as assignee, including shared)
 - **Mike:** 11 issues (as assignee, including shared)
-- **—:** 6 issues (unassigned)
+- **—:** 5 issues (unassigned)
 
 ## All open issues
 
@@ -58,7 +58,6 @@ Assignees are from GitHub. Dual assignees mean both are listed, not necessarily 
 | [#91](https://github.com/afw-org/afw/issues/91) | Mike | Use authorization mode 'intermediate' for accessing more resources adaptors need for their internal use | Currently user requests to adaptors use 'user' mode to access to resources needed internally by the adaptor. For reso… | Use intermediate auth mode for adapter-internal resource access. Open. | 2024-07-24 |
 | [#101](https://github.com/afw-org/afw/issues/101) | Jeremy | Changes to how evaluate() and how unevaluated values are handled | This issue involves several changes related to compiled values and when they are evaluated plus a few function name c… | Shipped PR **#105**. Assignment later refined by **#17** faces (evaluate, no clone). Docs/mocks may remain. | 2026-08-13 |
 | [#102](https://github.com/afw-org/afw/issues/102) | Jeremy | Allow model "on" functions access to adapterTypeSpecific parameter | When implementing an "adapter" entirely using models and "on" functions/adaptive scripts, the "on" functions currentl… | Expose adapterTypeSpecific to model on* scripts. Open (docs label). | 2025-04-27 |
-| [#106](https://github.com/afw-org/afw/issues/106) | — | Resolve FIXME's in afw tests | Resolve FIXME's in afw tests (source/afw/tests//.as) | Resolve FIXMEs in afw tests (test262 etc.). Unassigned long-burn. | 2025-04-26 |
 | [#108](https://github.com/afw-org/afw/issues/108) | Jeremy | Support for callbacks in curl functions | Currently, the curl http functions read and write data completely in memory. This will be not be very resourceful whe… | curl adaptive functions: streaming callbacks. Open. | 2025-04-27 |
 | [#114](https://github.com/afw-org/afw/issues/114) | — | [Fiddle] Closing an inactive tab with unsaved changes targets the active tab instead | To reproduce: | Fiddle: close inactive unsaved tab closes active tab. Unassigned UI bug. | 2026-07-07 |
 | [#125](https://github.com/afw-org/afw/issues/125) | Mike | Review max vs maximum (and related) property naming for consistency | For consistency with almost all other Adaptive property names, maximumNumberOfParameters on AdaptiveFunction should p… | max vs maximum property naming consistency. Parked naming pass. | 2026-07-19 |
@@ -81,7 +80,7 @@ Assignees are from GitHub. Dual assignees mean both are listed, not necessarily 
 | Admin / Fiddle / UI | [#8](https://github.com/afw-org/afw/issues/8), [#59](https://github.com/afw-org/afw/issues/59), [#60](https://github.com/afw-org/afw/issues/60), [#80](https://github.com/afw-org/afw/issues/80), [#114](https://github.com/afw-org/afw/issues/114) | Jeremy / unassigned UI |
 | afwdev / CI / packaging | [#6](https://github.com/afw-org/afw/issues/6), [#7](https://github.com/afw-org/afw/issues/7), [#13](https://github.com/afw-org/afw/issues/13), [#44](https://github.com/afw-org/afw/issues/44), [#45](https://github.com/afw-org/afw/issues/45), [#81](https://github.com/afw-org/afw/issues/81), [#157](https://github.com/afw-org/afw/issues/157) | [#61](https://github.com/afw-org/afw/issues/61) **closed**; orchestrated tests **#167**; blast retired; #13 knobs still open |
 | Meta / wire / journal | [#126](https://github.com/afw-org/afw/issues/126), [#138](https://github.com/afw-org/afw/issues/138) | Trackers / design pads |
-| Tests / rename debt | [#48](https://github.com/afw-org/afw/issues/48), [#106](https://github.com/afw-org/afw/issues/106) | list→array residuals; test262 FIXMEs |
+| Tests / rename debt | [#48](https://github.com/afw-org/afw/issues/48) | list→array residuals; [#106](https://github.com/afw-org/afw/issues/106) test262 FIXME mailbox **closing** |
 | Hosts / process stop | — | [#158](https://github.com/afw-org/afw/issues/158) **closed** (PR #165) |
 
 ## Recently closed (context only)
@@ -104,6 +103,7 @@ Useful for “don’t restart this.” Includes process-close batch **2026-08-04
 | [#61](https://github.com/afw-org/afw/issues/61) | Create Exception subclasses for some 'afwdev' errors | **Closed 2026-08-09** — afwdev exception subclasses (with test harness work) |
 | [#62](https://github.com/afw-org/afw/issues/62) | Adaptive Script language changes | **Closed 2026-08-13** — PR **#174** multi let/const, for init, assignment chain, running result, labels |
 | [#69](https://github.com/afw-org/afw/issues/69) | Implement data type 'json' and 'relaxed_json' | **Closed 2026-08-13** — types already on tree; PR **#175** tests + strict json rejects Infinity/NaN |
+| [#106](https://github.com/afw-org/afw/issues/106) | Resolve FIXME's in afw tests | **Closing 2026-08-14** — skip prefixes FIXME/Never; compiler literals; leftovers #35/#2, produce-type, #57 |
 | [#89](https://github.com/afw-org/afw/issues/89) | Passing a function as a parameter from an array seems to generate an error | **Closed 2026-08-07** — function from array as callback |
 | [#90](https://github.com/afw-org/afw/issues/90) | checkIndividualObjectReadAccess configuration parameter for adaptors | checkIndividualObjectReadAccess — closed earlier |
 | [#109](https://github.com/afw-org/afw/issues/109) | Improvements for creating adapters with adaptive scripts | Pure-script model adapters — closed earlier |

--- a/src/afw/compile/afw_compile_parse_compiler_internal.c
+++ b/src/afw/compile/afw_compile_parse_compiler_internal.c
@@ -15,8 +15,12 @@
  * This file owns the non-public accept path: forms that decompile() emits so
  * compile() can rebuild the same compiled-value graph.
  *
- * Not for ordinary Adaptive Script authoring. Policy directives (#compile)
- * live in afw_compile_parse_pragma.c.
+ * Also owns **compiler literals** (author-usable # names that fold to
+ * permanent values, not call forms): #doubleMax, #doubleMin,
+ * #doubleMinSubnormal, #doubleEpsilon, #integerMax, #integerMin, #pi, #e,
+ * and aliases #infinity / #inf / #minusInfinity / #nan. See afw_value.h.
+ *
+ * Policy directives (#compile) live in afw_compile_parse_pragma.c.
  *
  * On entry the current token is already pound_identifier. identifier_name is
  * the name without '#'; identifier is the full "#name" (for errors). There is
@@ -77,6 +81,38 @@ impl_compiler_internal_name_is(
 {
     return parser->token->identifier_name &&
         afw_utf8_equal_utf8_z(parser->token->identifier_name, name_z);
+}
+
+
+/* Compiler literal #Name → permanent value, or NULL if not one. */
+static const afw_value_t *
+impl_compiler_numeric_constant(afw_compile_parser_t *parser)
+{
+    static const struct {
+        const afw_utf8_z_t *name_z;
+        const afw_value_t * const *value;
+    } consts[] = {
+        { "doubleMax", &afw_value_double_max },
+        { "doubleMin", &afw_value_double_min },
+        { "doubleMinSubnormal", &afw_value_double_min_subnormal },
+        { "doubleEpsilon", &afw_value_double_epsilon },
+        { "integerMax", &afw_value_integer_max },
+        { "integerMin", &afw_value_integer_min },
+        { "pi", &afw_value_double_pi },
+        { "e", &afw_value_double_e },
+        { "infinity", &afw_value_infinity },
+        { "inf", &afw_value_infinity },
+        { "minusInfinity", &afw_value_minus_infinity },
+        { "nan", &afw_value_NaN }
+    };
+    afw_size_t i;
+
+    for (i = 0; i < sizeof(consts) / sizeof(consts[0]); i++) {
+        if (impl_compiler_internal_name_is(parser, consts[i].name_z)) {
+            return *consts[i].value;
+        }
+    }
+    return NULL;
 }
 
 
@@ -801,11 +837,17 @@ afw_compile_parse_CompilerInternalStatement(afw_compile_parser_t *parser)
 
 /*ebnf>>>
  *
- *# Value/expression-position compiler-internal #Name.
+ *# Value/expression-position #Name.
  *# Token is already pound_identifier.
- *# Forms match decompile #implementation_id where implemented.
+ *# Compiler-internal forms match decompile #implementation_id.
+ *# Compiler literals fold to permanent values (not call forms).
  *# #closure_binding / #function_thunk are recognized but always compile
  *# errors (runtime / C-side only; not recompilable from decompile text).
+ *
+ * CompilerLiteral ::=
+ *     '#doubleMax' | '#doubleMin' | '#doubleMinSubnormal' |
+ *     '#doubleEpsilon' | '#integerMax' | '#integerMin' |
+ *     '#pi' | '#e' | '#infinity' | '#inf' | '#minusInfinity' | '#nan'
  *
  * CompilerInternalValue ::=
  *     CompilerInternalBlock |
@@ -814,7 +856,8 @@ afw_compile_parse_CompilerInternalStatement(afw_compile_parser_t *parser)
  *     CompilerInternalScriptFunction |
  *     CompilerInternalTemplateDefinition |
  *     CompilerInternalSwitchDefault |
- *     CompilerInternalStatements
+ *     CompilerInternalStatements |
+ *     CompilerLiteral
  *
  *<<<ebnf*/
 /**
@@ -823,6 +866,8 @@ afw_compile_parse_CompilerInternalStatement(afw_compile_parser_t *parser)
 const afw_value_t *
 afw_compile_parse_CompilerInternalValue(afw_compile_parser_t *parser)
 {
+    const afw_value_t *numeric;
+
     if (impl_compiler_internal_name_is(parser, "block")) {
         return impl_parse_compiler_internal_block(parser);
     }
@@ -859,6 +904,11 @@ afw_compile_parse_CompilerInternalValue(afw_compile_parser_t *parser)
 
     if (impl_compiler_internal_name_is(parser, "statements")) {
         return impl_parse_compiler_internal_statements(parser);
+    }
+
+    numeric = impl_compiler_numeric_constant(parser);
+    if (numeric) {
+        return numeric;
     }
 
     impl_compiler_internal_unknown(parser,

--- a/src/afw/doc/reference/language/features.xml
+++ b/src/afw/doc/reference/language/features.xml
@@ -260,5 +260,21 @@ const n: integer = 1;
 
 /* Turn type checking off again in this script */
 #compile noTypeCheck;]]></code>
+    <header>Compiler literals</header>
+    <paragraph>
+        A compiler literal is a <literal>#</literal> name for a value the 
+        compiler already knows. It is a value in an expression, not a 
+        statement and not a function call. Examples include 
+        <literal>#doubleMax</literal>, <literal>#doubleMin</literal>, 
+        <literal>#integerMax</literal>, <literal>#pi</literal>, and 
+        <literal>#infinity</literal>. These are not the same as the 
+        <literal>#compile</literal> pragma or the <literal>#block</literal> 
+        forms used when decompiling. Reserved words such as 
+        <literal>Infinity</literal> and <literal>NaN</literal> stay as they 
+        are; <literal>#infinity</literal> is an alias.
+    </paragraph>
+    <code><![CDATA[assert(#doubleMax / 0.9 === Infinity);
+assert(#integerMax + #integerMin === -1);
+assert(#infinity === Infinity);]]></code>
 </doc>
 

--- a/src/afw/generated/ebnf/syntax.ebnf
+++ b/src/afw/generated/ebnf/syntax.ebnf
@@ -191,9 +191,15 @@ CompilerInternalStatement ::=
 /* From afw_compile_parse_compiler_internal.c                                 */
 /* Value/expression-position compiler-internal #Name.                         */
 /* Token is already pound_identifier.                                         */
-/* Forms match decompile #implementation_id where implemented.                */
+/* Compiler-internal forms match decompile #implementation_id.                */
+/* Compiler literals fold to permanent values (not call forms).               */
 /* #closure_binding / #function_thunk are recognized but always compile       */
 /* errors (runtime / C-side only; not recompilable from decompile text).      */
+
+CompilerLiteral ::=
+    '#doubleMax' | '#doubleMin' | '#doubleMinSubnormal' |
+    '#doubleEpsilon' | '#integerMax' | '#integerMin' |
+    '#pi' | '#e' | '#infinity' | '#inf' | '#minusInfinity' | '#nan'
 
 CompilerInternalValue ::=
     CompilerInternalBlock |
@@ -202,7 +208,8 @@ CompilerInternalValue ::=
     CompilerInternalScriptFunction |
     CompilerInternalTemplateDefinition |
     CompilerInternalSwitchDefault |
-    CompilerInternalStatements
+    CompilerInternalStatements |
+    CompilerLiteral
 
 /* From afw_compile_parse_expression.c                                        */
 /* The objectId of any /afw/_AdaptiveDataType_/ objects.                      */

--- a/src/afw/number/afw_number.h
+++ b/src/afw/number/afw_number.h
@@ -32,6 +32,18 @@ AFW_BEGIN_DECLARES
 #define AFW_NUMBER_Q_NEGATIVE_NAN       "-NaN"
 #define AFW_NUMBER_Q_EXPONENT_ZERO      "E0"
 
+/*
+ * IEEE / integer limits and a few math constants. C code can use these
+ * directly. Script sees them as compiler literals (#doubleMax, …).
+ * Permanent Adaptive values live in afw_value.h (afw_value_double_max, …).
+ */
+#define AFW_DOUBLE_MAX              DBL_MAX
+#define AFW_DOUBLE_MIN              DBL_MIN
+#define AFW_DOUBLE_EPSILON          DBL_EPSILON
+#define AFW_DOUBLE_MIN_SUBNORMAL    DBL_TRUE_MIN
+#define AFW_DOUBLE_PI               3.14159265358979323846
+#define AFW_DOUBLE_E                2.71828182845904523536
+
 /**
  * @brief Determine if double is finite.
  * @param d is double to check.

--- a/src/afw/tests/additional_test_scripts/exercise_script.as
+++ b/src/afw/tests/additional_test_scripts/exercise_script.as
@@ -11,7 +11,7 @@
 //? source: ...
 
 
-// There are still parts of this script that needs to be converted to assert()
+// Grab-bag script. Prefer assert() over print().
 
 let s: string;
 
@@ -171,24 +171,24 @@ assert(test9('1') == 'b is missing');
 // Trailing comma in array
 let y1: array = [1,3,2,4,];
 
-assert(string(y1) == string([1,3,2,4])); //FIXME Need to support array ==
+assert(y1 === [1, 3, 2, 4]);
 
 // Trailing comma in object
 let y2: object = {a:1,b:2,};
 
-assert(string(y2) == '{"a":1,"b":2}'); //FIXME Need to support object ==
+assert(y2 === { a: 1, b: 2 });
 
-// Test evaluate script  
+// eval() compiles and evaluates a string as a script
 {
-    const hello: unevaluated = eval("return 'Hello ' + 'World!\n';");
-    //FIXME Should pass
-    //assert(evaluate(hello) == 'Hello World!');
+    const hello = eval("return 'Hello ' + 'World!\\n';");
+    assert(hello === "Hello World!\n");
+    assert(evaluate(hello) === "Hello World!\n");
 }
 
-// Test produce a compile listing
+// compile listing is a string (human dump, not recompilable)
 {
-    const hello: unevaluated = compile(script("return 'Hello ' + 'World!\n';"), "| ");
-    //FIXME Figure out a way to assert this: hello
+    const listing = compile(script("return 'Hello ' + 'World!\\n';"), "| ");
+    assert(is_string(listing));
 }
 
 
@@ -320,36 +320,27 @@ assert(x == 'outside for-of');
 // Test make sure x same after for-of - should print >>>outside for-of\n>>>');
 assert(x == 'outside for-of');
 
-//FIXME Need to convert this
-/*
-print('\nTest for-of using retrieve_objects- should print >>> with info for each data type\n');
 {
-    for (const x: object of retrieve_objects('afw','_AdaptiveDataType_')) {
-        print('>>> ' + x.dataType + ' - ' + x.brief + '\n');
+    let n = 0;
+    let sawInteger = false;
+    for (const t of retrieve_objects("afw", "_AdaptiveDataType_")) {
+        n += 1;
+        if (t.dataType === "integer") {
+            sawInteger = true;
+        }
     }
-}
-print("\n");
-*/
+    assert(n > 0);
+    assert(sawInteger);
 
-//FIXME Need to convert this
-/*
-print('\nTest for-of using retrieve_objects- should print >>> with info for each data type\n');
-for (const {dataType, brief } of retrieve_objects('afw','_AdaptiveDataType_')) {
-    print('>>> ' + dataType + ' - ' + brief + '\n');
+    let n2 = 0;
+    for (const { dataType } of retrieve_objects("afw", "_AdaptiveDataType_")) {
+        n2 += 1;
+        if (dataType === "integer") {
+            sawInteger = true;
+        }
+    }
+    assert(n2 === n);
 }
-print("\n");
-*/
-
-//FIXME Need to convert this
-/*
-print('\nTest for-of using same retrieve_objects with object destructure - should print >>> with info for each data type\n');
-{
-    for (let {dataType, brief} of retrieve_objects('afw','_AdaptiveDataType_')) {
-        print('>>> ' + dataType + ' - ' + brief + '\n');
-    }    
-}
-print("\n");
-*/
 
 // Test while
 s = '';

--- a/src/afw/tests/compiler/compiler_literals.as
+++ b/src/afw/tests/compiler/compiler_literals.as
@@ -1,0 +1,56 @@
+#!/usr/bin/env -S afw --syntax test_script
+//?
+//? testScript: compiler_literals.as
+//? customPurpose: Compiler literals
+//? description: #doubleMax and other compiler literals fold to permanent values
+//? sourceType: script
+//?
+//? test: double-limits
+//? description: #doubleMax / #doubleMin / #doubleEpsilon / #doubleMinSubnormal
+//? expect: 0
+//? source: ...
+
+assert(#doubleMax === 1.7976931348623157E308);
+assert(#doubleMin > 0.0);
+assert(#doubleMin < 1.0);
+assert(#doubleMinSubnormal > 0.0);
+assert(#doubleMinSubnormal < #doubleMin);
+assert(#doubleEpsilon > 0.0);
+assert(#doubleEpsilon < 1.0);
+assert(1.0 + #doubleEpsilon !== 1.0);
+return 0;
+
+//?
+//? test: integer-limits
+//? description: #integerMax / #integerMin
+//? expect: 0
+//? source: ...
+
+assert(#integerMax > 0);
+assert(#integerMin < 0);
+assert(#integerMax + #integerMin === -1);
+return 0;
+
+//?
+//? test: math-and-ieee-aliases
+//? description: #pi #e #infinity #inf #minusInfinity #nan
+//? expect: 0
+//? source: ...
+
+assert(#pi > 3.14);
+assert(#pi < 3.15);
+assert(#e > 2.71);
+assert(#e < 2.72);
+assert(#infinity === Infinity);
+assert(#inf === Infinity);
+assert(#minusInfinity === -Infinity);
+assert(is_NaN(#nan));
+return 0;
+
+//?
+//? test: unknown-hash-name-still-error
+//? description: Unknown #name in expression is still an error
+//? expect: error
+//? source: ...
+
+return #doubleMaximum;

--- a/src/afw/tests/language/script/string_code_points.as
+++ b/src/afw/tests/language/script/string_code_points.as
@@ -291,19 +291,25 @@ const parts = split("a\u20ac" + "b", "\u20ac");
 assert(length(parts) === 2);
 assert(parts[0] === "a");
 assert(parts[1] === "b");
-return 0;//?
+return 0;
+
+//?
 //? test: Deferred-produce-type-script-call-return
 //? description: script call produce type for typed return (compile soft probes)
 //? skip: true
 //? skipReason: ...
-Deferred: produce-type percolation — script call IR does not yet report
-return type on get_data_type / quick inf->data_type. When that lands
-(see designs/compile-optimize-notes.md and #28 comment), type-check /
-soft iterator step type on call expressions can lock this without eval.
+FIXME: skipped because this body would pass at runtime and be a false
+positive. The real check is compile-time produce-type on the call, not
+eval of f().
 //? expect: 0
 //? source: ...
 
-/* Placeholder body: unskip when produce type is filled on script calls. */
+// Fixture only. Do not unskip until a compile/listing (or similar) probe
+// can assert, without evaluating f(), that the call IR for f() produces
+// string. Today get_data_type / inf->data_type on script-call is NULL
+// (@fixme Get right data type). When that lands: type-check and soft
+// iterator step type can use the call's produce type. See
+// designs/compile-optimize-notes.md.
 const f = function (): string {
     return "hi";
 };

--- a/src/afw/tests/test262/FIXME-triage.md
+++ b/src/afw/tests/test262/FIXME-triage.md
@@ -1,66 +1,18 @@
-# test262 `FIXME:` triage
+# test262 leftover `FIXME:`
 
-**Branch:** `test262-skipreason-sweep` (stacked on `mgg-develop` since merge-base `f945f97c`)  
-**Done log:** [`changes.md`](changes.md) — what already converted  
-**Suite rules:** [`README.md`](README.md)
+The convert / reclassify sweep on this branch is done. Skip prefixes are
+only **`FIXME:`** and **`Never:`** (see [`README.md`](README.md)).
+What already changed is in [`changes.md`](changes.md).
 
-**Skip counts (approx, re-grep after edits):** ~63 skips total — **FIXME ~24**, **Incompatible ~18**, **Never** (was Harness valueOf/ToPrimitive), **Deferred ~2**. **Harness leftovers: 0**.
+**`Never:`** is decided-not. Do not burn it down unless the product flips.
 
-Use this to pick **next** converts. Prefer small rewrites or single product decisions over full ES ports.
+## Remaining `FIXME:` (3)
 
-## Priority shortlist (remaining)
+| Test | Why it stays |
+|------|----------------|
+| `statements/for-of.as` `head-const-fresh-binding-per-iteration` | Closures from `for (const x of …)` all see the last binding. **#35 / #2**. Honest `expect: 0`. |
+| `language/script/string_code_points.as` `Deferred-produce-type-script-call-return` | Runtime `f()` would false-green. Needs compile-time produce-type on script-call IR. |
+| `lmdb/adapter/index_current.as` `index_current_object` | LMDB `index_create` hang. **#57**. |
 
-| Pri | Cluster | Status | Rough size | Notes |
-|-----|---------|--------|------------|-------|
-| **1** | **Arithmetic IEEE (more)** | In progress | division/subtraction/`**` residual | **modulus** pure `A4_*` + **division** `A4_T4/T5/T7–T9` done; coerce → **Incompatible** |
-| **2** | **try `cptn-*` completion** | Done (#62) | — | Assignment probes; see [`changes.md`](changes.md) |
-| **3** | **`**` signed-zero / ∞** | Open | ~5 | `exponentiation.as` edges |
-| **4** | **for-of TDZ / ASI leftovers** | TDZ → **Incompatible** (no Adaptive TDZ). ASI leftover still open | ~1 | `let-array-with-newline` / empty-body ASI |
-| **5** | **for-of const + closures** | Blocked | 1 | **#35 / #2** — keep skip+FIXME, honest expect |
-| **6** | **Harness leftovers** | Done | 0 | Converted to Adaptive LTR or **Never:** (no `valueOf` / `assert.throws`) |
-| **7** | **Half-converted try/catch Pattern** | Done (#62) | — | `scope-catch-*` rewritten; see [`changes.md`](changes.md) |
-
-**Already done on this line of work** (see [`changes.md`](changes.md)): void probes + `void` undefined; raw LT in strings; for-of non-iterable / member LHS / string CP; const reassignment; no TDZ self-init; leading/trailing-dot numerics; NonEscape/`\x`/`\0`/line-continuation; unary+ identity; `??=` whitespace; switch rewrite; LTR without assign-in-expr; modulus + division IEEE template; #55 array helpers; #39 elision; #140 param defaults; #62 try `cptn-*` / `S12.14_A6` / `scope-catch-*`.
-
-## Closures and lifetime (**#35**, **#2**)
-
-Adaptive **has** closures; many ES-style fails are **escape / capture / lifetime**. Prefer **`skip: true`** + **`FIXME: … (#35 / #2)`** with correct desired `expect` — not false-green `expect: error` stand-ins.
-
-## Theme inventory (remaining FIXME-ish)
-
-| Theme | Notes |
-|-------|--------|
-| Arithmetic IEEE / coercion | More `division`/`subtraction`/`**`; ToNumber cases → Incompatible |
-| try/catch `cptn-*` | Done (#62): assignment probes, not ES UpdateEmpty |
-| for-of TDZ | **Incompatible:** no Adaptive TDZ |
-| ES sloppy function-name reassignment | **Incompatible** |
-| ES per-iteration for-let | **Incompatible:** one slot (#62) |
-| unicode-escaped reserved property names | **Incompatible** |
-| for-of ASI / closures | Language / #35 |
-| Harness | Runner form first |
-| Half-converted try/switch | try `scope-catch-*` done (#62); switch leftovers separate |
-
-## Explicitly **not** first convert targets
-
-| Bucket | Why |
-|--------|-----|
-| **`Incompatible:`** | e.g. `String.fromCharCode`, unary `+` boolean, `%`/`/` ToNumber — permanent unless product flips |
-| **`Deferred:`** | TCO deep recursion |
-| **`Harness:`** | Fix runner form first |
-| **Assignment as expression** | Permanent non-support (typescript-differences) |
-| Full **cptn-*** / full IEEE in one go | Too large for one PR slice |
-
-## How to convert one candidate later
-
-1. Open original under https://github.com/tc39/test262/tree/main/test/language if intent is unclear.  
-2. Rewrite Adaptive `source` (assert / expect / no ES globals).  
-3. Unskip; run `afwdev test` on that file.  
-4. Refresh `description` / optional `differences`; keep prefixed `skipReason` only if still skipped.  
-5. Add/update a row in [`changes.md`](changes.md) in the **same** change.  
-6. Prefer product notes in `differences` or #22 over silent behavior drift.
-
-## Related
-
-- Suite conventions: [`README.md`](README.md)  
-- **Done log:** [`changes.md`](changes.md)  
-- Skip prefixes also in `.cursor/rules/afw-tests.mdc`  
+When one of those lands, unskip (or rewrite) the case and drop the row.
+Do not use this file as a convert shortlist anymore.

--- a/src/afw/tests/test262/FIXME-triage.md
+++ b/src/afw/tests/test262/FIXME-triage.md
@@ -4,7 +4,7 @@
 **Done log:** [`changes.md`](changes.md) — what already converted  
 **Suite rules:** [`README.md`](README.md)
 
-**Skip counts (approx, re-grep after edits):** ~63 skips total — **FIXME ~24**, **Incompatible ~18**, **Harness ~19**, **Deferred ~2**.
+**Skip counts (approx, re-grep after edits):** ~63 skips total — **FIXME ~24**, **Incompatible ~18**, **Never** (was Harness valueOf/ToPrimitive), **Deferred ~2**. **Harness leftovers: 0**.
 
 Use this to pick **next** converts. Prefer small rewrites or single product decisions over full ES ports.
 
@@ -17,7 +17,7 @@ Use this to pick **next** converts. Prefer small rewrites or single product deci
 | **3** | **`**` signed-zero / ∞** | Open | ~5 | `exponentiation.as` edges |
 | **4** | **for-of TDZ / ASI leftovers** | TDZ → **Incompatible** (no Adaptive TDZ). ASI leftover still open | ~1 | `let-array-with-newline` / empty-body ASI |
 | **5** | **for-of const + closures** | Blocked | 1 | **#35 / #2** — keep skip+FIXME, honest expect |
-| **6** | **Harness leftovers** | Open | ~19 | `valueOf` / `assert.throws` / ASI block-eval |
+| **6** | **Harness leftovers** | Done | 0 | Converted to Adaptive LTR or **Never:** (no `valueOf` / `assert.throws`) |
 | **7** | **Half-converted try/catch Pattern** | Done (#62) | — | `scope-catch-*` rewritten; see [`changes.md`](changes.md) |
 
 **Already done on this line of work** (see [`changes.md`](changes.md)): void probes + `void` undefined; raw LT in strings; for-of non-iterable / member LHS / string CP; const reassignment; no TDZ self-init; leading/trailing-dot numerics; NonEscape/`\x`/`\0`/line-continuation; unary+ identity; `??=` whitespace; switch rewrite; LTR without assign-in-expr; modulus + division IEEE template; #55 array helpers; #39 elision; #140 param defaults; #62 try `cptn-*` / `S12.14_A6` / `scope-catch-*`.

--- a/src/afw/tests/test262/FIXME-triage.md
+++ b/src/afw/tests/test262/FIXME-triage.md
@@ -15,7 +15,7 @@ Use this to pick **next** converts. Prefer small rewrites or single product deci
 | **1** | **Arithmetic IEEE (more)** | In progress | division/subtraction/`**` residual | **modulus** pure `A4_*` + **division** `A4_T4/T5/T7–T9` done; coerce → **Incompatible** |
 | **2** | **try `cptn-*` completion** | Done (#62) | — | Assignment probes; see [`changes.md`](changes.md) |
 | **3** | **`**` signed-zero / ∞** | Open | ~5 | `exponentiation.as` edges |
-| **4** | **for-of TDZ / ASI leftovers** | Open | ~2–3 | `head-const-…-tdz`, `let-array-with-newline`; language-wide |
+| **4** | **for-of TDZ / ASI leftovers** | TDZ → **Incompatible** (no Adaptive TDZ). ASI leftover still open | ~1 | `let-array-with-newline` / empty-body ASI |
 | **5** | **for-of const + closures** | Blocked | 1 | **#35 / #2** — keep skip+FIXME, honest expect |
 | **6** | **Harness leftovers** | Open | ~19 | `valueOf` / `assert.throws` / ASI block-eval |
 | **7** | **Half-converted try/catch Pattern** | Done (#62) | — | `scope-catch-*` rewritten; see [`changes.md`](changes.md) |
@@ -32,7 +32,11 @@ Adaptive **has** closures; many ES-style fails are **escape / capture / lifetime
 |-------|--------|
 | Arithmetic IEEE / coercion | More `division`/`subtraction`/`**`; ToNumber cases → Incompatible |
 | try/catch `cptn-*` | Done (#62): assignment probes, not ES UpdateEmpty |
-| for-of TDZ / ASI / closures | Language / #35 |
+| for-of TDZ | **Incompatible:** no Adaptive TDZ |
+| ES sloppy function-name reassignment | **Incompatible** |
+| ES per-iteration for-let | **Incompatible:** one slot (#62) |
+| unicode-escaped reserved property names | **Incompatible** |
+| for-of ASI / closures | Language / #35 |
 | Harness | Runner form first |
 | Half-converted try/switch | try `scope-catch-*` done (#62); switch leftovers separate |
 

--- a/src/afw/tests/test262/README.md
+++ b/src/afw/tests/test262/README.md
@@ -47,7 +47,7 @@ official** ones for this suite and for language tests in general:
 | Key | Role |
 |-----|------|
 | **`test`** | Case id (stable name) |
-| **`description`** | What the case checks. Prefer staying **close to the TC39 description**, lightly tweaked for Adaptive wording. |
+| **`description`** | Stay **close to the TC39 description**. Skip notes go in **`skipReason`**. For **`expect: error`**, say why in a source **`//`** comment — do not rewrite `description` to explain the Adaptive error. |
 | **`differences`** | Optional. **Language** differences between ECMAScript and Adaptive for the construct under test only. Not harness wrapping. Good future harvest input for differences docs. |
 | **`expect`** | **`success`** (compiled and ran, ignore result — usual test262 “did not throw”), Adaptive value (`0`, `undefined`, …), or **`error`** / **`error:…`** |
 | **`skip`** | `true` / `false` — do not run |

--- a/src/afw/tests/test262/README.md
+++ b/src/afw/tests/test262/README.md
@@ -62,39 +62,29 @@ harvests stay consistent. Prefer a **prefix + short clause**:
 
 | Prefix | Use when |
 |--------|----------|
-| **`Incompatible:`** | Never plan to convert (generators, `class`, prototypes, typed arrays via `new`, full ES iterator exotics, …) |
 | **`FIXME:`** | Adaptive should fix or decide; stays on the burn-down list |
-| **`Deferred:`** | Plausible later, not current priority |
-| **`Harness:`** | Rare — blocked by runner/adaptation limits, not language (prefer fixing harness instead) |
+| **`Never:`** | We do not plan to support this (ES-only, decided-not) |
 
 Examples:
 
 ```text
-//? skipReason: Incompatible: ES generators / function*
-//? skipReason: Incompatible: String.fromCharCode and prototype string APIs
-//? skipReason: FIXME: for-of member LHS (x.y)
-//? skipReason: FIXME: TDZ for for-of head const binding
-//? skipReason: Deferred: deep TCO; not planned for beta
+//? skipReason: Never: no String.fromCharCode / ES String prototype APIs
+//? skipReason: FIXME: for-of const + per-iteration closure capture (#35 / #2)
 
 // Long reason (any //? key can use this form):
 //? skipReason: ...
-FIXME: Adaptive for-of does not enforce TDZ for for-of head const
-binding (outer x may be readable in [x]); ES requires error.
+FIXME: skipped because this body would pass at runtime and be a
+false positive. The real check is compile-time produce-type.
 ```
 
-Plain **`Incompatible`** with no detail is fine for a bulk first pass; enrich
-when you touch the file. Do **not** use `Incompatible` for “not yet” features
-that Adaptive might still implement — use **`FIXME:`** or **`Deferred:`**.
+Do **not** use **`Never:`** for “not yet” features — use **`FIXME:`** and
+say when/why in the sentence.
 
-**First-pass status (2026-08, branch `test262-skipreason-sweep`):** every
-skipped case has a prefixed `skipReason`. Counts will drift as cases unskip or
-reclassify — re-grep after edits. Use **`Incompatible:`** only for ES-only
-behavior Adaptive does not plan to support (confirm against the original
-test262 case when unsure); default uncertain skips to **`FIXME:`** or
-**`Deferred:`**.
+**First-pass status (2026-08, branch `issue-#106-fixme-reclassify`):** two
+prefixes only. Counts drift as cases unskip or reclassify — re-grep after
+edits.
 
-**FIXME triage (what to convert next):** see [`FIXME-triage.md`](FIXME-triage.md)
-— shortlist and theme inventory after the labeling pass.
+**Leftover `FIXME:`** (not a convert shortlist): [`FIXME-triage.md`](FIXME-triage.md).
 
 **Case change log (what we already did):** see [`changes.md`](changes.md) —
 Index of unskips / rewrites / product `differences` **since `mgg-develop`

--- a/src/afw/tests/test262/changes.md
+++ b/src/afw/tests/test262/changes.md
@@ -80,6 +80,14 @@ Rough time order: **[#55](https://github.com/afw-org/afw/issues/55) → [#140](h
 | [First-pass skipReason labels](#first-pass-skipreason-labels) | meta | Every skip got a prefix |
 | [FIXME triage note](#fixme-triage-note) | [meta](https://github.com/afw-org/afw/commits/mgg-develop/src/afw/tests/test262/FIXME-triage.md) | [`FIXME-triage.md`](FIXME-triage.md) shortlist |
 
+### Harness convert ([#106](https://github.com/afw-org/afw/issues/106))
+
+| Case | How | Brief |
+|------|-----|--------|
+| LTR `xf() op yf()` (`\|\|` `/` `%` `-` `**`) | **T:** →run | throw from left; right must not run |
+| `valueOf` / ToPrimitive order | **T:** →inc | **Never:** no JS object ToNumber |
+| assignment `null.prop` after RHS | **T:** →run | `count += 1` happens; then property set fails |
+
 ### Script result ([#62](https://github.com/afw-org/afw/issues/62))
 
 | Case | How | Brief |

--- a/src/afw/tests/test262/changes.md
+++ b/src/afw/tests/test262/changes.md
@@ -21,7 +21,7 @@ ago, and not every harness-only line noise.
 | Doc | Role |
 |-----|------|
 | [`README.md`](README.md) | Suite purpose, `//?` tags, skip prefixes |
-| [`FIXME-triage.md`](FIXME-triage.md) | What is **left** / convert priority |
+| [`FIXME-triage.md`](FIXME-triage.md) | Leftover **FIXME:** only (sweep done) |
 | [`typescript-differences.md`](../../../typescript-differences.md) | Product ES vs Adaptive (beta) |
 | [`whats-new.md`](../../../whats-new.md) | User-facing language/runtime notes |
 
@@ -76,9 +76,16 @@ Rough time order: **[#55](https://github.com/afw-org/afw/issues/55) → [#140](h
 | Case | How | Brief |
 |------|-----|--------|
 | [Suite README + official `//?` tags](#suite-readme-and-official-tags) | [meta](https://github.com/afw-org/afw/commits/mgg-develop/src/afw/tests/test262/README.md) | Purpose, harness-once, tags |
-| [skipReason prefix convention](#skipreason-prefix-convention) | [meta](https://github.com/afw-org/afw/commits/mgg-develop/src/afw/tests/test262/README.md) | Incompatible/FIXME/Deferred/Harness |
+| [skipReason prefix convention](#skipreason-prefix-convention) | [meta](https://github.com/afw-org/afw/commits/mgg-develop/src/afw/tests/test262/README.md) | FIXME / Never |
 | [First-pass skipReason labels](#first-pass-skipreason-labels) | meta | Every skip got a prefix |
 | [FIXME triage note](#fixme-triage-note) | [meta](https://github.com/afw-org/afw/commits/mgg-develop/src/afw/tests/test262/FIXME-triage.md) | [`FIXME-triage.md`](FIXME-triage.md) shortlist |
+
+### Skip prefixes ([#106](https://github.com/afw-org/afw/issues/106))
+
+| Case | How | Brief |
+|------|-----|--------|
+| Two prefixes only | meta | **`FIXME:`** / **`Never:`** (was Incompatible/Deferred/Harness) |
+| ASI leftovers | **T:** →inc | **Never:** no ES eval/regexp ASI; no `let [` after empty for-of |
 
 ### Harness convert ([#106](https://github.com/afw-org/afw/issues/106))
 
@@ -182,9 +189,8 @@ ES), TC39 lineage, harness-once guidance, and **official** `//?` keys
 
 ## skipReason prefix convention
 
-Shared vocabulary (not compiler-enforced): **`Incompatible:`**, **`FIXME:`**,
-**`Deferred:`**, **`Harness:`**. Documented in README and project test rules.
-Use **Incompatible** only for permanent non-support.
+Shared vocabulary (not compiler-enforced): **`FIXME:`** and **`Never:`**.
+Documented in README and project test rules.
 
 [↑ Index](#index)
 
@@ -201,9 +207,9 @@ per-case behavior change in that pass alone. Counts drift as cases convert.
 
 ## FIXME triage note
 
-[`FIXME-triage.md`](FIXME-triage.md) is the **backlog** (what to convert next).
-This file is the **done log**. Update triage when a cluster moves; add Index
-rows here for the cases that actually changed.
+[`FIXME-triage.md`](FIXME-triage.md) lists leftover **FIXME:** only.
+This file is the **done log**. Add Index rows here for cases that
+actually changed.
 
 [↑ Index](#index)
 

--- a/src/afw/tests/test262/expressions/assignment/assignment.as
+++ b/src/afw/tests/test262/expressions/assignment/assignment.as
@@ -141,7 +141,7 @@ if (x !== true) {
 //? description: break is a valid identifier name, using escape (MemberExpression IdentifierName)
 //? skip: true
 //? skipReason: ...
-Incompatible: no plan to treat a unicode-escaped reserved word
+Never: no plan to treat a unicode-escaped reserved word
 (bre\\u0061k) as a property name.
 //? expect: success
 //? source: ...

--- a/src/afw/tests/test262/expressions/assignment/assignment.as
+++ b/src/afw/tests/test262/expressions/assignment/assignment.as
@@ -41,10 +41,11 @@ if (x !== 1) {
 }
 //? test: 11.13.1_A2.1_T2
 //? description: If GetBase(AssigmentExpression) is null, throw ReferenceError
-//? expect: error:Parse error at offset 28 around line 3 column 9: Unknown built-in function 'y'
+//? expect: error
 //? source: ...
 #!/usr/bin/env afw
 
+// undeclared y is a compile error
 let x = y;
 
 
@@ -215,19 +216,18 @@ let x;
 assert(x === 1);
 //? test: target-member-identifier-reference-null
 //? description: Assignment Operator evaluates the value prior validating a MemberExpression's reference (null)
-//? expect: error
-//? skip: true
-//? skipReason: ...
-Harness: Adaptive assignment statement cannot appear in expression
-position as this ES test requires
+//? expect: 0
 //? source: ...
-#!/usr/bin/env afw
 
 let count = 0;
 let base = null;
-
-// we can't test this because assignment statement can't be used in expression
-base.prop = count += 1;
+try {
+    base.prop = count += 1;
+    assert(false);
+} catch (e) {
+    assert(count === 1);
+}
+return 0;
 
 
 //? test: target-member-computed-reference-undefined

--- a/src/afw/tests/test262/expressions/assignment/assignment.as
+++ b/src/afw/tests/test262/expressions/assignment/assignment.as
@@ -140,15 +140,14 @@ if (x !== true) {
 //? description: break is a valid identifier name, using escape (MemberExpression IdentifierName)
 //? skip: true
 //? skipReason: ...
-FIXME: escaped reserved words as property names (break spelled with
-unicode escape) not decided
+Incompatible: no plan to treat a unicode-escaped reserved word
+(bre\\u0061k) as a property name.
 //? expect: success
 //? source: ...
 #!/usr/bin/env afw
 
 let obj = {};
 
-// FIXME don't know if we should support this
 obj.bre\u0061k = 42;
 
 assert(property_exists(obj, "break"));

--- a/src/afw/tests/test262/expressions/coalesce.as
+++ b/src/afw/tests/test262/expressions/coalesce.as
@@ -401,8 +401,8 @@ assert(x === 42);
 //? expect: 0
 //? skip: true
 //? skipReason: ...
-Deferred: ES-style tail-call optimization not planned for beta (deep
-recursion would overflow)
+Never: Adaptive ?? short-circuits; it does not tail-call-optimize.
+100k recursion is not a language requirement.
 //? source: ...
 #!/usr/bin/env afw
 
@@ -424,8 +424,8 @@ return 0;
 //? expect: 0
 //? skip: true
 //? skipReason: ...
-Deferred: ES-style tail-call optimization not planned for beta (deep
-recursion would overflow)
+Never: Adaptive ?? short-circuits; it does not tail-call-optimize.
+100k recursion is not a language requirement.
 //? source: ...
 #!/usr/bin/env afw
 

--- a/src/afw/tests/test262/expressions/division.as
+++ b/src/afw/tests/test262/expressions/division.as
@@ -28,8 +28,8 @@ assert(x ===  1);
 //? expect: success
 //? skip: true
 //? skipReason: ...
-FIXME: ASI / block-eval interaction around division vs regexp;
-half-converted
+Never: Adaptive has no ES eval / regexp-vs-division ASI after a
+block. Other / newline cases already run.
 //? source: ...
 
 
@@ -180,7 +180,7 @@ if (1 / 1 !== 1) {
 //? description: Type(x) and Type(y) vary between Null and Undefined
 //? expect: success
 //? skip: true
-//? skipReason: Incompatible: Adaptive / does not ToNumber-coerce (null/string/object); double or integer only
+//? skipReason: Never: Adaptive / does not ToNumber-coerce (null/string/object); double or integer only
 //? source: ...
 
 
@@ -207,7 +207,7 @@ if (is_NaN(null / null) !== true) {
 //? description: Type(x) and Type(y) vary between Object object and Function object
 //? expect: success
 //? skip: true
-//? skipReason: Incompatible: Adaptive / does not ToNumber-coerce (null/string/object); double or integer only
+//? skipReason: Never: Adaptive / does not ToNumber-coerce (null/string/object); double or integer only
 //? source: ...
 
 

--- a/src/afw/tests/test262/expressions/division.as
+++ b/src/afw/tests/test262/expressions/division.as
@@ -262,59 +262,22 @@ if (is_NaN(undefined / new String("1")) !== true) {
 //? test: S11.5.2_A4_T10
 //? description: If both operands are finite and nonzero, the quotient is computed and rounded using IEEE 754 round-to-nearest mode.  If the magnitude is too small to represent, the result is then a zero of appropriate sign throw new Test262Error('#2.2: Number.MIN_VALUE / -2.1 === -0. Actual: +0'); throw new Test262Error('#4.2: Number.MIN_VALUE / -2.0 === -0. Actual: +0');
 //? expect: success
-//? skip: true
-//? skipReason: ...
-FIXME: operator IEEE edge case; needs Adaptive is_NaN / double rewrite
-(no Number/Math globals)
 //? source: ...
 
-
 //CHECK#1
-if (Number.MIN_VALUE / 2.1 !== 0) {
-  throw '#1: Number.MIN_VALUE / 2.1 === 0. Actual: ' + (Number.MIN_VALUE / 2.1);
+if (#doubleMinSubnormal / 2.1 !== 0.0) {
+  throw '#1: #doubleMinSubnormal / 2.1 === 0. Actual: ' +
+    (#doubleMinSubnormal / 2.1);
 }
 
 //CHECK#2
-if (Number.MIN_VALUE / -2.1 !== -0) {
-  throw '#2.1: Number.MIN_VALUE / -2.1 === 0. Actual: ' + (Number.MIN_VALUE / -2.1);
+if (#doubleMinSubnormal / -2.1 !== -0.0) {
+  throw '#2.1: #doubleMinSubnormal / -2.1 === -0. Actual: ' +
+    (#doubleMinSubnormal / -2.1);
 } else {
-  if (1 / (Number.MIN_VALUE / -2.1) !== -Infinity) {
-    throw '#2.2: Number.MIN_VALUE / -2.1 === -0. Actual: +0';
+  if (1.0 / (#doubleMinSubnormal / -2.1) !== -Infinity) {
+    throw '#2.2: #doubleMinSubnormal / -2.1 === -0. Actual: +0';
   }
-}
-
-//CHECK#3
-if (Number.MIN_VALUE / 2.0 !== 0) {
-  throw '#3: Number.MIN_VALUE / 2.0 === 0. Actual: ' + (Number.MIN_VALUE / 2.0);
-}
-
-//CHECK#4
-if (Number.MIN_VALUE / -2.0 !== -0) {
-  throw '#4.1: Number.MIN_VALUE / -2.0 === -0. Actual: ' + (Number.MIN_VALUE / -2.0);
-} else {
-  if (1 / (Number.MIN_VALUE / -2.0) !== -Infinity) {
-    throw '#4.2: Number.MIN_VALUE / -2.0 === -0. Actual: +0';
-  }
-}
-
-//CHECK#5
-if (Number.MIN_VALUE / 1.9 !== Number.MIN_VALUE) {
-  throw '#5: Number.MIN_VALUE / 1.9 === Number.MIN_VALUE. Actual: ' + (Number.MIN_VALUE / 1.9);
-}
-
-//CHECK#6
-if (Number.MIN_VALUE / -1.9 !== -Number.MIN_VALUE) {
-  throw '#6: Number.MIN_VALUE / -1.9 === -Number.MIN_VALUE. Actual: ' + (Number.MIN_VALUE / -1.9);
-}
-
-//CHECK#7
-if (Number.MIN_VALUE / 1.1 !== Number.MIN_VALUE) {
-  throw '#7: Number.MIN_VALUE / 1.1 === Number.MIN_VALUE. Actual: ' + (Number.MIN_VALUE / 1.1);
-}
-
-//CHECK#8
-if (Number.MIN_VALUE / -1.1 !== -Number.MIN_VALUE) {
-  throw '#8: Number.MIN_VALUE / -1.1 === -Number.MIN_VALUE. Actual: ' + (Number.MIN_VALUE / -1.1);
 }
 //? test: S11.5.2_A4_T1.1
 //? description: If left operand is NaN, the result is NaN
@@ -649,14 +612,9 @@ if (-0.0 / 0.5 !== -0.0) {
 //? test: S11.5.2_A4_T9
 //? description: If the magnitude is too large to represent, the result is then an infinity of appropriate sign
 //? expect: success
-//? skip: true
-//? skipReason: ...
-FIXME: extreme double literals / overflow edges need reliable large
-exponents (Number.MAX_VALUE lineage); use Infinity cases in A4_T3/T5 for now
 //? source: ...
 
-
 //CHECK#1
-if (Number.MAX_VALUE / 0.9 !== Infinity) {
-  throw '#1: Number.MAX_VALUE / 0.9 === Infinity. Actual: ' + (Number.MAX_VALUE / 0.9);
+if (#doubleMax / 0.9 !== Infinity) {
+  throw '#1: #doubleMax / 0.9 === Infinity. Actual: ' + (#doubleMax / 0.9);
 }

--- a/src/afw/tests/test262/expressions/division.as
+++ b/src/afw/tests/test262/expressions/division.as
@@ -138,63 +138,34 @@ if (x / y !== 1) {
 }
 //? test: S11.5.2_A2.1_T2
 //? description: If GetBase(x) is null, throw ReferenceError
-//? expect: success
-//? skip: true
-//? skipReason: Harness: half-converted arithmetic operator case from test262
+//? expect: error
 //? source: ...
 
-
-//CHECK#1
-try {
-  x / 1;
-  throw '#1.1: x / 1 throw ReferenceError. Actual: ' + (x / 1);
-}
-catch (e) {
-  if ((e instanceof ReferenceError) !== true) {
-    throw '#1.2: x / 1 throw ReferenceError. Actual: ' + (e);
-  }
-}
+// undeclared x is a compile error
+x / 1;
 //? test: S11.5.2_A2.1_T3
 //? description: If GetBase(y) is null, throw ReferenceError
-//? expect: success
-//? skip: true
-//? skipReason: Harness: half-converted arithmetic operator case from test262
+//? expect: error
 //? source: ...
 
-
-//CHECK#1
-try {
-  1 / y;
-  throw '#1.1: 1 / y throw ReferenceError. Actual: ' + (1 / y);
-}
-catch (e) {
-  if ((e instanceof ReferenceError) !== true) {
-    throw '#1.2: 1 / y throw ReferenceError. Actual: ' + (e);
-  }
-}
+// undeclared y is a compile error
+1 / y;
 //? test: S11.5.2_A2.4_T2
 //? description: Checking with "throw"
-//? expect: success
-//? skip: true
-//? skipReason: Harness: half-converted arithmetic operator case from test262
+//? expect: 0
 //? source: ...
 
-
-//CHECK#1
-let x = function () { throw "x"; };
-let y = function () { throw "y"; };
+let saw = "";
+function xf() { saw = saw + "x"; throw "x"; }
+function yf() { saw = saw + "y"; throw "y"; }
 try {
-   x() / y();
-   throw '#1.1: let x = function () { throw "x"; }; let y = function () { throw "y"; }; x() / y() throw "x". Actual: ' + (x() / y());
+    let unused = xf() / yf();
+    assert(false);
 } catch (e) {
-   if (e === "y") {
-     throw '#1.2: First expression is evaluated first, and then second expression';
-   } else {
-     if (e !== "x") {
-       throw '#1.3: let x = function () { throw "x"; }; let y = function () { throw "y"; }; x() / y() throw "x". Actual: ' + (e);
-     }
-   }
+    assert(e.message === "x");
+    assert(saw === "x");
 }
+return 0;
 //? test: S11.5.2_A3_T1.2
 //? description: Type(x) and Type(y) vary between primitive number and Number object
 //? expect: success
@@ -264,8 +235,8 @@ if (is_NaN({} / {}) !== true) {
 //? expect: success
 //? skip: true
 //? skipReason: ...
-Harness: half-converted; still uses ES valueOf / boxed primitives /
-assert.throws
+Never: Adaptive / does not ToNumber-coerce strings or undefined
+(no new String / valueOf)
 //? source: ...
 
 

--- a/src/afw/tests/test262/expressions/exponentiation.as
+++ b/src/afw/tests/test262/expressions/exponentiation.as
@@ -88,20 +88,14 @@ for (let i = 0; i < length(exponents); i = i + 1) {
 //? test: applying-the-exp-operator_A14
 //? description:If base is −∞ and exponent > 0 and exponent is not an odd integer, the result is +∞.
 //? expect: success
-//? skip: true
-//? skipReason: ...
-FIXME: ** exponent edge cases (−∞/−0/non-integer) need Adaptive
-Math/signed-zero rewrite or product decision
 //? source: ...
-
-
 
 let base = -Infinity;
 let exponents = [
 0.000000000000001,
-2,
-Math.PI,
-1.7976931348623157E308, //largest finite number
+2.0,
+#pi,
+#doubleMax,
 +Infinity
 ];
 
@@ -130,25 +124,19 @@ for (let i = 0; i < length(exponents); i = i + 1) {
 //? test: applying-the-exp-operator_A16
 //? description:If base is −∞ and exponent < 0 and exponent is not an odd integer, the result is +0.
 //? expect: success
-//? skip: true
-//? skipReason: ...
-FIXME: ** exponent edge cases (−∞/−0/non-integer) need Adaptive
-Math/signed-zero rewrite or product decision
 //? source: ...
-
-
 
 let base = -Infinity;
 let exponents = [
 -0.000000000000001,
--2,
--Math.PI,
--1.7976931348623157E308, //largest (by module) finite number
+-2.0,
+-#pi,
+-#doubleMax,
 -Infinity
 ];
 
 for (let i = 0; i < length(exponents); i = i + 1) {
-  if ((base ** exponents[i]) !== +0) {
+  if ((base ** exponents[i]) !== +0.0) {
     throw "(" + string(base) + " **  " + string(exponents[i]) + ") !== +0";
   }
 }
@@ -237,25 +225,19 @@ for (let i = 0; i < length(bases); i = i + 1) {
 //? test: applying-the-exp-operator_A20
 //? description:If base is −0 and exponent > 0 and exponent is not an odd integer, the result is +0.
 //? expect: success
-//? skip: true
-//? skipReason: ...
-FIXME: ** exponent edge cases (−∞/−0/non-integer) need Adaptive
-Math/signed-zero rewrite or product decision
 //? source: ...
 
-
-
-let base = -0;
+let base = -0.0;
 let exponents = [
 0.000000000000001,
-2,
-Math.PI,
-1.7976931348623157E308, //largest finite number
+2.0,
+#pi,
+#doubleMax,
 +Infinity
 ];
 
 for (let i = 0; i < length(exponents); i = i + 1) {
-  if ((base ** exponents[i]) !== +0) {
+  if ((base ** exponents[i]) !== +0.0) {
     throw "(" + string(base) + " **  " + string(exponents[i]) + ") !== +0";
   }
 }
@@ -281,20 +263,14 @@ for (let i = 0; i < length(exponents); i = i + 1) {
 //? test: applying-the-exp-operator_A22
 //? description:If base is −0 and exponent < 0 and exponent is not an odd integer, the result is +∞.
 //? expect: success
-//? skip: true
-//? skipReason: ...
-FIXME: ** exponent edge cases (−∞/−0/non-integer) need Adaptive
-Math/signed-zero rewrite or product decision
 //? source: ...
 
-
-
-let base = -0;
+let base = -0.0;
 let exponents = [
 -0.000000000000001,
--2,
--Math.PI,
--1.7976931348623157E308, //largest (by module) finite number
+-2.0,
+-#pi,
+-#doubleMax,
 -Infinity
 ];
 
@@ -306,37 +282,31 @@ for (let i = 0; i < length(exponents); i = i + 1) {
 //? test: applying-the-exp-operator_A23
 //? description:If base < 0 and base is finite and exponent is finite and exponent is not an integer, the result is NaN.
 //? expect: success
-//? skip: true
-//? skipReason: ...
-FIXME: ** exponent edge cases (−∞/−0/non-integer) need Adaptive
-Math/signed-zero rewrite or product decision
 //? source: ...
 
-
-
-let bases = [];
--1.7976931348623157E308, //largest (by module) finite number
--Math.PI,
--1,
+let bases = [
+-#doubleMax,
+-#pi,
+-1.0,
 -0.000000000000001
 ];
 
 let exponents = [
--Math.PI,
--Math.E,
+-#pi,
+-#e,
 -1.000000000000001,
 -0.000000000000001,
 0.000000000000001,
 1.000000000000001,
-Math.E,
-Math.PI
+#e,
+#pi
 ];
 
 for (let i = 0; i < length(bases); i = i + 1) {
-  for (let j = 0; j < length(exponents); j++) {
+  for (let j = 0; j < length(exponents); j = j + 1) {
     assert(
-      bases[i] ** exponents[j] == NaN,      
-      bases[i] + " ** " + exponents[j]
+      is_NaN(bases[i] ** exponents[j]),
+      string(bases[i]) + " ** " + string(exponents[j])
     );
   }
 }

--- a/src/afw/tests/test262/expressions/exponentiation.as
+++ b/src/afw/tests/test262/expressions/exponentiation.as
@@ -512,27 +512,21 @@ for (let i = 0; i < length(bases); i = i + 1) {
   }
 }
 //? test: exp-operator-evaluation-order
-//? description:Exponentiation Operator expression order of evaluation
-//? expect: success
-//? skip: true
-//? skipReason: ...
-Harness: half-converted; still uses ES valueOf / assert.throws /
-evaluation-order probes
+//? description: Exponentiation Operator expression order of evaluation
+//? expect: 0
 //? source: ...
 
-
-let capture = [];
-let leftValue = { valueOf() { capture.push("leftValue"); return 3; }};
-let rightValue = { valueOf() { capture.push("rightValue"); return 2; }};
-
-(capture.push("left"), leftValue) ** (capture.push("right"), rightValue);
-
-// Expected per operator evaluation order: "left", "right", "leftValue", "rightValue"
-
-assert(capture[0] ===  "left", "Expected the 1st element captured to be 'left'");
-assert(capture[1] ===  "right", "Expected the 2nd element captured to be 'right'");
-assert(capture[2] ===  "leftValue", "Expected the 3rd element captured to be 'leftValue'");
-assert(capture[3] ===  "rightValue", "Expected the 4th element captured to be 'rightValue'");
+let saw = "";
+function xf() { saw = saw + "x"; throw "x"; }
+function yf() { saw = saw + "y"; throw "y"; }
+try {
+    let unused = xf() ** yf();
+    assert(false);
+} catch (e) {
+    assert(e.message === "x");
+    assert(saw === "x");
+}
+return 0;
 //? test: exp-operator
 //? description: Performs exponential calculation on operands. Same algorithm as %MathPow%(base, exponent)
 //? expect: success
@@ -630,8 +624,8 @@ assert(1.0**INT32_MIN === 1.0,
 //? expect: success
 //? skip: true
 //? skipReason: ...
-Harness: half-converted; still uses ES valueOf / assert.throws /
-evaluation-order probes
+Never: Adaptive does not ToPrimitive/ToNumeric via valueOf;
+left-to-right operand evaluation is exp-operator-evaluation-order
 //? source: ...
 
 

--- a/src/afw/tests/test262/expressions/function.as
+++ b/src/afw/tests/test262/expressions/function.as
@@ -144,7 +144,7 @@ assert(callCount === 1, "function invoked exactly once");
 //? expect: success
 //? skip: true
 //? skipReason: ...
-Incompatible: Adaptive has no ES sloppy mode. Reassignment of a
+Never: Adaptive has no ES sloppy mode. Reassignment of a
 function name in the body is not silently ignored.
 //? source: ...
 #!/usr/bin/env afw

--- a/src/afw/tests/test262/expressions/function.as
+++ b/src/afw/tests/test262/expressions/function.as
@@ -144,8 +144,8 @@ assert(callCount === 1, "function invoked exactly once");
 //? expect: success
 //? skip: true
 //? skipReason: ...
-FIXME: reassignment of function BindingIdentifier in body (ES silent
-ignore in sloppy mode) not modeled
+Incompatible: Adaptive has no ES sloppy mode. Reassignment of a
+function name in the body is not silently ignored.
 //? source: ...
 #!/usr/bin/env afw
 

--- a/src/afw/tests/test262/expressions/less-than-or-equal.as
+++ b/src/afw/tests/test262/expressions/less-than-or-equal.as
@@ -115,8 +115,7 @@ x <= 1;
 //? expect: success
 //? skip: true
 //? skipReason: ...
-Harness: half-converted; still uses ES valueOf / boxed primitives /
-assert.throws
+Never: Adaptive does not convert objects to numbers via valueOf
 //? source: ...
 #!/usr/bin/env afw
 

--- a/src/afw/tests/test262/expressions/less-than.as
+++ b/src/afw/tests/test262/expressions/less-than.as
@@ -115,8 +115,7 @@ x < 1;
 //? expect: success
 //? skip: true
 //? skipReason: ...
-Harness: half-converted; still uses ES valueOf / boxed primitives /
-assert.throws
+Never: Adaptive does not convert objects to numbers via valueOf
 //? source: ...
 #!/usr/bin/env afw
 

--- a/src/afw/tests/test262/expressions/less-than.as
+++ b/src/afw/tests/test262/expressions/less-than.as
@@ -417,17 +417,11 @@ if ((NaN < Number.MIN_VALUE) !== false) {
 
 //? test: S11.8.1_A4.2
 //? description: x is number primitive
-//? skip: true
-//? skipReason: ...
-FIXME: operator IEEE edge case; needs Adaptive is_NaN / double rewrite
-(no Number/Math globals)
 //? expect: success
 //? source: ...
-#!/usr/bin/env afw
-
 
 //CHECK#1
-if ((0 < NaN) !== false) {
+if ((0.0 < NaN) !== false) {
   throw '#1: (0 < NaN) === false';
 }
 
@@ -457,13 +451,13 @@ if ((-Infinity < NaN) !== false) {
 }
 
 //CHECK#7
-if ((Number.MAX_VALUE < NaN) !== false) {
-  throw '#7: (Number.MAX_VALUE < NaN) === false';
+if ((#doubleMax < NaN) !== false) {
+  throw '#7: (#doubleMax < NaN) === false';
 }
 
 //CHECK#8
-if ((Number.MIN_VALUE < NaN) !== false) {
-  throw '#8: (Number.MIN_VALUE < NaN) === false';
+if ((#doubleMin < NaN) !== false) {
+  throw '#8: (#doubleMin < NaN) === false';
 }
 //? test: S11.8.1_A4.3
 //? description: x and y are number primitives
@@ -575,17 +569,11 @@ if ((Infinity < Number.MIN_VALUE) !== false) {
 
 //? test: S11.8.1_A4.6
 //? description: x is number primitive
-//? skip: true
-//? skipReason: ...
-FIXME: operator IEEE edge case; needs Adaptive is_NaN / double rewrite
-(no Number/Math globals)
 //? expect: success
 //? source: ...
-#!/usr/bin/env afw
-
 
 //CHECK#1
-if ((0 < Infinity) !== true) {
+if ((0.0 < Infinity) !== true) {
   throw '#1: (0 < +Infinity) === true';
 }
 
@@ -605,13 +593,13 @@ if ((-Infinity < Infinity) !== true) {
 }
 
 //CHECK#5
-if ((Number.MAX_VALUE < Infinity) !== true) {
-  throw '#5: (Number.MAX_VALUE < +Infinity) === true';
+if ((#doubleMax < Infinity) !== true) {
+  throw '#5: (#doubleMax < +Infinity) === true';
 }
 
 //CHECK#6
-if ((Number.MIN_VALUE < Infinity) !== true) {
-  throw '#6: (Number.MIN_VALUE < +Infinity) === true';
+if ((#doubleMin < Infinity) !== true) {
+  throw '#6: (#doubleMin < +Infinity) === true';
 }
 //? test: S11.8.1_A4.7
 //? description: y is number primitive

--- a/src/afw/tests/test262/expressions/logical-or.as
+++ b/src/afw/tests/test262/expressions/logical-or.as
@@ -80,29 +80,32 @@ if ((false || true) !== true) {
 }
 //? test: S11.11.2_A2.1_T2
 //? description: If GetBase(x) is null, throw ReferenceError
-//? expect: error:Parse error at offset 20 around line 3 column 1: Unknown built-in function 'x'
+//? expect: error
 //? source: ...
 #!/usr/bin/env afw
 
+// undeclared x is a compile error
 x || true;
 
 
 
 //? test: S11.11.2_A2.1_T3
 //? description:  If ToBoolean(x) is false and GetBase(y) is null, throw ReferenceError throw new Test262Error('#1.2: false || y throw ReferenceError. Actual: ' + (e));
-//? expect: error:Parse error at offset 29 around line 3 column 10: Unknown built-in function 'y'
+//? expect: error
 //? source: ...
 #!/usr/bin/env afw
 
+// undeclared y is a compile error
 false || y;
 
 
 //? test: S11.11.2_A2.1_T4
 //? description: If ToBoolean(x) is true and GetBase(y) is null, return true
-//? expect: error:Parse error at offset 43 around line 4 column 14: Unknown built-in function 'x'
+//? expect: error
 //? source: ...
 #!/usr/bin/env afw
 
+// undeclared x is a compile error (name is checked even if || would skip it)
 //CHECK#1
 if ((true || x) !== true) {
   throw '#1: (true || x) === true';
@@ -111,28 +114,20 @@ if ((true || x) !== true) {
 
 //? test: S11.11.2_A2.4_T2
 //? description: Checking with "throw"
-//? expect: success
-//? skip: true
-//? skipReason: Harness: half-converted arithmetic operator case from test262
+//? expect: 0
 //? source: ...
-#!/usr/bin/env afw
 
-
-//CHECK#1
-let x = function () { throw "x"; };
-let y = function () { throw "y"; };
+let saw = "";
+function xf() { saw = saw + "x"; throw "x"; }
+function yf() { saw = saw + "y"; throw "y"; }
 try {
-   x() || y();
-   throw '#1.1: let x = function () { throw "x"; }; let y = function () { throw "y"; }; x() || y() throw "x". Actual: ' + (x() || y());
+    let unused = xf() || yf();
+    assert(false);
 } catch (e) {
-   if (e === "y") {
-     throw '#1.2: First expression is evaluated first, and then second expression';
-   } else {
-     if (e !== "x") {
-       throw '#1.3: let x = function () { throw "x"; }; let y = function () { throw "y"; }; x() || y() throw "x". Actual: ' + (e);
-     }
-   }
+    assert(e.message === "x");
+    assert(saw === "x");
 }
+return 0;
 //? test: S11.11.2_A2.4_T3
 //? description: Checking with undeclared variables
 //? expect: error:Parse error at offset 38 around line 5 column 3: Unknown built-in function 'x'

--- a/src/afw/tests/test262/expressions/modulus.as
+++ b/src/afw/tests/test262/expressions/modulus.as
@@ -26,140 +26,22 @@ let x = 18
 assert(x === 1);
 //? test: order-of-evaluation
 //? description: Type coercion order of operations for modulus operator
-//? expect: success
-//? skip: true
-//? skipReason: ...
-Harness: half-converted; still uses ES valueOf / boxed primitives /
-assert.throws
+//? expect: 0
 //? source: ...
-#!/usr/bin/env afw
 
+let saw = "";
+function xf() { saw = saw + "x"; throw "x"; }
+function yf() { saw = saw + "y"; throw "y"; }
+try {
+    let unused = xf() % yf();
+    assert(false);
+} catch (e) {
+    assert(e.message === "x");
+    assert(saw === "x");
+}
+return 0;
 
-function MyError() {}
-let trace;
-
-// ?GetValue(lhs) throws.
-trace = "";
-assert.throws(MyError, function() {
-  (function() {
-    trace += "1";
-    throw new MyError();
-  })() % (function() {
-    trace += "2";
-    throw "should not be evaluated";
-  })();
-}, "?GetValue(lhs) throws.");
-assert.sameValue(trace, "1", "?GetValue(lhs) throws.");
-
-// ?GetValue(rhs) throws.
-trace = "";
-assert.throws(MyError, function() {
-  (function() {
-    trace += "1";
-    return {
-      valueOf: function() {
-        trace += "3";
-        throw "should not be evaluated";
-      }
-    };
-  })() % (function() {
-    trace += "2";
-    throw new MyError();
-  })();
-}, "?GetValue(rhs) throws.");
-assert.sameValue(trace, "12", "?GetValue(rhs) throws.");
-
-// ?ToPrimive(lhs) throws.
-trace = "";
-assert.throws(MyError, function() {
-  (function() {
-    trace += "1";
-    return {
-      valueOf: function() {
-        trace += "3";
-        throw new MyError();
-      }
-    };
-  })() % (function() {
-    trace += "2";
-    return {
-      valueOf: function() {
-        trace += "4";
-        throw "should not be evaluated";
-      }
-    };
-  })();
-}, "?ToPrimive(lhs) throws.");
-assert.sameValue(trace, "123", "?ToPrimive(lhs) throws.");
-
-// ?ToPrimive(rhs) throws.
-trace = "";
-assert.throws(MyError, function() {
-  (function() {
-    trace += "1";
-    return {
-      valueOf: function() {
-        trace += "3";
-        return 1;
-      }
-    };
-  })() % (function() {
-    trace += "2";
-    return {
-      valueOf: function() {
-        trace += "4";
-        throw new MyError();
-      }
-    };
-  })();
-}, "?ToPrimive(rhs) throws.");
-assert.sameValue(trace, "1234", "?ToPrimive(rhs) throws.");
-
-// ?ToNumeric(lhs) throws.
-trace = "";
-assert.throws(TypeError, function() {
-  (function() {
-    trace += "1";
-    return {
-      valueOf: function() {
-        trace += "3";
-        return Symbol("1");
-      }
-    };
-  })() % (function() {
-    trace += "2";
-    return {
-      valueOf: function() {
-        trace += "4";
-        throw "should not be evaluated";
-      }
-    };
-  })();
-}, "?ToNumeric(lhs) throws.");
-assert.sameValue(trace, "123", "?ToNumeric(lhs) throws.");
-
-// GetValue(lhs) throws.
-trace = "";
-assert.throws(TypeError, function() {
-  (function() {
-    trace += "1";
-    return {
-      valueOf: function() {
-        trace += "3";
-        return 1;
-      }
-    };
-  })() % (function() {
-    trace += "2";
-    return {
-      valueOf: function() {
-        trace += "4";
-        return Symbol("1");
-      }
-    };
-  })();
-}, "GetValue(lhs) throws.");
-assert.sameValue(trace, "1234", "GetValue(lhs) throws.");
+//?
 //? test: S11.5.3_A1
 //? description: Checking by using eval
 //? expect: success
@@ -248,19 +130,21 @@ if (x % y !== 1) {
 }
 //? test: S11.5.3_A2.1_T2
 //? description: If GetBase(x) is null, throw ReferenceError
-//? expect: error:Parse error at offset 20 around line 3 column 1: Unknown built-in function 'x'
+//? expect: error
 //? source: ...
 #!/usr/bin/env afw
 
+// undeclared x is a compile error
 x % 1;
 
 
 //? test: S11.5.3_A2.1_T3
 //? description: If GetBase(y) is null, throw ReferenceError
-//? expect: error:Parse error at offset 24 around line 3 column 5: Unknown built-in function 'y'
+//? expect: error
 //? source: ...
 #!/usr/bin/env afw
 
+// undeclared y is a compile error
 1 % y;
 
 
@@ -268,9 +152,7 @@ x % 1;
 //? description: Checking with "throw"
 //? expect: success
 //? skip: true
-//? skipReason: ...
-Harness: half-converted; still uses ES valueOf / boxed primitives /
-assert.throws
+//? skipReason: Never: Adaptive does not convert objects to numbers via valueOf
 //? source: ...
 #!/usr/bin/env afw
 
@@ -292,28 +174,20 @@ try {
 }
 //? test: S11.5.3_A2.4_T2
 //? description: Checking with "throw"
-//? expect: success
-//? skip: true
-//? skipReason: Harness: half-converted arithmetic operator case from test262
+//? expect: 0
 //? source: ...
-#!/usr/bin/env afw
 
-
-//CHECK#1
-let x = function () { throw "x"; };
-let y = function () { throw "y"; };
+let saw = "";
+function xf() { saw = saw + "x"; throw "x"; }
+function yf() { saw = saw + "y"; throw "y"; }
 try {
-   x() % y();
-   throw '#1.1: let x = function () { throw "x"; }; let y = function () { throw "y"; }; x() % y() throw "x". Actual: ' + (x() % y());
+    let unused = xf() % yf();
+    assert(false);
 } catch (e) {
-   if (e === "y") {
-     throw '#1.2: First expression is evaluated first, and then second expression';
-   } else {
-     if (e !== "x") {
-       throw '#1.3: let x = function () { throw "x"; }; let y = function () { throw "y"; }; x() % y() throw "x". Actual: ' + (e);
-     }
-   }
+    assert(e.message === "x");
+    assert(saw === "x");
 }
+return 0;
 //? test: S11.5.3_A2.4_T3
 //? description: Checking with undeclarated variables
 //? expect: error:Parse error at offset 20 around line 3 column 1: Unknown built-in function 'x'
@@ -338,8 +212,7 @@ if (1 % 1 !== 0) {
 //? description: Type(x) and Type(y) vary between primitive string and String object
 //? skip: true
 //? skipReason: ...
-Harness: half-converted; still uses ES valueOf / boxed primitives /
-assert.throws
+Never: Adaptive % does not ToNumber-coerce strings (no new String)
 //? expect: success
 //? source: ...
 #!/usr/bin/env afw
@@ -506,8 +379,8 @@ if (is_NaN(undefined % 1) !== true) {
     String (primitive or object) and Undefined
 //? skip: true
 //? skipReason: ...
-Harness: half-converted; still uses ES valueOf / boxed primitives /
-assert.throws
+Never: Adaptive % does not ToNumber-coerce strings or undefined
+(no new String / valueOf)
 //? expect: success
 //? source: ...
 #!/usr/bin/env afw
@@ -538,8 +411,8 @@ if (is_NaN(undefined % new String("1")) !== true) {
     String (primitive or object) and Null
 //? skip: true
 //? skipReason: ...
-Harness: half-converted; still uses ES valueOf / boxed primitives /
-assert.throws
+Never: Adaptive % does not ToNumber-coerce strings or undefined
+(no new String / valueOf)
 //? expect: success
 //? source: ...
 #!/usr/bin/env afw

--- a/src/afw/tests/test262/expressions/modulus.as
+++ b/src/afw/tests/test262/expressions/modulus.as
@@ -250,7 +250,7 @@ if (is_NaN("1" % "x") !== true) {
 //? test: S11.5.3_A3_T1.4
 //? description: Type(x) and Type(y) vary between Null and Undefined
 //? skip: true
-//? skipReason: Incompatible: Adaptive % does not ToNumber-coerce (null/string/object); integer or double only
+//? skipReason: Never: Adaptive % does not ToNumber-coerce (null/string/object); integer or double only
 //? expect: success
 //? source: ...
 #!/usr/bin/env afw
@@ -278,7 +278,7 @@ if (is_NaN(null % null) !== true) {
 //? test: S11.5.3_A3_T1.5
 //? description: Type(x) and Type(y) vary between Object object and Function object
 //? skip: true
-//? skipReason: Incompatible: Adaptive % does not ToNumber-coerce (null/string/object); integer or double only
+//? skipReason: Never: Adaptive % does not ToNumber-coerce (null/string/object); integer or double only
 //? expect: success
 //? source: ...
 #!/usr/bin/env afw
@@ -308,7 +308,7 @@ if (is_NaN({} % {}) !== true) {
     Type(x) is different from Type(y) and both types vary between
     Number (primitive or object) and String (primitive and object)
 //? skip: true
-//? skipReason: Incompatible: Adaptive % does not ToNumber-coerce (null/string/object); integer or double only
+//? skipReason: Never: Adaptive % does not ToNumber-coerce (null/string/object); integer or double only
 //? expect: success
 //? source: ...
 #!/usr/bin/env afw
@@ -338,7 +338,7 @@ if (is_NaN(1 % "x") !== true) {
     Type(x) is different from Type(y) and both types vary between
     Number (primitive or object) and Null
 //? skip: true
-//? skipReason: Incompatible: Adaptive % does not ToNumber-coerce (null/string/object); integer or double only
+//? skipReason: Never: Adaptive % does not ToNumber-coerce (null/string/object); integer or double only
 //? expect: success
 //? source: ...
 #!/usr/bin/env afw
@@ -358,7 +358,7 @@ if (null % 1 !== 0) {
     Type(x) is different from Type(y) and both types vary between
     Number (primitive or object) and Undefined
 //? skip: true
-//? skipReason: Incompatible: Adaptive % does not ToNumber-coerce (null/string/object); integer or double only
+//? skipReason: Never: Adaptive % does not ToNumber-coerce (null/string/object); integer or double only
 //? expect: success
 //? source: ...
 #!/usr/bin/env afw

--- a/src/afw/tests/test262/expressions/subtraction.as
+++ b/src/afw/tests/test262/expressions/subtraction.as
@@ -355,14 +355,8 @@ if (-Infinity - Infinity !== -Infinity ) {
 }
 //? test: S11.6.2_A4_T3
 //? description: The difference of two infinities of the same sign is NaN
-//? skip: true
-//? skipReason: ...
-FIXME: operator IEEE edge case; needs Adaptive is_NaN / double rewrite
-(no Number/Math globals)
 //? expect: success
 //? source: ...
-#!/usr/bin/env afw
-
 
 //CHECK#1
 if (is_NaN(Infinity - Infinity) !== true ) {
@@ -377,53 +371,47 @@ if (is_NaN(-Infinity - -Infinity) !== true ) {
 //? description:...
     The difference of an infinity and a finite value is equal to
     infinity of appropriate sign
-//? skip: true
-//? skipReason: ...
-FIXME: operator IEEE edge case; needs Adaptive is_NaN / double rewrite
-(no Number/Math globals)
 //? expect: success
 //? source: ...
-#!/usr/bin/env afw
-
 
 //CHECK#1
-if (Infinity - 1 !== Infinity ) {
-  throw '#1: Infinity - 1 === Infinity. Actual: ' + (Infinity - 1);
+if (Infinity - 1.0 !== Infinity ) {
+  throw '#1: Infinity - 1 === Infinity. Actual: ' + (Infinity - 1.0);
 }
 
 //CHECK#2
-if (-1 - Infinity !== -Infinity ) {
-  throw '#2: -1 - Infinity === -Infinity. Actual: ' + (-1 - Infinity);
+if (-1.0 - Infinity !== -Infinity ) {
+  throw '#2: -1 - Infinity === -Infinity. Actual: ' + (-1.0 - Infinity);
 }
 
 //CHECK#3
-if (-Infinity - 1 !== -Infinity ) {
-  throw '#3: -Infinity - 1 === -Infinity. Actual: ' + (-Infinity - 1);
+if (-Infinity - 1.0 !== -Infinity ) {
+  throw '#3: -Infinity - 1 === -Infinity. Actual: ' + (-Infinity - 1.0);
 }
 
 //CHECK#4
-if (-1 - -Infinity !== Infinity ) {
-  throw '#4: -1 - -Infinity === Infinity. Actual: ' + (-1 - -Infinity);
+if (-1.0 - -Infinity !== Infinity ) {
+  throw '#4: -1 - -Infinity === Infinity. Actual: ' + (-1.0 - -Infinity);
 }
 
 //CHECK#5
-if (Infinity - Number.MAX_VALUE !== Infinity ) {
-  throw '#5: Infinity - Number.MAX_VALUE === Infinity. Actual: ' + (Infinity - Number.MAX_VALUE);
+if (Infinity - #doubleMax !== Infinity ) {
+  throw '#5: Infinity - #doubleMax === Infinity. Actual: ' + (Infinity - #doubleMax);
 }
 
 //CHECK#6
-if (-Number.MAX_VALUE - Infinity !== -Infinity ) {
-  throw '#6: -Number.MAX_VALUE - Infinity === I-nfinity. Actual: ' + (-Number.MAX_VALUE - Infinity);
+if (-#doubleMax - Infinity !== -Infinity ) {
+  throw '#6: -#doubleMax - Infinity === -Infinity. Actual: ' + (-#doubleMax - Infinity);
 }
 
 //CHECK#7
-if (-Infinity - Number.MAX_VALUE !== -Infinity ) {
-  throw '#7: -Infinity - Number.MAX_VALUE === -Infinity. Actual: ' + (-Infinity - Number.MAX_VALUE);
+if (-Infinity - #doubleMax !== -Infinity ) {
+  throw '#7: -Infinity - #doubleMax === -Infinity. Actual: ' + (-Infinity - #doubleMax);
 }
 
 //CHECK#8
-if (-Number.MAX_VALUE - -Infinity !== Infinity ) {
-  throw '#8: -Number.MAX_VALUE - -Infinity === Infinity. Actual: ' + (-Number.MAX_VALUE - -Infinity);
+if (-#doubleMax - -Infinity !== Infinity ) {
+  throw '#8: -#doubleMax - -Infinity === Infinity. Actual: ' + (-#doubleMax - -Infinity);
 }
 //? test: S11.6.2_A4_T5
 //? description:...
@@ -476,122 +464,104 @@ if (0 - 0 !== 0 ) {
 //? description:...
     Using the rule of sum of a zero and a nonzero finite value and the
     fact that a - b = a + (-b)
-//? skip: true
-//? skipReason: ...
-FIXME: operator IEEE edge case; needs Adaptive is_NaN / double rewrite
-(no Number/Math globals)
 //? expect: success
 //? source: ...
-#!/usr/bin/env afw
-
 
 //CHECK#1
-if (1 - -0 !== 1 ) {
-  throw '#1: 1 - -0 === 1. Actual: ' + (1 - -0);
+if (1.0 - -0.0 !== 1.0 ) {
+  throw '#1: 1 - -0 === 1. Actual: ' + (1.0 - -0.0);
 }
 
 //CHECK#2
-if (1 - 0 !== 1 ) {
-  throw '#2: 1 - 0 === 1. Actual: ' + (1 - 0);
+if (1.0 - 0.0 !== 1.0 ) {
+  throw '#2: 1 - 0 === 1. Actual: ' + (1.0 - 0.0);
 }
 
 //CHECK#3
-if (-0 - 1 !== -1 ) {
-  throw '#3: -0 - 1 === -1. Actual: ' + (-0 - 1);
+if (-0.0 - 1.0 !== -1.0 ) {
+  throw '#3: -0 - 1 === -1. Actual: ' + (-0.0 - 1.0);
 }
 
 //CHECK#4
-if (0 - 1 !== -1 ) {
-  throw '#4: 0 - 1 === -1. Actual: ' + (0 - 1);
+if (0.0 - 1.0 !== -1.0 ) {
+  throw '#4: 0 - 1 === -1. Actual: ' + (0.0 - 1.0);
 }
 
 //CHECK#5
-if (Number.MAX_VALUE - -0 !== Number.MAX_VALUE ) {
-  throw '#5: Number.MAX_VALUE - -0 === Number.MAX_VALUE. Actual: ' + (Number.MAX_VALUE - -0);
+if (#doubleMax - -0.0 !== #doubleMax ) {
+  throw '#5: #doubleMax - -0 === #doubleMax. Actual: ' + (#doubleMax - -0.0);
 }
 
 //CHECK#6
-if (Number.MAX_VALUE - 0 !== Number.MAX_VALUE ) {
-  throw '#6: Number.MAX_VALUE - 0 === Number.MAX_VALUE. Actual: ' + (Number.MAX_VALUE - 0);
+if (#doubleMax - 0.0 !== #doubleMax ) {
+  throw '#6: #doubleMax - 0 === #doubleMax. Actual: ' + (#doubleMax - 0.0);
 }
 
 //CHECK#7
-if (-0 - Number.MIN_VALUE !== -Number.MIN_VALUE ) {
-  throw '#7: -0 - Number.MIN_VALUE === -Number.MIN_VALUE. Actual: ' + (-0 - Number.MIN_VALUE);
+if (-0.0 - #doubleMin !== -#doubleMin ) {
+  throw '#7: -0 - #doubleMin === -#doubleMin. Actual: ' + (-0.0 - #doubleMin);
 }
 
 //CHECK#8
-if (0 - Number.MIN_VALUE !== -Number.MIN_VALUE ) {
-  throw '#8: 0 - Number.MIN_VALUE === -Number.MIN_VALUE. Actual: ' + (0 - Number.MIN_VALUE);
+if (0.0 - #doubleMin !== -#doubleMin ) {
+  throw '#8: 0 - #doubleMin === -#doubleMin. Actual: ' + (0.0 - #doubleMin);
 }
 //? test: S11.6.2_A4_T7
 //? description:...
     The mathematical difference of two nonzero finite values of the
     same magnitude and same sign is +0
-//? skip: true
-//? skipReason: ...
-FIXME: operator IEEE edge case; needs Adaptive is_NaN / double rewrite
-(no Number/Math globals)
 //? expect: success
 //? source: ...
-#!/usr/bin/env afw
-
 
 //CHECK#1
-if (Number.MIN_VALUE - Number.MIN_VALUE !== +0) {
-  throw '#1.1: Number.MIN_VALUE - Number.MIN_VALUE === 0. Actual: ' + (Number.MIN_VALUE - Number.MIN_VALUE);
+if (#doubleMin - #doubleMin !== +0.0) {
+  throw '#1.1: #doubleMin - #doubleMin === 0. Actual: ' + (#doubleMin - #doubleMin);
 } else {
-  if (1 / (Number.MIN_VALUE - Number.MIN_VALUE) !== Infinity) {
-    throw '#1.2: Number.MIN_VALUE - Number.MIN_VALUE === + 0. Actual: -0';
+  if (1.0 / (#doubleMin - #doubleMin) !== Infinity) {
+    throw '#1.2: #doubleMin - #doubleMin === + 0. Actual: -0';
   }
 }
 
 //CHECK#2
-if (-Number.MAX_VALUE - -Number.MAX_VALUE !== +0) {
-  throw '#2.2: -Number.MAX_VALUE - -Number.MAX_VALUE === 0. Actual: ' + (-Number.MAX_VALUE - -Number.MAX_VALUE);
+if (-#doubleMax - -#doubleMax !== +0.0) {
+  throw '#2.2: -#doubleMax - -#doubleMax === 0. Actual: ' + (-#doubleMax - -#doubleMax);
 } else {
-  if (1 / (-Number.MAX_VALUE - -Number.MAX_VALUE) !== Infinity) {
-    throw '#2.1: -Number.MAX_VALUE - -Number.MAX_VALUE === + 0. Actual: -0';
+  if (1.0 / (-#doubleMax - -#doubleMax) !== Infinity) {
+    throw '#2.1: -#doubleMax - -#doubleMax === + 0. Actual: -0';
   }
 }
 
 //CHECK#3
-if (1 / Number.MAX_VALUE - 1 / Number.MAX_VALUE !== +0) {
-  throw '#3.1: 1 / Number.MAX_VALUE - 1 / Number.MAX_VALUE === 0. Actual: ' + (1 / Number.MAX_VALUE - 1 / Number.MAX_VALUE);
+if (1.0 / #doubleMax - 1.0 / #doubleMax !== +0.0) {
+  throw '#3.1: 1 / #doubleMax - 1 / #doubleMax === 0. Actual: ' + (1.0 / #doubleMax - 1.0 / #doubleMax);
 } else {
-  if (1 / (1 / Number.MAX_VALUE - 1 / Number.MAX_VALUE) !== Infinity) {
-    throw '#3.2: 1 / Number.MAX_VALUE - 1 / Number.MAX_VALUE === + 0. Actual: -0';
+  if (1.0 / (1.0 / #doubleMax - 1.0 / #doubleMax) !== Infinity) {
+    throw '#3.2: 1 / #doubleMax - 1 / #doubleMax === + 0. Actual: -0';
   }
 }
 //? test: S11.6.2_A4_T8
 //? description:...
     If the magnitude is too large to represent, the operation
     overflows and the result is then an infinity of appropriate sign
-//? skip: true
-//? skipReason: ...
-FIXME: operator IEEE edge case; needs Adaptive is_NaN / double rewrite
-(no Number/Math globals)
 //? expect: success
 //? source: ...
-#!/usr/bin/env afw
-
 
 //CHECK#1
-if (Number.MAX_VALUE - -Number.MAX_VALUE !== Infinity) {
-  throw '#1: Number.MAX_VALUE - -Number.MAX_VALUE === Infinity. Actual: ' + (Number.MAX_VALUE - -Number.MAX_VALUE);
+if (#doubleMax - -#doubleMax !== Infinity) {
+  throw '#1: #doubleMax - -#doubleMax === Infinity. Actual: ' + (#doubleMax - -#doubleMax);
 }
 
 //CHECK#2
-if (-Number.MAX_VALUE - Number.MAX_VALUE !== -Infinity) {
-  throw '#2: -Number.MAX_VALUE - umber.MAX_VALUE === -Infinity. Actual: ' + (-Number.MAX_VALUE - Number.MAX_VALUE);
+if (-#doubleMax - #doubleMax !== -Infinity) {
+  throw '#2: -#doubleMax - #doubleMax === -Infinity. Actual: ' + (-#doubleMax - #doubleMax);
 }
 
 //CHECK#3
-if (1e+308 - -1e+308 !== Infinity) {
-  throw '#3: 1e+308 - -1e+308 === Infinity. Actual: ' + (1e+308 - -1e+308);
+if (1.0E308 - -1.0E308 !== Infinity) {
+  throw '#3: 1e+308 - -1e+308 === Infinity. Actual: ' + (1.0E308 - -1.0E308);
 }
 
 //CHECK#4
-if (-8.99e+307 - 8.99e+307 !== -Infinity) {
-  throw '#4: -8.99e+307 - 8.99e+307 === -Infinity. Actual: ' + (-8.99e+307 - 8.99e+307);
+if (-8.99E307 - 8.99E307 !== -Infinity) {
+  throw '#4: -8.99e+307 - 8.99e+307 === -Infinity. Actual: ' + (-8.99E307 - 8.99E307);
 }

--- a/src/afw/tests/test262/expressions/subtraction.as
+++ b/src/afw/tests/test262/expressions/subtraction.as
@@ -10,8 +10,8 @@
 //? expect: success
 //? skip: true
 //? skipReason: ...
-Harness: half-converted; still uses ES valueOf / boxed primitives /
-assert.throws
+Never: Adaptive does not ToPrimitive/ToNumeric via valueOf;
+left-to-right operand evaluation is S11.6.2_A2.4_T2
 //? source: ...
 #!/usr/bin/env afw
 
@@ -229,19 +229,21 @@ if (x - y !== 0) {
 }
 //? test: S11.6.2_A2.1_T2
 //? description: If GetBase(x) is null, throw ReferenceError
-//? expect: error:Parse error at offset 20 around line 3 column 1: Unknown built-in function 'x'
+//? expect: error
 //? source: ...
 #!/usr/bin/env afw
 
+// undeclared x is a compile error
 x - 1;
 
 
 //? test: S11.6.2_A2.1_T3
 //? description: If GetBase(y) is null, throw ReferenceError
-//? expect: error:Parse error at offset 24 around line 3 column 5: Unknown built-in function 'y'
+//? expect: error
 //? source: ...
 #!/usr/bin/env afw
 
+// undeclared y is a compile error
 1 - y;
 
 
@@ -250,9 +252,7 @@ x - 1;
 //? description: Checking with "throw"
 //? expect: success
 //? skip: true
-//? skipReason: ...
-Harness: half-converted; still uses ES valueOf / boxed primitives /
-assert.throws
+//? skipReason: Never: Adaptive does not convert objects to numbers via valueOf
 //? source: ...
 #!/usr/bin/env afw
 
@@ -274,28 +274,20 @@ try {
 }
 //? test: S11.6.2_A2.4_T2
 //? description: Checking with "throw"
-//? expect: success
-//? skip: true
-//? skipReason: Harness: half-converted arithmetic operator case from test262
+//? expect: 0
 //? source: ...
-#!/usr/bin/env afw
 
-
-//CHECK#1
-let x = function () { throw "x"; };
-let y = function () { throw "y"; };
+let saw = "";
+function xf() { saw = saw + "x"; throw "x"; }
+function yf() { saw = saw + "y"; throw "y"; }
 try {
-   x() - y();
-   throw '#1.1: let x = function () { throw "x"; }; let y = function () { throw "y"; }; x() - y() throw "x". Actual: ' + (x() - y());
+    let unused = xf() - yf();
+    assert(false);
 } catch (e) {
-   if (e === "y") {
-     throw '#1.2: First expression is evaluated first, and then second expression';
-   } else {
-     if (e !== "x") {
-       throw '#1.3: let x = function () { throw "x"; }; let y = function () { throw "y"; }; x() - y() throw "x". Actual: ' + (e);
-     }
-   }
+    assert(e.message === "x");
+    assert(saw === "x");
 }
+return 0;
 //? test: S11.6.2_A3_T1.2
 //? description: Type(x) and Type(y) vary between primitive number and Number object
 //? expect: success

--- a/src/afw/tests/test262/expressions/unary-plus.as
+++ b/src/afw/tests/test262/expressions/unary-plus.as
@@ -103,7 +103,7 @@ if (+(+x) !== 1) {
 //? expect: success
 //? skip: true
 //? skipReason: ...
-Incompatible: Adaptive does not coerce boolean with unary + (ES
+Never: Adaptive does not coerce boolean with unary + (ES
 ToNumber)
 //? source: ...
 #!/usr/bin/env afw
@@ -207,7 +207,7 @@ if (+(null) !== null) {
 //? expect: success
 //? skip: true
 //? skipReason: ...
-Incompatible: Adaptive does not coerce boolean with unary + (ES
+Never: Adaptive does not coerce boolean with unary + (ES
 ToNumber)
 //? source: ...
 #!/usr/bin/env afw

--- a/src/afw/tests/test262/literals/string.as
+++ b/src/afw/tests/test262/literals/string.as
@@ -483,7 +483,7 @@ for (let index = 0; index <= 9; index = index + 1) {
 //? description: "SingleEscapeSequence :: one of b f n r t v"
 //? expect: success
 //? skip: true
-//? skipReason: Incompatible: no String.fromCharCode / ES String prototype APIs
+//? skipReason: Never: no String.fromCharCode / ES String prototype APIs
 //? source: ...
 #!/usr/bin/env afw
 
@@ -521,7 +521,7 @@ if (String.fromCharCode(0x000D) !== "\r") {
 //? description: "SingleEscapeSequence :: one of ' \" \\"
 //? expect: success
 //? skip: true
-//? skipReason: Incompatible: no String.fromCharCode / ES String prototype APIs
+//? skipReason: Never: no String.fromCharCode / ES String prototype APIs
 //? source: ...
 #!/usr/bin/env afw
 
@@ -555,7 +555,7 @@ if ('\"' !== '"') {
 //? description: "NonEscapeSequence :: ENGLISH CAPITAL ALPHABET"
 //? expect: success
 //? skip: true
-//? skipReason: Incompatible: no String.fromCharCode / ES String prototype APIs
+//? skipReason: Never: no String.fromCharCode / ES String prototype APIs
 //? source: ...
 #!/usr/bin/env afw
 
@@ -682,7 +682,7 @@ if ("Z" !== "\Z") {
 //? description: "NonEscapeSequence :: ENGLISH SMALL ALPHABET"
 //? expect: success
 //? skip: true
-//? skipReason: Incompatible: no String.fromCharCode / ES String prototype APIs
+//? skipReason: Never: no String.fromCharCode / ES String prototype APIs
 //? source: ...
 #!/usr/bin/env afw
 
@@ -779,7 +779,7 @@ if ("z" !== "\z") {
 //? description: "NonEscapeSequence :: RUSSIAN CAPITAL ALPHABET"
 //? expect: success
 //? skip: true
-//? skipReason: Incompatible: no String.fromCharCode / ES String prototype APIs
+//? skipReason: Never: no String.fromCharCode / ES String prototype APIs
 //? source: ...
 #!/usr/bin/env afw
 
@@ -935,7 +935,7 @@ if ("Ё" !== "\Ё") {
 //? description: "NonEscapeSequence :: RUSSIAN SMALL ALPHABET"
 //? expect: success
 //? skip: true
-//? skipReason: Incompatible: no String.fromCharCode / ES String prototype APIs
+//? skipReason: Never: no String.fromCharCode / ES String prototype APIs
 //? source: ...
 #!/usr/bin/env afw
 
@@ -1147,7 +1147,7 @@ if ("v" === "\v") {
 //? description: String.fromCharCode(0x0000)
 //? expect: success
 //? skip: true
-//? skipReason: Incompatible: no String.fromCharCode / ES String prototype APIs
+//? skipReason: Never: no String.fromCharCode / ES String prototype APIs
 //? source: ...
 #!/usr/bin/env afw
 
@@ -1181,7 +1181,7 @@ if ("\x00" !== "\0") {
 //? description: "HexEscapeSequence ::  HexDigit"
 //? expect: success
 //? skip: true
-//? skipReason: Incompatible: no String.fromCharCode / ES String prototype APIs
+//? skipReason: Never: no String.fromCharCode / ES String prototype APIs
 //? source: ...
 #!/usr/bin/env afw
 
@@ -1297,7 +1297,7 @@ for (let index = 0; index <= 25; index = index + 1) {
 //? description: Check similar to ('\x01F' === String.fromCharCode('1') + 'F')
 //? expect: success
 //? skip: true
-//? skipReason: Incompatible: no String.fromCharCode / ES String prototype APIs
+//? skipReason: Never: no String.fromCharCode / ES String prototype APIs
 //? source: ...
 #!/usr/bin/env afw
 
@@ -1380,7 +1380,7 @@ if ('\x0F1' !== String.fromCharCode('15') + '1') {
 //? description: Check similar to ("\u0000" === String.fromCharCode("0"))
 //? expect: success
 //? skip: true
-//? skipReason: Incompatible: no String.fromCharCode / ES String prototype APIs
+//? skipReason: Never: no String.fromCharCode / ES String prototype APIs
 //? source: ...
 #!/usr/bin/env afw
 
@@ -1589,7 +1589,7 @@ for (let index = 0; index <= 25; index = index + 1) {
 //? description: Check similar to ("\u0001F" === String.fromCharCode("1") + "F")
 //? expect: success
 //? skip: true
-//? skipReason: Incompatible: no String.fromCharCode / ES String prototype APIs
+//? skipReason: Never: no String.fromCharCode / ES String prototype APIs
 //? source: ...
 #!/usr/bin/env afw
 

--- a/src/afw/tests/test262/statements/for-of.as
+++ b/src/afw/tests/test262/statements/for-of.as
@@ -1711,10 +1711,8 @@ for (const [x, x] of []) {}
 //? expect: error
 //? skip: true
 //? skipReason: ...
-FIXME: Adaptive has no general TDZ for let/const (inner binding is visible
-as undefined, not ReferenceError). for-of shares that gap: evaluating
-[x] with for (const x of [x]) does not throw. Needs language-wide TDZ,
-not a for-of-only hack.
+Incompatible: Adaptive has no TDZ. The inner for-of binding is
+undefined, not a ReferenceError. Not a for-of-only change.
 //? source: ...
 #!/usr/bin/env afw
 

--- a/src/afw/tests/test262/statements/for-of.as
+++ b/src/afw/tests/test262/statements/for-of.as
@@ -1711,7 +1711,7 @@ for (const [x, x] of []) {}
 //? expect: error
 //? skip: true
 //? skipReason: ...
-Incompatible: Adaptive has no TDZ. The inner for-of binding is
+Never: Adaptive has no TDZ. The inner for-of binding is
 undefined, not a ReferenceError. Not a for-of-only change.
 //? source: ...
 #!/usr/bin/env afw
@@ -3251,9 +3251,9 @@ for (let x of []) label1: label2: function f() {}
 //? expect: error
 //? skip: true
 //? skipReason: ...
-FIXME: ASI / let-as-identifier vs let-declaration after for-of empty body.
-Empty for-of does not force parse of the following statement the same way
-as ES; needs compiler ASI / statement parsing work, not for-of iteration.
+Never: Adaptive does not match ES ASI lookahead for let [ after an
+empty for-of. Not a for-of iteration bug; let-block-with-newline already
+runs.
 //? source: ...
 #!/usr/bin/env afw
 

--- a/src/afw/tests/test262/statements/let/syntax.as
+++ b/src/afw/tests/test262/statements/let/syntax.as
@@ -66,7 +66,7 @@ for (let k = 0; k < 5; ++k) {
 //? expect: error:Parse error at offset 114 around line 5 column 17: Unknown built-in function 'f'
 //? skip: true
 //? skipReason: ...
-Incompatible: for (let i = 0, f = …) parses (#62) but Adaptive for-let
+Never: for (let i = 0, f = …) parses (#62) but Adaptive for-let
 is one slot, not ES per-iteration bindings.
 //? source: ...
 #!/usr/bin/env afw
@@ -102,7 +102,7 @@ for (let k = 0; k < 5; ++k) {
 //? expect: error:Parse error at offset 126 around line 6 column 17: Unknown built-in function 'j'
 //? skip: true
 //? skipReason: ...
-Incompatible: for (let i = 0, j = 10; …) parses (#62). Adaptive for-let
+Never: for (let i = 0, j = 10; …) parses (#62). Adaptive for-let
 is one slot, not ES per-iteration fresh bindings.
 //? source: ...
 #!/usr/bin/env afw

--- a/src/afw/tests/test262/statements/let/syntax.as
+++ b/src/afw/tests/test262/statements/let/syntax.as
@@ -66,8 +66,8 @@ for (let k = 0; k < 5; ++k) {
 //? expect: error:Parse error at offset 114 around line 5 column 17: Unknown built-in function 'f'
 //? skip: true
 //? skipReason: ...
-FIXME: for (let i = 0, f = …) now parses (#62). Assertions need Adaptive
-for-let (one slot, not ES per-iteration bindings) plus increment form.
+Incompatible: for (let i = 0, f = …) parses (#62) but Adaptive for-let
+is one slot, not ES per-iteration bindings.
 //? source: ...
 #!/usr/bin/env afw
 
@@ -102,8 +102,8 @@ for (let k = 0; k < 5; ++k) {
 //? expect: error:Parse error at offset 126 around line 6 column 17: Unknown built-in function 'j'
 //? skip: true
 //? skipReason: ...
-FIXME: for (let i = 0, j = 10; …) now parses (#62). ES per-iteration
-fresh bindings are not Adaptive (one slot). Rewrite asserts later.
+Incompatible: for (let i = 0, j = 10; …) parses (#62). Adaptive for-let
+is one slot, not ES per-iteration fresh bindings.
 //? source: ...
 #!/usr/bin/env afw
 

--- a/src/afw/value/afw_value.c
+++ b/src/afw/value/afw_value.c
@@ -13,6 +13,7 @@
 
 #include "afw_internal.h"
 #include <libxml/xmlregexp.h>
+#include <math.h>
 
 
 
@@ -57,6 +58,127 @@ impl_value_unique_default_case_value = {
 AFW_DEFINE_CONST_DATA(afw_value_t *)
 afw_value_unique_default_case_value =
 { &impl_value_unique_default_case_value.pub };
+
+
+static const afw_value_double_t
+impl_value_double_max = {
+    { &afw_value_permanent_double_inf },
+    AFW_DOUBLE_MAX
+};
+
+AFW_DEFINE_CONST_DATA(afw_value_t *)
+afw_value_double_max =
+{ &impl_value_double_max.pub };
+
+
+static const afw_value_double_t
+impl_value_double_min = {
+    { &afw_value_permanent_double_inf },
+    AFW_DOUBLE_MIN
+};
+
+AFW_DEFINE_CONST_DATA(afw_value_t *)
+afw_value_double_min =
+{ &impl_value_double_min.pub };
+
+
+static const afw_value_double_t
+impl_value_double_min_subnormal = {
+    { &afw_value_permanent_double_inf },
+    AFW_DOUBLE_MIN_SUBNORMAL
+};
+
+AFW_DEFINE_CONST_DATA(afw_value_t *)
+afw_value_double_min_subnormal =
+{ &impl_value_double_min_subnormal.pub };
+
+
+static const afw_value_double_t
+impl_value_double_epsilon = {
+    { &afw_value_permanent_double_inf },
+    AFW_DOUBLE_EPSILON
+};
+
+AFW_DEFINE_CONST_DATA(afw_value_t *)
+afw_value_double_epsilon =
+{ &impl_value_double_epsilon.pub };
+
+
+static const afw_value_double_t
+impl_value_double_pi = {
+    { &afw_value_permanent_double_inf },
+    AFW_DOUBLE_PI
+};
+
+AFW_DEFINE_CONST_DATA(afw_value_t *)
+afw_value_double_pi =
+{ &impl_value_double_pi.pub };
+
+
+static const afw_value_double_t
+impl_value_double_e = {
+    { &afw_value_permanent_double_inf },
+    AFW_DOUBLE_E
+};
+
+AFW_DEFINE_CONST_DATA(afw_value_t *)
+afw_value_double_e =
+{ &impl_value_double_e.pub };
+
+
+static const afw_value_double_t
+impl_value_infinity = {
+    { &afw_value_permanent_double_inf },
+    INFINITY
+};
+
+AFW_DEFINE_CONST_DATA(afw_value_t *)
+afw_value_infinity =
+{ &impl_value_infinity.pub };
+
+
+static const afw_value_double_t
+impl_value_minus_infinity = {
+    { &afw_value_permanent_double_inf },
+    -INFINITY
+};
+
+AFW_DEFINE_CONST_DATA(afw_value_t *)
+afw_value_minus_infinity =
+{ &impl_value_minus_infinity.pub };
+
+
+static const afw_value_double_t
+impl_value_NaN = {
+    { &afw_value_permanent_double_inf },
+    NAN
+};
+
+AFW_DEFINE_CONST_DATA(afw_value_t *)
+afw_value_NaN =
+{ &impl_value_NaN.pub };
+
+
+static const afw_value_integer_t
+impl_value_integer_max = {
+    { &afw_value_permanent_integer_inf },
+    AFW_INTEGER_MAX
+};
+
+AFW_DEFINE_CONST_DATA(afw_value_t *)
+afw_value_integer_max =
+{ &impl_value_integer_max.pub };
+
+
+static const afw_value_integer_t
+impl_value_integer_min = {
+    { &afw_value_permanent_integer_inf },
+    AFW_INTEGER_MIN
+};
+
+AFW_DEFINE_CONST_DATA(afw_value_t *)
+afw_value_integer_min =
+{ &impl_value_integer_min.pub };
 
 
 /* Compile a value. */

--- a/src/afw/value/afw_value.h
+++ b/src/afw/value/afw_value.h
@@ -417,14 +417,58 @@ afw_value_unique_default_case_value;
 
 
 /**
+ * @brief Permanent values for compiler literals (script `#doubleMax`, …).
+ *
+ * C macros for the same numbers are in afw_number.h (`AFW_DOUBLE_MAX`,
+ * …) and afw_common.h (`AFW_INTEGER_MAX` / `MIN`). Infinity / NaN
+ * values match env->infinity_value / NaN_value (IEEE).
+ */
+AFW_DECLARE_CONST_DATA(afw_value_t *)
+afw_value_double_max;
+
+AFW_DECLARE_CONST_DATA(afw_value_t *)
+afw_value_double_min;
+
+AFW_DECLARE_CONST_DATA(afw_value_t *)
+afw_value_double_min_subnormal;
+
+AFW_DECLARE_CONST_DATA(afw_value_t *)
+afw_value_double_epsilon;
+
+AFW_DECLARE_CONST_DATA(afw_value_t *)
+afw_value_double_pi;
+
+AFW_DECLARE_CONST_DATA(afw_value_t *)
+afw_value_double_e;
+
+AFW_DECLARE_CONST_DATA(afw_value_t *)
+afw_value_infinity;
+
+AFW_DECLARE_CONST_DATA(afw_value_t *)
+afw_value_minus_infinity;
+
+AFW_DECLARE_CONST_DATA(afw_value_t *)
+afw_value_NaN;
+
+AFW_DECLARE_CONST_DATA(afw_value_t *)
+afw_value_integer_max;
+
+AFW_DECLARE_CONST_DATA(afw_value_t *)
+afw_value_integer_min;
+
+
+
+/**
  * @brief Value for boolean variable.
  * @param variable
  * @return afw_boolean_v_true or afw_boolean_v_false
  *
  * Prefer existing static const Adaptive values when the value is fixed:
  * afw_boolean_v_true / afw_boolean_v_false, afw_v_* from afw_strings.h
- * (including a_* names), afw_integer_v_zero / afw_integer_v_one, and
- * afw_value_null / afw_value_undefined in this header. Avoid
+ * (including a_* names), afw_integer_v_zero / afw_integer_v_one,
+ * afw_value_double_max / afw_value_integer_max / afw_value_infinity
+ * (and siblings), and afw_value_null / afw_value_undefined in this
+ * header. Avoid
  * create_unmanaged_* only to wrap those. Prefer
  * afw_object_set_property(..., afw_v_*, ...) over set_property_as_string
  * when an afw_v_* already exists for that constant.

--- a/src/afw_lmdb/tests/adapter/index_current.as
+++ b/src/afw_lmdb/tests/adapter/index_current.as
@@ -8,7 +8,7 @@
 //? test: index_current_object
 //? description: index_create value/filter scripts use current::object (issue #54)
 //? skip: true
-//? skipReason: Pre-existing LMDB index_create txn/save_config and retroactive hang; unskip when create path fixed (#57).
+//? skipReason: FIXME: LMDB index_create txn/save_config and retroactive hang; unskip when create path is fixed (#57)
 //? expect: 0
 //? source: ...
 #!/usr/bin/env afw

--- a/whats-new.md
+++ b/whats-new.md
@@ -72,6 +72,7 @@ sections end with [↑ Highlights](#highlights) to return here.
 | [**Runtime catalog / accessors**](#runtime-catalog-accessors-issue-149) ([#149](https://github.com/afw-org/afw/issues/149)) | Lock+copy **`referenceCount`**; accessor registry; rich objectOptions on permanent shells fixed; **metrics/properties** live-while-active with lock-safe pointer load |
 | [**Error codes**](#error-codes-trycatch-and-http-issue-33) ([#33](https://github.com/afw-org/afw/issues/33)) | Review of `e.id` / HTTP map; script `throw` … `id "not_found"` (and similar) sets the catch object and HTTP status |
 | [**Multi `let` / `const`**](#multi-let-and-const-issue-62) ([#62](https://github.com/afw-org/afw/issues/62)) | Several names on one `let` / `const`; C-style `for` init; `x = y = 1;` chain; script result is set by assignment, `return`, and a call that is not void; loop labels |
+| [**Compiler literals**](#compiler-literals-issue-106) ([#106](https://github.com/afw-org/afw/issues/106)) | `#doubleMax`, `#integerMax`, `#pi`, `#infinity`, and related `#` names fold to those values at compile |
 
 ---
 
@@ -209,6 +210,33 @@ outer: for (let i = 0; i < 3; i = i + 1) {
 ```
 
 Handbook: Language Reference **Statements**. Tests: `src/afw/tests/language/script/let_const.as`, `for.as`, `assignment.as`, `script_result.as`, `void_result.as`, `labels.as`.
+
+[↑ Highlights](#highlights)
+
+---
+
+## Compiler literals (issue [#106](https://github.com/afw-org/afw/issues/106))
+
+A **compiler literal** is a `#` name for a value the compiler already knows. It is a value in an expression, not a statement and not a function call.
+
+| Name | Value |
+|------|--------|
+| `#doubleMax` `#doubleMin` `#doubleMinSubnormal` `#doubleEpsilon` | IEEE double limits |
+| `#integerMax` `#integerMin` | 64-bit integer limits |
+| `#pi` `#e` | math constants |
+| `#infinity` `#inf` | same as `Infinity` |
+| `#minusInfinity` | same as `-Infinity` |
+| `#nan` | same as `NaN` |
+
+```adaptive
+assert(#doubleMax / 0.9 === Infinity);
+assert(#integerMax + #integerMin === -1);
+assert(#infinity === Infinity);
+```
+
+Reserved words `Infinity`, `NaN`, and `INF` are unchanged. `#compile` is still a pragma. `#block` and similar names are still for decompile, not everyday script.
+
+Handbook: Language Reference **Language Features** (Compiler literals). Tests: `src/afw/tests/compiler/compiler_literals.as`.
 
 [↑ Highlights](#highlights)
 


### PR DESCRIPTION
## Summary

Mailbox **#106** (resolve FIXMEs in afw tests) is done as a convert/reclassify sweep, not as “zero skips forever.”

- Skip reasons are only **`FIXME:`** (still wrong / later) and **`Never:`** (we will not do this). Former Incompatible / Deferred / Harness are gone.
- Remaining Harness cases were rewritten in Adaptive spirit (left-to-right `xf() op yf()`, or **Never:** for `valueOf` / ToPrimitive).
- IEEE / `**` FIXMEs unskipped using **compiler literals** (`#doubleMax`, `#pi`, `#infinity`, …). Those `#` names fold at compile to permanent values. Bare `Infinity` / `NaN` unchanged.
- ASI leftovers and ES-only cases (no `String.fromCharCode`, no ToNumber coerce, no TDZ, …) are **Never:**.
- `FIXME-triage.md` is now just the three leftover **FIXME:** rows: for-of const+closures (**#35 / #2**), produce-type placeholder, LMDB **#57**.

Handbook Features has a short Compiler literals section. `whats-new.md` has the author note.

## Leftovers (not this PR)

- `#35` / `#2` — loop binding + closure capture
- Produce-type on script-call compiled form
- `#57` — LMDB index_create hang

## Test plan

- [x] `./afwdev build --fulldev` (Mike)
- [x] `afwdev test -j` (Mike)