### PR TITLE
Treat C-array view index === count as not found

### DIFF
--- a/.cursor/rules/afw-tests.mdc
+++ b/.cursor/rules/afw-tests.mdc
@@ -116,7 +116,15 @@ same interface). A green suite that never saw the bug will not catch it
 next time. Mantra: *A new error gets a test that would have caught it*
 (`designs/mantras-and-working-style.md`).
 
-When fixing a C/runtime bug, add `.as` coverage that fails without the fix:
+When script cannot reach the hole (C-only size, a second impl of an
+interface that literals never use, …), the gate is a Python `run()`
+that compiles a checked-in `*_probe.c` against installed `libafw` and
+execs it. Same pattern: `src/afw/tests/advanced/pool_alloc/`,
+`src/afw/tests/advanced/array_view_index/`. Do not invent a cmake
+test target for these. The `.c` is not part of `libafw`.
+
+When fixing a C/runtime bug, add `.as` coverage that fails without the fix
+unless the hole is C-only (then the probe above):
 
 - Put cases next to related tests (`miscellaneous/`, category folder, or adapter group).
 - Mention the issue id in `//? description` (e.g. `issue #110`).

--- a/designs/agent-support.md
+++ b/designs/agent-support.md
@@ -100,7 +100,7 @@ Shape: **symptom → layer → probe → code / doc entry**.
 - **Create vs evaluate** — do not mix (`afw-script-eval`). `argv[0]` at create is the callee expression; `x->function` is harvest at evaluate.  
 - **New get, old delete** — look-through / face / view added on read; mutate/delete/count still the old impl. Faces: delete is a local NULL tombstone (`issue-17`).  
 - **Sibling already learned it** — `split()` empty separator vs `replace()` empty match; `create_array()` cap vs `read(n)`; `copies_under_lock` vs live metrics.  
