### PR TITLE
Require a catch block when try() has an error bind

### DIFF
--- a/src/afw/function/afw_function_compiler_internal.c
+++ b/src/afw/function/afw_function_compiler_internal.c
@@ -2048,6 +2048,13 @@ afw_function_execute_try(
                         ((const afw_value_block_t *)x->argv[3])->
                             statements[0])))
             {
+                /* Hand-built try() can set argv[4] without a catch block. */
+                if (!afw_value_is_block(x->argv[3])) {
+                    AFW_THROW_ERROR_Z(argument_error,
+                        "try catch body must be a block when an error bind "
+                        "is present",
+                        xctx);
+                }
                 error_object = afw_error_to_object(&this_THROWN_ERROR, p, xctx);
                 error_value = afw_value_create_unmanaged_object(
                     error_object, p, xctx);

--- a/src/afw/tests/language/script/try.as
+++ b/src/afw/tests/language/script/try.as
@@ -804,3 +804,31 @@ finally {
 
 return catch_outer_entered && finally_outer_entered && 
        catch_inner_entered && finally_inner_entered;
+
+//?
+//? test: try-function-catch-not-block-with-bind
+//? description: hand-built try() with a catch bind and a non-block catch throws
+//? expect: error
+//? source: ...
+
+try(throw("x"), undefined, "not-a-block", "e");
+
+//?
+//? test: try-function-plain-catch-block
+//? description: try() function form with a catch #block still catches
+//? expect: 1
+//? source: ...
+
+return try(throw("x"), undefined, #block(return(1)));
+
+//?
+//? test: try-statement-catch-bind-still-works
+//? description: normal try/catch (e) still binds the error
+//? expect: "x"
+//? source: ...
+
+try {
+    throw "x";
+} catch (e) {
+    return e.message;
+}


### PR DESCRIPTION
@JeremyGrieshop

\`execute_try\` entered the error-bind path when argv[4] was present and cast argv[3] to a block without checking. The parser never does that; a hand-built \`try(throw(\"x\"), undefined, \"not-a-block\", \"e\")\` crashed.

Require \`afw_value_is_block(argv[3])\` before that cast (\`argument_error\`). Statement \`try/catch (e)\` and \`try(..., #block(...))\` still work.

\`language/script/try\`: 35 passed (plus decompile_fidelity).