### PR TITLE
Release the type-error writer after copying type text

### DIFF
--- a/src/afw/tests/compiler/type_check.as
+++ b/src/afw/tests/compiler/type_check.as
@@ -469,6 +469,25 @@ try {
 return 0;
 
 //?
+//? test: check-error-mentions-decompiled-type
+//? description: type error text includes decompiled expected type
+//? expect: 0
+//? source: ...
+
+try {
+    compile<script>(script(
+        "#compile typeCheck;\n" +
+        "const u: integer|string = true;\n" +
+        "return 0;"
+    ));
+    assert(false);
+} catch (e) {
+    const msg = string(e);
+    assert(includes(msg, "integer|string"));
+}
+return 0;
+
+//?
 //? test: check-excess-property-object-literal
 //? description: compile rejects excess key on object literal
 //? expect: error

--- a/src/afw/value/afw_value_type_check.c
+++ b/src/afw/value/afw_value_type_check.c
@@ -85,20 +85,27 @@ impl_type_to_z(
 {
     const afw_writer_t *writer;
     afw_utf8_t current;
+    const afw_utf8_z_t *result;
 
     if (afw_value_type_is_any(type)) {
         return "any";
     }
 
+    /*
+     * Writer has its own sub-pool. Copy the text onto p, then release —
+     * same as afw_value_decompile_to_string. The current string is a
+     * view into the writer pool.
+     */
     writer = afw_utf8_writer_create(NULL, p, xctx);
-    if (!afw_value_decompile_type(type, writer, xctx)) {
-        return "any";
+    result = "any";
+    if (afw_value_decompile_type(type, writer, xctx)) {
+        afw_utf8_writer_current_string(writer, &current, xctx);
+        if (current.len != 0) {
+            result = afw_utf8_to_utf8_z(&current, p, xctx);
+        }
     }
-    afw_utf8_writer_current_string(writer, &current, xctx);
-    if (current.len == 0) {
-        return "any";
-    }
-    return afw_utf8_to_utf8_z(&current, p, xctx);
+    afw_writer_release(writer, xctx);
+    return result;
 }
 
 


### PR DESCRIPTION
## Summary

Type-error messages format the expected type with a utf8 writer. That writer has its own sub-pool. `impl_type_to_z` copied the text (or returned early) and never released the writer. Decompile already does copy-then-release (`afw_value_decompile_to_string`); this matches that.

The current-string pointer is a view into the writer pool, so the copy onto the caller pool has to happen *before* `afw_writer_release`.

No user-visible type-check change. No separate issue: one function, expected result already written, PR is enough.

## Test plan

- [x] `./afwdev build --cdev`
- [x] `afwdev test --srcdir-pattern afw --test-pattern 'compiler/type_check'` (98 passed)
- [x] `afwdev test --srcdir-pattern afw --test-pattern 'compiler/type_check.as' --env-mode valgrind` (68 passed)
- [x] New case `check-error-mentions-decompiled-type` (union mismatch still prints `integer|string`)