### PR TITLE
Evaluate Pattern defaults once at bind

### DIFF
--- a/src/afw/function/afw_function_compiler_internal.c
+++ b/src/afw/function/afw_function_compiler_internal.c
@@ -285,6 +285,26 @@ impl_create_closure_if_needed(
 
 
 
+/*
+ * Pattern leaves bind through a bare symbol_reference, which stores the
+ * value as-is. Parameter defaults already evaluate before bind; Pattern
+ * element/property defaults must too, or `const [a = make()] = []` stores
+ * the call node and make() runs on every use.
+ */
+static const afw_value_t *
+impl_evaluate_pattern_default(
+    const afw_value_t *default_value,
+    const afw_pool_t *p,
+    afw_xctx_t *xctx)
+{
+    if (!default_value) {
+        return afw_value_undefined;
+    }
+    return afw_value_evaluate(default_value, p, xctx);
+}
+
+
+
 static void
 impl_list_destructure(
     const afw_compile_assignment_target_t *at,
@@ -325,7 +345,7 @@ impl_list_destructure(
             continue; /* hole */
         }
         if (eol) {
-            v = ae->default_value;
+            v = impl_evaluate_pattern_default(ae->default_value, p, xctx);
         }
         /* Missing element and no default → undefined (TS/ES-like). */
         if (!v) {
@@ -429,10 +449,8 @@ impl_object_destructure(
                 ? afw_object_get_property(object, bound_name, xctx)
                 : NULL;
             if (!v) {
-                v = ap->assignment_element->default_value;
-            }
-            if (!v) {
-                v = afw_value_undefined;
+                v = impl_evaluate_pattern_default(
+                    ap->assignment_element->default_value, p, xctx);
             }
             if (ap->assignment_element->type && v &&
                 !afw_value_is_undefined(v))
@@ -452,10 +470,8 @@ impl_object_destructure(
             v = afw_object_get_property(object,
                 ap->symbol_reference->symbol->name, xctx);
             if (!v) {
-                v = ap->default_value;
-            }
-            if (!v) {
-                v = afw_value_undefined;
+                v = impl_evaluate_pattern_default(
+                    ap->default_value, p, xctx);
             }
             impl_assign_value(&ap->symbol_reference->pub,
                 v, assignment_type, p, xctx);

--- a/src/afw/tests/language/script/evaluate_once.as
+++ b/src/afw/tests/language/script/evaluate_once.as
@@ -1,0 +1,278 @@
+#!/usr/bin/env -S afw --syntax test_script
+//? testScript: evaluate_once.as
+//? customPurpose: Part of language/script tests
+//? description: User expressions in recent compiler syntax evaluate once (same class as #181)
+//? sourceType: script
+//?
+//? test: object-construct-computed-name-once
+//? description: Object value [expr] name is evaluated once
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+let n = 0;
+function key() {
+    n = n + 1;
+    return "a";
+}
+
+const o = { [key()]: 1 };
+assert(o.a === 1);
+assert(n === 1);
+
+return 0;
+//?
+//? test: object-construct-spread-once
+//? description: Object value ...expr is evaluated once
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+let n = 0;
+function make() {
+    n = n + 1;
+    return { a: n };
+}
+
+const o = { ...make(), b: 2 };
+assert(o.a === 1);
+assert(o.b === 2);
+assert(n === 1);
+
+return 0;
+//?
+//? test: array-constructor-spread-once
+//? description: array(...expr) evaluates the spread expression once
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+let n = 0;
+function make() {
+    n = n + 1;
+    return [n];
+}
+
+const a = array(...make());
+assert(length(a) === 1);
+assert(a[0] === 1);
+assert(n === 1);
+
+return 0;
+//?
+//? test: array-literal-spread-once
+//? description: [...expr] compiles to array() and evaluates expr once
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+let n = 0;
+function make() {
+    n = n + 1;
+    return [n, n + 10];
+}
+
+const a = [...make(), 99];
+assert(length(a) === 3);
+assert(a[0] === 1);
+assert(a[1] === 11);
+assert(a[2] === 99);
+assert(n === 1);
+
+return 0;
+//?
+//? test: parameter-default-once
+//? description: Parameter default Expression evaluates once when used
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+let n = 0;
+function make() {
+    n = n + 1;
+    return n;
+}
+
+function f(x = make()) {
+    return x;
+}
+
+assert(f() === 1);
+assert(n === 1);
+assert(f(9) === 9);
+assert(n === 1);
+
+return 0;
+//?
+//? test: list-pattern-default-once
+//? description: List Pattern element default evaluates once at bind (not on each use)
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+let n = 0;
+function make() {
+    n = n + 1;
+    return n;
+}
+
+const [a = make()] = [];
+assert(n === 1);
+assert(a === 1);
+assert(a === 1);
+assert(n === 1);
+
+const [b = make()] = [7];
+assert(b === 7);
+assert(n === 1);
+
+return 0;
+//?
+//? test: object-pattern-default-once
+//? description: Object Pattern property default evaluates once at bind (not on each use)
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+let n = 0;
+function make() {
+    n = n + 1;
+    return n;
+}
+
+const { a = make() } = {};
+assert(n === 1);
+assert(a === 1);
+assert(a === 1);
+assert(n === 1);
+
+const { b = make() } = { b: 7 };
+assert(b === 7);
+assert(n === 1);
+
+return 0;
+//?
+//? test: param-pattern-default-once
+//? description: Pattern formal default evaluates once at bind (same path as let/const)
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+let n = 0;
+function make() {
+    n = n + 1;
+    return n;
+}
+
+function f({ x = make() }) {
+    return x;
+}
+
+assert(f({}) === 1);
+assert(n === 1);
+assert(f({ x: 9 }) === 9);
+assert(n === 1);
+
+return 0;
+//?
+//? test: reference-by-key-get-once
+//? description: obj[expr] evaluates the key expression once
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+let n = 0;
+function key() {
+    n = n + 1;
+    return "a";
+}
+
+const o = { a: 42 };
+assert(o[key()] === 42);
+assert(n === 1);
+
+return 0;
+//?
+//? test: reference-by-key-assign-once
+//? description: obj[expr] = value evaluates the key expression once
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+let n = 0;
+function key() {
+    n = n + 1;
+    return "a";
+}
+
+const o = {};
+o[key()] = 42;
+assert(o.a === 42);
+assert(n === 1);
+
+return 0;
+//?
+//? test: chained-assignment-rhs-once
+//? description: x = y = expr evaluates the right-hand Expression once (#62)
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+let n = 0;
+function make() {
+    n = n + 1;
+    return n;
+}
+
+let x;
+let y;
+x = y = make();
+assert(x === 1);
+assert(y === 1);
+assert(n === 1);
+
+return 0;
+//?
+//? test: for-of-source-once
+//? description: for (x of expr) evaluates the source expression once
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+let n = 0;
+function make() {
+    n = n + 1;
+    return [10, 20];
+}
+
+let sum = 0;
+for (const x of make()) {
+    sum = sum + x;
+}
+assert(sum === 30);
+assert(n === 1);
+
+return 0;
+//?
+//? test: throw-data-computed-name-once
+//? description: throw data { [expr]: … } evaluates the name expression once (#33)
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+let n = 0;
+function key() {
+    n = n + 1;
+    return "k";
+}
+
+try {
+    throw "boom" data { [key()]: 1 };
+}
+catch (e) {
+    assert(e.data.k === 1);
+    assert(n === 1);
+}
+
+return 0;
+//?

--- a/src/afw/value/afw_value.h
+++ b/src/afw/value/afw_value.h
@@ -2012,30 +2012,6 @@ afw_value_decompile_call_args(
 
 
 /**
- * @brief Expand call-site spreads (...arr) into a flat argv.
- * @param argc_in User parameter count (not including argv[0]).
- * @param argv_in argv[0]=function, argv[1..argc_in]=args; may contain
- *        list_expression values marking spreads.
- * @param argc_out Expanded user parameter count.
- * @param argv_out Expanded argv (argv[0] same as argv_in[0]); may equal
- *        argv_in when there is no spread.
- * @param p Pool for expanded argv when needed.
- * @param xctx of caller.
- *
- * list_expression entries evaluate to an array once and are spliced as
- * separate arguments (issue #140). Non-spread args are left unevaluated.
- */
-AFW_DEFINE(void)
-afw_value_call_args_expand_spreads(
-    afw_size_t argc_in,
-    const afw_value_t * const *argv_in,
-    afw_size_t *argc_out,
-    const afw_value_t * const **argv_out,
-    const afw_pool_t *p,
-    afw_xctx_t *xctx);
-
-
-/**
  * @brief Write synthetic decompile name `#` + implementation_id.
  * @param instance value whose inf id is used.
  * @param writer

--- a/src/afw/value/afw_value_call.c
+++ b/src/afw/value/afw_value_call.c
@@ -346,7 +346,7 @@ impl_afw_value_decompile(
 /*
  * Expand call-site ...spreads (list_expression markers) into flat argv.
  */
-AFW_DEFINE(void)
+void
 afw_value_call_args_expand_spreads(
     afw_size_t argc_in,
     const afw_value_t * const *argv_in,

--- a/src/afw/value/afw_value_internal.h
+++ b/src/afw/value/afw_value_internal.h
@@ -866,6 +866,19 @@ typedef struct {
     afw_value_meta_special_set_t set;
 } afw_value_meta_name_handler_t;
 
+/*
+ * Runtime helper for the three call evaluate paths. Not public: only
+ * generic call, built-in, and script-function evaluate expand spreads.
+ */
+extern void
+afw_value_call_args_expand_spreads(
+    afw_size_t argc_in,
+    const afw_value_t * const *argv_in,
+    afw_size_t *argc_out,
+    const afw_value_t * const **argv_out,
+    const afw_pool_t *p,
+    afw_xctx_t *xctx);
+
 extern const afw_value_t *
 afw_value_call_built_in_function(
     const afw_compile_value_contextual_t *contextual,


### PR DESCRIPTION
## Summary

`const [a = make()] = []` stored the **call node**, not the result. `make()` did not run at bind; every later use of `a` ran it again. Parameter defaults (`f(x = make())`) already evaluate before bind. Pattern leaves go through a bare `symbol_reference` (store as-is), so the default must be evaluated first.

Also moves `afw_value_call_args_expand_spreads` off the public `afw_value.h` surface (only the three call evaluate paths use it).

`evaluate_once.as` locks Pattern defaults and the other recent compiler paths that already evaluate once (`{ [key()]: … }`, `[...make()]`, `obj[key()]`, chained assign, `throw` data, …).

@JeremyGrieshop — same once-eval class as #181, different bind path.

## Test plan

- [x] Incremental libafw rebuild + install
- [x] `afwdev test --srcdir-pattern afw --test-pattern 'language/script|list/spread'` (358 passed, 11 skipped when this landed)