### PR TITLE
Bound UTF-8 case walks and sort recursion depth

### DIFF
--- a/designs/agent-support.md
+++ b/designs/agent-support.md
@@ -113,6 +113,8 @@ Shape: **symptom → layer → probe → code / doc entry**.
 - **Wrong bound then narrow** — a field stored as signed 32-bit must be checked against the signed max, not the unsigned max. Sibling fields in the same parse are the hint.
 - **Release the existing, not the incoming** — replace/clear must drop the object already stored. The generic associative-array impl already did; the memory object impl released the argument (NULL on clear).
 - **malloc(n) then write `[n]`** — a NULL-terminated copy needs `n + 1` slots. Count first, allocate one extra, then terminate.
+- **UNSAFE ICU walk** — `U8_NEXT_UNSAFE` / `U8_APPEND_UNSAFE` trust well-formed UTF-8 and have no bound. Hand-set `.s`/`.len` can truncate a multi-byte sequence. Current ICU names the bounded macros `U8_NEXT` / `U8_APPEND` (there is no `*_SAFE`). Throw on `c < 0` / append error, same as `afw_utf8_nfc`. Validating constructors are not the only door.
+- **Last-element quicksort** — Lomuto + last pivot is O(n) stack on already-sorted input. Recurse the smaller partition, loop the larger. Time can still be O(n²); the stack is what that bounds.
 
 **Wrong path:** deep-cloning whole adapters/registries to “fix” one bad lifetime; treating short-test green as long-run proof.
 

