### PR TITLE
Honor remaining space when reading a request body

### DIFF
--- a/src/afw/request/afw_request.c
+++ b/src/afw/request/afw_request.c
@@ -128,22 +128,45 @@ afw_request_body_to_utf8(
     afw_utf8_z_t *cursor_z;
     afw_boolean_t more;
     afw_size_t read;
-    
+    afw_size_t remaining;
+    afw_size_t total;
 
     /** @fixme Put in support of chunked encoding. */
-    if (instance->content_length <= 0) return NULL;
+    /* Content-Length is unsigned; 0 means no body. */
+    if (instance->content_length == 0) {
+        return NULL;
+    }
 
-    /* Read request body into string and return. */
-    buffer_z = afw_pool_calloc(p, instance->content_length, xctx);
+    remaining = instance->content_length;
+    buffer_z = afw_pool_calloc(p, remaining, xctx);
     cursor_z = buffer_z;
-    read = 0;
+    total = 0;
     do {
-        cursor_z += read;
         afw_request_read_raw_request_body(instance,
-            instance->content_length, cursor_z,
-            &read, &more, xctx);
-    } while (more);
-    return afw_utf8_create(buffer_z, instance->content_length, p, xctx);
+            remaining, cursor_z, &read, &more, xctx);
+        if (read == 0) {
+            if (more) {
+                AFW_THROW_ERROR_Z(request_syntax,
+                    "Request body read made no progress.",
+                    xctx);
+            }
+            break;
+        }
+        if (read > remaining) {
+            AFW_THROW_ERROR_Z(coding_error,
+                "Request body read exceeded buffer.",
+                xctx);
+        }
+        cursor_z += read;
+        remaining -= read;
+        total += read;
+        if (more && remaining == 0) {
+            AFW_THROW_ERROR_Z(request_syntax,
+                "Request body is larger than Content-Length.",
+                xctx);
+        }
+    } while (more && remaining > 0);
+    return afw_utf8_create(buffer_z, total, p, xctx);
 }
 
 /* Read a request body to value a specifed pool. */

