### PR TITLE
Bound URI percent-decode, query/YAML parse depth, and journal cursors

### DIFF
--- a/src/afw/file/afw_file_journal.c
+++ b/src/afw/file/afw_file_journal.c
@@ -80,6 +80,12 @@ impl_object_id_to_relative_entry_path(
     if (entry_object_id->len < strlen("ccyymmddhh_0")) return NULL;
     o = &relative_entry_path_wa_z[0];
     i = entry_object_id->s;
+    for (count = 0; count < 10; count++) {
+        if (i[count] < '0' || i[count] > '9') {
+            return NULL;
+        }
+    }
+    if (i[10] != '_') return NULL;
     *o++ = 'y';
     *o++ = *i++;
     *o++ = *i++;
@@ -98,7 +104,7 @@ impl_object_id_to_relative_entry_path(
     *o++ = *i++;
     *o++ = *i++;
     *o = 0;
-    if (*i++ != '_') return NULL;
+    i++; /* skip '_' already checked */
     for (*offset = 0, count = entry_object_id->len - strlen("ccyymmddhh_");
         count > 0; count--)
     {

--- a/src/afw/file/afw_file_journal.c
+++ b/src/afw/file/afw_file_journal.c
@@ -62,8 +62,8 @@ const afw_adapter_journal_inf_t * afw_file_internal_get_journal_inf()
  *
  * And journal entry will be at offset 3183.
  *
- * Note: this doesn't strictly check cursor syntax because open will
- * take care of not found.  Should probably do more checking.
+ * Date prefix is ten digits. Offset is decimal digits that fit in
+ * signed afw_off_t. Invalid cursor returns NULL.
  */
 #define IMPL_RELATIVE_ENTRY_PATH_WA_Z_SIZE sizeof("y2016/m07/d04/h23")
 static afw_utf8_z_t *
@@ -766,10 +766,26 @@ impl_afw_adapter_journal_get_entry_internal(
 
     /* If get_first, get path to first journal file. */
     if (get_first) {
+        const afw_utf8_z_t *first_entry_save_path_z;
+        apr_finfo_t first_finfo;
+
         first_entry_save_path = afw_utf8_printf(xctx->p, xctx,
             AFW_UTF8_FMT AFW_OBJECT_Q_OBJECT_TYPE_ID_JOURNAL_ENTRY
             "/path_to_first_journal_file",
             AFW_UTF8_FMT_ARG(adapter->root));
+        first_entry_save_path_z = afw_utf8_to_utf8_z(
+            first_entry_save_path, p, xctx);
+        AFW_ERROR_FOOTPRINT("apr_stat()");
+        rv = apr_stat(&first_finfo, first_entry_save_path_z,
+            APR_FINFO_TYPE, apr_p);
+        /* No pointer file yet: empty journal, not an error. */
+        if (APR_STATUS_IS_ENOENT(rv)) {
+            return;
+        }
+        if (rv != APR_SUCCESS) {
+            AFW_THROW_ERROR_RV_Z(general, apr, rv,
+                "apr_stat() failed.", xctx);
+        }
         relative_entry_path_z = afw_utf8_to_utf8_z(
             afw_utf8_from_raw(
                 afw_file_to_memory(first_entry_save_path, 0, p, xctx),

--- a/src/afw/file/afw_file_journal.c
+++ b/src/afw/file/afw_file_journal.c
@@ -102,7 +102,27 @@ impl_object_id_to_relative_entry_path(
     for (*offset = 0, count = entry_object_id->len - strlen("ccyymmddhh_");
         count > 0; count--)
     {
-        *offset = *offset * 10 + (*i++ - '0');
+        unsigned int digit;
+
+        if (*i < '0' || *i > '9') {
+            return NULL;
+        }
+        digit = (unsigned int)(*i++ - '0');
+        /*
+         * Offset is a signed afw_off_t fed to apr_file_seek, and later
+         * printed as afw_integer_t. Bound to the smaller of those.
+         */
+        if (sizeof(afw_off_t) < sizeof(afw_integer_t)) {
+            if (*offset > ((afw_off_t)AFW_INT32_MAX - (afw_off_t)digit) / 10) {
+                return NULL;
+            }
+        }
+        else if (*offset >
+            ((afw_off_t)AFW_INTEGER_MAX - (afw_off_t)digit) / 10)
+        {
+            return NULL;
+        }
+        *offset = *offset * 10 + (afw_off_t)digit;
     }
 
     return &relative_entry_path_wa_z[0];
@@ -756,7 +776,11 @@ impl_afw_adapter_journal_get_entry_internal(
     else if (entry_object_id) {
         relative_entry_path_z = impl_object_id_to_relative_entry_path(
             entry_object_id, relative_entry_path_wa_z, &offset, xctx);
-        if (!relative_entry_path_z) return; /** @fixme Is this an error?*/
+        if (!relative_entry_path_z) {
+            AFW_THROW_ERROR_FZ(syntax, xctx,
+                "Invalid journal cursor " AFW_UTF8_FMT_Q,
+                AFW_UTF8_FMT_ARG(entry_object_id));
+        }
     }
 
     else {

--- a/src/afw/query_criteria/afw_query_criteria.c
+++ b/src/afw/query_criteria/afw_query_criteria.c
@@ -45,6 +45,9 @@ typedef struct impl_string_parser_s {
     afw_boolean_t bang_is_a_delimiter;
     afw_boolean_t expect_an_operation;
 
+    /* Nested '(' / and()/or() depth. See AFW_QUERY_CRITERIA_PARSE_NESTING_MAX. */
+    afw_size_t parse_nesting;
+
 } impl_string_parser_t;
 
 static void
@@ -505,6 +508,29 @@ do { \
         AFW__FILE_LINE__, format_z, __VA_ARGS__); \
     longjmp(((parser->xctx)->current_try->throw_jmp_buf), \
         (afw_error_code_syntax)); \
+} while (0)
+
+
+/*
+ * Max nested '(' / and()/or() in a url-encoded RQL string. Stops C-stack
+ * overflow on pathological filters. Generous for real queries.
+ */
+#define AFW_QUERY_CRITERIA_PARSE_NESTING_MAX 256
+
+#define impl_query_parse_nesting_enter(parser) \
+do { \
+    AFW_XCTX_THROW_IF_TERMINATING((parser)->xctx); \
+    (parser)->parse_nesting++; \
+    if ((parser)->parse_nesting > AFW_QUERY_CRITERIA_PARSE_NESTING_MAX) { \
+        IMPL_STRING_THROW_ERROR_Z("Filter nesting is too deep"); \
+    } \
+} while (0)
+
+#define impl_query_parse_nesting_leave(parser) \
+do { \
+    if ((parser)->parse_nesting > 0) { \
+        (parser)->parse_nesting--; \
+    } \
 } while (0)
 
 
@@ -1010,9 +1036,11 @@ impl_parse_string_factor(
     const afw_query_criteria_filter_entry_t *on_false)
 {
     if (*(parser->c) == '(') {
+        impl_query_parse_nesting_enter(parser);
         (parser->c)++;
         impl_parse_string_sugar(parser, filter, tree,
             on_true, on_false);
+        impl_query_parse_nesting_leave(parser);
         if (*(parser->c) != ')') {
             IMPL_STRING_THROW_ERROR_Z("missing ')'");
         }
@@ -1181,6 +1209,8 @@ impl_parse_string_function(
         IMPL_STRING_THROW_ERROR_Z("Expecting '(' after operator");
     }
 
+    impl_query_parse_nesting_enter(parser);
+
     /* Allocate and initialize new filter entry. */
     entry = afw_pool_calloc_type(
         parser->p,
@@ -1308,6 +1338,8 @@ impl_parse_string_function(
             }
         }
     }
+
+    impl_query_parse_nesting_leave(parser);
 }
 
 

--- a/src/afw/query_criteria/afw_query_criteria.c
+++ b/src/afw/query_criteria/afw_query_criteria.c
@@ -132,6 +132,7 @@ typedef struct impl_AdaptiveQueryCriteria_object_parser_s {
     const afw_pool_t *p;
     afw_query_criteria_t *criteria;
     afw_query_criteria_filter_entry_t *last;
+    afw_size_t parse_nesting;
 } impl_AdaptiveQueryCriteria_object_parser_t;
 
 static void
@@ -527,6 +528,23 @@ do { \
 } while (0)
 
 #define impl_query_parse_nesting_leave(parser) \
+do { \
+    if ((parser)->parse_nesting > 0) { \
+        (parser)->parse_nesting--; \
+    } \
+} while (0)
+
+#define impl_query_object_parse_nesting_enter(parser) \
+do { \
+    AFW_XCTX_THROW_IF_TERMINATING((parser)->xctx); \
+    (parser)->parse_nesting++; \
+    if ((parser)->parse_nesting > AFW_QUERY_CRITERIA_PARSE_NESTING_MAX) { \
+        AFW_THROW_ERROR_Z(syntax, \
+            "Filter nesting is too deep", (parser)->xctx); \
+    } \
+} while (0)
+
+#define impl_query_object_parse_nesting_leave(parser) \
 do { \
     if ((parser)->parse_nesting > 0) { \
         (parser)->parse_nesting--; \
@@ -1209,8 +1227,6 @@ impl_parse_string_function(
         IMPL_STRING_THROW_ERROR_Z("Expecting '(' after operator");
     }
 
-    impl_query_parse_nesting_enter(parser);
-
     /* Allocate and initialize new filter entry. */
     entry = afw_pool_calloc_type(
         parser->p,
@@ -1229,6 +1245,7 @@ impl_parse_string_function(
     if (entry->op_id == afw_query_criteria_filter_op_id_and ||
         entry->op_id == afw_query_criteria_filter_op_id_or)
     {
+        impl_query_parse_nesting_enter(parser);
         for (
             previous_entry = previous_tree = NULL
             ;
@@ -1268,6 +1285,7 @@ impl_parse_string_function(
                 IMPL_STRING_THROW_ERROR_Z("Expecting ','");
             }
         }
+        impl_query_parse_nesting_leave(parser);
     }
 
     /* Process comparisons. */
@@ -1338,8 +1356,6 @@ impl_parse_string_function(
             }
         }
     }
-
-    impl_query_parse_nesting_leave(parser);
 }
 
 
@@ -1435,6 +1451,7 @@ impl_AdaptiveQueryCriteria_object_parse_filter(
     if (entry->op_id == afw_query_criteria_filter_op_id_and ||
         entry->op_id == afw_query_criteria_filter_op_id_or)
     {
+        impl_query_object_parse_nesting_enter(parser);
         filters_list = afw_object_old_get_property_as_array(filter_object,
             afw_s_filters, parser->xctx);
         if (!filters_list) {
@@ -1487,6 +1504,7 @@ impl_AdaptiveQueryCriteria_object_parse_filter(
                 }
             }
         }
+        impl_query_object_parse_nesting_leave(parser);
     }
 
     /* Process comparisons. */

--- a/src/afw/tests/file_adapter/retrieve_objects.as
+++ b/src/afw/tests/file_adapter/retrieve_objects.as
@@ -272,6 +272,22 @@ assert(obj.TestObject1.prop1 === "val1");
 return 0;
 
 
+//? test: retrieve_objects_query_criteria_rql_eq_percent_value
+//? description: file adapter urlEncodedRQLString decodes a valid %31 in the value
+//? expect: 0
+//? source: ...
+
+const objects: array = retrieve_objects("file", "TestObjectType1", {
+    "urlEncodedRQLString": "TestObject1.prop1=val%31"
+});
+
+const obj: object = objects[0];
+assert(obj !== undefined);
+assert(obj.TestObject1.prop1 === "val1");
+
+return 0;
+
+
 //? test: retrieve_objects_query_criteria_rql_eq_object_no_allowQuery
 //? description: Test file adapter retrieve_objects with rql query criteria eq object when allowQuery=false.
 //? expect: error:Query string error at offset +0: Property 'TestObject1.prop2' cannot be queried

--- a/src/afw/tests/file_journal/journal_cursor.as
+++ b/src/afw/tests/file_journal/journal_cursor.as
@@ -10,11 +10,13 @@ entry.objectId (not request.objectId). before_each runs once per file.
 //? sourceType: script
 //?
 //? test: empty-get-first
-//? description: journal_get_first with no entries is an error
-//? expect: error
+//? description: journal_get_first with no entries returns no entry
+//? expect: 0
 //? source: ...
 
-journal_get_first("journal")
+const journal = journal_get_first("journal");
+assert(is_nullish(journal.entry), "empty journal has no entry");
+return 0;
 
 //?
 //? test: cursor-too-short

--- a/src/afw/tests/file_journal/journal_cursor.as
+++ b/src/afw/tests/file_journal/journal_cursor.as
@@ -1,0 +1,151 @@
+#!/usr/bin/env -S afw --syntax test_script
+//?
+//? testScript: journal_cursor.as
+//? customPurpose: Part of file journal tests
+//? description: ...
+File journal cursor parse and get_by_cursor. Token is ccyymmddhh_offset;
+offset must be decimal digits that fit in signed off_t. A bad cursor is
+a syntax error (not a seek to a wrapped offset). Assigned id is
+entry.objectId (not request.objectId). before_each runs once per file.
+//? sourceType: script
+//?
+//? test: empty-get-first
+//? description: journal_get_first with no entries is an error
+//? expect: error
+//? source: ...
+
+journal_get_first("journal")
+
+//?
+//? test: cursor-too-short
+//? description: cursor shorter than ccyymmddhh_0 is an error
+//? expect: error
+//? source: ...
+
+journal_get_by_cursor("journal", "2016070423")
+
+//?
+//? test: cursor-missing-underscore
+//? description: 12 characters with no underscore is an error
+//? expect: error
+//? source: ...
+
+journal_get_by_cursor("journal", "201607042300")
+
+//?
+//? test: cursor-non-digit-date
+//? description: date prefix must be ten digits
+//? expect: error
+//? source: ...
+
+journal_get_by_cursor("journal", "abcdefghij_0")
+
+//?
+//? test: cursor-non-digit-offset
+//? description: cursor offset that is not all digits is an error
+//? expect: error
+//? source: ...
+
+journal_get_by_cursor("journal", "2016070423_abc")
+
+//?
+//? test: cursor-mixed-offset
+//? description: digits then a letter in the offset is an error
+//? expect: error
+//? source: ...
+
+journal_get_by_cursor("journal", "2016070423_12a")
+
+//?
+//? test: cursor-offset-overflow
+//? description: cursor offset that does not fit in signed off_t is an error
+//? expect: error
+//? source: ...
+
+journal_get_by_cursor("journal",
+    "2016070423_999999999999999999999999999999")
+
+//?
+//? test: next-after-bad-cursor
+//? description: journal_get_next_after_cursor uses the same cursor parse
+//? expect: error
+//? source: ...
+
+journal_get_next_after_cursor("journal", "2016070423_abc")
+
+//?
+//? test: well-formed-missing-file
+//? description: valid cursor whose journal hour file does not exist is an error
+//? expect: error
+//? source: ...
+
+journal_get_by_cursor("journal", "2099123123_0")
+
+//?
+//? test: get-by-cursor-roundtrip
+//? description: get_by_cursor of a real cursor returns that entry
+//? expect: 0
+//? source: ...
+
+const added = add_object("file", "_AdaptiveObject_", { firstName: "cursor1" });
+const first = journal_get_first("journal");
+assert(first.entry !== undefined);
+assert(first.entryCursor != null);
+assert(first.entry.objectId === added.objectId);
+
+const again = journal_get_by_cursor("journal", first.entryCursor);
+assert(again.entryCursor === first.entryCursor);
+assert(again.entry.objectId === added.objectId);
+return 0;
+
+//?
+//? test: padded-offset-same-entry
+//? description: leading zeros on the offset still seek to the same entry
+//? expect: 0
+//? source: ...
+
+add_object("file", "_AdaptiveObject_", { firstName: "pad" });
+const first = journal_get_first("journal");
+const cursor = first.entryCursor;
+const padded = replace(cursor, "_", "_000");
+const again = journal_get_by_cursor("journal", padded);
+assert(again.entry.objectId === first.entry.objectId);
+return 0;
+
+//?
+//? test: three-entries-walk-and-get
+//? description: next after cursor walks three entries; get_by_cursor hits each
+//? expect: 0
+//? source: ...
+
+add_object("file", "_AdaptiveObject_", { firstName: "a" }, "idA");
+add_object("file", "_AdaptiveObject_", { firstName: "b" }, "idB");
+add_object("file", "_AdaptiveObject_", { firstName: "c" }, "idC");
+
+/* before_each is per file, not per case. Earlier cases in this file may
+ * have appended entries; skip to the three we just added. */
+let e1 = journal_get_first("journal");
+let n = 0;
+while (!is_nullish(e1.entry) && e1.entry.objectId !== "idA" && n < 50) {
+    e1 = journal_get_next_after_cursor("journal", e1.entryCursor);
+    n = n + 1;
+}
+assert(e1.entry.objectId === "idA");
+const g1 = journal_get_by_cursor("journal", e1.entryCursor);
+assert(g1.entry.objectId === "idA");
+
+const e2 = journal_get_next_after_cursor("journal", e1.entryCursor);
+assert(e2.entry !== undefined);
+assert(e2.entry.objectId === "idB");
+const g2 = journal_get_by_cursor("journal", e2.entryCursor);
+assert(g2.entry.objectId === "idB");
+
+const e3 = journal_get_next_after_cursor("journal", e2.entryCursor);
+assert(e3.entry !== undefined);
+assert(e3.entry.objectId === "idC");
+const g3 = journal_get_by_cursor("journal", e3.entryCursor);
+assert(g3.entry.objectId === "idC");
+
+const end = journal_get_next_after_cursor("journal", e3.entryCursor);
+assert(is_nullish(end.entry), "no entry after the last of the three");
+return 0;

--- a/src/afw/tests/file_journal/journal_tests_1.as
+++ b/src/afw/tests/file_journal/journal_tests_1.as
@@ -30,7 +30,7 @@ const result = add_object("file", "_AdaptiveObject_", {
 });
 
 let journal = journal_get_first("journal");
-assert(journal.entry.request.objectId === result.request.objectId);
+assert(journal.entry.objectId === result.objectId);
 
 return 0;
 
@@ -299,21 +299,3 @@ assert(j.entry !== undefined, "face-only must not hide entry");
 journal_mark_consumed("journal", "faceConsumerLook", cursor);
 
 return 0;
-
-
-//?
-//? test: journal_cursor-non-digit-offset
-//? description: cursor offset that is not all digits is an error
-//? expect: error
-//? source: ...
-
-journal_get_by_cursor("journal", "2016070423_abc")
-
-//?
-//? test: journal_cursor-offset-overflow
-//? description: cursor offset that does not fit in signed off_t is an error
-//? expect: error
-//? source: ...
-
-journal_get_by_cursor("journal",
-    "2016070423_999999999999999999999999999999")

--- a/src/afw/tests/file_journal/journal_tests_1.as
+++ b/src/afw/tests/file_journal/journal_tests_1.as
@@ -5,15 +5,17 @@
 //? description: Test file journal interface methods.
 //? sourceType: script
 //?
-//? test: journal_get_first
-//? description: test file journal_get_first with no entries
-//? skip: true
+//? test: journal_get_first-empty
+//? description: journal_get_first with no entries returns no entry
+//? skip: false
 //? expect: 0
 //? source: ...
 #!/usr/bin/env afw
 
 let journal = journal_get_first("journal");
+assert(is_nullish(journal.entry), "empty journal has no entry");
 let journal2 = journal_get_first("journal");
+assert(is_nullish(journal2.entry), "second empty get_first still has no entry");
 
 return 0;
 

--- a/src/afw/tests/file_journal/journal_tests_1.as
+++ b/src/afw/tests/file_journal/journal_tests_1.as
@@ -299,3 +299,21 @@ assert(j.entry !== undefined, "face-only must not hide entry");
 journal_mark_consumed("journal", "faceConsumerLook", cursor);
 
 return 0;
+
+
+//?
+//? test: journal_cursor-non-digit-offset
+//? description: cursor offset that is not all digits is an error
+//? expect: error
+//? source: ...
+
+journal_get_by_cursor("journal", "2016070423_abc")
+
+//?
+//? test: journal_cursor-offset-overflow
+//? description: cursor offset that does not fit in signed off_t is an error
+//? expect: error
+//? source: ...
+
+journal_get_by_cursor("journal",
+    "2016070423_999999999999999999999999999999")

--- a/src/afw/tests/file_journal/journal_tests_2.as
+++ b/src/afw/tests/file_journal/journal_tests_2.as
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S afw --syntax test_script
 //?
-//? testScript: journal_tests_3.as
+//? testScript: journal_tests_2.as
 //? customPurpose: Part of file_journal tests
 //? description: test a series of journal entries
 //? sourceType: script
@@ -12,13 +12,8 @@
 //? source: ...
 #!/usr/bin/env afw
 
-let err = false;
-try {
-    let j1 = journal_get_first("journal");
-} catch (e) {
-    err = true;
-}
-assert(err);
+let empty = journal_get_first("journal");
+assert(is_nullish(empty.entry), "empty journal has no entry");
 
 for (let i = 0; i < 100; i += 1) {
     add_object("file", "_AdaptiveObject_", { 

--- a/src/afw/tests/file_journal/journal_tests_2.as
+++ b/src/afw/tests/file_journal/journal_tests_2.as
@@ -31,13 +31,25 @@ let j2 = journal_get_first("journal");
 let entryCursor = j2.entryCursor;
 assert(entryCursor != null);
 
+const firstCursor = entryCursor;
+const firstAgain = journal_get_by_cursor("journal", firstCursor);
+assert(firstAgain.entryCursor === firstCursor);
+
 let j3;
+let midCursor = null;
 for (let i = 0; i < 100; i += 1) {
     j3 = journal_get_next_after_cursor("journal", entryCursor);
     assert(j3.entryCursor !== entryCursor);
     entryCursor = j3.entryCursor;
+    if (i === 49) {
+        midCursor = entryCursor;
+    }
 }
 
 assert(j3.entry == null, string(j3));
+
+const mid = journal_get_by_cursor("journal", midCursor);
+assert(mid.entry !== undefined);
+assert(mid.entryCursor === midCursor);
 
 return 0;

--- a/src/afw/tests/rql/parse_bounds.as
+++ b/src/afw/tests/rql/parse_bounds.as
@@ -1,0 +1,136 @@
+#!/usr/bin/env -S afw --syntax test_script
+//?
+//? testScript: parse_bounds.as
+//? customPurpose: Part of rql tests
+//? description: urlEncodedRQLString percent-decode and filter nesting bounds
+//? sourceType: script
+//?
+//? test: encoded-underscore-still-matches
+//? description: valid %5f in a filter value still retrieves
+//? expect: 0
+//? source: ...
+
+const objects = retrieve_objects("afw", "_AdaptiveObjectType_", {
+    "urlEncodedRQLString": "objectType=_AdaptiveObjectType%5f"
+}, undefined, undefined, 0);
+assert(length(objects) === 1);
+assert(objects[0].objectType === "_AdaptiveObjectType_");
+return 0;
+
+//?
+//? test: trailing-percent-is-error
+//? description: a value ending in a bare % is invalid percent-encoding
+//? expect: error
+//? source: ...
+
+retrieve_objects("afw", "_AdaptiveObjectType_", {
+    "urlEncodedRQLString": "objectType=_AdaptiveObjectType_%"
+}, undefined, undefined, 0)
+
+//?
+//? test: truncated-hex-is-error
+//? description: % followed by one hex digit is invalid
+//? expect: error
+//? source: ...
+
+retrieve_objects("afw", "_AdaptiveObjectType_", {
+    "urlEncodedRQLString": "objectType=foo%2"
+}, undefined, undefined, 0)
+
+//?
+//? test: non-hex-percent-is-error
+//? description: % followed by non-hex is invalid
+//? expect: error
+//? source: ...
+
+retrieve_objects("afw", "_AdaptiveObjectType_", {
+    "urlEncodedRQLString": "objectType=foo%GG"
+}, undefined, undefined, 0)
+
+//?
+//? test: and-nesting-modest
+//? description: 32 nested and() still parses
+//? expect: 0
+//? source: ...
+
+function nestAnd(n) {
+    let i = 0;
+    let s = "eq(objectType,_AdaptiveObjectType_)";
+    while (i < n) {
+        s = "and(" + s + ")";
+        i = i + 1;
+    }
+    return s;
+}
+
+const objects = retrieve_objects("afw", "_AdaptiveObjectType_", {
+    "urlEncodedRQLString": nestAnd(32)
+}, undefined, undefined, 0);
+assert(length(objects) === 1);
+return 0;
+
+//?
+//? test: and-nesting-too-deep
+//? description: 300 nested and() is a syntax error
+//? expect: error
+//? source: ...
+
+function nestAnd(n) {
+    let i = 0;
+    let s = "eq(objectType,_AdaptiveObjectType_)";
+    while (i < n) {
+        s = "and(" + s + ")";
+        i = i + 1;
+    }
+    return s;
+}
+
+retrieve_objects("afw", "_AdaptiveObjectType_", {
+    "urlEncodedRQLString": nestAnd(300)
+}, undefined, undefined, 0)
+
+//?
+//? test: paren-nesting-modest
+//? description: 32 parenthesized FIQL still parses
+//? expect: 0
+//? source: ...
+
+function wrap(open, mid, close, n) {
+    let i = 0;
+    let left = "";
+    let right = "";
+    while (i < n) {
+        left = left + open;
+        right = right + close;
+        i = i + 1;
+    }
+    return left + mid + right;
+}
+
+const objects = retrieve_objects("afw", "_AdaptiveObjectType_", {
+    "urlEncodedRQLString": wrap("(", "objectType=_AdaptiveObjectType_", ")", 32)
+}, undefined, undefined, 0);
+assert(length(objects) === 1);
+return 0;
+
+//?
+//? test: paren-nesting-too-deep
+//? description: 300 parenthesized FIQL is a syntax error
+//? expect: error
+//? source: ...
+
+function wrap(open, mid, close, n) {
+    let i = 0;
+    let left = "";
+    let right = "";
+    while (i < n) {
+        left = left + open;
+        right = right + close;
+        i = i + 1;
+    }
+    return left + mid + right;
+}
+
+retrieve_objects("afw", "_AdaptiveObjectType_", {
+    "urlEncodedRQLString": wrap("(", "objectType=_AdaptiveObjectType_", ")", 300)
+}, undefined, undefined, 0)

--- a/src/afw/tests/rql/parse_bounds.as
+++ b/src/afw/tests/rql/parse_bounds.as
@@ -134,3 +134,255 @@ function wrap(open, mid, close, n) {
 retrieve_objects("afw", "_AdaptiveObjectType_", {
     "urlEncodedRQLString": wrap("(", "objectType=_AdaptiveObjectType_", ")", 300)
 }, undefined, undefined, 0)
+
+//?
+//? test: uppercase-hex-still-matches
+//? description: valid %5F (uppercase hex) in a filter value still retrieves
+//? expect: 0
+//? source: ...
+
+const objects = retrieve_objects("afw", "_AdaptiveObjectType_", {
+    "urlEncodedRQLString": "objectType=_AdaptiveObjectType%5F"
+}, undefined, undefined, 0);
+assert(length(objects) === 1);
+return 0;
+
+//?
+//? test: percent-in-middle-is-error
+//? description: a bare % in the middle of a value is invalid
+//? expect: error
+//? source: ...
+
+retrieve_objects("afw", "_AdaptiveObjectType_", {
+    "urlEncodedRQLString": "objectType=foo%bar"
+}, undefined, undefined, 0)
+
+//?
+//? test: or-nesting-modest
+//? description: 32 nested or() still parses
+//? expect: 0
+//? source: ...
+
+function nestOr(n) {
+    let i = 0;
+    let s = "eq(objectType,_AdaptiveObjectType_)";
+    while (i < n) {
+        s = "or(" + s + ")";
+        i = i + 1;
+    }
+    return s;
+}
+
+const objects = retrieve_objects("afw", "_AdaptiveObjectType_", {
+    "urlEncodedRQLString": nestOr(32)
+}, undefined, undefined, 0);
+assert(length(objects) === 1);
+return 0;
+
+//?
+//? test: or-nesting-too-deep
+//? description: 300 nested or() is a syntax error
+//? expect: error
+//? source: ...
+
+function nestOr(n) {
+    let i = 0;
+    let s = "eq(objectType,_AdaptiveObjectType_)";
+    while (i < n) {
+        s = "or(" + s + ")";
+        i = i + 1;
+    }
+    return s;
+}
+
+retrieve_objects("afw", "_AdaptiveObjectType_", {
+    "urlEncodedRQLString": nestOr(300)
+}, undefined, undefined, 0)
+
+//?
+//? test: and-nesting-at-limit
+//? description: 256 nested and() is accepted
+//? expect: 0
+//? source: ...
+
+function nestAnd(n) {
+    let i = 0;
+    let s = "eq(objectType,_AdaptiveObjectType_)";
+    while (i < n) {
+        s = "and(" + s + ")";
+        i = i + 1;
+    }
+    return s;
+}
+
+const objects = retrieve_objects("afw", "_AdaptiveObjectType_", {
+    "urlEncodedRQLString": nestAnd(256)
+}, undefined, undefined, 0);
+assert(length(objects) === 1);
+return 0;
+
+//?
+//? test: and-nesting-over-limit
+//? description: 257 nested and() is a syntax error
+//? expect: error
+//? source: ...
+
+function nestAnd(n) {
+    let i = 0;
+    let s = "eq(objectType,_AdaptiveObjectType_)";
+    while (i < n) {
+        s = "and(" + s + ")";
+        i = i + 1;
+    }
+    return s;
+}
+
+retrieve_objects("afw", "_AdaptiveObjectType_", {
+    "urlEncodedRQLString": nestAnd(257)
+}, undefined, undefined, 0)
+
+//?
+//? test: paren-nesting-at-limit
+//? description: 256 parenthesized FIQL is accepted
+//? expect: 0
+//? source: ...
+
+function wrap(open, mid, close, n) {
+    let i = 0;
+    let left = "";
+    let right = "";
+    while (i < n) {
+        left = left + open;
+        right = right + close;
+        i = i + 1;
+    }
+    return left + mid + right;
+}
+
+const objects = retrieve_objects("afw", "_AdaptiveObjectType_", {
+    "urlEncodedRQLString": wrap("(", "objectType=_AdaptiveObjectType_", ")", 256)
+}, undefined, undefined, 0);
+assert(length(objects) === 1);
+return 0;
+
+//?
+//? test: paren-nesting-over-limit
+//? description: 257 parenthesized FIQL is a syntax error
+//? expect: error
+//? source: ...
+
+function wrap(open, mid, close, n) {
+    let i = 0;
+    let left = "";
+    let right = "";
+    while (i < n) {
+        left = left + open;
+        right = right + close;
+        i = i + 1;
+    }
+    return left + mid + right;
+}
+
+retrieve_objects("afw", "_AdaptiveObjectType_", {
+    "urlEncodedRQLString": wrap("(", "objectType=_AdaptiveObjectType_", ")", 257)
+}, undefined, undefined, 0)
+
+//?
+//? test: object-filter-nesting-modest
+//? description: 32 nested object-form and filters still parse
+//? expect: 0
+//? source: ...
+
+function nestFilter(n) {
+    let f = {
+        "op": "eq",
+        "property": "objectType",
+        "value": "_AdaptiveObjectType_"
+    };
+    let i = 0;
+    while (i < n) {
+        f = { "op": "and", "filters": [f] };
+        i = i + 1;
+    }
+    return f;
+}
+
+const objects = retrieve_objects("afw", "_AdaptiveObjectType_", {
+    "filter": nestFilter(32)
+}, undefined, undefined, 0);
+assert(length(objects) === 1);
+return 0;
+
+//?
+//? test: object-filter-nesting-too-deep
+//? description: 300 nested object-form and filters is a syntax error
+//? expect: error
+//? source: ...
+
+function nestFilter(n) {
+    let f = {
+        "op": "eq",
+        "property": "objectType",
+        "value": "_AdaptiveObjectType_"
+    };
+    let i = 0;
+    while (i < n) {
+        f = { "op": "and", "filters": [f] };
+        i = i + 1;
+    }
+    return f;
+}
+
+retrieve_objects("afw", "_AdaptiveObjectType_", {
+    "filter": nestFilter(300)
+}, undefined, undefined, 0)
+
+//?
+//? test: object-filter-nesting-at-limit
+//? description: 256 nested object-form and filters is accepted
+//? expect: 0
+//? source: ...
+
+function nestFilter(n) {
+    let f = {
+        "op": "eq",
+        "property": "objectType",
+        "value": "_AdaptiveObjectType_"
+    };
+    let i = 0;
+    while (i < n) {
+        f = { "op": "and", "filters": [f] };
+        i = i + 1;
+    }
+    return f;
+}
+
+const objects = retrieve_objects("afw", "_AdaptiveObjectType_", {
+    "filter": nestFilter(256)
+}, undefined, undefined, 0);
+assert(length(objects) === 1);
+return 0;
+
+//?
+//? test: object-filter-nesting-over-limit
+//? description: 257 nested object-form and filters is a syntax error
+//? expect: error
+//? source: ...
+
+function nestFilter(n) {
+    let f = {
+        "op": "eq",
+        "property": "objectType",
+        "value": "_AdaptiveObjectType_"
+    };
+    let i = 0;
+    while (i < n) {
+        f = { "op": "and", "filters": [f] };
+        i = i + 1;
+    }
+    return f;
+}
+
+retrieve_objects("afw", "_AdaptiveObjectType_", {
+    "filter": nestFilter(257)
+}, undefined, undefined, 0)

--- a/src/afw/uri/afw_uri.c
+++ b/src/afw/uri/afw_uri.c
@@ -995,7 +995,67 @@ afw_uri_encode_raw_to_preallocated(
 
 
 
-/* % encoding should already be validate. */
+/*
+ * Decode percent-encoded octets. Each '%' must be followed by two hex
+ * digits. Length is counted up, never computed as len - 2*percents
+ * (that underflows when a '%' is truncated).
+ */
+static void
+impl_uri_decode_percent(
+    const afw_utf8_octet_t *s,
+    afw_size_t len,
+    afw_memory_t *result,
+    const afw_pool_t *p,
+    afw_xctx_t *xctx)
+{
+    const afw_utf8_octet_t *c;
+    const afw_utf8_octet_t *end;
+    afw_utf8_octet_t *o;
+    afw_size_t decoded_len;
+    int x1, x2;
+
+    end = s + len;
+    decoded_len = 0;
+    for (c = s; c < end; ) {
+        if (*c == '%') {
+            if (c + 2 >= end) {
+                AFW_THROW_ERROR_Z(syntax,
+                    "Invalid percent-encoding in URI",
+                    xctx);
+            }
+            x1 = afw_ascii_decode_hex_digit(c[1]);
+            x2 = afw_ascii_decode_hex_digit(c[2]);
+            if (x1 < 0 || x2 < 0) {
+                AFW_THROW_ERROR_Z(syntax,
+                    "Invalid percent-encoding in URI",
+                    xctx);
+            }
+            c += 3;
+            decoded_len++;
+        }
+        else {
+            c++;
+            decoded_len++;
+        }
+    }
+
+    result->size = decoded_len;
+    o = afw_pool_malloc(p, decoded_len, xctx);
+    result->ptr = (const afw_octet_t *)o;
+    for (c = s; c < end; ) {
+        if (*c == '%') {
+            x1 = afw_ascii_decode_hex_digit(c[1]);
+            x2 = afw_ascii_decode_hex_digit(c[2]);
+            *o++ = (afw_utf8_octet_t)(x1 * 16 + x2);
+            c += 3;
+        }
+        else {
+            *o++ = *c++;
+        }
+    }
+}
+
+
 AFW_DEFINE(const afw_utf8_t *)
 afw_uri_decode(
     const afw_utf8_t *encoded,
@@ -1051,50 +1111,32 @@ afw_uri_decode_to_raw_create(
     afw_xctx_t *xctx)
 {
     afw_memory_t *result;
-    afw_utf8_octet_t *o;
     const afw_utf8_octet_t *c;
-    afw_utf8_octet_t c1, c2;
     const afw_utf8_octet_t *end;
-    afw_size_t percent_count;
-    afw_size_t decoded_len;
+    afw_boolean_t has_percent;
 
     result = afw_pool_calloc_type(p, afw_memory_t, xctx);
 
-    for (percent_count = 0, c = s, end = c + len;
-        c < end; c++)
-    {
-        if (*c == '%') percent_count++;
+    has_percent = false;
+    for (c = s, end = c + len; c < end; c++) {
+        if (*c == '%') {
+            has_percent = true;
+            break;
+        }
     }
 
-    if (percent_count == 0 || len == 0) {
+    if (!has_percent || len == 0) {
         result->ptr = (const afw_octet_t *)s;
         result->size = len;
         return result;
     }
 
-    result->size = decoded_len = len - 2 * percent_count;
-    o = afw_pool_malloc(p, result->size, xctx);
-    result->ptr = (const afw_octet_t *)o;
-
-    for (c = s; decoded_len > 0; decoded_len--) {
-        if (*c == '%') {
-            c++;
-            c1 = *c++;
-            c2 = *c++;
-            *o++ = afw_ascii_decode_hex_digit(c1) * 16 +
-                afw_ascii_decode_hex_digit(c2);
-        }
-        else {
-            *o++ = *c++;
-        }
-    }
-
+    impl_uri_decode_percent(s, len, result, p, xctx);
     return result;
 }
 
 
 
-/* % encoding should already be validate. */
 AFW_DEFINE(const afw_memory_t *)
 afw_uri_decode_to_raw(
     const afw_utf8_t *encoded,
@@ -1102,41 +1144,24 @@ afw_uri_decode_to_raw(
     afw_xctx_t *xctx)
 {
     afw_memory_t *result;
-    afw_utf8_octet_t *o;
     const afw_utf8_octet_t *c;
     const afw_utf8_octet_t *end;
-    afw_utf8_octet_t c1, c2;
-    afw_size_t len;
-    afw_size_t percent_count;
+    afw_boolean_t has_percent;
 
-    for (percent_count = 0, c = encoded->s, end = c + encoded->len;
-        c < end; c++)
-    {
-        if (*c == '%') percent_count++;
+    has_percent = false;
+    for (c = encoded->s, end = c + encoded->len; c < end; c++) {
+        if (*c == '%') {
+            has_percent = true;
+            break;
+        }
     }
 
-    if (percent_count == 0 || encoded->len == 0) {
+    if (!has_percent || encoded->len == 0) {
         return (const afw_memory_t *)encoded;
     }
 
     result = afw_pool_malloc_type(p, afw_memory_t, xctx);
-    result->size = len = encoded->len - 2 * percent_count;
-    o = afw_pool_malloc(p, result->size, xctx);
-    result->ptr = (const afw_octet_t *)o;
-
-    for (c = encoded->s; len > 0; len--) {
-        if (*c == '%') {
-            c++;
-            c1 = *c++;
-            c2 = *c++;
-            *o++ = afw_ascii_decode_hex_digit(c1) * 16 +
-                afw_ascii_decode_hex_digit(c2);
-        }
-        else {
-            *o++ = *c++;
-        }
-    }
-
+    impl_uri_decode_percent(encoded->s, encoded->len, result, p, xctx);
     return result;
 }
 

--- a/src/afw_yaml/afw_yaml_to_value.c
+++ b/src/afw_yaml/afw_yaml_to_value.c
@@ -25,7 +25,32 @@ typedef struct afw_yaml_parser_s {
     const afw_pool_t *p;
     const afw_utf8_t *path;
     afw_boolean_t cede_p;
+    afw_size_t parse_nesting;
 } afw_yaml_parser_t;
+
+
+/*
+ * Max nested YAML mappings/sequences. Stops C-stack overflow on
+ * pathological input. Generous for real documents.
+ */
+#define AFW_YAML_PARSE_NESTING_MAX 256
+
+#define impl_yaml_parse_nesting_enter(parser, xctx) \
+do { \
+    AFW_XCTX_THROW_IF_TERMINATING(xctx); \
+    (parser)->parse_nesting++; \
+    if ((parser)->parse_nesting > AFW_YAML_PARSE_NESTING_MAX) { \
+        AFW_THROW_ERROR_Z(syntax, \
+            "YAML nesting is too deep", xctx); \
+    } \
+} while (0)
+
+#define impl_yaml_parse_nesting_leave(parser) \
+do { \
+    if ((parser)->parse_nesting > 0) { \
+        (parser)->parse_nesting--; \
+    } \
+} while (0)
 
 const afw_value_t * afw_yaml_parse_value(
     afw_yaml_parser_t *parser, afw_xctx_t *xctx);
@@ -154,6 +179,8 @@ const afw_array_t * afw_yaml_parse_list(
     const afw_array_t *list;
     const afw_value_t *value;
 
+    impl_yaml_parse_nesting_enter(parser, xctx);
+
     list = afw_array_create_generic(parser->p, xctx);
 
     do {
@@ -162,6 +189,8 @@ const afw_array_t * afw_yaml_parse_list(
             afw_array_push_value(list, value, xctx);
         }
     } while (value);
+
+    impl_yaml_parse_nesting_leave(parser);
 
     /* Return. */
     return list;
@@ -178,6 +207,8 @@ const afw_object_t * afw_yaml_parse_object(
     const afw_object_t *saved_embedding_object;
     const afw_utf8_t *saved_property_name;
     const afw_object_t *_meta_;
+
+    impl_yaml_parse_nesting_enter(parser, xctx);
 
     /* Create new memory object.*/
     AFW_OBJECT_CREATE_ENTITY_OR_EMBEDDED(object,
@@ -261,6 +292,7 @@ const afw_object_t * afw_yaml_parse_object(
     /* Set parser->embedding_object to previous value and return object. */
     parser->embedding_object = saved_embedding_object;
     parser->property_name = saved_property_name;
+    impl_yaml_parse_nesting_leave(parser);
     return object;
 }
 

--- a/src/afw_yaml/tests/yaml_to_object.py
+++ b/src/afw_yaml/tests/yaml_to_object.py
@@ -14,6 +14,7 @@ Coverage:
   - add_object + get round-trip through YAML encode/decode
   - non-object YAML root rejected for adapter object load
   - plain scalar typing (integer vs double, null/~, quoted, partial number)
+  - mapping/sequence parse depth: modest, limit (256), over limit
 """
 
 from __future__ import annotations
@@ -345,6 +346,105 @@ def run():
             _case(
                 "file_adapter_yaml_mapping_too_deep",
                 "300 nested YAML mappings is a syntax error",
+                code == 0 and body == "0",
+                detail="exit=%s body=%r stderr=%r" % (code, body, err[-500:]),
+            )
+        )
+
+        _write(os.path.join(ot_dir, "deep256.yaml"), _nested_mapping(256))
+        code, out, err = _yaml_script(
+            """\
+            let o = get_object("yamlfile", "YamlOt", "deep256");
+            let i = 0;
+            while (i < 256) {
+                o = o.a;
+                i = i + 1;
+            }
+            assert(o === 1, "256 nested mappings");
+            return 0;
+            """
+        )
+        body = out.strip()
+        tests.append(
+            _case(
+                "file_adapter_yaml_mapping_at_limit",
+                "256 nested YAML mappings still load",
+                code == 0 and body == "0",
+                detail="exit=%s body=%r stderr=%r" % (code, body, err[-500:]),
+            )
+        )
+
+        _write(os.path.join(ot_dir, "deep257.yaml"), _nested_mapping(257))
+        code, out, err = _yaml_script(
+            """\
+            assert(
+                safe_evaluate(
+                    get_object("yamlfile", "YamlOt", "deep257"),
+                    "error"
+                ) == "error",
+                "257 nested mappings must not load"
+            );
+            return 0;
+            """
+        )
+        body = out.strip()
+        tests.append(
+            _case(
+                "file_adapter_yaml_mapping_over_limit",
+                "257 nested YAML mappings is a syntax error",
+                code == 0 and body == "0",
+                detail="exit=%s body=%r stderr=%r" % (code, body, err[-500:]),
+            )
+        )
+
+        def _nested_list_in_mapping(n):
+            body = "1"
+            for _ in range(n):
+                body = "[%s]" % body
+            return "{a: %s}" % body
+
+        _write(os.path.join(ot_dir, "list32.yaml"), _nested_list_in_mapping(32))
+        code, out, err = _yaml_script(
+            """\
+            let o = get_object("yamlfile", "YamlOt", "list32");
+            let v = o.a;
+            let i = 0;
+            while (i < 32) {
+                v = v[0];
+                i = i + 1;
+            }
+            assert(v === 1, "32 nested sequences");
+            return 0;
+            """
+        )
+        body = out.strip()
+        tests.append(
+            _case(
+                "file_adapter_yaml_sequence_modest_depth",
+                "32 nested YAML sequences under a mapping still load",
+                code == 0 and body == "0",
+                detail="exit=%s body=%r stderr=%r" % (code, body, err[-500:]),
+            )
+        )
+
+        _write(os.path.join(ot_dir, "list300.yaml"), _nested_list_in_mapping(300))
+        code, out, err = _yaml_script(
+            """\
+            assert(
+                safe_evaluate(
+                    get_object("yamlfile", "YamlOt", "list300"),
+                    "error"
+                ) == "error",
+                "300 nested sequences must not load"
+            );
+            return 0;
+            """
+        )
+        body = out.strip()
+        tests.append(
+            _case(
+                "file_adapter_yaml_sequence_too_deep",
+                "300 nested YAML sequences is a syntax error",
                 code == 0 and body == "0",
                 detail="exit=%s body=%r stderr=%r" % (code, body, err[-500:]),
             )

--- a/src/afw_yaml/tests/yaml_to_object.py
+++ b/src/afw_yaml/tests/yaml_to_object.py
@@ -296,4 +296,58 @@ def run():
             )
         )
 
+        # Nested mappings: modest depth still loads; pathological depth
+        # is a syntax error (not a crash). Limit is AFW_YAML_PARSE_NESTING_MAX.
+        def _nested_mapping(n):
+            body = "1"
+            for _ in range(n):
+                body = "{a: %s}" % body
+            return body
+
+        _write(os.path.join(ot_dir, "deep32.yaml"), _nested_mapping(32))
+        code, out, err = _yaml_script(
+            """\
+            let o = get_object("yamlfile", "YamlOt", "deep32");
+            let i = 0;
+            while (i < 32) {
+                o = o.a;
+                i = i + 1;
+            }
+            assert(o === 1, "32 nested mappings");
+            return 0;
+            """
+        )
+        body = out.strip()
+        tests.append(
+            _case(
+                "file_adapter_yaml_mapping_modest_depth",
+                "32 nested YAML mappings still load",
+                code == 0 and body == "0",
+                detail="exit=%s body=%r stderr=%r" % (code, body, err[-500:]),
+            )
+        )
+
+        _write(os.path.join(ot_dir, "deep300.yaml"), _nested_mapping(300))
+        code, out, err = _yaml_script(
+            """\
+            assert(
+                safe_evaluate(
+                    get_object("yamlfile", "YamlOt", "deep300"),
+                    "error"
+                ) == "error",
+                "300 nested mappings must not load"
+            );
+            return 0;
+            """
+        )
+        body = out.strip()
+        tests.append(
+            _case(
+                "file_adapter_yaml_mapping_too_deep",
+                "300 nested YAML mappings is a syntax error",
+                code == 0 and body == "0",
+                detail="exit=%s body=%r stderr=%r" % (code, body, err[-500:]),
+            )
+        )
+
     return {"description": description, "tests": tests}


### PR DESCRIPTION
@JeremyGrieshop

Percent-encoded URI tokens are checked for a `%` plus two hex digits before the decode buffer is sized. Length is counted up, not computed as `len - 2 * percents`.

Nested FIQL/RQL `and()`/`or()` and parenthesized filters, the object-form `filter` parser, and YAML mappings/sequences share a parse-depth cap of 256.

A file-journal cursor must be ten date digits, an underscore, and an offset that fits in signed `off_t`. A bad cursor is a syntax error. `journal_get_first` on an empty journal returns no entry (missing `path_to_first_journal_file` is the empty state, not a failure).

Tests: `src/afw/tests/rql/parse_bounds.as`, `src/afw/tests/file_journal/journal_cursor.as`, YAML depth cases in `src/afw_yaml/tests/yaml_to_object.py`, and a file-adapter `%31` retrieve.