### PR TITLE
#125: maxNumberOfParameters (max… for limit ids)

### DIFF
--- a/.cursor/rules/afw-generate-metadata.mdc
+++ b/.cursor/rules/afw-generate-metadata.mdc
@@ -15,7 +15,7 @@ alwaysApply: false
 - `_AdaptiveFunctionGenerate_/` — Adaptive functions (`functionId`, `functionLabel`, `category`, `parameters`, `returns`). Example: `src/afw/generate/objects/_AdaptiveFunctionGenerate_/and.json`.
 - `_AdaptiveDataTypeGenerate_/` — data types (not `_AdaptiveDataType_`).
 - `_AdaptivePolymorphicFunction_/` — polymorphic / shared execute dispatch.
-- `_AdaptiveObjectType_/` and related — object type metadata. Inheritance uses `propertyTypes._meta_.parentPaths` (not flattened on generate→generated copy). Package-root JSON Schema for editors is projected from these OTs — see `afw-json-schema`.
+- `_AdaptiveObjectType_/` and related — object type metadata. Inheritance uses `propertyTypes._meta_.parentPaths` (not flattened on generate→generated copy). Package-root JSON Schema for editors is projected from these OTs — see `afw-json-schema`. Limit/cap property ids use **`max…`** (`maxNumberOfParameters`, `maxReadBytes`); “Maximum …” is brief/label text only.
 - Interfaces: `generate/interfaces/*.xml` (core: `src/afw/generate/interfaces/afw_interface.xml`).
 - EBNF: `generate/ebnf/*.txt` lists which compile sources to scan; grammar text lives in `/*ebnf>>>` comments in those `.c` files → `generated/ebnf/`. See `.cursor/rules/afw-compiler-ebnf.mdc`.
 

--- a/generated/schemas/afw/_AdaptiveFunction_.json
+++ b/generated/schemas/afw/_AdaptiveFunction_.json
@@ -307,7 +307,7 @@
                     "title": "Signature",
                     "type": "string"
                 },
