### PR TITLE
Guard empty includes, integer-min negate, duration bounds, and two object copies

### DIFF
--- a/designs/agent-support.md
+++ b/designs/agent-support.md
@@ -108,6 +108,11 @@ Shape: **symptom → layer → probe → code / doc entry**.
 - **Evaluate twice, first result sizes a buffer** — call-site `...expr` (#181, fixed). Same class: Pattern rest keys.
 - **Early return skips eval-stack / error-contextual pop** — a not-found or empty path returns before the cleanup every other exit does; the next unrelated error points at the wrong source. Route through the same pop/restore. A braced block's `AFW_ENDTRY` resets the stack each time and hides the leak; gate with a single-statement `for` body (default max 500).
 - **Allocator is sacred** — overflow on `size + prefix` is a local check (shipped). A free-list that only relinks adjacent blocks is **optional reuse**, not lifetime; a naive `else` splice livelocks first-fit. That hole waits on **#2** / pool redesign. Do **not** invent a new pool on a findings card.
+- **Empty collection + modulo** — `fromIndex % length` on length 0 is undefined (`SIGFPE` on x86; aarch64 divide returns 0). Guard before the remainder.
+- **Signed min negation** — `abs` / `negative` of `#integerMin` cannot be represented. Throw, same as integer add overflow. Do not rely on two’s-complement wrap.
+- **Wrong bound then narrow** — a field stored as signed 32-bit must be checked against the signed max, not the unsigned max. Sibling fields in the same parse are the hint.
+- **Release the existing, not the incoming** — replace/clear must drop the object already stored. The generic associative-array impl already did; the memory object impl released the argument (NULL on clear).
+- **malloc(n) then write `[n]`** — a NULL-terminated copy needs `n + 1` slots. Count first, allocate one extra, then terminate.
 
 **Wrong path:** deep-cloning whole adapters/registries to “fix” one bad lifetime; treating short-test green as long-run proof.
 

--- a/src/afw/function/afw_function_array.c
+++ b/src/afw/function/afw_function_array.c
@@ -219,6 +219,10 @@ afw_function_execute_includes_array(
     len = afw_array_get_count(array->internal, xctx);
 
     if (fromIndex) {
+        /* Empty array: fromIndex % 0 is undefined (SIGFPE on some hosts). */
+        if (len == 0) {
+            return afw_boolean_v_false;
+        }
         index = abs((int)fromIndex->internal) % len;
 
         if (fromIndex->internal < 0 && index != 0) {

--- a/src/afw/function/afw_function_integer.c
+++ b/src/afw/function/afw_function_integer.c
@@ -52,6 +52,10 @@ afw_function_execute_abs_integer(
 
     AFW_FUNCTION_EVALUATE_REQUIRED_DATA_TYPE_PARAMETER(arg, 1, integer);
 
+    if (arg->internal == AFW_INTEGER_MIN) {
+        AFW_THROW_ERROR_Z(argument_error, "Integer abs overflow", x->xctx);
+    }
+
     return (arg->internal >= 0)
         ? &arg->pub
         : afw_value_create_unmanaged_integer(-(arg->internal), x->p, x->xctx);
@@ -391,6 +395,10 @@ afw_function_execute_negative_integer(
     const afw_value_integer_t *arg;
 
     AFW_FUNCTION_EVALUATE_REQUIRED_DATA_TYPE_PARAMETER(arg, 1, integer);
+
+    if (arg->internal == AFW_INTEGER_MIN) {
+        AFW_THROW_ERROR_Z(argument_error, "Integer negate overflow", x->xctx);
+    }
 
     return afw_value_create_unmanaged_integer(-arg->internal, x->p, x->xctx);
 }

--- a/src/afw/model/afw_model_adapter.c
+++ b/src/afw/model/afw_model_adapter.c
@@ -466,7 +466,7 @@ impl_convert_select(
 
     /* Return converted select. */
     for (i = 0; select[i]; i++);
-    result = afw_pool_malloc(p, sizeof(const afw_utf8_t *) * i, xctx);
+    result = afw_pool_malloc(p, sizeof(const afw_utf8_t *) * (i + 1), xctx);
     result[i] = NULL;
     for (i = 0; select[i]; i++) {
         afw_model_internal_convert_property_name(

--- a/src/afw/object/afw_object_memory_associative_array.c
+++ b/src/afw/object/afw_object_memory_associative_array.c
@@ -206,7 +206,7 @@ impl_afw_object_associative_array_set (
     /* If an object is associated with key, call its release(). */
     existing = apr_hash_get(self->objects, key->s, key->len);
     if (existing) {
-        afw_object_release(object, xctx);
+        afw_object_release(existing, xctx);
     }
 
     /* If object passed, add reference. */

--- a/src/afw/tests/advanced/associative_array_set/associative_array_set.py
+++ b/src/afw/tests/advanced/associative_array_set/associative_array_set.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Associative-array set() releases the existing object, not the incoming one.
+
+Script never calls this impl. Clearing a key used to pass NULL into
+release(); replacing used to drop the new object and leak the old one.
+"""
+
+from __future__ import print_function
+
+import os
+import subprocess
+import tempfile
+
+
+def _apr_includes():
+    try:
+        out = subprocess.check_output(
+            ["apr-1-config", "--includes"], text=True)
+        return out.split()
+    except (OSError, subprocess.CalledProcessError):
+        return ["-I/usr/include/apr-1.0"]
+
+
+def _compile_probe(dest):
+    here = os.path.dirname(os.path.abspath(__file__))
+    src = os.path.join(here, "associative_array_set_probe.c")
+    include_afw = os.environ.get("AFW_INCLUDE_DIR", "/usr/local/include/afw")
+    libdir = os.environ.get("AFW_LIB_DIR", "/usr/local/lib/afw")
+    cmd = [
+        "cc", "-O0", "-g",
+        "-I", include_afw,
+    ]
+    cmd.extend(_apr_includes())
+    cmd.extend([
+        "-o", dest, src,
+        "-L", libdir, "-Wl,-rpath," + libdir,
+        "-lafw",
+    ])
+    subprocess.check_call(cmd)
+
+
+def _case(name, description, passed, error=None):
+    return {
+        "test": name,
+        "description": description,
+        "passed": bool(passed),
+        "skip": False,
+        "error": error,
+    }
+
+
+def run():
+    description = "Associative-array set releases the existing object"
+    tests = []
+    work = tempfile.mkdtemp(prefix="afw_associative_array_set_")
+    probe = os.path.join(work, "associative_array_set_probe")
+
+    try:
+        _compile_probe(probe)
+    except Exception as e:
+        return {
+            "description": description,
+            "tests": [
+                _case(
+                    "compile_probe",
+                    "Compile associative-array set probe against libafw",
+                    False,
+                    str(e),
+                )
+            ],
+        }
+
+    cases = [
+        (
+            "clear",
+            "set then clear: key is removed and NULL is not released",
+        ),
+        (
+            "replace",
+            "replace: stored object is the incoming one",
+        ),
+        (
+            "replace_clear",
+            "replace then clear: key is removed",
+        ),
+    ]
+    for name, desc in cases:
+        r = subprocess.run(
+            [probe, name],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        err = (r.stderr or "").strip() or (r.stdout or "").strip()
+        tests.append(_case(
+            name,
+            desc,
+            passed=(r.returncode == 0),
+            error=None if r.returncode == 0 else (
+                err or "exit {}".format(r.returncode)),
+        ))
+
+    return {
+        "description": description,
+        "tests": tests,
+    }

--- a/src/afw/tests/advanced/associative_array_set/associative_array_set_probe.c
+++ b/src/afw/tests/advanced/associative_array_set/associative_array_set_probe.c
@@ -1,0 +1,146 @@
+// See the 'COPYING' file in the project root for licensing information.
+/*
+ * Adaptive Framework associative-array set probe
+ *
+ * Copyright (c) 2010-2026 Clemson University
+ *
+ */
+
+#include "afw.h"
+
+#include <stdio.h>
+#include <string.h>
+
+/**
+ * @file associative_array_set_probe.c
+ * @brief C probe for associative-array set() releasing the existing object.
+ *
+ * Script cannot reach this impl. set() used to release the incoming object
+ * when replacing, then store a dangling pointer and leak the previous one.
+ * Clearing a key passed NULL as that incoming object.
+ *
+ * Same shape as tests/advanced/array_view_index/array_view_index_probe.c.
+ */
+
+static const afw_utf8_t impl_key = AFW_UTF8_LITERAL("k");
+
+static const afw_object_t *
+impl_create_pinned(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    const afw_object_t *object;
+
+    object = afw_object_create(p, xctx);
+    afw_object_get_reference(object, xctx);
+    return object;
+}
+
+static const afw_object_t *
+impl_stored(
+    const afw_object_associative_array_t *aa,
+    afw_xctx_t *xctx)
+{
+    return afw_object_associative_array_get_associated_object_reference(
+        aa, &impl_key, xctx);
+}
+
+static int
+impl_clear(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    const afw_object_associative_array_t *aa;
+    const afw_object_t *a;
+    const afw_object_t *got;
+
+    aa = afw_object_memory_associative_array_create(p, xctx);
+    a = impl_create_pinned(p, xctx);
+    afw_object_associative_array_set(aa, &impl_key, a, xctx);
+    afw_object_associative_array_set(aa, &impl_key, NULL, xctx);
+    got = impl_stored(aa, xctx);
+    if (got != NULL) {
+        fprintf(stderr, "clear: key still associated\n");
+        return 1;
+    }
+    return 0;
+}
+
+static int
+impl_replace(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    const afw_object_associative_array_t *aa;
+    const afw_object_t *a;
+    const afw_object_t *b;
+    const afw_object_t *got;
+
+    aa = afw_object_memory_associative_array_create(p, xctx);
+    a = impl_create_pinned(p, xctx);
+    b = impl_create_pinned(p, xctx);
+    afw_object_associative_array_set(aa, &impl_key, a, xctx);
+    afw_object_associative_array_set(aa, &impl_key, b, xctx);
+    got = impl_stored(aa, xctx);
+    if (got != b) {
+        fprintf(stderr, "replace: stored object is not the incoming one\n");
+        return 1;
+    }
+    return 0;
+}
+
+static int
+impl_replace_clear(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    const afw_object_associative_array_t *aa;
+    const afw_object_t *a;
+    const afw_object_t *b;
+    const afw_object_t *got;
+
+    aa = afw_object_memory_associative_array_create(p, xctx);
+    a = impl_create_pinned(p, xctx);
+    b = impl_create_pinned(p, xctx);
+    afw_object_associative_array_set(aa, &impl_key, a, xctx);
+    afw_object_associative_array_set(aa, &impl_key, b, xctx);
+    afw_object_associative_array_set(aa, &impl_key, NULL, xctx);
+    got = impl_stored(aa, xctx);
+    if (got != NULL) {
+        fprintf(stderr, "replace_clear: key still associated\n");
+        return 1;
+    }
+    return 0;
+}
+
+int
+main(int argc, char **argv)
+{
+    const afw_error_t *create_error;
+    afw_xctx_t *xctx;
+    const afw_pool_t *p;
+    const char *case_name;
+    int rc;
+
+    xctx = afw_environment_create(afw_version(), argc,
+        (const char * const *)argv, &create_error);
+    if (!xctx) {
+        fprintf(stderr, "environment create failed\n");
+        return 2;
+    }
+
+    case_name = (argc > 1) ? argv[1] : "";
+    p = afw_pool_create(xctx->p, xctx);
+    rc = 0;
+
+    if (strcmp(case_name, "clear") == 0) {
+        rc = impl_clear(p, xctx);
+    }
+    else if (strcmp(case_name, "replace") == 0) {
+        rc = impl_replace(p, xctx);
+    }
+    else if (strcmp(case_name, "replace_clear") == 0) {
+        rc = impl_replace_clear(p, xctx);
+    }
+    else {
+        fprintf(stderr, "usage: associative_array_set_probe "
+            "clear|replace|replace_clear\n");
+        rc = 2;
+    }
+
+    afw_pool_release(p, xctx);
+    afw_environment_release(xctx);
+    return rc;
+}

--- a/src/afw/tests/list/includes_empty.as
+++ b/src/afw/tests/list/includes_empty.as
@@ -1,0 +1,56 @@
+#!/usr/bin/env -S afw --syntax test_script
+//?
+//? testScript: includes_empty.as
+//? customPurpose: Part of core function tests
+//? description: includes() on an empty array with fromIndex does not divide by zero
+//? sourceType: script
+//?
+//? test: empty-no-fromIndex
+//? description: includes on empty array without fromIndex is false
+//? expect: 0
+//? source: ...
+
+assert(includes([], 1) === false);
+assert(includes([], "x") === false);
+return 0;
+
+//?
+//? test: empty-fromIndex-zero
+//? description: includes on empty array with fromIndex 0 is false
+//? expect: 0
+//? source: ...
+
+assert(includes([], 1, 0) === false);
+return 0;
+
+//?
+//? test: empty-fromIndex-positive
+//? description: includes on empty array with positive fromIndex is false
+//? expect: 0
+//? source: ...
+
+assert(includes([], 1, 1) === false);
+assert(includes([], 1, 100) === false);
+return 0;
+
+//?
+//? test: empty-fromIndex-negative
+//? description: includes on empty array with negative fromIndex is false
+//? expect: 0
+//? source: ...
+
+assert(includes([], 1, -1) === false);
+assert(includes([], 1, -100) === false);
+return 0;
+
+//?
+//? test: one-element-fromIndex
+//? description: includes fromIndex still works on a non-empty array
+//? expect: 0
+//? source: ...
+
+assert(includes([1], 1, 0) === true);
+assert(includes([1], 1, -1) === true);
+assert(includes([1, 2], 1, 1) === false);
+assert(includes([1, 2], 2, 1) === true);
+return 0;

--- a/src/afw/tests/miscellaneous/duration_bounds.as
+++ b/src/afw/tests/miscellaneous/duration_bounds.as
@@ -1,0 +1,65 @@
+#!/usr/bin/env -S afw --syntax test_script
+//?
+//? testScript: duration_bounds.as
+//? customPurpose: Part of miscellaneous category tests
+//? description: dayTimeDuration minutes and seconds reject values above signed 32-bit max
+//? sourceType: script
+//?
+//? test: minutes-int32-max
+//? description: PT2147483647M is accepted
+//? expect: 0
+//? source: ...
+
+const d = dayTimeDuration("PT2147483647M");
+assert(d !== undefined);
+return 0;
+
+//?
+//? test: minutes-int32-max-plus-one
+//? description: PT2147483648M is out of range
+//? expect: error
+//? source: ...
+
+dayTimeDuration("PT2147483648M")
+
+//?
+//? test: minutes-above-uint-range-example
+//? description: PT3000000000M is out of range
+//? expect: error
+//? source: ...
+
+dayTimeDuration("PT3000000000M")
+
+//?
+//? test: seconds-int32-max
+//? description: PT2147483647S is accepted
+//? expect: 0
+//? source: ...
+
+const d = dayTimeDuration("PT2147483647S");
+assert(d !== undefined);
+return 0;
+
+//?
+//? test: seconds-int32-max-plus-one
+//? description: PT2147483648S is out of range
+//? expect: error
+//? source: ...
+
+dayTimeDuration("PT2147483648S")
+
+//?
+//? test: days-still-int32
+//? description: days already used the signed 32-bit max
+//? expect: error
+//? source: ...
+
+dayTimeDuration("P2147483648D")
+
+//?
+//? test: yearMonth-months-still-int32
+//? description: yearMonth months already used the signed 32-bit max
+//? expect: error
+//? source: ...
+
+yearMonthDuration("P2147483648M")

--- a/src/afw/tests/miscellaneous/integer_overflow.as
+++ b/src/afw/tests/miscellaneous/integer_overflow.as
@@ -1,0 +1,47 @@
+#!/usr/bin/env -S afw --syntax test_script
+//?
+//? testScript: integer_overflow.as
+//? customPurpose: Part of miscellaneous category tests
+//? description: abs and negative reject #integerMin instead of overflowing
+//? sourceType: script
+//?
+//? test: abs-min
+//? description: abs of #integerMin throws
+//? expect: error
+//? source: ...
+
+abs(#integerMin)
+
+//?
+//? test: negative-min
+//? description: negative of #integerMin throws
+//? expect: error
+//? source: ...
+
+negative(#integerMin)
+
+//?
+//? test: abs-neighbors
+//? description: abs of 0, -1, 1, and #integerMin + 1
+//? expect: 0
+//? source: ...
+
+assert(abs(0) === 0);
+assert(abs(-1) === 1);
+assert(abs(1) === 1);
+assert(abs(#integerMin + 1) === #integerMax);
+assert(abs(#integerMax) === #integerMax);
+return 0;
+
+//?
+//? test: negative-neighbors
+//? description: negative of 0, -1, 1, and #integerMin + 1
+//? expect: 0
+//? source: ...
+
+assert(negative(0) === 0);
+assert(negative(-1) === 1);
+assert(negative(1) === -1);
+assert(negative(#integerMin + 1) === #integerMax);
+assert(negative(#integerMax) === #integerMin + 1);
+return 0;

--- a/src/afw/tests/model_adapter/retrieve_objects.as
+++ b/src/afw/tests/model_adapter/retrieve_objects.as
@@ -21,3 +21,20 @@ assert(obj !== undefined);
 assert(obj.MyTestString1 === "This is a test string.", "MyTestString1 was " + obj.MyTestString1);
 
 return 0;
+
+//?
+//? test: retrieve-select
+//? description: retrieve with a non-empty select list against a model adapter
+//? skip: false
+//? expect: 0
+//? source: ...
+
+const objects: array = retrieve_objects("model", "MyObjectType1", {
+    select: ["MyTestString1"]
+});
+const obj: object = objects[0];
+assert(obj !== undefined);
+assert(obj.MyTestString1 === "This is a test string.",
+    "MyTestString1 was " + obj.MyTestString1);
+
+return 0;

--- a/src/afw/time/afw_time.c
+++ b/src/afw/time/afw_time.c
@@ -1309,7 +1309,7 @@ afw_dayTimeDuration_utf8_set_internal(
 
     /* Next can be 'M'. */
     if (*s == 'M') {
-        if (i > AFW_UINT32_MAX) goto error;
+        if (i > AFW_INT32_MAX) goto error;
         internal->minutes = (afw_int32_t)((is_negative) ? -i  : i);
         s++;
         if (--len <= 0) goto finished;
@@ -1321,7 +1321,7 @@ afw_dayTimeDuration_utf8_set_internal(
     }
 
     /* Must be seconds at this point. Will check for 'S' later. */
-    if (i > AFW_UINT32_MAX) goto error;
+    if (i > AFW_INT32_MAX) goto error;
     internal->seconds = (afw_int32_t)((is_negative) ? -i  : i);
 
     /* Next can be '.' followed by microseconds. */


### PR DESCRIPTION
@JeremyGrieshop

`includes()` on an empty array with `fromIndex` no longer takes a remainder of zero.

`abs` and `negative` of `#integerMin` throw `argument_error`, same as integer add overflow.

`dayTimeDuration` minutes and seconds are checked against the signed 32-bit max before they are stored (days, hours, and yearMonth already were). A value such as `PT2147483648M` is now an error instead of wrapping negative.

Memory associative-array `set()` releases the object already stored for that key, including when the key is cleared.

A model retrieve with a non-empty `select` list allocates a terminator slot.

Tests: `src/afw/tests/list/includes_empty.as`, `src/afw/tests/miscellaneous/integer_overflow.as`, `src/afw/tests/miscellaneous/duration_bounds.as`, `src/afw/tests/advanced/associative_array_set/`, and a `select` case on the model retrieve suite.