### PR TITLE
Reject wrapping pool alloc sizes

### DIFF
--- a/src/afw/pool/afw_pool.c
+++ b/src/afw/pool/afw_pool.c
@@ -622,12 +622,17 @@ impl_alloc_memory(
     afw_pool_internal_free_memory_t *prev;
     afw_pool_internal_free_memory_t *curr;
     afw_pool_internal_free_memory_t *new_block;
+    afw_size_t requested;
 
-    *actual_size = APR_ALIGN_DEFAULT(
-        (size < sizeof(afw_pool_internal_free_memory_t))
+    requested = (size < sizeof(afw_pool_internal_free_memory_t))
         ? sizeof(afw_pool_internal_free_memory_t)
-        : size
-    );
+        : size;
+    *actual_size = APR_ALIGN_DEFAULT(requested);
+    if (*actual_size < requested) {
+        AFW_THROW_ERROR_Z(memory,
+            "Requested allocation size is too large",
+            xctx);
+    }
 
     /* Find the first free memory that fits. */
     curr = NULL;
@@ -865,6 +870,14 @@ impl_afw_pool_malloc(
             xctx);
     }
 
+    if (size > AFW_SIZE_T_MAX -
+        sizeof(afw_pool_internal_memory_prefix_t))
+    {
+        AFW_THROW_ERROR_Z(memory,
+            "Requested allocation size is too large",
+            xctx);
+    }
+
     size_with_prefix = size + sizeof(afw_pool_internal_memory_prefix_t);
 
     impl_alloc_memory(&mem, &actual_size, self, size_with_prefix, xctx);
