### PR TITLE
Call a built-in through a variable

### DIFF
--- a/.cursor/rules/afw-script-eval.mdc
+++ b/.cursor/rules/afw-script-eval.mdc
@@ -33,6 +33,15 @@ afw_compile_to_value*
 - Calls: `afw_value_call_create` specializes built-in vs script vs closure (`value/afw_value_call.c`).
 - Closures: `closure_binding` holds definition + scope ref (`get_reference` / release).
 
+### Call create vs evaluate (do not mix)
+
+- **Create** (compile): parser sees `(` after an evaluation and builds a call node. `argv[0]` is the **callee expression** (built-in name, variable, `(expr)`, property). `argv` is not rewritten later. `call_built_in_function_create` is only the specialize fork when `argv[0]` is already a function definition (`add(2,3)`).
+- **Evaluate** (runtime): generic `call` evaluates `argv[0]`, then harvests into **`x->function`**. Do not re-enter `create` for that harvest. Script functions already did; built-ins through a variable must use the one-shot `afw_value_call_built_in_function` (harvested definition, original `argv`).
+- **`compile()` / `unevaluated`:** assigning that to a variable stores the graph; it does **not** run. `evaluate(variable)` (or a built-in formal that is not typed `unevaluated`) runs it. Do not evaluate on every symbol bind.
+- **Ordinary defaults** (`[a = make()]`) are not `compile()` results — evaluate once at bind, then store. Pattern leaves go through bare `symbol_reference` (store as-is), so the default must be evaluated first.
+- **Spread `#181`:** `expand_spreads` (internal) copies `argv` **only** when there is a `...`. Evaluate each spread once, stash arrays, then size/fill. Not a copy on every call. Not `x->function`.
+- **`afw_stack`:** general grow-then-`copy_and_release`. `afw_compile_args_*` is parser sugar over that (`parser->p` / `xctx`).
+
 ## Key hand files
 
 | Area | Files |

--- a/src/afw/tests/language/script/call_builtin_value.as
+++ b/src/afw/tests/language/script/call_builtin_value.as
@@ -1,0 +1,113 @@
+#!/usr/bin/env -S afw --syntax test_script
+//? testScript: call_builtin_value.as
+//? customPurpose: Part of language/script tests
+//? description: Built-in assigned to a variable (or other callee) is callable
+//? sourceType: script
+//?
+//? test: let-builtin-call
+//? description: let add1 = add; add1(2, 3)
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+let add1 = add;
+assert(add1(2, 3) === 5);
+return 0;
+//?
+//? test: const-builtin-call
+//? description: const add1 = add; add1(2, 3)
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+const add1 = add;
+assert(add1(2, 3) === 5);
+return 0;
+//?
+//? test: assign-builtin-call
+//? description: Later assign of a built-in, then call
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+let add1;
+add1 = add;
+assert(add1(2, 3) === 5);
+return 0;
+//?
+//? test: object-property-builtin-call
+//? description: o.fn(2, 3) when fn is a built-in
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+const o = { fn: add };
+assert(o.fn(2, 3) === 5);
+return 0;
+//?
+//? test: array-slot-builtin-call
+//? description: a[0](2, 3) when the slot is a built-in
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+const a = [add];
+assert(a[0](2, 3) === 5);
+return 0;
+//?
+//? test: apply-builtin
+//? description: Pass a built-in into a script function and call it
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+function apply(fn, x, y) {
+    return fn(x, y);
+}
+
+assert(apply(add, 2, 3) === 5);
+return 0;
+//?
+//? test: getter-returns-builtin
+//? description: get()(2, 3) when get returns a built-in
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+function get() {
+    return add;
+}
+
+assert(get()(2, 3) === 5);
+return 0;
+//?
+//? test: paren-builtin-name
+//? description: (add)(2, 3) — compile may already specialize
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+assert((add)(2, 3) === 5);
+return 0;
+//?
+//? test: polymorphic-eq-via-variable
+//? description: let eq1 = eq; eq1(1, 1) resolves the data-type method
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+let eq1 = eq;
+assert(eq1(1, 1) === true);
+assert(eq1("a", "a") === true);
+return 0;
+//?
+//? test: print-via-variable
+//? description: Non-polymorphic built-in called through a variable
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+let p = print;
+p("ok");
+return 0;
+//?

