### PR TITLE
Note throwing-probe valgrind noise and ignore-case lockstep

### DIFF
--- a/.cursor/rules/afw-tests.mdc
+++ b/.cursor/rules/afw-tests.mdc
@@ -120,8 +120,15 @@ When script cannot reach the hole (C-only size, a second impl of an
 interface that literals never use, …), the gate is a Python `run()`
 that compiles a checked-in `*_probe.c` against installed `libafw` and
 execs it. Same pattern: `src/afw/tests/advanced/pool_alloc/`,
-`src/afw/tests/advanced/array_view_index/`. Do not invent a cmake
+`src/afw/tests/advanced/array_view_index/`,
+`src/afw/tests/advanced/utf8_icu_bound/`. Do not invent a cmake
 test target for these. The `.c` is not part of `libafw`.
+
+`afwdev test --env-mode valgrind` wraps the **`afw` CLI**, not that
+compiled probe binary. A standalone `valgrind` on a probe that
+**throws** can trip libunwind in `afw_os_backtrace`; that is not an
+overread in the code under test. Judge the probe by its exit code
+(and by valgrind on `afw` when the hole is script-reachable).
 
 When fixing a C/runtime bug, add `.as` coverage that fails without the fix
 unless the hole is C-only (then the probe above):

--- a/.cursor/rules/afw-tests.mdc
+++ b/.cursor/rules/afw-tests.mdc
@@ -129,6 +129,7 @@ compiled probe binary. A standalone `valgrind` on a probe that
 **throws** can trip libunwind in `afw_os_backtrace`; that is not an
 overread in the code under test. Judge the probe by its exit code
 (and by valgrind on `afw` when the hole is script-reachable).
+Making probes first-class (and addressing unwind) is issue **#207**.
 
 When fixing a C/runtime bug, add `.as` coverage that fails without the fix
 unless the hole is C-only (then the probe above):

--- a/designs/agent-support.md
+++ b/designs/agent-support.md
@@ -113,7 +113,7 @@ Shape: **symptom → layer → probe → code / doc entry**.
 - **Wrong bound then narrow** — a field stored as signed 32-bit must be checked against the signed max, not the unsigned max. Sibling fields in the same parse are the hint.
 - **Release the existing, not the incoming** — replace/clear must drop the object already stored. The generic associative-array impl already did; the memory object impl released the argument (NULL on clear).
 - **malloc(n) then write `[n]`** — a NULL-terminated copy needs `n + 1` slots. Count first, allocate one extra, then terminate.
-- **UNSAFE ICU walk** — `U8_NEXT_UNSAFE` / `U8_APPEND_UNSAFE` trust well-formed UTF-8 and have no bound. Hand-set `.s`/`.len` can truncate a multi-byte sequence. Current ICU names the bounded macros `U8_NEXT` / `U8_APPEND` (there is no `*_SAFE`). Throw on `c < 0` / append error, same as `afw_utf8_nfc`. Validating constructors are not the only door.
+- **UNSAFE ICU walk** — `U8_NEXT_UNSAFE` / `U8_APPEND_UNSAFE` trust well-formed UTF-8 and have no bound. Hand-set `.s`/`.len` can truncate a multi-byte sequence. Current ICU names the bounded macros `U8_NEXT` / `U8_APPEND` (there is no `*_SAFE`). Throw on `c < 0` / append error, same as `afw_utf8_nfc`. Validating constructors are not the only door. `compare_ignore_case` still starts both strings at the same byte offset; that is a leftover (mixed-width pairing), not the overread.
 - **Last-element quicksort** — Lomuto + last pivot is O(n) stack on already-sorted input. Recurse the smaller partition, loop the larger. Time can still be O(n²); the stack is what that bounds.
 
 **Wrong path:** deep-cloning whole adapters/registries to “fix” one bad lifetime; treating short-test green as long-run proof.
@@ -141,6 +141,8 @@ Shape: **symptom → layer → probe → code / doc entry**.
 **Orchestrated:** marker `orchestration.yaml`/`json`; hosts **`afwfcgi`** (hermetic) or **`local`** (`afw --local`); x-afw demux expects. **#13** still open for Jeremy’s stress knobs/stats story.
 
 **Valgrind hang lesson:** parallel valgrind can park the pool if one worker blocks forever (e.g. `Session("local").close()` → `wait()`). Harness now times out/kills; if wall time is absurd with idle CPU, check for a stuck worker before assuming “just slow.”
+
+**Throwing C probe + valgrind:** `afwdev test --env-mode valgrind` wraps `afw`, not the compiled `*_probe.c`. Standalone valgrind on a probe that throws can report libunwind noise in `afw_os_backtrace`. That is not an overread. Judge the probe by exit code.
 
 ---
 