@@ -1087,6 +1100,14 @@ impl_subpool_afw_pool_malloc(
     if (size == 0) {
         AFW_THROW_ERROR_Z(general,
             "Attempt to allocate memory for a size of 0",
+            xctx);
+    }
+
+    if (size > AFW_SIZE_T_MAX -
+        sizeof(afw_pool_internal_memory_prefix_with_links_t))
+    {
+        AFW_THROW_ERROR_Z(memory,
+            "Requested allocation size is too large",
             xctx);
     }
 

--- a/src/afw/tests/advanced/pool_alloc/pool_alloc.py
+++ b/src/afw/tests/advanced/pool_alloc/pool_alloc.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Pool malloc rejects a wrapping size.
+
+Boots a tiny C probe against installed libafw. Script integers cannot
+reach a wrapping size_t on 64-bit hosts.
+"""
+
+from __future__ import print_function
+
+import os
+import subprocess
+import tempfile
+
+
+def _apr_includes():
+    try:
+        out = subprocess.check_output(
+            ["apr-1-config", "--includes"], text=True)
+        return out.split()
+    except (OSError, subprocess.CalledProcessError):
+        return ["-I/usr/include/apr-1.0"]
+
+
+def _compile_probe(dest):
+    here = os.path.dirname(os.path.abspath(__file__))
+    src = os.path.join(here, "pool_alloc_probe.c")
+    include_afw = os.environ.get("AFW_INCLUDE_DIR", "/usr/local/include/afw")
+    libdir = os.environ.get("AFW_LIB_DIR", "/usr/local/lib/afw")
+    cmd = [
+        "cc", "-O0", "-g",
+        "-I", include_afw,
+    ]
+    cmd.extend(_apr_includes())
+    cmd.extend([
+        "-o", dest, src,
+        "-L", libdir, "-Wl,-rpath," + libdir,
+        "-lafw",
+    ])
+    subprocess.check_call(cmd)
+
+
+def _case(name, description, passed, error=None):
+    return {
+        "test": name,
+        "description": description,
+        "passed": bool(passed),
+        "skip": False,
+        "error": error,
+    }
+
+
+def run():
+    description = "Pool malloc rejects a wrapping size"
+    tests = []
+    work = tempfile.mkdtemp(prefix="afw_pool_alloc_")
+    probe = os.path.join(work, "pool_alloc_probe")
+
+    try:
+        _compile_probe(probe)
+    except Exception as e:
+        return {
+            "description": description,
+            "tests": [
+                _case(
+                    "compile_probe",
+                    "Compile pool alloc probe against libafw",
+                    False,
+                    str(e),
+                )
+            ],
+        }
+
+    cases = [
+        (
+            "overflow",
+            "pool malloc of SIZE_MAX throws memory",
+        ),
+        (
+            "overflow-subpool",
+            "subpool malloc of SIZE_MAX throws memory",
+        ),
+    ]
+    for name, desc in cases:
+        r = subprocess.run(
+            [probe, name],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        err = (r.stderr or "").strip() or (r.stdout or "").strip()
+        tests.append(_case(
+            name,
+            desc,
+            passed=(r.returncode == 0),
+            error=None if r.returncode == 0 else (
+                err or "exit {}".format(r.returncode)),
+        ))
+
+    return {
+        "description": description,
+        "tests": tests,
+    }

--- a/src/afw/tests/advanced/pool_alloc/pool_alloc_probe.c
+++ b/src/afw/tests/advanced/pool_alloc/pool_alloc_probe.c
@@ -1,0 +1,102 @@
+// See the 'COPYING' file in the project root for licensing information.
+/*
+ * Adaptive Framework pool alloc/free-list probe
+ *
+ * Copyright (c) 2010-2026 Clemson University
+ *
+ */
+
+#include "afw.h"
+
+#include <stdio.h>
+#include <string.h>
+
+/**
+ * @file pool_alloc_probe.c
+ * @brief C probe for pool size wrap.
+ *
+ * Script integers cannot reach a wrapping size_t on 64-bit, so this
+ * boots a core environment and calls the pool C API directly.
+ */
+
+static int
+impl_expect_overflow(
+    const afw_pool_t *p,
+    afw_xctx_t *xctx,
+    const char *label)
+{
+    int threw;
+    int unexpected;
+
+    threw = 0;
+    unexpected = 0;
+    AFW_TRY {
+        (void)afw_pool_malloc(p, (afw_size_t)-1, xctx);
+    }
+    AFW_CATCH_UNHANDLED {
+        if (AFW_ERROR_THROWN->code == afw_error_code_memory &&
+            AFW_ERROR_THROWN->message_z &&
+            strstr(AFW_ERROR_THROWN->message_z, "too large"))
+        {
+            threw = 1;
+        }
+        else {
+            unexpected = 1;
+            fprintf(stderr, "%s: threw %s\n", label,
+                AFW_ERROR_THROWN->message_z
+                ? AFW_ERROR_THROWN->message_z : "?");
+        }
+    }
+    AFW_ENDTRY;
+
+    if (unexpected) {
+        return 1;
+    }
+    if (!threw) {
+        fprintf(stderr, "%s: did not throw\n", label);
+        return 1;
+    }
+    return 0;
+}
+
+int
+main(int argc, char **argv)
+{
+    const afw_error_t *create_error;
+    afw_xctx_t *xctx;
+    const afw_pool_t *p;
+    const afw_pool_t *sub;
+    const char *case_name;
+    int rc;
+
+    xctx = afw_environment_create(afw_version(), argc,
+        (const char * const *)argv, &create_error);
+    if (!xctx) {
+        fprintf(stderr, "environment create failed\n");
+        return 2;
+    }
+
+    case_name = (argc > 1) ? argv[1] : "";
+    rc = 0;
+
+    if (strcmp(case_name, "overflow") == 0) {
+        p = afw_pool_create(xctx->p, xctx);
+        rc = impl_expect_overflow(p, xctx, "overflow");
+        afw_pool_release(p, xctx);
+    }
+    else if (strcmp(case_name, "overflow-subpool") == 0) {
+        p = afw_pool_create(xctx->p, xctx);
+        sub = afw_pool_create_subpool(p, xctx);
+        rc = impl_expect_overflow(sub, xctx, "overflow-subpool");
+        afw_pool_release(sub, xctx);
+        afw_pool_release(p, xctx);
+    }
+    else {
+        fprintf(stderr, "usage: pool_alloc_probe "
+            "overflow|overflow-subpool\n");
+        rc = 2;
+    }
+
+    afw_environment_release(xctx);
+    return rc;
+}


### PR DESCRIPTION
@JeremyGrieshop

`afw_pool_malloc` / `calloc` (pool and subpool) added the prefix with no wrap check. A size near the top of `size_t` became a tiny allocation; `calloc` then `memset` the original size.

Throw `memory` when size plus prefix would wrap, and again if alignment would wrap. Zero-size is still the existing `general` error.

Hermetic C probe (script integers cannot reach a wrapping `size_t` on 64-bit): `malloc((size_t)-1)` throws on a pool and a subpool.