### PR TITLE
Validate host protocol lengths in afwfcgi and local mode

### DIFF
--- a/.cursor/rules/afw-server-fcgi.mdc
+++ b/.cursor/rules/afw-server-fcgi.mdc
@@ -63,6 +63,8 @@ FCGX_Accept_r (per thread)
 
 FCGI quirks: HTTP status via **`Status: code reason`** header; first body write ends headers with `CRLF`. Write failures → `client_closed` with rv source `"fcgi"`.
 
+**Request `TRY`:** `create_request` runs *outside* the request `AFW_TRY` in `impl_process_request`. A throw there is an unhandled thread error and the client sees an empty 200. Anything that must become an HTTP error body (bad `CONTENT_LENGTH`, …) belongs inside that `TRY` after the request object exists.
+
 ## CLI / socket
 
 - `-f` conf, `-p` socket path (Unix `/path.sock` or TCP `:port`; default **`:9345`** if omitted), `-n` threads, `-e` extension, `-t` conf content type.

--- a/designs/agent-support.md
+++ b/designs/agent-support.md
@@ -43,6 +43,8 @@ Shape: **symptom → layer → probe → code / doc entry**.
 
 **Never:** close listen fd alone as the multi-thread wake story while main is joining — **thread signal** is the libfcgi path. Don’t invent one wake strategy for every future `afw_server` host.
 
