### PR TITLE
Escape LDAP filter assertion values and cap filter-build depth

### DIFF
--- a/.cursor/rules/afw-extensions.mdc
+++ b/.cursor/rules/afw-extensions.mdc
@@ -81,7 +81,7 @@ Impl ids: extension DSO id is `"afw_<name>"`; adapter/factory often shorter (`"l
 
 - **curl**: `curl_global_init` in `initialize` before `generated_register`.
 - **lmdb**: richest adapter; docs say load **ubjson** content type for storage; conf samples may say `extension_id: "ubjson"` — runtime id is **`afw_ubjson`**. Optional **indexes** (only consumer of core `afw_adapter_impl_index` today): defs in DB via `index_*`, not conf; filter/value use **`current::`** — see **`afw-adapter-index`**.
-- **ldap**: heavy `afw_ldap_syntax_handler.c` / metadata for schema ↔ values.
+- **ldap**: heavy `afw_ldap_syntax_handler.c` / metadata for schema ↔ values. Filter splice escapes RFC 4515 assertion values (`* ( ) \\` NUL) at build time, not in `*_to_ber`. Property names must be LDAP attr tokens (descr / numericoid / options). Builder nesting cap is 256, same as query-criteria parse. No live directory in-tree — helper gates are the C probe under `src/afw_ldap/tests/ldap_filter/`.
 - **vfs**: factory symbol `afw_vfs_adapter_factory_vfs`; conf `adapterType: "vfs"` lazy-loads. Whole-file `data`, empty-file read (#79), multi-map longest prefix, `maxReadBytes` — details **`afw-vfs`**.
 - **ubjson/yaml**: dual-interface entry files; codecs in `*_from_value` / `*_to_value`.
 - **crypto**: OpenSSL `libcrypto` only (curl-style find module); process-global mutexed keystore; `decode_to_string` for password UTF-8 (not `string(binary)`); LDAP `bindParameters` single-sub template → object recipe in README. Extension README lives at **`src/<ext>/README.md`** when present (Jeremy/LMDB style).

--- a/src/afw_ldap/afw_ldap_adapter_session.c
+++ b/src/afw_ldap/afw_ldap_adapter_session.c
@@ -80,6 +80,7 @@ impl_afw_adapter_session_retrieve_objects(
     LDAPMessage *e;
     const afw_utf8_t *filter;
     const afw_utf8_t *filter_class;
+    const afw_utf8_t *escaped_type;
     const char *filter_z;
     const afw_object_t *o;
     const afw_utf8_t *object_id;
@@ -110,15 +111,17 @@ impl_afw_adapter_session_retrieve_objects(
 
     /* Determine filter_z. */
     if (object_type_id) {
+        escaped_type = afw_ldap_internal_filter_escape(
+            object_type_id, p, xctx);
         /* Check to see if the user wants inherited object types to be returned */
         if (AFW_OBJECT_OPTION_IS(impl_request->options, includeDescendentObjectTypes)) {
             filter_class = afw_utf8_printf(p, xctx,
                 "objectclass=" AFW_UTF8_FMT,
-                AFW_UTF8_FMT_ARG(object_type_id));
+                AFW_UTF8_FMT_ARG(escaped_type));
         } else {
             filter_class = afw_utf8_printf(p, xctx,
                 "structuralobjectclass=" AFW_UTF8_FMT,
-                AFW_UTF8_FMT_ARG(object_type_id));
+                AFW_UTF8_FMT_ARG(escaped_type));
         }
     } else {
         filter_class = afw_utf8_printf(p, xctx, "objectclass=*");
@@ -226,6 +229,7 @@ impl_afw_adapter_session_get_object(
     LDAPMessage *e;
     const afw_utf8_z_t *dn_z;
     const afw_utf8_z_t *filter_z;
+    const afw_utf8_t *escaped_type;
     const afw_object_t *obj;
     int ldap_scope;
     int count;
@@ -246,9 +250,11 @@ impl_afw_adapter_session_get_object(
     /* Read entry. */
     res = NULL;
     ldap_scope = LDAP_SCOPE_BASE;
+    escaped_type = afw_ldap_internal_filter_escape(
+        object_type_id, p, xctx);
     filter_z = apr_psprintf(afw_pool_get_apr_pool(xctx->p),
         "(structuralobjectclass=" AFW_UTF8_FMT ")",
-        AFW_UTF8_FMT_ARG(object_type_id));
+        AFW_UTF8_FMT_ARG(escaped_type));
     rv = ldap_search_s(self->ld, (char *)dn_z, ldap_scope, (char *)filter_z,
         afw_ldap_internal_allattrs, 0, &res);
     if (res) {

--- a/src/afw_ldap/afw_ldap_internal.c
+++ b/src/afw_ldap/afw_ldap_internal.c
@@ -324,6 +324,174 @@ afw_ldap_internal_create_object_from_entry(
 #define AFW_QUERY_CRITERIA_CONTINUE(x) \
     (x != AFW_QUERY_CRITERIA_FALSE && x != AFW_QUERY_CRITERIA_TRUE)
 
+static const char impl_filter_hex[16] = "0123456789ABCDEF";
+
+static afw_boolean_t
+impl_is_alpha(afw_octet_t c)
+{
+    return
+        (c >= 'A' && c <= 'Z') ||
+        (c >= 'a' && c <= 'z');
+}
+
+static afw_boolean_t
+impl_is_digit(afw_octet_t c)
+{
+    return c >= '0' && c <= '9';
+}
+
+static afw_boolean_t
+impl_is_keychar(afw_octet_t c)
+{
+    return impl_is_alpha(c) || impl_is_digit(c) || c == '-';
+}
+
+static afw_boolean_t
+impl_filter_attr_is_safe(const afw_utf8_t *attr)
+{
+    const afw_octet_t *s;
+    afw_size_t i;
+    afw_size_t len;
+
+    if (!attr || !attr->s || attr->len == 0) {
+        return false;
+    }
+    s = (const afw_octet_t *)attr->s;
+    len = attr->len;
+    i = 0;
+
+    if (impl_is_digit(s[0])) {
+        for (;;) {
+            if (i >= len || !impl_is_digit(s[i])) {
+                return false;
+            }
+            while (i < len && impl_is_digit(s[i])) {
+                i++;
+            }
+            if (i >= len || s[i] != '.') {
+                break;
+            }
+            i++;
+        }
+    }
+    else if (impl_is_alpha(s[0])) {
+        i = 1;
+        while (i < len && impl_is_keychar(s[i])) {
+            i++;
+        }
+    }
+    else {
+        return false;
+    }
+
+    while (i < len && s[i] == ';') {
+        i++;
+        if (i >= len || !impl_is_keychar(s[i])) {
+            return false;
+        }
+        i++;
+        while (i < len && impl_is_keychar(s[i])) {
+            i++;
+        }
+    }
+
+    return i == len;
+}
+
+static void
+impl_filter_require_depth(
+    const afw_query_criteria_filter_entry_t *entry,
+    afw_size_t depth,
+    afw_xctx_t *xctx)
+{
+    if (entry == AFW_QUERY_CRITERIA_TRUE ||
+        entry == AFW_QUERY_CRITERIA_FALSE)
+    {
+        return;
+    }
+    if (depth > AFW_LDAP_FILTER_NESTING_MAX) {
+        AFW_THROW_ERROR_Z(query_too_complex,
+            "LDAP filter nesting is too deep", xctx);
+    }
+    impl_filter_require_depth(entry->on_true, depth + 1, xctx);
+    impl_filter_require_depth(entry->on_false, depth + 1, xctx);
+}
+
+/*
+ * RFC 4515 assertionvalue: escape NUL, '(', ')', '*', and '\' as
+ * '\' HEX HEX. Other octets, including UTF-8, are left as-is.
+ */
+const afw_utf8_t *
+afw_ldap_internal_filter_escape(
+    const afw_utf8_t *s,
+    const afw_pool_t *p,
+    afw_xctx_t *xctx)
+{
+    const afw_octet_t *in;
+    afw_octet_t *out;
+    afw_octet_t *d;
+    afw_size_t i;
+    afw_size_t extra;
+    afw_octet_t c;
+
+    if (!s || !s->s || s->len == 0) {
+        return s;
+    }
+    if (s->len > ((afw_size_t)-1) / 3) {
+        AFW_THROW_ERROR_Z(memory,
+            "LDAP filter value is too large", xctx);
+    }
+
+    in = (const afw_octet_t *)s->s;
+    extra = 0;
+    for (i = 0; i < s->len; i++) {
+        c = in[i];
+        if (c == 0 || c == '(' || c == ')' || c == '*' || c == '\\') {
+            extra += 2;
+        }
+    }
+    if (extra == 0) {
+        return s;
+    }
+
+    out = afw_pool_malloc(p, s->len + extra, xctx);
+    d = out;
+    for (i = 0; i < s->len; i++) {
+        c = in[i];
+        if (c == 0 || c == '(' || c == ')' || c == '*' || c == '\\') {
+            *d++ = '\\';
+            *d++ = (afw_octet_t)impl_filter_hex[(c >> 4) & 0x0f];
+            *d++ = (afw_octet_t)impl_filter_hex[c & 0x0f];
+        }
+        else {
+            *d++ = c;
+        }
+    }
+
+    return afw_utf8_create((const afw_utf8_octet_t *)out,
+        s->len + extra, p, xctx);
+}
+
+void
+afw_ldap_internal_filter_require_safe_attr(
+    const afw_utf8_t *attr,
+    afw_xctx_t *xctx)
+{
+    if (!impl_filter_attr_is_safe(attr)) {
+        AFW_THROW_ERROR_Z(query_too_complex,
+            "LDAP filter attribute is not a valid attribute type",
+            xctx);
+    }
+}
+
+void
+afw_ldap_internal_filter_require_depth(
+    const afw_query_criteria_filter_entry_t *entry,
+    afw_xctx_t *xctx)
+{
+    impl_filter_require_depth(entry, 1, xctx);
+}
+
 /*
  * afw_ldap_internal_expression_from_filter_entry()
  *
@@ -349,6 +517,7 @@ afw_ldap_internal_expression_from_filter_entry(
     }
 
     property_name = entry->property_name;
+    afw_ldap_internal_filter_require_safe_attr(property_name, xctx);
 
     /* convert the filter value to a string for LDAP comparison to use */
     bv = afw_ldap_metadata_value_to_bv(session, property_name, entry->value, xctx);
@@ -357,8 +526,10 @@ afw_ldap_internal_expression_from_filter_entry(
             "Query criteria could not be converted into an LDAP filter string.", xctx);
     }
 
-    /* turn it into an afw string for easy use by the format routines */
+    /* Assertion value: NFC string, then RFC 4515 filter escape. */
     property_value = afw_utf8_create((*bv)->bv_val, (*bv)->bv_len, xctx->p, xctx);
+    property_value = afw_ldap_internal_filter_escape(property_value,
+        xctx->p, xctx);
 
     switch (entry->op_id) {
         case afw_query_criteria_filter_op_id_eq:
@@ -406,11 +577,8 @@ afw_ldap_internal_expression_from_filter_entry(
     return filter_expression;
 }
 
-/*
- *
- */
-const afw_utf8_t *
-afw_ldap_internal_expression_from_query_criteria(
+static const afw_utf8_t *
+impl_expression_from_query_criteria(
     afw_ldap_internal_adapter_session_t *session,
     const afw_query_criteria_filter_entry_t * entry,
     afw_xctx_t *xctx)
@@ -433,9 +601,9 @@ afw_ldap_internal_expression_from_query_criteria(
     else if (AFW_QUERY_CRITERIA_CONTINUE(entry->on_true) &&
             AFW_QUERY_CRITERIA_CONTINUE(entry->on_false))
     {
-        on_true = afw_ldap_internal_expression_from_query_criteria(
+        on_true = impl_expression_from_query_criteria(
             session, entry->on_true, xctx);
-        on_false = afw_ldap_internal_expression_from_query_criteria(
+        on_false = impl_expression_from_query_criteria(
             session, entry->on_false, xctx);
 
         /* (|(&(filter_expression)(on_true))(on_false)) */
@@ -448,7 +616,7 @@ afw_ldap_internal_expression_from_query_criteria(
     /* (entry AND on_true) */
     else if (AFW_QUERY_CRITERIA_CONTINUE(entry->on_true)) 
     {
-        on_true = afw_ldap_internal_expression_from_query_criteria(
+        on_true = impl_expression_from_query_criteria(
             session, entry->on_true, xctx);
 
         /* (&(filter_expression)(on_true)) */
@@ -460,7 +628,7 @@ afw_ldap_internal_expression_from_query_criteria(
     /* (entry OR on_false) */
     else if (AFW_QUERY_CRITERIA_CONTINUE(entry->on_false))
     {
-        on_false = afw_ldap_internal_expression_from_query_criteria(
+        on_false = impl_expression_from_query_criteria(
             session, entry->on_false, xctx);
 
         /* (|(filter_expression)(on_false)) */
@@ -472,4 +640,15 @@ afw_ldap_internal_expression_from_query_criteria(
 
     return filter_expression;
 
+}
+
+
+const afw_utf8_t *
+afw_ldap_internal_expression_from_query_criteria(
+    afw_ldap_internal_adapter_session_t *session,
+    const afw_query_criteria_filter_entry_t * entry,
+    afw_xctx_t *xctx)
+{
+    afw_ldap_internal_filter_require_depth(entry, xctx);
+    return impl_expression_from_query_criteria(session, entry, xctx);
 }

--- a/src/afw_ldap/afw_ldap_internal.h
+++ b/src/afw_ldap/afw_ldap_internal.h
@@ -160,6 +160,25 @@ afw_ldap_internal_create_object_from_entry(
     const afw_pool_t *p,
     afw_xctx_t *xctx);
 
+/* Same cap as AFW_QUERY_CRITERIA_PARSE_NESTING_MAX. */
+#define AFW_LDAP_FILTER_NESTING_MAX 256
+
+const afw_utf8_t *
+afw_ldap_internal_filter_escape(
+    const afw_utf8_t *s,
+    const afw_pool_t *p,
+    afw_xctx_t *xctx);
+
+void
+afw_ldap_internal_filter_require_safe_attr(
+    const afw_utf8_t *attr,
+    afw_xctx_t *xctx);
+
+void
+afw_ldap_internal_filter_require_depth(
+    const afw_query_criteria_filter_entry_t *entry,
+    afw_xctx_t *xctx);
+
 const afw_utf8_t *
 afw_ldap_internal_expression_from_query_criteria(
     afw_ldap_internal_adapter_session_t *session,

--- a/src/afw_ldap/tests/ldap_filter/ldap_filter.py
+++ b/src/afw_ldap/tests/ldap_filter/ldap_filter.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+LDAP filter splice helpers: RFC 4515 escape, attr token, nesting.
+
+A retrieve through the adapter needs a live directory and schema
+metadata (value_to_bv). Script cannot reach the splice. This boots a
+C probe against installed libafwldap and calls the helpers directly.
+"""
+
+from __future__ import print_function
+
+import os
+import subprocess
+import tempfile
+
+
+def _apr_includes():
+    try:
+        out = subprocess.check_output(
+            ["apr-1-config", "--includes"], text=True)
+        return out.split()
+    except (OSError, subprocess.CalledProcessError):
+        return ["-I/usr/include/apr-1.0"]
+
+
+def _compile_probe(dest):
+    here = os.path.dirname(os.path.abspath(__file__))
+    src = os.path.join(here, "ldap_filter_probe.c")
+    include_afw = os.environ.get("AFW_INCLUDE_DIR", "/usr/local/include/afw")
+    libdir = os.environ.get("AFW_LIB_DIR", "/usr/local/lib/afw")
+    cmd = [
+        "cc", "-O0", "-g",
+        "-I", include_afw,
+    ]
+    cmd.extend(_apr_includes())
+    cmd.extend([
+        "-o", dest, src,
+        "-L", libdir, "-Wl,-rpath," + libdir,
+        "-lafwldap", "-lafw",
+    ])
+    subprocess.check_call(cmd)
+
+
+def _case(name, description, passed, error=None):
+    return {
+        "test": name,
+        "description": description,
+        "passed": bool(passed),
+        "skip": False,
+        "error": error,
+    }
+
+
+def run():
+    description = "LDAP filter escape, attr token, and nesting"
+    tests = []
+    work = tempfile.mkdtemp(prefix="afw_ldap_filter_")
+    probe = os.path.join(work, "ldap_filter_probe")
+
+    try:
+        _compile_probe(probe)
+    except Exception as e:
+        return {
+            "description": description,
+            "tests": [
+                _case(
+                    "compile_probe",
+                    "Compile LDAP filter probe against libafwldap",
+                    False,
+                    str(e),
+                )
+            ],
+        }
+
+    cases = [
+        (
+            "escape-plain",
+            "plain and UTF-8 values are unchanged",
+        ),
+        (
+            "escape-specials",
+            "NUL ( ) * \\ become RFC 4515 hex escapes",
+        ),
+        (
+            "attr-ok",
+            "descr, numericoid, and option names are accepted",
+        ),
+        (
+            "attr-bad",
+            "empty or illegal attribute types are rejected",
+        ),
+        (
+            "depth-ok",
+            "256-deep query-criteria chain is accepted",
+        ),
+        (
+            "depth-too-deep",
+            "257-deep query-criteria chain is query_too_complex",
+        ),
+    ]
+    for name, desc in cases:
+        r = subprocess.run(
+            [probe, name],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        err = (r.stderr or "").strip() or (r.stdout or "").strip()
+        tests.append(_case(
+            name,
+            desc,
+            passed=(r.returncode == 0),
+            error=None if r.returncode == 0 else (
+                err or "exit {}".format(r.returncode)),
+        ))
+
+    return {
+        "description": description,
+        "tests": tests,
+    }

--- a/src/afw_ldap/tests/ldap_filter/ldap_filter_probe.c
+++ b/src/afw_ldap/tests/ldap_filter/ldap_filter_probe.c
@@ -1,0 +1,371 @@
+// See the 'COPYING' file in the project root for licensing information.
+/*
+ * Adaptive Framework LDAP filter helper probe
+ *
+ * Copyright (c) 2010-2026 Clemson University
+ *
+ */
+
+#include "afw.h"
+
+#include <stdio.h>
+#include <string.h>
+
+/**
+ * @file ldap_filter_probe.c
+ * @brief C probe for LDAP filter escape, attr check, and depth.
+ *
+ * Retrieve needs a directory and schema metadata. These helpers are
+ * the splice/depth gates and can be called without a session.
+ *
+ * Same shape as tests/advanced/pool_alloc/pool_alloc_probe.c.
+ */
+
+const afw_utf8_t *
+afw_ldap_internal_filter_escape(
+    const afw_utf8_t *s,
+    const afw_pool_t *p,
+    afw_xctx_t *xctx);
+
+void
+afw_ldap_internal_filter_require_safe_attr(
+    const afw_utf8_t *attr,
+    afw_xctx_t *xctx);
+
+void
+afw_ldap_internal_filter_require_depth(
+    const afw_query_criteria_filter_entry_t *entry,
+    afw_xctx_t *xctx);
+
+#define IMPL_NESTING_MAX 256
+
+static void
+impl_utf8_set(afw_utf8_t *s, const char *z, afw_size_t len)
+{
+    s->s = (const afw_utf8_octet_t *)z;
+    s->len = len;
+}
+
+static int
+impl_expect_escape(
+    const char *in_z,
+    afw_size_t in_len,
+    const char *expect_z,
+    afw_size_t expect_len,
+    const afw_pool_t *p,
+    afw_xctx_t *xctx,
+    const char *label)
+{
+    afw_utf8_t in;
+    const afw_utf8_t *out;
+
+    impl_utf8_set(&in, in_z, in_len);
+    out = afw_ldap_internal_filter_escape(&in, p, xctx);
+    if (!out || out->len != expect_len ||
+        memcmp(out->s, expect_z, expect_len) != 0)
+    {
+        fprintf(stderr, "%s: escape mismatch\n", label);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+impl_expect_attr_ok(
+    const char *z,
+    const afw_pool_t *p,
+    afw_xctx_t *xctx,
+    const char *label)
+{
+    afw_utf8_t attr;
+    int threw;
+
+    (void)p;
+    impl_utf8_set(&attr, z, strlen(z));
+    threw = 0;
+    AFW_TRY {
+        afw_ldap_internal_filter_require_safe_attr(&attr, xctx);
+    }
+    AFW_CATCH_UNHANDLED {
+        threw = 1;
+        fprintf(stderr, "%s: unexpected throw %s\n", label,
+            AFW_ERROR_THROWN->message_z
+            ? AFW_ERROR_THROWN->message_z : "?");
+    }
+    AFW_ENDTRY;
+    return threw;
+}
+
+static int
+impl_expect_attr_bad(
+    const char *z,
+    afw_xctx_t *xctx,
+    const char *label)
+{
+    afw_utf8_t attr;
+    int threw;
+    int unexpected;
+
+    impl_utf8_set(&attr, z, z ? strlen(z) : 0);
+    threw = 0;
+    unexpected = 0;
+    AFW_TRY {
+        afw_ldap_internal_filter_require_safe_attr(&attr, xctx);
+    }
+    AFW_CATCH_UNHANDLED {
+        if (AFW_ERROR_THROWN->code ==
+            afw_error_code_query_too_complex)
+        {
+            threw = 1;
+        }
+        else {
+            unexpected = 1;
+            fprintf(stderr, "%s: threw %s\n", label,
+                AFW_ERROR_THROWN->message_z
+                ? AFW_ERROR_THROWN->message_z : "?");
+        }
+    }
+    AFW_ENDTRY;
+    if (unexpected) {
+        return 1;
+    }
+    if (!threw) {
+        fprintf(stderr, "%s: did not throw\n", label);
+        return 1;
+    }
+    return 0;
+}
+
+static const afw_query_criteria_filter_entry_t *
+impl_chain(afw_size_t n, const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    afw_query_criteria_filter_entry_t *nodes;
+    afw_size_t i;
+
+    if (n == 0) {
+        return AFW_QUERY_CRITERIA_TRUE;
+    }
+    nodes = afw_pool_calloc(p,
+        sizeof(afw_query_criteria_filter_entry_t) * n, xctx);
+    for (i = 0; i < n; i++) {
+        nodes[i].on_true = (i + 1 < n)
+            ? &nodes[i + 1]
+            : AFW_QUERY_CRITERIA_TRUE;
+        nodes[i].on_false = AFW_QUERY_CRITERIA_FALSE;
+    }
+    return nodes;
+}
+
+static int
+impl_escape_plain(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    int rc;
+
+    rc = 0;
+    rc |= impl_expect_escape("cn", 2, "cn", 2, p, xctx, "plain");
+    rc |= impl_expect_escape("", 0, "", 0, p, xctx, "empty");
+    rc |= impl_expect_escape("inetOrgPerson", 13,
+        "inetOrgPerson", 13, p, xctx, "oc");
+    /* UTF-8 e-acute must pass through. */
+    rc |= impl_expect_escape("caf\xC3\xA9", 5,
+        "caf\xC3\xA9", 5, p, xctx, "utf8");
+    return rc;
+}
+
+static int
+impl_escape_specials(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    int rc;
+    char nul_in[3];
+    char nul_out[5];
+
+    rc = 0;
+    rc |= impl_expect_escape("*", 1, "\\2A", 3, p, xctx, "star");
+    rc |= impl_expect_escape("(", 1, "\\28", 3, p, xctx, "lparen");
+    rc |= impl_expect_escape(")", 1, "\\29", 3, p, xctx, "rparen");
+    rc |= impl_expect_escape("\\", 1, "\\5C", 3, p, xctx, "backslash");
+
+    nul_in[0] = 'a';
+    nul_in[1] = 0;
+    nul_in[2] = 'b';
+    nul_out[0] = 'a';
+    nul_out[1] = '\\';
+    nul_out[2] = '0';
+    nul_out[3] = '0';
+    nul_out[4] = 'b';
+    rc |= impl_expect_escape(nul_in, 3, nul_out, 5, p, xctx, "nul");
+
+    rc |= impl_expect_escape(
+        "x)(objectClass=*", 16,
+        "x\\29\\28objectClass=\\2A", 22,
+        p, xctx, "mixed");
+    return rc;
+}
+
+static int
+impl_attr_ok(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    int rc;
+
+    rc = 0;
+    rc |= impl_expect_attr_ok("cn", p, xctx, "cn");
+    rc |= impl_expect_attr_ok("objectClass", p, xctx, "objectClass");
+    rc |= impl_expect_attr_ok("givenName", p, xctx, "givenName");
+    rc |= impl_expect_attr_ok("2.5.4.3", p, xctx, "oid");
+    rc |= impl_expect_attr_ok("cn;lang-en", p, xctx, "option");
+    rc |= impl_expect_attr_ok("0", p, xctx, "single-digit-oid");
+    return rc;
+}
+
+static int
+impl_attr_bad(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    int rc;
+
+    (void)p;
+    rc = 0;
+    rc |= impl_expect_attr_bad("cn)(x", xctx, "inject-name");
+    rc |= impl_expect_attr_bad("cn*", xctx, "star-name");
+    rc |= impl_expect_attr_bad("(cn", xctx, "lparen-name");
+    rc |= impl_expect_attr_bad("1cn", xctx, "digit-then-alpha");
+    rc |= impl_expect_attr_bad("1.", xctx, "trailing-dot");
+    rc |= impl_expect_attr_bad(";lang-en", xctx, "option-only");
+    rc |= impl_expect_attr_bad("", xctx, "empty");
+    {
+        int threw;
+        int unexpected;
+
+        threw = 0;
+        unexpected = 0;
+        AFW_TRY {
+            afw_ldap_internal_filter_require_safe_attr(NULL, xctx);
+        }
+        AFW_CATCH_UNHANDLED {
+            if (AFW_ERROR_THROWN->code ==
+                afw_error_code_query_too_complex)
+            {
+                threw = 1;
+            }
+            else {
+                unexpected = 1;
+            }
+        }
+        AFW_ENDTRY;
+        if (unexpected || !threw) {
+            fprintf(stderr, "null-attr: %s\n",
+                threw ? "wrong code" : "did not throw");
+            rc |= 1;
+        }
+    }
+    return rc;
+}
+
+static int
+impl_depth_ok(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    const afw_query_criteria_filter_entry_t *chain;
+    int threw;
+
+    chain = impl_chain(IMPL_NESTING_MAX, p, xctx);
+    threw = 0;
+    AFW_TRY {
+        afw_ldap_internal_filter_require_depth(chain, xctx);
+    }
+    AFW_CATCH_UNHANDLED {
+        threw = 1;
+        fprintf(stderr, "depth-ok: unexpected throw %s\n",
+            AFW_ERROR_THROWN->message_z
+            ? AFW_ERROR_THROWN->message_z : "?");
+    }
+    AFW_ENDTRY;
+    return threw;
+}
+
+static int
+impl_depth_too_deep(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    const afw_query_criteria_filter_entry_t *chain;
+    int threw;
+    int unexpected;
+
+    chain = impl_chain(IMPL_NESTING_MAX + 1, p, xctx);
+    threw = 0;
+    unexpected = 0;
+    AFW_TRY {
+        afw_ldap_internal_filter_require_depth(chain, xctx);
+    }
+    AFW_CATCH_UNHANDLED {
+        if (AFW_ERROR_THROWN->code ==
+                afw_error_code_query_too_complex &&
+            AFW_ERROR_THROWN->message_z &&
+            strstr(AFW_ERROR_THROWN->message_z, "too deep"))
+        {
+            threw = 1;
+        }
+        else {
+            unexpected = 1;
+            fprintf(stderr, "depth-too-deep: threw %s\n",
+                AFW_ERROR_THROWN->message_z
+                ? AFW_ERROR_THROWN->message_z : "?");
+        }
+    }
+    AFW_ENDTRY;
+    if (unexpected) {
+        return 1;
+    }
+    if (!threw) {
+        fprintf(stderr, "depth-too-deep: did not throw\n");
+        return 1;
+    }
+    return 0;
+}
+
+int
+main(int argc, char **argv)
+{
+    const afw_error_t *create_error;
+    afw_xctx_t *xctx;
+    const afw_pool_t *p;
+    const char *case_name;
+    int rc;
+
+    xctx = afw_environment_create(afw_version(), argc,
+        (const char * const *)argv, &create_error);
+    if (!xctx) {
+        fprintf(stderr, "environment create failed\n");
+        return 2;
+    }
+
+    case_name = (argc > 1) ? argv[1] : "";
+    p = afw_pool_create(xctx->p, xctx);
+    rc = 0;
+
+    if (strcmp(case_name, "escape-plain") == 0) {
+        rc = impl_escape_plain(p, xctx);
+    }
+    else if (strcmp(case_name, "escape-specials") == 0) {
+        rc = impl_escape_specials(p, xctx);
+    }
+    else if (strcmp(case_name, "attr-ok") == 0) {
+        rc = impl_attr_ok(p, xctx);
+    }
+    else if (strcmp(case_name, "attr-bad") == 0) {
+        rc = impl_attr_bad(p, xctx);
+    }
+    else if (strcmp(case_name, "depth-ok") == 0) {
+        rc = impl_depth_ok(p, xctx);
+    }
+    else if (strcmp(case_name, "depth-too-deep") == 0) {
+        rc = impl_depth_too_deep(p, xctx);
+    }
+    else {
+        fprintf(stderr, "usage: ldap_filter_probe "
+            "escape-plain|escape-specials|attr-ok|attr-bad|"
+            "depth-ok|depth-too-deep\n");
+        rc = 2;
+    }
+
+    afw_pool_release(p, xctx);
+    afw_environment_release(xctx);
+    return rc;
+}


### PR DESCRIPTION
@JeremyGrieshop

LDAP retrieve and get now escape filter assertion values (RFC 4515) before splicing them into search filters. Property names that are not a valid LDAP attribute type are rejected. Query-criteria trees deeper than 256 throw `query_too_complex`.

No live directory in the suite. Helper gates are the C probe under `src/afw_ldap/tests/ldap_filter/`. `--fulldev` clang scan clean. Full suite under valgrind: 4076 passed, 82 skipped.