--- a/src/afw/tests/advanced/request_body_remaining/request_body_remaining.py
+++ b/src/afw/tests/advanced/request_body_remaining/request_body_remaining.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Declared Content-Length bounds how much of the request body is read.
+
+Uses hermetic afwfcgi and the FastCGI client so CONTENT_LENGTH can
+differ from the stdin bytes. A matching-length POST must still work;
+extra stdin after the declared length is an error; the worker stays up.
+"""
+
+from __future__ import print_function
+
+import json
+import os
+import tempfile
+
+from _afwdev.test.orchestrated.fcgi_client import fcgi_request
+from _afwdev.test.orchestrated.hosts.afwfcgi import start_afwfcgi, stop_afwfcgi
+
+
+MINIMAL_CONF = """\
+[
+  {
+    type: "requestHandler",
+    uriPrefix: "/",
+    requestHandlerType: "adapter"
+  }
+]
+"""
+
+MATCHED_BODY = json.dumps(
+    {"function": "eval<script>", "source": "return 1;"},
+    separators=(",", ":"),
+).encode("utf-8")
+
+
+def _case(name, description, passed, error=None):
+    return {
+        "test": name,
+        "description": description,
+        "passed": bool(passed),
+        "skip": False,
+        "error": error,
+    }
+
+
+def _json_object(result):
+    body = result.get("body") or b""
+    text = body.decode("utf-8", errors="replace")
+    try:
+        obj = json.loads(text) if text.strip() else {}
+    except ValueError:
+        return None, text
+    if not isinstance(obj, dict):
+        return None, text
+    return obj, text
+
+
+def _is_success(result):
+    obj, _ = _json_object(result)
+    return int(result.get("status_code") or 0) == 200 and (
+        obj or {}).get("status") == "success"
+
+
+def run():
+    description = (
+        "Request body read uses remaining Content-Length; extra stdin "
+        "is an error and the worker stays up"
+    )
+    tests = []
+    work = tempfile.mkdtemp(prefix="afw_req_body_")
+    handle = None
+    try:
+        with open(os.path.join(work, "afw.conf"), "w", encoding="utf-8") as fd:
+            fd.write(MINIMAL_CONF)
+        handle = start_afwfcgi(work, threads=1)
+        sock = handle["socket_path"]
+
+        matched = fcgi_request(
+            sock, path="/afw", method="POST", body=MATCHED_BODY)
+        matched_ok = _is_success(matched)
+        tests.append(_case(
+            "matched-content-length",
+            "POST /afw with Content-Length equal to the body succeeds",
+            passed=matched_ok,
+            error=None if matched_ok else (
+                "status={} body={}".format(
+                    matched.get("status_code"),
+                    (matched.get("body") or b"")[:400])),
+        ))
+
+        extra = MATCHED_BODY + (b"X" * 64)
+        oversized = fcgi_request(
+            sock,
+            path="/afw",
+            method="POST",
+            body=extra,
+            param_overrides={
+                "CONTENT_LENGTH": str(len(MATCHED_BODY)),
+            },
+        )
+        obj, raw = _json_object(oversized)
+        err = (obj or {}).get("error") if isinstance(obj, dict) else None
+        err_id = err.get("id") if isinstance(err, dict) else None
+        err_msg = err.get("message") if isinstance(err, dict) else ""
+        oversized_ok = (
+            int(oversized.get("status_code") or 0) == 400
+            and err_id == "request_syntax"
+            and "Content-Length" in (err_msg or "")
+        )
+        tests.append(_case(
+            "extra-after-content-length",
+            "Extra stdin after Content-Length is request_syntax, not success",
+            passed=oversized_ok,
+            error=None if oversized_ok else (
+                "status={} id={!r} message={!r} body={}".format(
+                    oversized.get("status_code"),
+                    err_id,
+                    err_msg,
+                    (raw or "")[:400])),
+        ))
+
+        after = fcgi_request(
+            sock, path="/afw", method="POST", body=MATCHED_BODY)
+        after_ok = _is_success(after)
+        tests.append(_case(
+            "worker-after-mismatch",
+            "The same afwfcgi worker still serves a matching POST",
+            passed=after_ok,
+            error=None if after_ok else (
+                "status={} body={}".format(
+                    after.get("status_code"),
+                    (after.get("body") or b"")[:400])),
+        ))
+    except Exception as e:
+        tests.append(_case(
+            "setup",
+            "Spawn afwfcgi and exercise request-body reads",
+            passed=False,
+            error=str(e),
+        ))
+    finally:
+        stop_afwfcgi(handle)
+
+    return {
+        "description": description,
+        "tests": tests,
+    }

--- a/src/afw_server_fcgi/afw_server_fcgi_request.c
+++ b/src/afw_server_fcgi/afw_server_fcgi_request.c
@@ -218,15 +218,25 @@ impl_afw_request_read_raw_request_body(
 
 
     /* Read into buffer until buffer full or EOF. */
-    *more_to_read = 1;
+    *more_to_read = 0;
     for (*size = 0; *size < buffer_size; (*size)++) {
         c = FCGX_GetChar(self->fcgx_request->in);
         if (c == EOF) {
-            *more_to_read = 0;
-            break;
+            return;
         }
         *(b++) = c;
     }
+
+    /*
+     * Buffer filled. One-byte look-ahead so more_to_read means there
+     * is another byte, not only that this call filled the buffer.
+     */
+    c = FCGX_GetChar(self->fcgx_request->in);
+    if (c == EOF) {
+        return;
+    }
+    FCGX_UnGetChar(c, self->fcgx_request->in);
+    *more_to_read = 1;
 }
 
 


### PR DESCRIPTION
@JeremyGrieshop

`afw_request_body_to_utf8` asked for the full declared length on every raw read. `content_length` is unsigned, so `<= 0` only caught empty. This pass leftover space each time, treat `0` as no body, and reject extra stdin after the declared length (`request_syntax`).

FastCGI used to set `more` whenever the buffer filled, including at EOF. A matching-length POST then looked like an overrun. One-byte look-ahead so `more` means another byte is actually there.

Hermetic FastCGI test: matching POST still works; extra stdin is `request_syntax`; the same worker still serves after.