-- **Two impls of one interface** — memory array index uses `>= count`; C-array view used `> count`.  
+- **Two impls of one interface** — memory array index uses `>= count`; C-array view used `> count` (gate: `tests/advanced/array_view_index/`).  
 - **Script integer → malloc / spin / C stack** — APR pools often abort on huge alloc; empty match + “replace all” never advances; type and destructure parse have a nesting limit (`AFW_COMPILE_PARSE_NESTING_MAX`); other grammars may not.  
 - **Type names are declared before use** — like script values, not hoisted. Self-ref in the same `type` / `interface` body is allowed. Unknown names are a compile error even with typeCheck off.  
 - **Evaluate twice, first result sizes a buffer** — call-site `...expr` (#181, fixed). Same class: Pattern rest keys.

--- a/designs/knowledge-atlas.md
+++ b/designs/knowledge-atlas.md
@@ -269,7 +269,7 @@ generate/  →  generated/  →  env registries (afw_environment_t)
 
 | Field | Content |
 |-------|---------|
-| **Settled map** | **Gate** vs **lab**; **orchestrated** leaves (`orchestration.yaml`); blast **retired** (PR **#167**); handbook Developer Guide **Writing Tests**; gate `src/afw/tests/README.md`; extras SCHEMA in `tests-extra/` |
+| **Settled map** | **Gate** vs **lab**; **orchestrated** leaves (`orchestration.yaml`); blast **retired** (PR **#167**); handbook Developer Guide **Writing Tests**; gate `src/afw/tests/README.md`; extras SCHEMA in `tests-extra/`; C-only holes use a Python `run()` that compiles a checked-in `*_probe.c` against `libafw` (`advanced/pool_alloc/`, `advanced/array_view_index/`) |
 | **Day rules** | `afw-tests`, `afw-afwdev-python`, `afw-afwdev-generate` |
 | **Deep pads** | [`afwdev-test-recipe.md`](afwdev-test-recipe.md), [`afwdev-advanced-test.md`](afwdev-advanced-test.md) (history), [`afwdev-blast.md`](afwdev-blast.md) (retired); `src/afw/tests-extra/{README,SCHEMA}.md`; handbook `guide/developer/writing-tests.xml` |
 | **Probe** | See recipe commands below |

--- a/src/afw/array/afw_array_view_of_c_array.c
+++ b/src/afw/array/afw_array_view_of_c_array.c
@@ -221,7 +221,7 @@ impl_afw_array_get_entry_internal(
 
     /* List of internals. */
     else {
-        if (i > self->count) {
+        if (i >= self->count) {
             e = NULL;
         }
         else if (self->indirect) {

--- a/src/afw/doc/guide/developer/writing-tests.xml
+++ b/src/afw/doc/guide/developer/writing-tests.xml
@@ -72,7 +72,7 @@ afwdev test --list --test-pattern smoke
                 </row>
                 <row>
                     <column>Python (<literal>.py</literal> with <literal>run()</literal>)</column>
-                    <column>Use a Python test when you need to control the process, read environment values, or call APIs that are not easy to use from Adaptive Script.</column>
+                    <column>Use a Python test when you need to control the process, read environment values, or call APIs that are not easy to use from Adaptive Script. A few of these compile a small checked-in <literal>.c</literal> against installed <literal>libafw</literal> and run it, when script cannot reach the code under test.</column>
                 </row>
                 <row>
                     <column><literal>commands_*.txt</literal></column>

--- a/src/afw/tests/README.md
+++ b/src/afw/tests/README.md
@@ -14,7 +14,11 @@ A few places that are easy to misunderstand:
 - `test262/` — language tests derived from TC39; see that folder's README
 - `environments/` — shared fixtures named from a group's `config.py`
 - `advanced/` — short orchestrated tests (`orchestration.yaml`) that are
-  part of the default run
+  part of the default run. A few groups are a Python `run()` that
+  compiles a checked-in `*_probe.c` against installed `libafw` and
+  execs it (pool wrap, C-array view index). Use that when Adaptive
+  Script cannot reach the hole. The `.c` is not part of the cmake
+  library build.
 
 Longer tests, including firehose, live next door in
 `src/afw/tests-extra/` and are only run when you pass

--- a/src/afw/tests/advanced/array_view_index/array_view_index.py
+++ b/src/afw/tests/advanced/array_view_index/array_view_index.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+C-array view get at index === count is not found.
+
+Script memory arrays already used >=. The view used >, so a script
+a[length] on a literal does not catch this impl.
+"""
+
+from __future__ import print_function
+
+import os
+import subprocess
+import tempfile
+
+
+def _apr_includes():
+    try:
+        out = subprocess.check_output(
+            ["apr-1-config", "--includes"], text=True)
+        return out.split()
+    except (OSError, subprocess.CalledProcessError):
+        return ["-I/usr/include/apr-1.0"]
+
+
+def _compile_probe(dest):
+    here = os.path.dirname(os.path.abspath(__file__))
+    src = os.path.join(here, "array_view_index_probe.c")
+    include_afw = os.environ.get("AFW_INCLUDE_DIR", "/usr/local/include/afw")
+    libdir = os.environ.get("AFW_LIB_DIR", "/usr/local/lib/afw")
+    cmd = [
+        "cc", "-O0", "-g",
+        "-I", include_afw,
+    ]
+    cmd.extend(_apr_includes())
+    cmd.extend([
+        "-o", dest, src,
+        "-L", libdir, "-Wl,-rpath," + libdir,
+        "-lafw",
+    ])
+    subprocess.check_call(cmd)
+
+
+def _case(name, description, passed, error=None):
+    return {
+        "test": name,
+        "description": description,
+        "passed": bool(passed),
+        "skip": False,
+        "error": error,
+    }
+
+
+def run():
+    description = "C-array view index === count is not found"
+    tests = []
+    work = tempfile.mkdtemp(prefix="afw_array_view_index_")
+    probe = os.path.join(work, "array_view_index_probe")
+
+    try:
+        _compile_probe(probe)
+    except Exception as e:
+        return {
+            "description": description,
+            "tests": [
+                _case(
+                    "compile_probe",
+                    "Compile array view index probe against libafw",
+                    False,
+                    str(e),
+                )
+            ],
+        }
+
+    cases = [
+        (
+            "direct",
+            "counted non-indirect view: index === count is not found",
+        ),
+        (
+            "empty",
+            "empty view with live storage: index 0 is not found",
+        ),
+        (
+            "indirect",
+            "counted indirect view: index === count is not found",
+        ),
+    ]
+    for name, desc in cases:
+        r = subprocess.run(
+            [probe, name],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        err = (r.stderr or "").strip() or (r.stdout or "").strip()
+        tests.append(_case(
+            name,
+            desc,
+            passed=(r.returncode == 0),
+            error=None if r.returncode == 0 else (
+                err or "exit {}".format(r.returncode)),
+        ))
+
+    return {
+        "description": description,
+        "tests": tests,
+    }

--- a/src/afw/tests/advanced/array_view_index/array_view_index_probe.c
+++ b/src/afw/tests/advanced/array_view_index/array_view_index_probe.c
@@ -1,0 +1,184 @@
+// See the 'COPYING' file in the project root for licensing information.
+/*
+ * Adaptive Framework C-array view index probe
+ *
+ * Copyright (c) 2010-2026 Clemson University
+ *
+ */
+
+#include "afw.h"
+
+#include <stdio.h>
+#include <string.h>
+
+/**
+ * @file array_view_index_probe.c
+ * @brief C probe for array-view index === count.
+ *
+ * Script arrays use the memory impl (`>=`). The C-array view used `>`.
+ * A script test of a[length] does not hit this impl, so this boots a
+ * core environment and calls get_entry on a counted view.
+ *
+ * Same shape as tests/advanced/pool_alloc/pool_alloc_probe.c.
+ */
+
+static int
+impl_expect_missing(
+    const afw_array_t *array,
+    afw_integer_t index,
+    afw_xctx_t *xctx,
+    const char *label)
+{
+    const afw_data_type_t *data_type;
+    const void *internal;
+    afw_boolean_t found;
+
+    data_type = NULL;
+    internal = (const void *)(afw_size_t)1;
+    found = afw_array_get_entry_internal(array, index,
+        &data_type, &internal, xctx);
+    if (found || internal != NULL ||
+        afw_array_get_entry_value(array, index, xctx->p, xctx) != NULL)
+    {
+        fprintf(stderr, "%s: index %d treated as found\n",
+            label, (int)index);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+impl_expect_integer(
+    const afw_array_t *array,
+    afw_integer_t index,
+    afw_integer_t expect,
+    afw_xctx_t *xctx,
+    const char *label)
+{
+    const afw_data_type_t *data_type;
+    const void *internal;
+    const afw_value_t *value;
+
+    data_type = NULL;
+    internal = NULL;
+    if (!afw_array_get_entry_internal(array, index,
+            &data_type, &internal, xctx) ||
+        !internal ||
+        data_type != afw_data_type_integer ||
+        *(const afw_integer_t *)internal != expect)
+    {
+        fprintf(stderr, "%s: index %d missing or wrong internal\n",
+            label, (int)index);
+        return 1;
+    }
+    value = afw_array_get_entry_value(array, index, xctx->p, xctx);
+    if (!value ||
+        !afw_value_is_integer(value) ||
+        ((const afw_value_integer_t *)value)->internal != expect)
+    {
+        fprintf(stderr, "%s: index %d missing or wrong value\n",
+            label, (int)index);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+impl_counted_direct(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    /*
+     * Third slot is a sentinel: with `i > count` the view would return
+     * 999 at index 2. With `i >= count` it must be not found.
+     */
+    afw_integer_t ints[3];
+    const afw_array_t *array;
+    int rc;
+
+    ints[0] = 10;
+    ints[1] = 20;
+    ints[2] = 999;
+    array = afw_array_create_view_of_c_array(
+        ints, false, afw_data_type_integer, 2, p, xctx);
+    rc = 0;
+    rc |= impl_expect_integer(array, 0, 10, xctx, "direct");
+    rc |= impl_expect_integer(array, 1, 20, xctx, "direct");
+    rc |= impl_expect_missing(array, 2, xctx, "direct");
+    rc |= impl_expect_missing(array, 3, xctx, "direct");
+    rc |= impl_expect_missing(array, -1, xctx, "direct");
+    return rc;
+}
+
+static int
+impl_empty_with_storage(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    afw_integer_t dummy;
+    const afw_array_t *array;
+
+    dummy = 99;
+    array = afw_array_create_view_of_c_array(
+        &dummy, false, afw_data_type_integer, 0, p, xctx);
+    return impl_expect_missing(array, 0, xctx, "empty");
+}
+
+static int
+impl_counted_indirect(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    afw_integer_t ints[3];
+    const void *slots[3];
+    const afw_array_t *array;
+    int rc;
+
+    ints[0] = 10;
+    ints[1] = 20;
+    ints[2] = 999;
+    slots[0] = &ints[0];
+    slots[1] = &ints[1];
+    slots[2] = &ints[2];
+    array = afw_array_create_view_of_c_array(
+        slots, true, afw_data_type_integer, 2, p, xctx);
+    rc = 0;
+    rc |= impl_expect_integer(array, 0, 10, xctx, "indirect");
+    rc |= impl_expect_integer(array, 1, 20, xctx, "indirect");
+    rc |= impl_expect_missing(array, 2, xctx, "indirect");
+    return rc;
+}
+
+int
+main(int argc, char **argv)
+{
+    const afw_error_t *create_error;
+    afw_xctx_t *xctx;
+    const afw_pool_t *p;
+    const char *case_name;
+    int rc;
+
+    xctx = afw_environment_create(afw_version(), argc,
+        (const char * const *)argv, &create_error);
+    if (!xctx) {
+        fprintf(stderr, "environment create failed\n");
+        return 2;
+    }
+
+    case_name = (argc > 1) ? argv[1] : "";
+    p = afw_pool_create(xctx->p, xctx);
+    rc = 0;
+
+    if (strcmp(case_name, "direct") == 0) {
+        rc = impl_counted_direct(p, xctx);
+    }
+    else if (strcmp(case_name, "empty") == 0) {
+        rc = impl_empty_with_storage(p, xctx);
+    }
+    else if (strcmp(case_name, "indirect") == 0) {
+        rc = impl_counted_indirect(p, xctx);
+    }
+    else {
+        fprintf(stderr, "usage: array_view_index_probe "
+            "direct|empty|indirect\n");
+        rc = 2;
+    }
+
+    afw_pool_release(p, xctx);
+    afw_environment_release(xctx);
+    return rc;
+}


### PR DESCRIPTION
@JeremyGrieshop

The immutable C-array view (`afw_array_view_of_c_array`) treated `index == count` as found and returned the slot past the last element. Memory / const arrays already used `>=`.

A script `a[length]` on a literal does not hit this impl. Gate is a hermetic C probe (same pattern as the pool wrap probe in `tests/advanced/pool_alloc/`): counted direct, empty-with-storage, and indirect views, each with a sentinel in the next slot.

`afwdev test -j`: 3988 passed. Probe also clean under valgrind.