--- a/designs/agent-support.md
+++ b/designs/agent-support.md
@@ -113,7 +113,7 @@ Shape: **symptom → layer → probe → code / doc entry**.
 - **Wrong bound then narrow** — a field stored as signed 32-bit must be checked against the signed max, not the unsigned max. Sibling fields in the same parse are the hint.
 - **Release the existing, not the incoming** — replace/clear must drop the object already stored. The generic associative-array impl already did; the memory object impl released the argument (NULL on clear).
 - **malloc(n) then write `[n]`** — a NULL-terminated copy needs `n + 1` slots. Count first, allocate one extra, then terminate.
-- **UNSAFE ICU walk** — `U8_NEXT_UNSAFE` / `U8_APPEND_UNSAFE` trust well-formed UTF-8 and have no bound. Hand-set `.s`/`.len` can truncate a multi-byte sequence. Current ICU names the bounded macros `U8_NEXT` / `U8_APPEND` (there is no `*_SAFE`). Throw on `c < 0` / append error, same as `afw_utf8_nfc`. Validating constructors are not the only door. `compare_ignore_case` still starts both strings at the same byte offset; that is a leftover (mixed-width pairing), not the overread.
+- **UNSAFE ICU walk** — `U8_NEXT_UNSAFE` / `U8_APPEND_UNSAFE` trust well-formed UTF-8 and have no bound. Hand-set `.s`/`.len` can truncate a multi-byte sequence. Current ICU names the bounded macros `U8_NEXT` / `U8_APPEND` (there is no `*_SAFE`). Throw on `c < 0` / append error, same as `afw_utf8_nfc`. Validating constructors are not the only door. `compare_ignore_case` lockstep leftover is [#206](https://github.com/afw-org/afw/issues/206).
 - **Last-element quicksort** — Lomuto + last pivot is O(n) stack on already-sorted input. Recurse the smaller partition, loop the larger. Time can still be O(n²); the stack is what that bounds.
 
 **Wrong path:** deep-cloning whole adapters/registries to “fix” one bad lifetime; treating short-test green as long-run proof.
@@ -142,7 +142,7 @@ Shape: **symptom → layer → probe → code / doc entry**.
 
 **Valgrind hang lesson:** parallel valgrind can park the pool if one worker blocks forever (e.g. `Session("local").close()` → `wait()`). Harness now times out/kills; if wall time is absurd with idle CPU, check for a stuck worker before assuming “just slow.”
 
-**Throwing C probe + valgrind:** `afwdev test --env-mode valgrind` wraps `afw`, not the compiled `*_probe.c`. Standalone valgrind on a probe that throws can report libunwind noise in `afw_os_backtrace`. That is not an overread. Judge the probe by exit code.
+**Throwing C probe + valgrind:** `afwdev test --env-mode valgrind` wraps `afw`, not the compiled `*_probe.c`. Standalone valgrind on a probe that throws can report libunwind noise in `afw_os_backtrace`. That is not an overread. Judge the probe by exit code. First-class probes + addressing unwind is [#207](https://github.com/afw-org/afw/issues/207). Error-struct / backtrace as `afw_utf8_t` is [#206](https://github.com/afw-org/afw/issues/206).
 
 ---
 

--- a/designs/knowledge-atlas.md
+++ b/designs/knowledge-atlas.md
@@ -345,7 +345,7 @@ After install, **restart afwfcgi** if attach tools talk to a long-lived process.
 |-------|------------|--------|
 | Array semantics | `array-semantics.md` | Shipped (#39) |
 | Converts | `conversion-functions.md` | Shipped with #39 wave |
-| UTF-8 code points | `utf8-code-point-sequences.md` | #153 oriented; #190 empty-match `replace`; `to_lower` / ignore-case compare use bounded `U8_NEXT` / `U8_APPEND`; ignore-case still locksteps on a shared byte offset |
+| UTF-8 code points | `utf8-code-point-sequences.md` | #153 oriented; #190 empty-match `replace`; `to_lower` / ignore-case compare use bounded `U8_NEXT` / `U8_APPEND`; ignore-case lockstep leftover is [#206](https://github.com/afw-org/afw/issues/206) |
 | Mutable faces | `issue-17-mutable-object-faces.md` | Closed PR #150 |
 | Expression property names | `issue-38-…` | Closed |
 | Meta on wire | `issue-138-…` | Design/status in pad |

--- a/designs/knowledge-atlas.md
+++ b/designs/knowledge-atlas.md
@@ -345,7 +345,7 @@ After install, **restart afwfcgi** if attach tools talk to a long-lived process.
 |-------|------------|--------|
 | Array semantics | `array-semantics.md` | Shipped (#39) |
 | Converts | `conversion-functions.md` | Shipped with #39 wave |
-| UTF-8 code points | `utf8-code-point-sequences.md` | #153 oriented; #190 empty-match `replace`; `to_lower` / ignore-case compare use bounded `U8_NEXT` / `U8_APPEND` |
+| UTF-8 code points | `utf8-code-point-sequences.md` | #153 oriented; #190 empty-match `replace`; `to_lower` / ignore-case compare use bounded `U8_NEXT` / `U8_APPEND`; ignore-case still locksteps on a shared byte offset |
 | Mutable faces | `issue-17-mutable-object-faces.md` | Closed PR #150 |
 | Expression property names | `issue-38-…` | Closed |
 | Meta on wire | `issue-138-…` | Design/status in pad |

--- a/designs/utf8-code-point-sequences.md
+++ b/designs/utf8-code-point-sequences.md
@@ -50,7 +50,7 @@ Specialized hot paths (e.g. **substring**) may stay hand-tuned; they must share 
 | `starts_with` / `ends_with` | Full-string byte compare (OK for complete valid UTF-8 strings) |
 | **`replace`**, **split** (non-empty separator), **`afw_utf8_contains`** | **Fixed** — search advances by code point (still `memcmp` of full needle) |
 | Empty-match **`replace`** | **Fixed (#190)** — insert at each code-point boundary (including start and end); `limit = -1` must terminate |
-| **`to_lower` / `compare_ignore_case`** | **Bound (P4)** — `U8_NEXT` / `U8_APPEND`; throw on truncated. Compare still walks both strings from the same byte offset `i` (OK for ASCII; wrong for mixed-width like `"A"` vs `"À"`). Not rewritten with the bound. |
+| **`to_lower` / `compare_ignore_case`** | **Bound (P4)** — `U8_NEXT` / `U8_APPEND`; throw on truncated. Compare still walks both strings from the same byte offset `i` (OK for ASCII; wrong for mixed-width like `"A"` vs `"À"`). Leftover owned by [#206](https://github.com/afw-org/afw/issues/206). |
 | XACML bag formals | **Not** code-point expand (bag-of-one scalar); see `as_array_sequence` notes |
 
 ## Goals

--- a/designs/utf8-code-point-sequences.md
+++ b/designs/utf8-code-point-sequences.md
@@ -50,6 +50,7 @@ Specialized hot paths (e.g. **substring**) may stay hand-tuned; they must share 
 | `starts_with` / `ends_with` | Full-string byte compare (OK for complete valid UTF-8 strings) |
 | **`replace`**, **split** (non-empty separator), **`afw_utf8_contains`** | **Fixed** — search advances by code point (still `memcmp` of full needle) |
 | Empty-match **`replace`** | **Fixed (#190)** — insert at each code-point boundary (including start and end); `limit = -1` must terminate |
+| **`to_lower` / `compare_ignore_case`** | **Bound (P4)** — `U8_NEXT` / `U8_APPEND`; throw on truncated. Compare still walks both strings from the same byte offset `i` (OK for ASCII; wrong for mixed-width like `"A"` vs `"À"`). Not rewritten with the bound. |
 | XACML bag formals | **Not** code-point expand (bag-of-one scalar); see `as_array_sequence` notes |
 
 ## Goals

--- a/src/afw/tests/README.md
+++ b/src/afw/tests/README.md
@@ -21,6 +21,7 @@ A few places that are easy to misunderstand:
   the cmake library build. `afwdev test --env-mode valgrind` wraps
   `afw`, not the probe. Standalone valgrind on a throwing probe can
   hit libunwind in `afw_os_backtrace`; that is not the hole.
+  First-class probes: issue **#207**.
 
 Longer tests, including firehose, live next door in
 `src/afw/tests-extra/` and are only run when you pass

--- a/src/afw/tests/README.md
+++ b/src/afw/tests/README.md
@@ -18,7 +18,9 @@ A few places that are easy to misunderstand:
   compiles a checked-in `*_probe.c` against installed `libafw` and
   execs it (pool wrap, C-array view index, UTF-8 ICU bound). Use that
   when Adaptive Script cannot reach the hole. The `.c` is not part of
-  the cmake library build.
+  the cmake library build. `afwdev test --env-mode valgrind` wraps
+  `afw`, not the probe. Standalone valgrind on a throwing probe can
+  hit libunwind in `afw_os_backtrace`; that is not the hole.
 
 Longer tests, including firehose, live next door in
 `src/afw/tests-extra/` and are only run when you pass


### PR DESCRIPTION
@JeremyGrieshop

Docs only. Standalone valgrind on a throwing C probe can trip libunwind in `afw_os_backtrace`; the suite wraps `afw`, not the probe. `compare_ignore_case` still locksteps on a shared byte offset.

Those leftovers now point at #206 (NFC / lockstep / error-struct UTF-8) and #207 (first-class probes / unwind).