--- a/src/afw/value/afw_value_call_built_in_function.c
+++ b/src/afw/value/afw_value_call_built_in_function.c
@@ -132,12 +132,32 @@ afw_value_call_built_in_function(
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    const afw_value_t *value;
+    afw_value_call_built_in_function_t *self;
 
-    /* Optimize is set to false since this is one time call. */
-    value = afw_value_call_built_in_function_create(
-        contextual, argc, argv, false, p, xctx);
-    return impl_afw_value_optional_evaluate((AFW_VALUE_SELF_T *)value, p, xctx);
+    /*
+     * Runtime harvest: argv is the immutable call layout (argv[0] may be a
+     * variable, property, or other callee). Do not go through create(),
+     * which is the compile-time specialize path and requires argv[0] to
+     * already be the definition.
+     */
+    if (!function) {
+        AFW_THROW_ERROR_Z(general,
+            "afw_value_call_built_in_function() function is required",
+            xctx);
+    }
+
+    self = afw_pool_calloc_type(p, afw_value_call_built_in_function_t, xctx);
+    self->inf = &afw_value_call_built_in_function_inf;
+    self->function = function;
+    self->args.contextual = contextual;
+    self->args.argc = argc;
+    self->args.argv = argv;
+    self->optimized_value = (const afw_value_t *)self;
+    if (function->returns && function->returns->data_type) {
+        self->evaluated_data_type = function->returns->data_type;
+    }
+
+    return impl_afw_value_optional_evaluate(self, p, xctx);
 }
 
 

--- a/whats-new.md
+++ b/whats-new.md
@@ -486,6 +486,7 @@ Adaptive Script already allowed list/object **Patterns** on `let` / `const`, ass
 - In **function and lambda parameter lists** (nested rename, holes, rest, property defaults, **computed/string keys**).
 - In **`catch (…)`** bindings (e.g. `catch ({ message, data })`).
 - **Call-site spread:** `f(...arr)` / `f(a, ...rest, b)` expands an array into separate arguments. The spread expression is evaluated **once** (not once to size `argv` and again to fill). Object Pattern rest (`{ [key()]: v, ...r }`) does not re-evaluate computed keys. [#181](https://github.com/afw-org/afw/issues/181)
+- **Built-in as a value:** `let add1 = add; add1(2, 3)` (also a property, array slot, or argument) calls that built-in. Previously only a compile-time name like `add(2, 3)` worked.
 
 Parameter **defaults are Expressions**. Pattern leaves and whole formals may carry **type annotations** (syntax for upcoming compile-time checking; not enforced yet). Options-style example:
 


### PR DESCRIPTION
## Summary

`let add1 = add; add1(2, 3)` (also a property, array slot, or argument) should call that built-in. A script function in a variable already worked.

The compiler puts the callee **expression** in `argv[0]` and does not rewrite `argv`. Generic `call` evaluate already harvested the definition. It then went through `call_built_in_function_create`, which is the compile-time specialize path and requires `argv[0]` to already be that definition. Harvest into `x->function` / the call node instead; leave `argv` as written.

`create` is unchanged. Same path covers `o.fn()`, `a[0]()`, `apply(add, …)`, `get()()`, `eq1(1, 1)`. `(add)(2, 3)` already specialized at compile.

@JeremyGrieshop — function-as-a-value for built-ins.

## Test plan

- [x] Incremental libafw rebuild + install
- [x] `afwdev test --srcdir-pattern afw --test-pattern 'language/script'` (349 passed, 11 skipped)
- [x] New `language/script/call_builtin_value.as`