### PR TITLE
#181: evaluate call-site spreads and object rest keys once

### DIFF
--- a/src/afw/function/afw_function_compiler_internal.c
+++ b/src/afw/function/afw_function_compiler_internal.c
@@ -385,14 +385,34 @@ impl_object_destructure(
     const afw_iterator_old_t *iterator;
     const afw_utf8_t *property_name;
     const afw_utf8_t *bound_name;
+    const afw_utf8_t **resolved_names;
     const afw_value_t *v;
     const afw_value_t *name_v;
     const afw_object_t *rest;
+    afw_size_t nprops;
+    afw_size_t i;
 
     object = afw_value_as_object(value, xctx);
 
+    /*
+     * Remember each bound name (evaluate computed keys once). The rest
+     * walk must not re-evaluate property_name_expr.
+     */
+    resolved_names = NULL;
+    if (od->rest) {
+        nprops = 0;
+        for (ap = od->assignment_property; ap; ap = ap->next) {
+            nprops++;
+        }
+        if (nprops > 0) {
+            resolved_names = afw_pool_calloc(p,
+                sizeof(afw_utf8_t *) * nprops, xctx);
+        }
+    }
+
     /* Process assignment properties. */
-    for (ap = od->assignment_property; ap; ap = ap->next)
+    i = 0;
+    for (ap = od->assignment_property; ap; ap = ap->next, i++)
     {
         if (ap->is_rename) {
             if (ap->property_name_expr) {
@@ -401,6 +421,9 @@ impl_object_destructure(
             }
             else {
                 bound_name = ap->property_name;
+            }
+            if (resolved_names) {
+                resolved_names[i] = bound_name;
             }
             v = bound_name
                 ? afw_object_get_property(object, bound_name, xctx)
@@ -422,6 +445,10 @@ impl_object_destructure(
                 assignment_type, p, xctx);
         }
         else {
+            if (resolved_names) {
+                resolved_names[i] =
+                    ap->symbol_reference->symbol->name;
+            }
             v = afw_object_get_property(object,
                 ap->symbol_reference->symbol->name, xctx);
             if (!v) {
@@ -445,25 +472,14 @@ impl_object_destructure(
                 break;
             }
 
-            for (ap = od->assignment_property; ap; ap = ap->next)
+            for (i = 0, ap = od->assignment_property;
+                ap;
+                ap = ap->next, i++)
             {
-                if (ap->is_rename) {
-                    if (ap->property_name_expr) {
-                        name_v = afw_value_evaluate(
-                            ap->property_name_expr, p, xctx);
-                        bound_name = afw_value_as_utf8(name_v, p, xctx);
-                    }
-                    else {
-                        bound_name = ap->property_name;
-                    }
-                    if (bound_name &&
-                        afw_utf8_equal(bound_name, property_name))
-                    {
-                        break;
-                    }
-                }
-                else if (afw_utf8_equal(
-                    ap->symbol_reference->symbol->name, property_name))
+                bound_name = resolved_names
+                    ? resolved_names[i] : NULL;
+                if (bound_name &&
+                    afw_utf8_equal(bound_name, property_name))
                 {
                     break;
                 }

--- a/src/afw/tests/language/script/param_destructure.as
+++ b/src/afw/tests/language/script/param_destructure.as
@@ -318,6 +318,60 @@ assert(join(...["a", "b"], "c") === '["a","b","c"]');
 
 return 0;
 //?
+//? test: call-site-spread-evaluates-once
+//? description: Call-site ...expr evaluates the spread expression once (not once to size argv and again to fill)
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+let n = 0;
+function make() {
+    n = n + 1;
+    return [n];
+}
+function take(x) {
+    return x;
+}
+
+assert(take(...make()) === 1);
+assert(n === 1);
+
+n = 0;
+assert(add(...make(), 10) === 11);
+assert(n === 1);
+
+return 0;
+//?
+//? test: call-site-spread-growing-second-eval
+//? description: Spread expression that would be longer on a second eval must not overflow argv
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+let n = 0;
+function growing() {
+    n = n + 1;
+    if (n === 1) {
+        return [10];
+    }
+    return [10, 20, 30, 40, 50];
+}
+function take(x) {
+    return x;
+}
+
+assert(take(...growing()) === 10);
+assert(n === 1);
+
+n = 0;
+function join(...parts) {
+    return length(parts);
+}
+assert(join(1, ...growing(), 2) === 3);
+assert(n === 1);
+
+return 0;
+//?
 //? test: ts-computed-key-destructure
 //? description: Computed and string keys in object Patterns
 //? expect: 0
@@ -334,6 +388,26 @@ assert(take({ inner: 11, other: 22 }) === 33);
 
 const { [key]: x } = { inner: 5 };
 assert(x === 5);
+
+return 0;
+//?
+//? test: object-rest-computed-key-evaluates-once
+//? description: Object Pattern rest must not re-evaluate computed key expressions
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+let n = 0;
+function key() {
+    n = n + 1;
+    return "a";
+}
+
+const { [key()]: v, ...r } = { a: 1, b: 2 };
+assert(v === 1);
+assert(r.b === 2);
+assert(length(keys(r)) === 1);
+assert(n === 1);
 
 return 0;
 //?

--- a/src/afw/value/afw_value.h
+++ b/src/afw/value/afw_value.h
@@ -2022,8 +2022,8 @@ afw_value_decompile_call_args(
  * @param p Pool for expanded argv when needed.
  * @param xctx of caller.
  *
- * list_expression entries evaluate to an array and are spliced as separate
- * arguments (issue #140). Non-spread args are left unevaluated.
+ * list_expression entries evaluate to an array once and are spliced as
+ * separate arguments (issue #140). Non-spread args are left unevaluated.
  */
 AFW_DEFINE(void)
 afw_value_call_args_expand_spreads(

--- a/src/afw/value/afw_value_call.c
+++ b/src/afw/value/afw_value_call.c
@@ -358,11 +358,11 @@ afw_value_call_args_expand_spreads(
     afw_size_t i;
     afw_size_t j;
     afw_size_t total;
-    afw_size_t n;
     afw_boolean_t any_spread;
     const afw_value_t *arg;
     const afw_value_t *evaled;
     const afw_value_t **new_argv;
+    const afw_value_t **evaled_argv;
     const afw_array_t *arr;
     const afw_iterator_old_t *it;
     const afw_value_t *elem;
@@ -384,7 +384,13 @@ afw_value_call_args_expand_spreads(
         return;
     }
 
-    /* Count expanded size. */
+    /*
+     * Evaluate each spread once, remember the arrays, then allocate and
+     * splice. Re-evaluating to fill would run side effects twice and can
+     * write past new_argv if the second result is longer.
+     */
+    evaled_argv = afw_pool_calloc(p,
+        sizeof(afw_value_t *) * (argc_in + 1), xctx);
     total = 0;
     for (i = 1; i <= argc_in; i++) {
         arg = argv_in[i];
@@ -394,17 +400,9 @@ afw_value_call_args_expand_spreads(
                 AFW_THROW_ERROR_Z(general,
                     "Call-site spread (...) requires an array", xctx);
             }
+            evaled_argv[i] = evaled;
             arr = ((const afw_value_array_t *)evaled)->internal;
-            n = 0;
-            it = NULL;
-            for (;;) {
-                elem = afw_array_get_next_value(arr, &it, p, xctx);
-                if (!elem) {
-                    break;
-                }
-                n++;
-            }
-            total += n;
+            total += afw_array_get_count(arr, xctx);
         }
         else {
             total++;
@@ -418,13 +416,18 @@ afw_value_call_args_expand_spreads(
     for (i = 1; i <= argc_in; i++) {
         arg = argv_in[i];
         if (arg && afw_value_is_array_expression(arg)) {
-            evaled = afw_value_evaluate(arg, p, xctx);
+            evaled = evaled_argv[i];
             arr = ((const afw_value_array_t *)evaled)->internal;
             it = NULL;
             for (;;) {
                 elem = afw_array_get_next_value(arr, &it, p, xctx);
                 if (!elem) {
                     break;
+                }
+                if (j > total) {
+                    AFW_THROW_ERROR_Z(general,
+                        "Call-site spread array grew during expand",
+                        xctx);
                 }
                 new_argv[j++] = elem;
             }
@@ -434,7 +437,7 @@ afw_value_call_args_expand_spreads(
         }
     }
 
-    *argc_out = total;
+    *argc_out = j - 1;
     *argv_out = new_argv;
 }
 

--- a/whats-new.md
+++ b/whats-new.md
@@ -485,7 +485,7 @@ Adaptive Script already allowed list/object **Patterns** on `let` / `const`, ass
 
 - In **function and lambda parameter lists** (nested rename, holes, rest, property defaults, **computed/string keys**).
 - In **`catch (…)`** bindings (e.g. `catch ({ message, data })`).
-- **Call-site spread:** `f(...arr)` / `f(a, ...rest, b)` expands an array into separate arguments.
+- **Call-site spread:** `f(...arr)` / `f(a, ...rest, b)` expands an array into separate arguments. The spread expression is evaluated **once** (not once to size `argv` and again to fill). Object Pattern rest (`{ [key()]: v, ...r }`) does not re-evaluate computed keys. [#181](https://github.com/afw-org/afw/issues/181)
 
 Parameter **defaults are Expressions**. Pattern leaves and whole formals may carry **type annotations** (syntax for upcoming compile-time checking; not enforced yet). Options-style example:
 


### PR DESCRIPTION
## Summary

Closes **#181**. Call-site `f(...expr)` and object Pattern rest evaluate each user expression **once**.

Jeremy relayed a Claude concern about `afw_value_call_args_expand_spreads()`: it evaluated each spread to size `argv`, then evaluated again to fill. Adaptive Script is not pure, so a longer second result can write past the allocation.

- **`afw_value_call_args_expand_spreads()`** — evaluate each spread once, remember the arrays, allocate, splice. `argc_out` is what was actually written.
- **Object Pattern rest** — `const { [key()]: v, ...r } = obj` no longer re-evaluates computed keys while building `...rest`.
- Same-class scan of hand C (same user expression twice, especially when the first result sizes a C buffer) did not turn up another sibling. `{ ...obj }`, `array(...)`, and object construct computed names already evaluate once.
- `whats-new.md`: one sentence on the existing #140 call-site spread bullet.

@JeremyGrieshop — this is the Claude `expand_spreads` concern.

## Test plan

- [x] Incremental cmake rebuild + install of `libafw`
- [x] `afwdev test --srcdir-pattern afw --test-pattern 'language/script|list/spread|decompile_accept/emit_and_roundtrip'` (352 passed, 11 skipped)