### PR TITLE
Record lineage, base vs private packages, and the library floor

### DIFF
--- a/designs/README.md
+++ b/designs/README.md
@@ -49,6 +49,7 @@ Per-**issue** or per-**theme** working notes: why, options, footguns, parked ide
 | [`issue-33-error-codes.md`](issue-33-error-codes.md) | **#33** — review error codes / HTTP map / script `e.id` (closed; PR **#173** → `mgg-develop`) |
 | [`issue-62-script-language.md`](issue-62-script-language.md) | **#62 closed** (PR **#174**) — Adaptive Script language index (multi `let`/`const`, `for` init, assignment chain, result value, labels) |
 | [`libafw-headers-and-api-surface.md`](libafw-headers-and-api-surface.md) | libafw header layers (`afw.h` / internal / minimal / common), install public-only goal, Doxygen public vs internal |
+| [`lineage-and-library-floor.md`](lineage-and-library-floor.md) | Base vs private packages; Docker ICU/APR floor; ICU stays in `afw_utf8` |
 
 ## Conventions
 

--- a/designs/afw-philosophy-and-core-model.md
+++ b/designs/afw-philosophy-and-core-model.md
@@ -40,6 +40,42 @@ These are the sticky choices that explain a lot of surface oddity:
 
 ---
 
+## Adaptive concepts
+
+**Adaptive Objects** started it. The type square (handbook architecture) is the core:
+
+| Noun | Role |
+|------|------|
+| **Adaptive Object** | The instance. Described by an Adaptive Object Type. |
+| **Adaptive Object Type** | Describes one or more Adaptive Objects. **Is itself an Adaptive Object** (its type is `_AdaptiveObjectType_`). |
+| **Adaptive Property** | A name plus an **Adaptive Value** on an object. |
+| **Adaptive Property Type** | Describes a property (data type, constraints, …). Lives on the Object Type (usually under `propertyTypes`). |
+
+**Adaptive Value** is a 2012 pillar, not a primitive sitting in the type square. A property’s payload is a value, but a value is much more than that: a typed instance (including object and array), or something that **evaluates** to one (call, compiled unit, symbol, …) via an Adaptive Value Interface. That is also the center of the libafw implementation (`afw_value_t`). Same idea at both layers, not two different “values.” **Adaptive Data Type** is how a kind of value is represented, compared, and converted.
+
+The rest of **Adaptive Framework** is more concepts to *support* that square. The vision has not changed since 2012; the implementation has. **libafw** (`src/afw`) is the C implementation of most of it. The public **`afw` repository** is the **base**. See [`lineage-and-library-floor.md`](lineage-and-library-floor.md) and [`AGENTS.md`](../AGENTS.md) *Main components*.
+
+Some implementation surfaces also use the Adaptive prefix (**Adaptive Script**, **Adaptive Template**; **Adaptive Expression** is the original language surface). Those are how you write against the vision, not extra pillars. Do not treat Script as the whole of AFW.
+
+Handbook architecture and the glossary use the same names. When a row and the tree disagree, the tree wins.
+
+| Noun | Role |
+|------|------|
+| **Adaptive Interface** | Formal contract (generate XML → C call macros / vtables). Core and extensions supply **implementations** (adapter, content type, request handler, …). |
+| **Adapter** | Adaptive Interface for access to Adaptive Objects (and their types). Each `adapterType` is an implementation (file, ldap, model, …). |
+| **Adaptive Mapping** | Transform objects between shapes / adapters. The shipped adapter implementation is the **model adapter** (`adapterType` `model`). Other adapter types could do mapping another way later. `_AdaptiveModel_` is what that adapter loads — not a 2012 pillar. |
+| **Adaptive Layout** | Map objects and properties onto UI (layout objects and components). Peer of Adaptive Mapping. |
+| **Adaptive Function** | Named function registered in the environment; called from expressions, scripts, or templates. |
+| **Adaptive Environment** | Process registries. Extensions register the same way as core. |
+| **Content type** | External encoding of Adaptive Objects and their values. |
+| **Adaptive Schema** | The Adaptive Object Types an adapter presents. |
+| **Adaptive Service** | How an adapter, log, authorization handler, and similar are configured and started. |
+| **Request handler** | How a host turns a client request into work. |
+
+Related: **authorization** (handlers on the environment).
+
+---
+
 ## Intended uses (product framing)
 
 Historically and still, AFW aims at places where **policy, mapping, and automation** need to be precise, embeddable, and inspectable:
@@ -58,7 +94,7 @@ Hosts today include the **`afw` CLI** (including `--local`) and **`afwfcgi`**; b
 
 ### Values are the center
 