--- a/designs/knowledge-atlas.md
+++ b/designs/knowledge-atlas.md
@@ -345,7 +345,7 @@ After install, **restart afwfcgi** if attach tools talk to a long-lived process.
 |-------|------------|--------|
 | Array semantics | `array-semantics.md` | Shipped (#39) |
 | Converts | `conversion-functions.md` | Shipped with #39 wave |
-| UTF-8 code points | `utf8-code-point-sequences.md` | #153 oriented; #190 empty-match `replace` |
+| UTF-8 code points | `utf8-code-point-sequences.md` | #153 oriented; #190 empty-match `replace`; `to_lower` / ignore-case compare use bounded `U8_NEXT` / `U8_APPEND` |
 | Mutable faces | `issue-17-mutable-object-faces.md` | Closed PR #150 |
 | Expression property names | `issue-38-…` | Closed |
 | Meta on wire | `issue-138-…` | Design/status in pad |

--- a/src/afw/function/afw_function_higher_order_array.c
+++ b/src/afw/function/afw_function_higher_order_array.c
@@ -991,18 +991,38 @@ static void
 impl_quick_sort(
     impl_sort_ctx_t *ctx,
     afw_size_t low,
-    afw_size_t high) 
-{ 
+    afw_size_t high)
+{
     afw_size_t pivot_i;
+    afw_size_t left_n;
+    afw_size_t right_n;
 
-    if (low < high) 
-    { 
+    /*
+     * Recurse the smaller partition and loop the larger so worst-case
+     * depth is log2(n). Last-element Lomuto still has O(n^2) time on
+     * already-sorted input; the stack is what this bounds.
+     */
+    while (low < high) {
         pivot_i = impl_partition(ctx, low, high);
-        if (pivot_i > 0) {
-            impl_quick_sort(ctx, low, pivot_i - 1);
+        left_n = (pivot_i > low) ? (pivot_i - low) : 0;
+        right_n = high - pivot_i;
+
+        if (left_n < right_n) {
+            if (left_n > 1) {
+                impl_quick_sort(ctx, low, pivot_i - 1);
+            }
+            low = pivot_i + 1;
         }
-        impl_quick_sort(ctx, pivot_i + 1, high);
-    } 
+        else {
+            if (right_n > 1) {
+                impl_quick_sort(ctx, pivot_i + 1, high);
+            }
+            if (pivot_i == 0) {
+                break;
+            }
+            high = pivot_i - 1;
+        }
+    }
 } 
 
 /*

--- a/src/afw/tests/README.md
+++ b/src/afw/tests/README.md
@@ -16,9 +16,9 @@ A few places that are easy to misunderstand:
 - `advanced/` — short orchestrated tests (`orchestration.yaml`) that are
   part of the default run. A few groups are a Python `run()` that
   compiles a checked-in `*_probe.c` against installed `libafw` and
-  execs it (pool wrap, C-array view index). Use that when Adaptive
-  Script cannot reach the hole. The `.c` is not part of the cmake
-  library build.
+  execs it (pool wrap, C-array view index, UTF-8 ICU bound). Use that
+  when Adaptive Script cannot reach the hole. The `.c` is not part of
+  the cmake library build.
 
 Longer tests, including firehose, live next door in
 `src/afw/tests-extra/` and are only run when you pass

--- a/src/afw/tests/advanced/utf8_icu_bound/utf8_icu_bound.py
+++ b/src/afw/tests/advanced/utf8_icu_bound/utf8_icu_bound.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+to_lower / compare_ignore_case bound a truncated UTF-8 sequence.
+
+Script constructors validate UTF-8. Hand-set .s/.len can still present
+a truncated multi-byte sequence to the ICU walk.
+"""
+
+from __future__ import print_function
+
+import os
+import subprocess
+import tempfile
+
+
+def _apr_includes():
+    try:
+        out = subprocess.check_output(
+            ["apr-1-config", "--includes"], text=True)
+        return out.split()
+    except (OSError, subprocess.CalledProcessError):
+        return ["-I/usr/include/apr-1.0"]
+
+
+def _compile_probe(dest):
+    here = os.path.dirname(os.path.abspath(__file__))
+    src = os.path.join(here, "utf8_icu_bound_probe.c")
+    include_afw = os.environ.get("AFW_INCLUDE_DIR", "/usr/local/include/afw")
+    libdir = os.environ.get("AFW_LIB_DIR", "/usr/local/lib/afw")
+    cmd = [
+        "cc", "-O0", "-g",
+        "-I", include_afw,
+    ]
+    cmd.extend(_apr_includes())
+    cmd.extend([
+        "-o", dest, src,
+        "-L", libdir, "-Wl,-rpath," + libdir,
+        "-lafw",
+    ])
+    subprocess.check_call(cmd)
+
+
+def _case(name, description, passed, error=None):
+    return {
+        "test": name,
+        "description": description,
+        "passed": bool(passed),
+        "skip": False,
+        "error": error,
+    }
+
+
+def run():
+    description = "UTF-8 to_lower/compare bound truncated sequences"
+    tests = []
+    work = tempfile.mkdtemp(prefix="afw_utf8_icu_bound_")
+    probe = os.path.join(work, "utf8_icu_bound_probe")
+
+    try:
+        _compile_probe(probe)
+    except Exception as e:
+        return {
+            "description": description,
+            "tests": [
+                _case(
+                    "compile_probe",
+                    "Compile UTF-8 ICU bound probe against libafw",
+                    False,
+                    str(e),
+                )
+            ],
+        }
+
+    cases = [
+        (
+            "to_lower-valid",
+            "to_lower of valid UTF-8, including already-lower",
+        ),
+        (
+            "to_lower-truncated",
+            "to_lower of a truncated multi-byte sequence throws",
+        ),
+        (
+            "compare-valid",
+            "compare_ignore_case of valid UTF-8",
+        ),
+        (
+            "compare-truncated",
+            "compare_ignore_case of a truncated sequence throws",
+        ),
+    ]
+    for name, desc in cases:
+        r = subprocess.run(
+            [probe, name],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        err = (r.stderr or "").strip() or (r.stdout or "").strip()
+        tests.append(_case(
+            name,
+            desc,
+            passed=(r.returncode == 0),
+            error=None if r.returncode == 0 else (
+                err or "exit {}".format(r.returncode)),
+        ))
+
+    return {
+        "description": description,
+        "tests": tests,
+    }

--- a/src/afw/tests/advanced/utf8_icu_bound/utf8_icu_bound_probe.c
+++ b/src/afw/tests/advanced/utf8_icu_bound/utf8_icu_bound_probe.c
@@ -1,0 +1,230 @@
+// See the 'COPYING' file in the project root for licensing information.
+/*
+ * Adaptive Framework UTF-8 to_lower / compare bound probe
+ *
+ * Copyright (c) 2010-2026 Clemson University
+ *
+ */
+
+#include "afw.h"
+
+#include <stdio.h>
+#include <string.h>
+
+/**
+ * @file utf8_icu_bound_probe.c
+ * @brief C probe for bounded ICU next/append in to_lower / compare.
+ *
+ * Script constructors validate UTF-8. This boots a core environment and
+ * calls the C APIs with .s/.len set by hand, including a truncated
+ * multi-byte sequence.
+ *
+ * Same shape as tests/advanced/pool_alloc/pool_alloc_probe.c.
+ */
+
+static void
+impl_utf8_set(afw_utf8_t *s, const char *z, afw_size_t len)
+{
+    s->s = (const afw_utf8_octet_t *)z;
+    s->len = len;
+}
+
+static int
+impl_expect_throw(
+    const afw_utf8_t *s1,
+    const afw_utf8_t *s2,
+    afw_boolean_t do_lower,
+    const afw_pool_t *p,
+    afw_xctx_t *xctx,
+    const char *label)
+{
+    int threw;
+    int unexpected;
+
+    threw = 0;
+    unexpected = 0;
+    AFW_TRY {
+        if (do_lower) {
+            (void)afw_utf8_to_lower(s1, p, xctx);
+        }
+        else {
+            (void)afw_utf8_compare_ignore_case(s1, s2, xctx);
+        }
+    }
+    AFW_CATCH_UNHANDLED {
+        if (AFW_ERROR_THROWN->message_z &&
+            strstr(AFW_ERROR_THROWN->message_z, "Not valid UTF-8"))
+        {
+            threw = 1;
+        }
+        else {
+            unexpected = 1;
+            fprintf(stderr, "%s: threw %s\n", label,
+                AFW_ERROR_THROWN->message_z
+                ? AFW_ERROR_THROWN->message_z : "?");
+        }
+    }
+    AFW_ENDTRY;
+
+    if (unexpected) {
+        return 1;
+    }
+    if (!threw) {
+        fprintf(stderr, "%s: did not throw\n", label);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+impl_to_lower_valid(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    afw_utf8_t in;
+    const afw_utf8_t *out;
+    const afw_utf8_t already = AFW_UTF8_LITERAL("already");
+    const afw_utf8_t empty = AFW_UTF8_LITERAL("");
+
+    impl_utf8_set(&in, "ABC", 3);
+    out = afw_utf8_to_lower(&in, p, xctx);
+    if (!out || out->len != 3 || memcmp(out->s, "abc", 3) != 0) {
+        fprintf(stderr, "to_lower valid: ABC mismatch\n");
+        return 1;
+    }
+
+    out = afw_utf8_to_lower(&already, p, xctx);
+    if (out != &already) {
+        fprintf(stderr, "to_lower valid: already-lower not reused\n");
+        return 1;
+    }
+
+    out = afw_utf8_to_lower(&empty, p, xctx);
+    if (out != &empty) {
+        fprintf(stderr, "to_lower valid: empty not reused\n");
+        return 1;
+    }
+
+    /* U+00C9 LATIN CAPITAL E WITH ACUTE -> U+00E9 */
+    impl_utf8_set(&in, "\xC3\x89", 2);
+    out = afw_utf8_to_lower(&in, p, xctx);
+    if (!out || out->len != 2 ||
+        memcmp(out->s, "\xC3\xA9", 2) != 0)
+    {
+        fprintf(stderr, "to_lower valid: E-acute mismatch\n");
+        return 1;
+    }
+
+    return 0;
+}
+
+static int
+impl_to_lower_truncated(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    afw_utf8_t in;
+    int rc;
+
+    rc = 0;
+    /* 2-byte lead, no trail. */
+    impl_utf8_set(&in, "\xC3", 1);
+    rc |= impl_expect_throw(&in, NULL, true, p, xctx, "to_lower 2-byte");
+    /* 3-byte lead + one trail, missing last. */
+    impl_utf8_set(&in, "\xE2\x82", 2);
+    rc |= impl_expect_throw(&in, NULL, true, p, xctx, "to_lower 3-byte");
+    return rc;
+}
+
+static int
+impl_compare_valid(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    afw_utf8_t a;
+    afw_utf8_t b;
+    int cmp;
+
+    (void)p;
+    impl_utf8_set(&a, "AbC", 3);
+    impl_utf8_set(&b, "aBc", 3);
+    cmp = afw_utf8_compare_ignore_case(&a, &b, xctx);
+    if (cmp != 0) {
+        fprintf(stderr, "compare valid: AbC vs aBc -> %d\n", cmp);
+        return 1;
+    }
+
+    impl_utf8_set(&a, "abc", 3);
+    impl_utf8_set(&b, "abd", 3);
+    cmp = afw_utf8_compare_ignore_case(&a, &b, xctx);
+    if (cmp >= 0) {
+        fprintf(stderr, "compare valid: abc vs abd -> %d\n", cmp);
+        return 1;
+    }
+
+    impl_utf8_set(&a, "ab", 2);
+    impl_utf8_set(&b, "abc", 3);
+    cmp = afw_utf8_compare_ignore_case(&a, &b, xctx);
+    if (cmp >= 0) {
+        fprintf(stderr, "compare valid: ab vs abc -> %d\n", cmp);
+        return 1;
+    }
+
+    return 0;
+}
+
+static int
+impl_compare_truncated(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    afw_utf8_t a;
+    afw_utf8_t b;
+    int rc;
+
+    (void)p;
+    rc = 0;
+    impl_utf8_set(&a, "\xC3", 1);
+    impl_utf8_set(&b, "a", 1);
+    rc |= impl_expect_throw(&a, &b, false, p, xctx, "compare s1");
+    impl_utf8_set(&a, "a", 1);
+    impl_utf8_set(&b, "\xC3", 1);
+    rc |= impl_expect_throw(&a, &b, false, p, xctx, "compare s2");
+    return rc;
+}
+
+int
+main(int argc, char **argv)
+{
+    const afw_error_t *create_error;
+    afw_xctx_t *xctx;
+    const afw_pool_t *p;
+    const char *case_name;
+    int rc;
+
+    xctx = afw_environment_create(afw_version(), argc,
+        (const char * const *)argv, &create_error);
+    if (!xctx) {
+        fprintf(stderr, "environment create failed\n");
+        return 2;
+    }
+
+    case_name = (argc > 1) ? argv[1] : "";
+    p = afw_pool_create(xctx->p, xctx);
+    rc = 0;
+
+    if (strcmp(case_name, "to_lower-valid") == 0) {
+        rc = impl_to_lower_valid(p, xctx);
+    }
+    else if (strcmp(case_name, "to_lower-truncated") == 0) {
+        rc = impl_to_lower_truncated(p, xctx);
+    }
+    else if (strcmp(case_name, "compare-valid") == 0) {
+        rc = impl_compare_valid(p, xctx);
+    }
+    else if (strcmp(case_name, "compare-truncated") == 0) {
+        rc = impl_compare_truncated(p, xctx);
+    }
+    else {
+        fprintf(stderr, "usage: utf8_icu_bound_probe "
+            "to_lower-valid|to_lower-truncated|"
+            "compare-valid|compare-truncated\n");
+        rc = 2;
+    }
+
+    afw_pool_release(p, xctx);
+    afw_environment_release(xctx);
+    return rc;
+}

--- a/src/afw/tests/language/script/higher_order_array.as
+++ b/src/afw/tests/language/script/higher_order_array.as
@@ -5,7 +5,8 @@
 //? description: ...
 Edge cases for higher-order array functions (map, filter, find, reduce,
 every/some, all_of/any_of, sort): empty arrays, undefined entries, omitted
-literal elements, identity map on homogeneous strings, and mixed types.
+literal elements, identity map on homogeneous strings, mixed types, and
+sort of already-sorted / reverse / duplicate input.
 //? sourceType: script
 //?
 //? test: map-empty
@@ -267,6 +268,67 @@ return 0;
 
 let out = sort(function (a, b) { return a < b; }, ["c", "a", "b"]);
 assert(out[0] === "a" && out[1] === "b" && out[2] === "c");
+return 0;
+
+//?
+//? test: sort-already-sorted
+//? description: already-sorted integers stay in order
+//? expect: 0
+//? source: ...
+
+let out = sort(function (a, b) { return a < b; }, [1, 2, 3, 4, 5]);
+assert(out[0] === 1 && out[4] === 5);
+assert(out[1] === 2 && out[2] === 3 && out[3] === 4);
+return 0;
+
+//?
+//? test: sort-reverse-sorted
+//? description: reverse-sorted integers become ascending
+//? expect: 0
+//? source: ...
+
+let out = sort(function (a, b) { return a < b; }, [5, 4, 3, 2, 1]);
+assert(out[0] === 1 && out[1] === 2 && out[2] === 3);
+assert(out[3] === 4 && out[4] === 5);
+return 0;
+
+//?
+//? test: sort-duplicates
+//? description: equal integers stay together
+//? expect: 0
+//? source: ...
+
+let out = sort(function (a, b) { return a < b; }, [2, 1, 2, 1, 2]);
+assert(length(out) === 5);
+assert(out[0] === 1 && out[1] === 1);
+assert(out[2] === 2 && out[3] === 2 && out[4] === 2);
+return 0;
+
+//?
+//? test: sort-single
+//? description: one-element typed array is unchanged
+//? expect: 0
+//? source: ...
+
+let out = sort(function (a, b) { return a < b; }, [7]);
+assert(length(out) === 1 && out[0] === 7);
+return 0;
+
+//?
+//? test: sort-already-sorted-64
+//? description: already-sorted 64-integer array stays in order
+//? expect: 0
+//? source: ...
+
+let a = [0];
+for (let i = 1; i < 64; i = i + 1) {
+    push(a, i);
+}
+let out = sort(function (x, y) { return x < y; }, a);
+assert(length(out) === 64);
+for (let i = 0; i < 64; i = i + 1) {
+    assert(out[i] === i);
+}
 return 0;
 
 //?

--- a/src/afw/utf8/afw_utf8.c
+++ b/src/afw/utf8/afw_utf8.c
@@ -685,6 +685,7 @@ AFW_DEFINE(const afw_utf8_t *) afw_utf8_to_lower(
     uint8_t *cs2;
     afw_utf8_t *result;
     afw_boolean_t already_lower_case;
+    UBool isError;
 
     if (!s) {
         return NULL;
@@ -706,7 +707,10 @@ AFW_DEFINE(const afw_utf8_t *) afw_utf8_to_lower(
     /* Pre-scan to see if already lower case and to get length of result. */
     for (i1 = 0, len2 = 0, already_lower_case = true; i1 < len1; )
     {
-        U8_NEXT_UNSAFE(cs1, i1, c);
+        U8_NEXT(cs1, i1, len1, c);
+        if (c < 0) {
+            AFW_THROW_ERROR_Z(general, "Not valid UTF-8", xctx);
+        }
         len2 += U8_LENGTH(c);
         if (c != u_tolower(c)) {
             already_lower_case = false;
@@ -725,9 +729,16 @@ AFW_DEFINE(const afw_utf8_t *) afw_utf8_to_lower(
     result->len = len2;
 
     for (i1 = 0, i2 = 0; i1 < len1;) {
-        U8_NEXT_UNSAFE(cs1, i1, c);
+        U8_NEXT(cs1, i1, len1, c);
+        if (c < 0) {
+            AFW_THROW_ERROR_Z(general, "Not valid UTF-8", xctx);
+        }
         c_lower = u_tolower(c);
-        U8_APPEND_UNSAFE(cs2, i2, c_lower);
+        isError = false;
+        U8_APPEND(cs2, i2, len2, c_lower, isError);
+        if (isError) {
+            AFW_THROW_ERROR_Z(general, "Not valid UTF-8", xctx);
+        }
     }
 
     return result;
@@ -819,7 +830,7 @@ AFW_DEFINE(int) afw_utf8_compare_ignore_case(
     const afw_utf8_t *s1, const afw_utf8_t *s2, afw_xctx_t *xctx)
 {
     UChar32 c1, c2;
-    int32_t i, len, i2;
+    int32_t i, len, i2, len1, len2;
     const uint8_t *cs1, *cs2;
     int result;
 
@@ -833,16 +844,21 @@ AFW_DEFINE(int) afw_utf8_compare_ignore_case(
 
     cs1 = (const uint8_t *)s1->s;
     cs2 = (const uint8_t *)s2->s;
-    len = afw_safe_cast_size_to_int32((s1->len <= s2->len) ? s1->len : s2->len,
-        xctx);
+    len1 = (int32_t)s1->len;
+    len2 = (int32_t)s2->len;
+    len = (len1 <= len2) ? len1 : len2;
     result = 0;
     for (i = 0; i < len;) {
-        /* U8_NEXT_UNSAFE increments i.  Don't use i in first call so offset
-        will be correct for both the 'for' loop and pointing to the
-        correct character in both strings. */
+        /*
+         * U8_NEXT increments i. Don't use i in the first call so the
+         * offset stays correct for both the loop and the other string.
+         */
         i2 = i;
-        U8_NEXT_UNSAFE(cs1, i2, c1);
-        U8_NEXT_UNSAFE(cs2, i, c2);
+        U8_NEXT(cs1, i2, len1, c1);
+        U8_NEXT(cs2, i, len2, c2);
+        if (c1 < 0 || c2 < 0) {
+            AFW_THROW_ERROR_Z(general, "Not valid UTF-8", xctx);
+        }
         c1 = u_tolower(c1);
         c2 = u_tolower(c2);
         if (c1 == c2) continue;


### PR DESCRIPTION
@JeremyGrieshop

`to_lower` and ignore-case compare walk UTF-8 with ICU `U8_NEXT` / `U8_APPEND` (the bounded macros) and throw on a truncated sequence. `sort()` recurses the smaller partition and loops the larger so worst-case stack depth is log n.

No public issue. `--fulldev` clang scan clean. Full suite under valgrind: 4085 passed, 82 skipped.

Tests: `src/afw/tests/advanced/utf8_icu_bound/`, sort cases in `src/afw/tests/language/script/higher_order_array.as`.