-                "maximumNumberOfParameters": {
+                "maxNumberOfParameters": {
                     "description": "This is the maximum number of parameters or -1 if there is no maximum.",
                     "markdownDescription": "**Maximum Parameters**\n\nThis is the maximum number of parameters or -1 if there is no maximum.",
                     "title": "Maximum Parameters",
@@ -535,7 +535,7 @@
                     "title": "Signature",
                     "type": "string"
                 },
-                "maximumNumberOfParameters": {
+                "maxNumberOfParameters": {
                     "description": "This is the maximum number of parameters or -1 if there is no maximum.",
                     "markdownDescription": "**Maximum Parameters**\n\nThis is the maximum number of parameters or -1 if there is no maximum.",
                     "title": "Maximum Parameters",
@@ -766,7 +766,7 @@
             "title": "Signature",
             "type": "string"
         },
-        "maximumNumberOfParameters": {
+        "maxNumberOfParameters": {
             "description": "This is the maximum number of parameters or -1 if there is no maximum.",
             "markdownDescription": "**Maximum Parameters**\n\nThis is the maximum number of parameters or -1 if there is no maximum.",
             "title": "Maximum Parameters",

--- a/generated/schemas/afw/_AdaptivePolymorphicFunction_.json
+++ b/generated/schemas/afw/_AdaptivePolymorphicFunction_.json
@@ -297,7 +297,7 @@
                     "title": "Signature",
                     "type": "string"
                 },
-                "maximumNumberOfParameters": {
+                "maxNumberOfParameters": {
                     "description": "This is the maximum number of parameters or -1 if there is no maximum.",
                     "markdownDescription": "**Maximum Parameters**\n\nThis is the maximum number of parameters or -1 if there is no maximum.",
                     "title": "Maximum Parameters",
@@ -533,7 +533,7 @@
                     "title": "Signature",
                     "type": "string"
                 },
-                "maximumNumberOfParameters": {
+                "maxNumberOfParameters": {
                     "description": "This is the maximum number of parameters or -1 if there is no maximum.",
                     "markdownDescription": "**Maximum Parameters**\n\nThis is the maximum number of parameters or -1 if there is no maximum.",
                     "title": "Maximum Parameters",
@@ -829,7 +829,7 @@
             "title": "Signature",
             "type": "string"
         },
-        "maximumNumberOfParameters": {
+        "maxNumberOfParameters": {
             "description": "This is the maximum number of parameters or -1 if there is no maximum.",
             "markdownDescription": "**Maximum Parameters**\n\nThis is the maximum number of parameters or -1 if there is no maximum.",
             "title": "Maximum Parameters",

--- a/open-issues-status.md
+++ b/open-issues-status.md
@@ -2,7 +2,7 @@
 
 **Repo:** [afw-org/afw](https://github.com/afw-org/afw)  
 **Branch context:** `mgg-develop` (beta readiness)  
-**Generated / refreshed:** 2026-08-14 (#106 wrap)  
+**Generated / refreshed:** 2026-08-14 (#125 wrap)  
 **Source:** live GitHub open issues (`gh issue list --state open`) + maintainer notes from recent `mgg-develop` work.
 
 This is a **working tracker**, not a substitute for issue bodies or PRs. “How it stands” mixes GitHub metadata with known landings on `mgg-develop`; re-verify before closing anything.
@@ -19,9 +19,9 @@ Assignees are from GitHub. Dual assignees mean both are listed, not necessarily 
 
 ## Summary counts
 
-- **Open issues:** 38
+- **Open issues:** 37
 - **Jeremy:** 27 issues (as assignee, including shared)
-- **Mike:** 11 issues (as assignee, including shared)
+- **Mike:** 10 issues (as assignee, including shared)
 - **—:** 5 issues (unassigned)
 
 ## All open issues
@@ -60,7 +60,6 @@ Assignees are from GitHub. Dual assignees mean both are listed, not necessarily 
 | [#102](https://github.com/afw-org/afw/issues/102) | Jeremy | Allow model "on" functions access to adapterTypeSpecific parameter | When implementing an "adapter" entirely using models and "on" functions/adaptive scripts, the "on" functions currentl… | Expose adapterTypeSpecific to model on* scripts. Open (docs label). | 2025-04-27 |
 | [#108](https://github.com/afw-org/afw/issues/108) | Jeremy | Support for callbacks in curl functions | Currently, the curl http functions read and write data completely in memory. This will be not be very resourceful whe… | curl adaptive functions: streaming callbacks. Open. | 2025-04-27 |
 | [#114](https://github.com/afw-org/afw/issues/114) | — | [Fiddle] Closing an inactive tab with unsaved changes targets the active tab instead | To reproduce: | Fiddle: close inactive unsaved tab closes active tab. Unassigned UI bug. | 2026-07-07 |
-| [#125](https://github.com/afw-org/afw/issues/125) | Mike | Review max vs maximum (and related) property naming for consistency | For consistency with almost all other Adaptive property names, maximumNumberOfParameters on AdaptiveFunction should p… | max vs maximum property naming consistency. Parked naming pass. | 2026-07-19 |
 | [#126](https://github.com/afw-org/afw/issues/126) | Mike | Review and harden journal support (meta) | Meta issue for journal work: review, harden, document, and track follow-ups. Use this as the single place to note jou… | Meta: journal support review/harden/docs. Tracker. | 2026-07-19 |
 | [#138](https://github.com/afw-org/afw/issues/138) | Mike, Jeremy | Meta issue: sideband meta on the wire ("_meta_"), object options, and rich type info for apps | Adaptive objects keep sideband meta (identity, paths, parents, view decorations, edit helpers, optional type-related … | Meta: _meta_ on wire, object options, rich type info. Design pad; dual-assignee. | 2026-08-01 |
 | [#157](https://github.com/afw-org/afw/issues/157) | — | afwdev advanced-test: hermetic afwfcgi scenario leaves | Add advanced tests to afwdev test: marker-file leaf directories (advanced-test.yaml / .json) that spawn the installed… | **Shipped as orchestrated tests** (PR **#167**): `orchestration.yaml`, hosts afwfcgi/local, `tests-extra/`, expect-stdout. Issue may stay open for residuals; schema in `src/afw/tests-extra/SCHEMA.md`. | 2026-08-08 |
@@ -104,6 +103,7 @@ Useful for “don’t restart this.” Includes process-close batch **2026-08-04
 | [#62](https://github.com/afw-org/afw/issues/62) | Adaptive Script language changes | **Closed 2026-08-13** — PR **#174** multi let/const, for init, assignment chain, running result, labels |
 | [#69](https://github.com/afw-org/afw/issues/69) | Implement data type 'json' and 'relaxed_json' | **Closed 2026-08-13** — types already on tree; PR **#175** tests + strict json rejects Infinity/NaN |
 | [#106](https://github.com/afw-org/afw/issues/106) | Resolve FIXME's in afw tests | **Closed 2026-08-14** — PR **#176**; leftovers #35/#2, produce-type, #57 |
+| [#125](https://github.com/afw-org/afw/issues/125) | Review max vs maximum property naming | **Closing 2026-08-14** — `maxNumberOfParameters`; `max…` for limit ids |
 | [#89](https://github.com/afw-org/afw/issues/89) | Passing a function as a parameter from an array seems to generate an error | **Closed 2026-08-07** — function from array as callback |
 | [#90](https://github.com/afw-org/afw/issues/90) | checkIndividualObjectReadAccess configuration parameter for adaptors | checkIndividualObjectReadAccess — closed earlier |
 | [#109](https://github.com/afw-org/afw/issues/109) | Improvements for creating adapters with adaptive scripts | Pure-script model adapters — closed earlier |
@@ -137,6 +137,7 @@ Useful for “don’t restart this.” Includes process-close batch **2026-08-04
 | [#62](https://github.com/afw-org/afw/issues/62) | Language index — PR [#174](https://github.com/afw-org/afw/pull/174) |
 | [#69](https://github.com/afw-org/afw/issues/69) | json / relaxed_json types — PR [#175](https://github.com/afw-org/afw/pull/175) |
 | [#106](https://github.com/afw-org/afw/issues/106) | test262 FIXME sweep / compiler literals — PR [#176](https://github.com/afw-org/afw/pull/176) |
+| [#125](https://github.com/afw-org/afw/issues/125) | max vs maximum property ids — this wrap |
 | [#127](https://github.com/afw-org/afw/issues/127) | Progressive retrieve write-then-release — **closed 2026-08-11** |
 | [#28](https://github.com/afw-org/afw/issues/28) | Compile-time type checking — PRs [#144](https://github.com/afw-org/afw/pull/144)/[#145](https://github.com/afw-org/afw/pull/145) core; wrap-up PR [#171](https://github.com/afw-org/afw/pull/171) (fence, FunctionSignature typeCheck, call-site formals, handbook Types). **Closed 2026-08-12** |
 

--- a/src/afw/doc/guide/developer/contributing.xml
+++ b/src/afw/doc/guide/developer/contributing.xml
@@ -22,7 +22,12 @@
         <list>
             <item>
                 Adaptive object property names should be lower camel case (i.e., first 
-                character lower case).
+                character lower case). For a limit or cap, use a 
+                <literal>max…</literal> id (for example 
+                <literal>maxNumberOfParameters</literal>, 
+                <literal>maxReadBytes</literal>, <literal>maxValue</literal>). 
+                Write “Maximum …” in briefs and labels, not in the property 
+                id.
             </item>
             <item>
                 The id of objects of type AdaptiveObjectType, AdaptivePropertyType, and 

--- a/src/afw/generate/objects/_AdaptiveObjectType_/_AdaptiveFunction_.json
+++ b/src/afw/generate/objects/_AdaptiveObjectType_/_AdaptiveFunction_.json
@@ -159,7 +159,7 @@
                 "valueAccessor": "value"
             }
         },
-        "maximumNumberOfParameters": {
+        "maxNumberOfParameters": {
             "allowQuery": true,
             "brief": "Maximum number of parameters",
             "dataType": "integer",

--- a/src/afw/generated/afw_const_objects.c
+++ b/src/afw/generated/afw_const_objects.c
@@ -49986,7 +49986,7 @@ static const afw_runtime_const_object_instance_t
 impl_479;
 
 /*
- * /afw/_AdaptiveObjectType_/_AdaptiveFunction_/propertyTypes/maximumNumberOfParameters/runtime
+ * /afw/_AdaptiveObjectType_/_AdaptiveFunction_/propertyTypes/maxNumberOfParameters/runtime
  */
 
 static const afw_runtime_property_t
@@ -50023,7 +50023,7 @@ impl_479_meta_object__value = {
 
 static const afw_utf8_t
 impl_479_meta_path =
-    AFW_UTF8_LITERAL("/afw/_AdaptiveObjectType_/_AdaptiveFunction_/propertyTypes/maximumNumberOfParameters/runtime");
+    AFW_UTF8_LITERAL("/afw/_AdaptiveObjectType_/_AdaptiveFunction_/propertyTypes/maxNumberOfParameters/runtime");
 
 static const afw_value_object_t
 impl_479__value;
@@ -50052,7 +50052,7 @@ impl_479__value = {
 };
 
 /*
- * /afw/_AdaptiveObjectType_/_AdaptiveFunction_/propertyTypes/maximumNumberOfParameters
+ * /afw/_AdaptiveObjectType_/_AdaptiveFunction_/propertyTypes/maxNumberOfParameters
  */
 
 static const afw_runtime_property_t
@@ -50137,7 +50137,7 @@ impl_478_meta_object__value = {
 
 static const afw_utf8_t
 impl_478_meta_path =
-    AFW_UTF8_LITERAL("/afw/_AdaptiveObjectType_/_AdaptiveFunction_/propertyTypes/maximumNumberOfParameters");
+    AFW_UTF8_LITERAL("/afw/_AdaptiveObjectType_/_AdaptiveFunction_/propertyTypes/maxNumberOfParameters");
 
 static const afw_value_object_t
 impl_478__value;
@@ -50151,7 +50151,7 @@ impl_478 = {
         {
             (const afw_object_t *)&impl_478_meta_object,
             (const afw_object_t *)&impl_450,
-            &afw_self_s_maximumNumberOfParameters,
+            &afw_self_s_maxNumberOfParameters,
             &afw_self_s__AdaptiveValueMeta_,
             &impl_478_meta_path
         }
@@ -52667,15 +52667,15 @@ impl_450_property_functionSignature = {
 };
 
 static const afw_value_object_t
-impl_450_property_value_maximumNumberOfParameters = {
+impl_450_property_value_maxNumberOfParameters = {
     {&afw_value_permanent_object_inf},
     (const afw_object_t *)&impl_478
 };
 
 static const afw_runtime_property_t
-impl_450_property_maximumNumberOfParameters = {
-    &afw_self_s_maximumNumberOfParameters,
-    &impl_450_property_value_maximumNumberOfParameters.pub
+impl_450_property_maxNumberOfParameters = {
+    &afw_self_s_maxNumberOfParameters,
+    &impl_450_property_value_maxNumberOfParameters.pub
 };
 
 static const afw_value_object_t
@@ -52850,7 +52850,7 @@ impl_450_properties[] = {
     &impl_450_property_functionLabel,
     &impl_450_property_functionResourceId,
     &impl_450_property_functionSignature,
-    &impl_450_property_maximumNumberOfParameters,
+    &impl_450_property_maxNumberOfParameters,
     &impl_450_property_numberOfRequiredParameters,
     &impl_450_property_op,
     &impl_450_property_parameters,

--- a/src/afw/generated/afw_runtime_object_maps.c
+++ b/src/afw/generated/afw_runtime_object_maps.c
@@ -1797,8 +1797,8 @@ impl_properties__AdaptiveFunction_[] = {
         afw_runtime_value_accessor_value
     },
     {
-        &afw_self_s_maximumNumberOfParameters,
-        offsetof(afw_value_function_definition_t, maximumNumberOfParameters),
+        &afw_self_s_maxNumberOfParameters,
+        offsetof(afw_value_function_definition_t, maxNumberOfParameters),
         -1,
         &afw_data_type_integer_direct,
         AFW_UTF8_LITERAL(""),

--- a/src/afw/generated/afw_strings.c
+++ b/src/afw/generated/afw_strings.c
@@ -16737,6 +16737,12 @@ afw_self_v_maxNormalLength = {
 };
 
 AFW_DEFINE_CONST_DATA(afw_value_string_t)
+afw_self_v_maxNumberOfParameters = {
+    {&afw_value_permanent_string_inf},
+    AFW_UTF8_LITERAL(AFW_Q_maxNumberOfParameters)
+};
+
+AFW_DEFINE_CONST_DATA(afw_value_string_t)
 afw_self_v_maxObjects = {
     {&afw_value_permanent_string_inf},
     AFW_UTF8_LITERAL(AFW_Q_maxObjects)
@@ -16800,12 +16806,6 @@ AFW_DEFINE_CONST_DATA(afw_value_string_t)
 afw_self_v_max_time = {
     {&afw_value_permanent_string_inf},
     AFW_UTF8_LITERAL(AFW_Q_max_time)
-};
-
-AFW_DEFINE_CONST_DATA(afw_value_string_t)
-afw_self_v_maximumNumberOfParameters = {
-    {&afw_value_permanent_string_inf},
-    AFW_UTF8_LITERAL(AFW_Q_maximumNumberOfParameters)
 };
 
 AFW_DEFINE_CONST_DATA(afw_value_string_t)

--- a/src/afw/generated/afw_strings.h
+++ b/src/afw/generated/afw_strings.h
@@ -72439,6 +72439,32 @@ afw_self_v_maxNormalLength;
 
 
 /** @brief #define for string in quotes */
+#define AFW_Q_maxNumberOfParameters \
+    "maxNumberOfParameters"
+
+/** @brief 'afw_utf8_t' for AFW_Q_maxNumberOfParameters */
+#define afw_s_maxNumberOfParameters \
+    (&afw_self_v_maxNumberOfParameters.internal)
+
+/** @brief 'afw_utf8_t' for AFW_Q_maxNumberOfParameters */
+#define afw_self_s_maxNumberOfParameters \
+    (afw_self_v_maxNumberOfParameters.internal)
+
+/** @brief 'afw_value_string_t' for AFW_Q_maxNumberOfParameters */
+AFW_DECLARE_CONST_DATA(afw_value_string_t)
+afw_self_v_maxNumberOfParameters;
+
+/** @brief 'afw_utf8_z_t *' for AFW_Q_maxNumberOfParameters */
+#define afw_z_maxNumberOfParameters \
+    (afw_self_v_maxNumberOfParameters.internal.s)
+
+/** @brief 'const afw_value_t *' for AFW_Q_maxNumberOfParameters */
+#define afw_v_maxNumberOfParameters \
+    (&afw_self_v_maxNumberOfParameters.pub)
+
+
+
+/** @brief #define for string in quotes */
 #define AFW_Q_maxObjects \
     "maxObjects"
 
@@ -72721,32 +72747,6 @@ afw_self_v_max_time;
 /** @brief 'const afw_value_t *' for AFW_Q_max_time */
 #define afw_v_max_time \
     (&afw_self_v_max_time.pub)
-
-
-
-/** @brief #define for string in quotes */
-#define AFW_Q_maximumNumberOfParameters \
-    "maximumNumberOfParameters"
-
-/** @brief 'afw_utf8_t' for AFW_Q_maximumNumberOfParameters */
-#define afw_s_maximumNumberOfParameters \
-    (&afw_self_v_maximumNumberOfParameters.internal)
-
-/** @brief 'afw_utf8_t' for AFW_Q_maximumNumberOfParameters */
-#define afw_self_s_maximumNumberOfParameters \
-    (afw_self_v_maximumNumberOfParameters.internal)
-
-/** @brief 'afw_value_string_t' for AFW_Q_maximumNumberOfParameters */
-AFW_DECLARE_CONST_DATA(afw_value_string_t)
-afw_self_v_maximumNumberOfParameters;
-
-/** @brief 'afw_utf8_z_t *' for AFW_Q_maximumNumberOfParameters */
-#define afw_z_maximumNumberOfParameters \
-    (afw_self_v_maximumNumberOfParameters.internal.s)
-
-/** @brief 'const afw_value_t *' for AFW_Q_maximumNumberOfParameters */
-#define afw_v_maximumNumberOfParameters \
-    (&afw_self_v_maximumNumberOfParameters.pub)
 
 
 

--- a/src/afw/generated/ebnf/syntax.ebnf
+++ b/src/afw/generated/ebnf/syntax.ebnf
@@ -189,7 +189,7 @@ CompilerInternalStatement ::=
     CompilerInternalBlock
 
 /* From afw_compile_parse_compiler_internal.c                                 */
-/* Value/expression-position compiler-internal #Name.                         */
+/* Value/expression-position #Name.                                           */
 /* Token is already pound_identifier.                                         */
 /* Compiler-internal forms match decompile #implementation_id.                */
 /* Compiler literals fold to permanent values (not call forms).               */

--- a/src/afw/generated/objects/_AdaptiveObjectType_/_AdaptiveFunction_.json
+++ b/src/afw/generated/objects/_AdaptiveObjectType_/_AdaptiveFunction_.json
@@ -159,7 +159,7 @@
                 "valueAccessor": "value"
             }
         },
-        "maximumNumberOfParameters": {
+        "maxNumberOfParameters": {
             "allowQuery": true,
             "brief": "Maximum number of parameters",
             "dataType": "integer",

--- a/src/afw/value/afw_value.h
+++ b/src/afw/value/afw_value.h
@@ -187,8 +187,8 @@ struct afw_value_function_definition_s {
     /** @brief The number of required parameters. */
     const afw_value_integer_t *numberOfRequiredParameters;
 
-    /** @brief The maximum number of required parameters or -1 is no max. */
-    const afw_value_integer_t *maximumNumberOfParameters;
+    /** @brief The maximum number of parameters or -1 if there is no max. */
+    const afw_value_integer_t *maxNumberOfParameters;
 
     /** @brief Function parameters. */
     const afw_value_function_parameter_t * const *parameters;

--- a/src/afw/value/afw_value_call_built_in_function.c
+++ b/src/afw/value/afw_value_call_built_in_function.c
@@ -182,14 +182,14 @@ impl_afw_value_optional_evaluate(
     }
 
     /* Make there are at least the required number of parameters. */
-    if (x.function->maximumNumberOfParameters->internal != -1 &&
-        x.argc > x.function->maximumNumberOfParameters->internal)
+    if (x.function->maxNumberOfParameters->internal != -1 &&
+        x.argc > x.function->maxNumberOfParameters->internal)
     {
         AFW_THROW_ERROR_FZ(argument_error, xctx,
             AFW_UTF8_FMT_Q
             " expects no more than " AFW_SIZE_T_FMT " parameters",
             AFW_UTF8_FMT_ARG(&x.function->functionId->internal),
-            x.function->maximumNumberOfParameters->internal);
+            x.function->maxNumberOfParameters->internal);
     }
 
     /*

--- a/src/afw/value/afw_value_type_check.c
+++ b/src/afw/value/afw_value_type_check.c
@@ -1699,10 +1699,10 @@ afw_value_type_check_adaptive_function_call(
     if (fn->numberOfRequiredParameters) {
         required = (afw_size_t)fn->numberOfRequiredParameters->internal;
     }
-    if (fn->maximumNumberOfParameters &&
-        fn->maximumNumberOfParameters->internal != -1)
+    if (fn->maxNumberOfParameters &&
+        fn->maxNumberOfParameters->internal != -1)
     {
-        maximum = (afw_size_t)fn->maximumNumberOfParameters->internal;
+        maximum = (afw_size_t)fn->maxNumberOfParameters->internal;
     }
     if (argc < required) {
         AFW_THROW_ERROR_FZ(syntax, xctx,

--- a/src/afw_dev/_afwdev/generate/function_bindings.py
+++ b/src/afw_dev/_afwdev/generate/function_bindings.py
@@ -956,7 +956,7 @@ def generate(generated_by, prefix, data_type_list, object_dir_path,
                 functionDeclaration += "<dataType>"
 
             numberOfRequiredParameters = 0
-            maximumNumberOfParameters = 0
+            maxNumberOfParameters = 0
             encounteredOptional = False
             encounteredMinArgs = False
             functionDeclaration += '(\n'
@@ -973,7 +973,7 @@ def generate(generated_by, prefix, data_type_list, object_dir_path,
                     if n > 1 and encounteredOptional:
                         msg.error_exit(obj.get('functionId') + ': minArgs > 1 is only allowed if there are no optional parameters')
                     numberOfRequiredParameters += n
-                    maximumNumberOfParameters = -1
+                    maxNumberOfParameters = -1
                     while i <= n:
                         functionDeclaration += (
                             '    ' + p.get('name') + '_' + str(i) + ': ' +
@@ -988,7 +988,7 @@ def generate(generated_by, prefix, data_type_list, object_dir_path,
                         functionDeclaration += p.get('name') + '_rest: ' + make_rest_Type(
                             p, note_style='none')
                 else:
-                    maximumNumberOfParameters += 1
+                    maxNumberOfParameters += 1
                     type_note = make_Type_note(p)
                     functionDeclaration += '    ' + p.get('name')
                     if p.get('optional', False):
@@ -1042,8 +1042,8 @@ def generate(generated_by, prefix, data_type_list, object_dir_path,
             # numberOfRequiredParameters
             fd.write('    &' + get_string_label(options, str(numberOfRequiredParameters), 'self_v', dataType='integer') + ',\n')
 
-            # maximumNumberOfParameters
-            fd.write('    &' + get_string_label(options, str(maximumNumberOfParameters), 'self_v', dataType='integer') + ',\n')
+            # maxNumberOfParameters
+            fd.write('    &' + get_string_label(options, str(maxNumberOfParameters), 'self_v', dataType='integer') + ',\n')
 
             # parameters
             fd.write('    &impl_' + label + '_parameters[0],\n')

--- a/whats-new.md
+++ b/whats-new.md
@@ -73,6 +73,7 @@ sections end with [↑ Highlights](#highlights) to return here.
 | [**Error codes**](#error-codes-trycatch-and-http-issue-33) ([#33](https://github.com/afw-org/afw/issues/33)) | Review of `e.id` / HTTP map; script `throw` … `id "not_found"` (and similar) sets the catch object and HTTP status |
 | [**Multi `let` / `const`**](#multi-let-and-const-issue-62) ([#62](https://github.com/afw-org/afw/issues/62)) | Several names on one `let` / `const`; C-style `for` init; `x = y = 1;` chain; script result is set by assignment, `return`, and a call that is not void; loop labels |
 | [**Compiler literals**](#compiler-literals-issue-106) ([#106](https://github.com/afw-org/afw/issues/106)) | `#doubleMax`, `#integerMax`, `#pi`, `#infinity`, and related `#` names fold to those values at compile |
+| [**`maxNumberOfParameters`**](#maxnumberofparameters-issue-125) ([#125](https://github.com/afw-org/afw/issues/125)) | Function metadata property renamed from `maximumNumberOfParameters` |
 
 ---
 
@@ -237,6 +238,18 @@ assert(#infinity === Infinity);
 Reserved words `Infinity`, `NaN`, and `INF` are unchanged. `#compile` is still a pragma. `#block` and similar names are still for decompile, not everyday script.
 
 Handbook: Language Reference **Language Features** (Compiler literals). Tests: `src/afw/tests/compiler/compiler_literals.as`.
+
+[↑ Highlights](#highlights)
+
+---
+
+## `maxNumberOfParameters` (issue [#125](https://github.com/afw-org/afw/issues/125))
+
+On `_AdaptiveFunction_` (and polymorphic functions that inherit it), the property id is now **`maxNumberOfParameters`**. It still means the largest number of parameters, or **-1** if there is no maximum.
+
+If a script or client read **`maximumNumberOfParameters`** from a function object on `adapterId=afw`, use the new name. Briefs and labels still say “Maximum …”.
+
+New limit/cap property ids should use a **`max…`** prefix (`maxReadBytes`, `maxValue`, `maxObjects`).
 
 [↑ Highlights](#highlights)
 


### PR DESCRIPTION
## Summary

Closes **#125**. Limit/cap Adaptive property ids use a **`max…`** prefix.

- Renamed `_AdaptiveFunction_` **`maximumNumberOfParameters`** → **`maxNumberOfParameters`** (OT, C member, generator, runtime maps, schemas).
- Audit: that was the only `maximum*` generate-object property id. `minArgs` and `numberOfRequiredParameters` left on purpose (different ideas; `minArgs` is the usual arity name).
- Documented in contributing: `max…` for ids; “Maximum …” in briefs/labels only.
- `whats-new.md`: breaking note for anyone reading function objects.

## Test plan

- [x] `./afwdev build --cdev`
- [x] `afwdev test -j` (3907 passed)
- [x] Live probe: `add.maxNumberOfParameters` is `-1`; old name gone