-Every significant script/eval entity is (or is reached through) an **`afw_value_t`**: an interface pointer (`inf`) plus payload. Evaluation is mostly **lazy** via `inf` methods (`optional_evaluate`, and for long-running correctness, release/clone policies — see value-memory rules and [`memory-management.md`](memory-management.md)).
+This is the libafw side of the **Adaptive Value** concept above. Every significant script/eval entity is (or is reached through) an **`afw_value_t`**: an interface pointer (`inf`) plus payload. Evaluation is mostly **lazy** via `inf` methods (`optional_evaluate`, and for long-running correctness, release/clone policies — see value-memory rules and [`memory-management.md`](memory-management.md)).
 
 Rough families of value kinds (names evolve; see `afw_value.h` / generated declares for truth):
 

--- a/designs/knowledge-atlas.md
+++ b/designs/knowledge-atlas.md
@@ -105,11 +105,11 @@ generate/  →  generated/  →  env registries (afw_environment_t)
 |-------|---------|
 | **Settled map** | Ongoing partner role; beta = quality bar; hard choices by **consensus** (ask what you think → discuss → live verify → either side can be wrong) |
 | **Day rules** | `afw-project` (role one-liner, hard rules, terminology, plain language) |
-| **Deep / reference** | [`ai-partner-lessons.md`](ai-partner-lessons.md) (optional team one-pager), mantras (*How consensus is grown*), philosophy pad, agent-support |
+| **Deep / reference** | [`ai-partner-lessons.md`](ai-partner-lessons.md) (optional team one-pager), mantras (*How consensus is grown*), philosophy pad (*Adaptive concepts*), agent-support |
 | **Probe** | Live system when debating models (`afwfcgi`, env registries) — not CI |
 | **Open** | More mantras as shared over time |
 | **Gap** | None critical; grow mantras pad, don’t invent phrases |
-| **Also** | Crash-shaped review lists: private Project + how-to issue; public `afw` one card at a time — [`agent-support.md`](agent-support.md) *Disclosure-sensitive C review* |
+| **Also** | Crash-shaped review lists: private Project + how-to issue; public `afw` one card at a time — [`agent-support.md`](agent-support.md) *Disclosure-sensitive C review*. Base vs private packages, Docker ICU/APR floor, ICU home: [`lineage-and-library-floor.md`](lineage-and-library-floor.md) |
 | **Origin note** | Env/runtime “smaller chunks → live discovery → adapters click” discussion: genesis of this support-partner path (ah-ha → map) |
 
 ---
@@ -196,7 +196,7 @@ generate/  →  generated/  →  env registries (afw_environment_t)
 |-------|---------|
 | **Settled map** | #158 closed (PR **#165**): host-specific wake + core `terminating` |
 | **Day rules** | `afw-server`, `afw-server-fcgi`, `afw-command` |
-| **Deep pad** | None required; user notes in `whats-new.md` |
+| **Deep pad** | [`lineage-and-library-floor.md`](lineage-and-library-floor.md) — Docker bases are the ICU/APR floor (this Ubuntu container is not the oldest) |
 | **Probe** | `src/afw/tests/advanced/afwfcgi_signal_shutdown/`; `afwfcgi --help`; after `--cdev`/`--install`, restart long-lived `afwfcgi` (stale process maps deleted `libafw` — CLI `afw` does not) |
 | **Open** | Drain timeout, SIGHUP, Windows service, general signal framework, every extension retrieve loop, `--local` read unblock |
 | **Gap** | Stale-`afwfcgi` and GDB `-n 1` notes now in `agent-support` live-stack playbook |
@@ -309,6 +309,7 @@ After install, **restart afwfcgi** if attach tools talk to a long-lived process.
 | **Probe** | Extension tests under `src/afw_*/tests/` |
 | **Open** | Index residuals on LMDB; other adapters index interface NULL |
 | **Gap** | No per-extension support cards — add when symptoms cluster |
+| **Also** | Not-yet-public extensions live in `inter-afw-private` and promote to this repo if they become base — [`lineage-and-library-floor.md`](lineage-and-library-floor.md) |
 
 ---
 