+**Request error body:** `afw_server_fcgi_internal_create_request` runs *outside* the request `AFW_TRY`. A throw there increments unhandled errors and the FastCGI client sees an empty 200. Hunt shape: **constructor throw skips request TRY**. Validate `CONTENT_LENGTH` (and anything else that must be a 400) inside the `TRY` after the request object exists.
+
 **Later (not bugs in #158):** drain timeout, SIGHUP, Windows service, full signal framework, every extension loop, unblock `--local` read.
 
 ---

--- a/designs/knowledge-atlas.md
+++ b/designs/knowledge-atlas.md
@@ -210,7 +210,7 @@ generate/  →  generated/  →  env registries (afw_environment_t)
 
 **Core:** error code `terminating` → HTTP **503**; `AFW_XCTX_THROW_IF_TERMINATING(xctx)` at work-unit boundaries.
 
-**Wrong path:** close listen fd alone to wake multi-thread accept while main is in join — use **thread signal** for libfcgi.
+**Wrong path:** close listen fd alone to wake multi-thread accept while main is in join — use **thread signal** for libfcgi. A throw in `create_request` is outside the request `TRY` — empty 200, unhandled thread error; parse/validate that needs an HTTP error body *after* the request exists.
 
 ---
 

--- a/src/afw/tests/advanced/afwfcgi_n_argc/afwfcgi_n_argc.py
+++ b/src/afw/tests/advanced/afwfcgi_n_argc/afwfcgi_n_argc.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+afwfcgi -n without a thread count must print usage and exit, not start.
+"""
+
+from __future__ import print_function
+
+import subprocess
+
+
+def _case(name, description, passed, error=None):
+    return {
+        "test": name,
+        "description": description,
+        "passed": bool(passed),
+        "skip": False,
+        "error": error,
+    }
+
+
+def run():
+    description = (
+        "afwfcgi -n with no following argument prints usage and exits"
+    )
+    tests = []
+
+    try:
+        missing = subprocess.run(
+            ["afwfcgi", "-n"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=10,
+        )
+        err = (missing.stderr or b"").decode("utf-8", errors="replace")
+        missing_ok = (
+            missing.returncode != 0
+            and "Usage:" in err
+        )
+        tests.append(_case(
+            "n-missing-argument",
+            "afwfcgi -n with no count prints usage and is non-zero",
+            passed=missing_ok,
+            error=None if missing_ok else (
+                "returncode={} stderr={!r}".format(
+                    missing.returncode, err[:400])),
+        ))
+
+        help_run = subprocess.run(
+            ["afwfcgi", "--help"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=10,
+        )
+        help_err = (help_run.stderr or b"").decode("utf-8", errors="replace")
+        help_ok = help_run.returncode == 0 and "Usage:" in help_err
+        tests.append(_case(
+            "help-still-works",
+            "afwfcgi --help still prints usage and exits 0",
+            passed=help_ok,
+            error=None if help_ok else (
+                "returncode={} stderr={!r}".format(
+                    help_run.returncode, help_err[:400])),
+        ))
+    except FileNotFoundError as e:
+        tests.append(_case(
+            "setup",
+            "afwfcgi on PATH",
+            passed=False,
+            error="afwfcgi not on PATH (./afwdev build --cdev --install): "
+            + str(e),
+        ))
+    except Exception as e:
+        tests.append(_case(
+            "setup",
+            "Run afwfcgi CLI cases",
+            passed=False,
+            error=str(e),
+        ))
+
+    return {
+        "description": description,
+        "tests": tests,
+    }

--- a/src/afw/tests/advanced/content_length_parse/content_length_parse.py
+++ b/src/afw/tests/advanced/content_length_parse/content_length_parse.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+FastCGI CONTENT_LENGTH must be unsigned decimal digits.
+
+Uses hermetic afwfcgi and the FastCGI client so the param can be
+set independently of the stdin bytes.
+"""
+
+from __future__ import print_function
+
+import json
+import os
+import tempfile
+
+from _afwdev.test.orchestrated.fcgi_client import fcgi_request
+from _afwdev.test.orchestrated.hosts.afwfcgi import start_afwfcgi, stop_afwfcgi
+
+
+MINIMAL_CONF = """\
+[
+  {
+    type: "requestHandler",
+    uriPrefix: "/",
+    requestHandlerType: "adapter"
+  }
+]
+"""
+
+MATCHED_BODY = json.dumps(
+    {"function": "eval<script>", "source": "return 1;"},
+    separators=(",", ":"),
+).encode("utf-8")
+
+
+def _case(name, description, passed, error=None):
+    return {
+        "test": name,
+        "description": description,
+        "passed": bool(passed),
+        "skip": False,
+        "error": error,
+    }
+
+
+def _json_object(result):
+    body = result.get("body") or b""
+    text = body.decode("utf-8", errors="replace")
+    try:
+        obj = json.loads(text) if text.strip() else {}
+    except ValueError:
+        return None, text
+    if not isinstance(obj, dict):
+        return None, text
+    return obj, text
+
+
+def _is_success(result):
+    obj, _ = _json_object(result)
+    return int(result.get("status_code") or 0) == 200 and (
+        obj or {}).get("status") == "success"
+
+
+def _is_invalid_content_length(result):
+    obj, _ = _json_object(result)
+    err = (obj or {}).get("error") if isinstance(obj, dict) else None
+    err_id = err.get("id") if isinstance(err, dict) else None
+    err_msg = err.get("message") if isinstance(err, dict) else ""
+    return (
+        int(result.get("status_code") or 0) == 400
+        and err_id == "request_syntax"
+        and "Content-Length" in (err_msg or "")
+    )
+
+
+def run():
+    description = (
+        "Invalid FastCGI CONTENT_LENGTH is request_syntax; "
+        "a matching decimal length still works"
+    )
+    tests = []
+    work = tempfile.mkdtemp(prefix="afw_clen_parse_")
+    handle = None
+    try:
+        with open(os.path.join(work, "afw.conf"), "w", encoding="utf-8") as fd:
+            fd.write(MINIMAL_CONF)
+        handle = start_afwfcgi(work, threads=1)
+        sock = handle["socket_path"]
+
+        matched = fcgi_request(
+            sock, path="/afw", method="POST", body=MATCHED_BODY)
+        matched_ok = _is_success(matched)
+        tests.append(_case(
+            "matched-digits",
+            "POST /afw with decimal Content-Length equal to the body succeeds",
+            passed=matched_ok,
+            error=None if matched_ok else (
+                "status={} body={}".format(
+                    matched.get("status_code"),
+                    (matched.get("body") or b"")[:400])),
+        ))
+
+        for name, raw, desc in (
+            ("negative", "-1", "A leading minus is request_syntax"),
+            ("non-digits", "abc", "Non-digit Content-Length is request_syntax"),
+            ("trailing-junk", "12x",
+             "Trailing non-digit after the length is request_syntax"),
+            ("empty", "", "Empty Content-Length is request_syntax"),
+        ):
+            result = fcgi_request(
+                sock,
+                path="/afw",
+                method="POST",
+                body=MATCHED_BODY,
+                param_overrides={"CONTENT_LENGTH": raw},
+            )
+            obj, raw_body = _json_object(result)
+            err = (obj or {}).get("error") if isinstance(obj, dict) else None
+            ok = _is_invalid_content_length(result)
+            tests.append(_case(
+                name,
+                desc,
+                passed=ok,
+                error=None if ok else (
+                    "status={} id={!r} message={!r} body={}".format(
+                        result.get("status_code"),
+                        err.get("id") if isinstance(err, dict) else None,
+                        err.get("message") if isinstance(err, dict) else "",
+                        (raw_body or "")[:400])),
+            ))
+
+        after = fcgi_request(
+            sock, path="/afw", method="POST", body=MATCHED_BODY)
+        after_ok = _is_success(after)
+        tests.append(_case(
+            "worker-after-invalid",
+            "The same afwfcgi worker still serves a matching POST",
+            passed=after_ok,
+            error=None if after_ok else (
+                "status={} body={}".format(
+                    after.get("status_code"),
+                    (after.get("body") or b"")[:400])),
+        ))
+    except Exception as e:
+        tests.append(_case(
+            "setup",
+            "Spawn afwfcgi and exercise CONTENT_LENGTH parse",
+            passed=False,
+            error=str(e),
+        ))
+    finally:
+        stop_afwfcgi(handle)
+
+    return {
+        "description": description,
+        "tests": tests,
+    }

--- a/src/afw_command/afw_command_local_server.c
+++ b/src/afw_command/afw_command_local_server.c
@@ -29,6 +29,10 @@
  * This is the implementation of afw_server for afw_command_local.
  */
 
+/* Hard cap so a chunk length cannot grow the input buffer without bound. */
+#define AFW_COMMAND_LOCAL_MAX_CHUNK 10000000
+
+
 /* Compiled afw version. */
 static const afw_utf8_t
 impl_compiled_afw_version =
@@ -53,10 +57,10 @@ impl_local_get_input(
     afw_xctx_t *xctx)
 {
     afw_memory_t *result;
-    long long len;
-    int rv;
+    afw_size_t len;
+    unsigned int digit;
     int c;
-    
+
     /* If eof, just return NULL. */
     if (self->eof) {
         return NULL;
@@ -66,11 +70,7 @@ impl_local_get_input(
     apr_array_clear(self->input_buffer);
     for (;;) {
 
-        /*
-         * Get and unget first char to make sure it is a digit.  Function
-         * fscanf() can skip characters, so this is here to make sure
-         * a stealth chunk error doesn't occur.
-         */
+        /* First char must be a digit so a stealth skip cannot happen. */
         c = fgetc(self->fd_input);
         if (c == EOF) {
             if (self->input_buffer->nelts != 0) {
@@ -81,19 +81,24 @@ impl_local_get_input(
         if (c < '0' || c > '9') {
             goto error;
         }
-        rv = ungetc(c, self->fd_input);
-        if (rv != c) {
-            goto error;
-        }
 
-        /* Get len followed by \n. If 0\n, break. */
-        rv = fscanf(self->fd_input, "%lld", &len);
-        if (rv < 0 || rv != 1) {
-            goto error;
-        }
-        c = fgetc(self->fd_input);
-        if (c != '\n') {
-            goto error;
+        /* Parse length digits up to newline; reject overflow and over-cap. */
+        len = (afw_size_t)(c - '0');
+        for (;;) {
+            c = fgetc(self->fd_input);
+            if (c == '\n') {
+                break;
+            }
+            if (c < '0' || c > '9') {
+                goto error;
+            }
+            digit = (unsigned int)(c - '0');
+            if (len > (AFW_COMMAND_LOCAL_MAX_CHUNK -
+                (afw_size_t)digit) / 10)
+            {
+                goto error;
+            }
+            len = len * 10 + (afw_size_t)digit;
         }
         if (len == 0) {
             break;

--- a/src/afw_command/tests/local_chunk_length.py
+++ b/src/afw_command/tests/local_chunk_length.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Local-mode chunk length must stay within the protocol cap.
+
+A length line over the cap is an invalid chunk. Do not send that many
+bytes — the parse rejects before the read loop.
+"""
+
+from __future__ import print_function
+
+import subprocess
+
+from _afwdev.test.orchestrated.hosts.local import (
+    build_action_session_stdin,
+    parse_local_json_responses,
+)
+
+
+# Must stay above AFW_COMMAND_LOCAL_MAX_CHUNK in
+# src/afw_command/afw_command_local_server.c (10,000,000).
+OVER_CAP = b"10000001\n"
+
+
+def _case(name, description, passed, error=None):
+    return {
+        "test": name,
+        "description": description,
+        "passed": bool(passed),
+        "skip": False,
+        "error": error,
+    }
+
+
+def _run_local(stdin, timeout=10):
+    return subprocess.run(
+        ["afw", "--local", "1"],
+        input=stdin,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+    )
+
+
+def run():
+    description = (
+        "afw --local rejects a chunk length over the protocol cap; "
+        "a small valid session still works"
+    )
+    tests = []
+
+    try:
+        valid = _run_local(build_action_session_stdin(
+            "application/json",
+            {"function": "eval<script>", "source": "return 3;"},
+        ))
+        responses = parse_local_json_responses(valid.stdout or b"")
+        valid_ok = False
+        if responses:
+            last = responses[-1]
+            if isinstance(last, dict) and last.get("status") == "success":
+                result = last.get("result")
+                valid_ok = result == 3 or result == "3"
+        tests.append(_case(
+            "small-valid-chunk",
+            "A small local-mode session still runs",
+            passed=valid_ok,
+            error=None if valid_ok else (
+                "returncode={} stdout={!r} stderr={!r}".format(
+                    valid.returncode,
+                    (valid.stdout or b"")[:300],
+                    (valid.stderr or b"")[:300])),
+        ))
+
+        over = _run_local(OVER_CAP)
+        over_text = ((over.stdout or b"") + (over.stderr or b"")).decode(
+            "utf-8", errors="replace")
+        over_ok = over.returncode != 0 and "Invalid chunk" in over_text
+        tests.append(_case(
+            "over-cap-length",
+            "A chunk length over the cap is Invalid chunk",
+            passed=over_ok,
+            error=None if over_ok else (
+                "returncode={} out={!r}".format(
+                    over.returncode, over_text[:400])),
+        ))
+
+        junk = _run_local(b"12x\n")
+        junk_text = ((junk.stdout or b"") + (junk.stderr or b"")).decode(
+            "utf-8", errors="replace")
+        junk_ok = junk.returncode != 0 and "Invalid chunk" in junk_text
+        tests.append(_case(
+            "non-digit-length",
+            "A non-digit in the length line is Invalid chunk",
+            passed=junk_ok,
+            error=None if junk_ok else (
+                "returncode={} out={!r}".format(
+                    junk.returncode, junk_text[:400])),
+        ))
+    except FileNotFoundError as e:
+        tests.append(_case(
+            "setup",
+            "afw on PATH",
+            passed=False,
+            error="afw not on PATH (./afwdev build --cdev --install): "
+            + str(e),
+        ))
+    except Exception as e:
+        tests.append(_case(
+            "setup",
+            "Run local-mode chunk length cases",
+            passed=False,
+            error=str(e),
+        ))
+
+    return {
+        "description": description,
+        "tests": tests,
+    }

--- a/src/afw_server_fcgi/afw_server_fcgi.c
+++ b/src/afw_server_fcgi/afw_server_fcgi.c
@@ -262,6 +262,9 @@ static void impl_process_request(afw_server_fcgi_internal_t *self,
     /* Handle request errors in request session xctx. */
     AFW_TRY{
 
+        afw_server_fcgi_internal_set_content_length(
+            (afw_server_fcgi_internal_request_t *)request, xctx);
+
         afw_request_impl_trace_begin(request, xctx);
 
         /* Process request. */

--- a/src/afw_server_fcgi/afw_server_fcgi_internal.h
+++ b/src/afw_server_fcgi/afw_server_fcgi_internal.h
@@ -111,6 +111,16 @@ afw_server_fcgi_internal_create_request(
     afw_xctx_t *xctx);
 
 /**
+ * Parse CONTENT_LENGTH onto the request. Throws request_syntax if present
+ * and not unsigned digits that fit in afw_size_t. Call inside the request
+ * TRY so the client gets an HTTP error body.
+ */
+void
+afw_server_fcgi_internal_set_content_length(
+    afw_server_fcgi_internal_request_t *self,
+    afw_xctx_t *xctx);
+
+/**
  * Create an internal fcgi request.
  */
 const afw_object_t *

--- a/src/afw_server_fcgi/afw_server_fcgi_main.c
+++ b/src/afw_server_fcgi/afw_server_fcgi_main.c
@@ -87,6 +87,10 @@ static int process_args(int argc, const char * const * argv, self_args_t *args, 
         }
         else if (strcmp(argv[i], "-n") == 0) {
             i++;
+            if (i >= argc) {
+                print_usage();
+                goto error;
+            }
             n = strtol(argv[i], NULL, 10);
             if (n < 0 || n > 9999 || errno == ERANGE) {
                 print_usage();

--- a/src/afw_server_fcgi/afw_server_fcgi_request.c
+++ b/src/afw_server_fcgi/afw_server_fcgi_request.c
@@ -43,6 +43,58 @@ impl_read_content_cb(
 }
 
 
+/* CONTENT_LENGTH is unsigned digits that fit in afw_size_t. */
+static afw_boolean_t
+impl_parse_content_length(
+    const afw_utf8_z_t *s,
+    afw_size_t *out)
+{
+    afw_size_t n;
+    unsigned int digit;
+
+    if (!s || *s == 0) {
+        return false;
+    }
+
+    n = 0;
+    for (; *s; s++) {
+        if (*s < '0' || *s > '9') {
+            return false;
+        }
+        digit = (unsigned int)(*s - '0');
+        if (n > (AFW_SIZE_T_MAX - (afw_size_t)digit) / 10) {
+            return false;
+        }
+        n = n * 10 + (afw_size_t)digit;
+    }
+
+    *out = n;
+    return true;
+}
+
+
+void
+afw_server_fcgi_internal_set_content_length(
+    afw_server_fcgi_internal_request_t *self,
+    afw_xctx_t *xctx)
+{
+    const afw_value_t *value;
+    const afw_utf8_z_t *length_z;
+
+    value = afw_object_get_property(self->pub.properties,
+        AFW_REQUEST_s_PN_CONTENT_LENGTH, xctx);
+    if (!value) {
+        return;
+    }
+    length_z = afw_value_as_utf8_z(value, xctx->p, xctx);
+    if (!impl_parse_content_length(length_z, &self->pub.content_length))
+    {
+        AFW_THROW_ERROR_Z(request_syntax,
+            "Invalid Content-Length.", xctx);
+    }
+}
+
+
 static afw_size_t
 impl_write_content_cb(
     void *context,
@@ -67,7 +119,6 @@ afw_server_fcgi_internal_create_request(
 {
     afw_server_fcgi_internal_request_t *self = NULL;
     const afw_value_t *value;
-    const afw_utf8_z_t *length_z;
     const afw_utf8_octet_t *c;
     afw_size_t len;
 
@@ -137,14 +188,6 @@ afw_server_fcgi_internal_create_request(
     self->pub.content_type = afw_object_old_get_property_as_utf8(
         self->pub.properties,
         AFW_REQUEST_s_PN_CONTENT_TYPE, xctx->p, xctx);
-
-    /* Get request content length. */
-    value = afw_object_get_property(self->pub.properties,
-        AFW_REQUEST_s_PN_CONTENT_LENGTH, xctx);
-    if (value) {
-        length_z = afw_value_as_utf8_z(value, xctx->p, xctx);
-        self->pub.content_length = atoi(length_z);
-    }
 
     /* Get request accept header. */
     value = afw_object_get_property(self->pub.properties,


### PR DESCRIPTION
@JeremyGrieshop

FastCGI `CONTENT_LENGTH` is now unsigned decimal digits that fit in `afw_size_t`. A present-but-invalid value is `request_syntax` (400). The parse runs after the request object exists so the client gets an error body.

`afwfcgi -n` without a following argument prints usage and exits, same as the other flags.

`afw --local` chunk lengths are digits with a 10,000,000 cap. Over that, or a non-digit in the length line, is still `Invalid chunk`.

Hermetic tests: `src/afw/tests/advanced/content_length_parse/`, `src/afw/tests/advanced/afwfcgi_n_argc/`, `src/afw_command/tests/local_chunk_length.py`. Matching POST / small local session still work.