--- a/designs/lineage-and-library-floor.md
+++ b/designs/lineage-and-library-floor.md
@@ -1,0 +1,59 @@
+# Lineage, base vs private packages, library floor
+
+**Audience:** maintainers and AI assistants. **Not** handbook or a product promise.
+
+Facts that are easy to lose and that change how you write C, pick APIs, and where unfinished work lives. When this pad and the tree disagree, the tree wins.
+
+## Layers
+
+Three different things, easy to flatten:
+
+| Layer | What it is |
+|-------|------------|
+| **Adaptive concepts** | The high-level Adaptive things inside Adaptive Framework (object, value, adapter, mapping, layout, interface, environment, …). Canonical list: [`afw-philosophy-and-core-model.md`](afw-philosophy-and-core-model.md) (*Adaptive concepts*). Handbook architecture / glossary use the same names. |
+| **Core (libafw)** | The C implementation of most of that model, in **`src/afw`**. |
+| **Base (this repository)** | Public **`afw`**: libafw **plus** `afwdev`, shipped commands (`afw`, `afwfcgi`), shipped extensions (`src/afw_*`), and the admin app. Srcdir map: [`AGENTS.md`](../AGENTS.md) *Main components*. |
+
+Not-yet-public extensions live in **`inter-afw-private`**. If one becomes part of the base, it is **promoted into this repository**. That is not a schedule.
+
+A predecessor system was an **XACML** implementation in C. AFW is not that engine renamed. Some trees in `inter-afw-private` still reflect a possible later mapping (XACML function names onto AFW built-ins, XACML policy onto an AFW authorization-policy shape). **That is context only** — not a commitment to finish, ship, or schedule that work.
+
+## Other repos (work placement)
+
+| Repo | Role |
+|------|------|
+| Public **`afw`** | Base. Issues/PRs that belong in the open. |
+| **`inter-afw`** | Whole-project private AFW (pre-public history; private boards and similar). Not where new extension code is added. |
+| **`inter-afw-private`** | Not-yet-public **extensions** and related trees (examples already cited elsewhere: Oracle, Berkeley DB). Includes `src/afw_xacml`, `src/afw_xacml_pdp`, and `src/afw_authorization_policy`. New work of that kind goes here, not into a separate XACML repo. |
+
+If something in `inter-afw-private` is ready to be part of the base, it is **promoted into public `afw`**. Do not assume that will happen, and do not start private-repo work unless asked.
+
+When working in `inter-afw-private`, check out **`afw` as a sibling directory** (same parent). How the private tree should include or reference the base can wait until that work starts.
+
+## Library floor (Docker)
+
+Develop against the **published image bases**, not against “whatever this workstation or this one container happens to have.” The in-tree `docker/images/afw-dev-base/` files are the matrix:
+
+| Dockerfile | Base |
+|------------|------|
+| `Dockerfile.alpine` | Alpine 3.16 |
+| `Dockerfile.ubuntu` | Ubuntu 22.04 |
+| `Dockerfile.rockylinux` | Rocky Linux 8.9 |
+| `Dockerfile.opensuse` | openSUSE Leap 15.5 |
+
+This development container is **Ubuntu 22.04** (ICU 70.1, APR 1.7 as of 2026-08). That is **not** the oldest base. Rocky 8 is the conservative end (RHEL 8-era ICU is about 60). An ICU or APR API that exists only on Ubuntu 22.04 can still fail the Rocky or Alpine image.
+
+`U8_NEXT` / `U8_APPEND` (the bounded ICU macros used in `afw_utf8`) are old enough for this matrix. “A newer ICU call” means **present on the oldest base**, not present on this container.
+
+## Where ICU belongs
+
+Keep ICU (`unicode/*.h`, `U8_*`, `u_*`, `unorm2_*`) in **`src/afw/utf8/`** (`afw_utf8.c` / `afw_utf8.h`) except rare overrides.
+
+On current `develop`, the only other core includes are:
+
+| Place | Use |
+|-------|-----|
+| `src/afw/compile/afw_compile_code_point.c` | `u_hasBinaryProperty` / `u_charType` for identifier start/continue and whitespace |
+| `src/afw/environment/afw_environment_register_core.c` | `u_errorName` for the ICU error-code decoder |
+
+A later pass can wrap those through `afw_utf8.h` so the rest of core does not include ICU. Prefer **functions** in that header over macros that pull `unicode/*.h` into every translation unit. Not a current sitting unless asked.

--- a/designs/lineage-and-library-floor.md
+++ b/designs/lineage-and-library-floor.md
@@ -56,4 +56,4 @@ On current `develop`, the only other core includes are:
 | `src/afw/compile/afw_compile_code_point.c` | `u_hasBinaryProperty` / `u_charType` for identifier start/continue and whitespace |
 | `src/afw/environment/afw_environment_register_core.c` | `u_errorName` for the ICU error-code decoder |
 
-A later pass can wrap those through `afw_utf8.h` so the rest of core does not include ICU. Prefer **functions** in that header over macros that pull `unicode/*.h` into every translation unit. Not a current sitting unless asked.
+A later pass can wrap those through `afw_utf8.h` so the rest of core does not include ICU. Prefer **functions** in that header over macros that pull `unicode/*.h` into every translation unit. Owned by [#206](https://github.com/afw-org/afw/issues/206).


### PR DESCRIPTION
@JeremyGrieshop

Docs only. Adaptive concepts (type square first) live on the philosophy pad. New pad for work placement and the Docker ICU/APR floor so later sittings do not write to a newer library than the published images.

ICU-home leftover points at #206.