### PR TITLE
Reject an embedded NUL when converting utf8 to a C string

### DIFF
--- a/designs/c-naming-and-payloads.md
+++ b/designs/c-naming-and-payloads.md
@@ -24,16 +24,19 @@ Most scalars are one chunk (`afw_integer_t`). Objects/arrays are a `const` point
 
 | Verb | Struct | Bytes |
 |------|--------|--------|
-| **`create` / `create_z`** | New `const` in `p` | **Copy** (utf8: NFC or throw) |
-| **`create_no_copy` / `_z`** | New `const` in `p` | **Point** at `s`. NFC or throw. `p` is the struct only. |
-| **`set` / `set_z`** | Your non-const struct | Copy into `p` |
-| **`set_no_copy` / `_z`** | Your non-const struct | Point. No `p`. |
+| **`create`** | New `const` in `p` | **Copy** (utf8: NFC or throw) |
+| **`create_no_copy`** | New `const` in `p` | **Point** at `s`. NFC or throw. `p` is the struct only. |
+| **`z_to_utf8`** | New `const` in `p` | Ingest `utf8_z` (copy + NFC) |
+| **`z_as_utf8`** | New `const` in `p` | Ingest `utf8_z` (point) |
+| **`set` / `z_set`** | Your non-const struct | Copy into `p` (octets vs `utf8_z`) |
+| **`set_no_copy` / `z_set_no_copy`** | Your non-const struct | Point. No `p`. |
 | **`clone`** | New `const` in `p` | Copy struct **and** `.s` from an existing `afw_utf8_t` |
 
 **Rule:** shorter name does more / is safer. Extra words take a guard off (`no_copy`, like `create_unmanaged` on objects). **`p` only if something new lives there.**
 
-- Suffix **`_z`** = that **argument** is `0`-terminated.
-- Prefix **`z_`** = the **result** is `utf8_z`.
+- Prefix **`afw_utf8_z_`** when you **have** a C string. Prefix **`afw_utf8_`** when you have length-prefixed `utf8`.
+- **`to_utf8_z` / `z_create`**: result is a C string (throw if the bytes contain a `0`).
+- Mixed predicates spell both types in argument order (`starts_with_utf8_z`).
 - **`from_memory` / `as_memory`**: utf8 ↔ `afw_memory_t`. No `afw_raw_t`.
 
 `AFW_UTF8_LITERAL` is a trusted C `"…"` initializer. ASCII (including `\n`) is always UTF-8 NFC. `\x` or a non-UTF-8 source file is a programmer error. AFW does not support EBCDIC.
@@ -65,7 +68,7 @@ Do **not** rename `afw_value_create_managed_<dt>` to `afw_value_create_<dt>` on 
 
 **Gotcha:** a walker that treats `afw_utf8_t->s` as a C string needs a trailing `0`. Old `create` could point at a `z` buffer. New `create` copies **without** a `0`. The RQL origin string uses `create_no_copy` onto `afw_utf8_z_create` for that.
 
-**C-string door:** `afw_utf8_to_utf8_z`, `afw_utf8_z_create`, and `afw_utf8_array_to_utf8_z_with_separator` throw if the length-prefixed bytes contain a `0` (pieces and separator). `afw_utf8_z_array_to_utf8_z_with_separator` checks the separator the same way; the `utf8_z` pieces are already C strings. A C string cannot hold that value. The length-prefixed concat (`array_to_utf8_with_separator`) does not throw. Do not ban `\0`/`\x00` in the lexer — Adaptive strings are length-prefixed. `forced_safe` / `z_printf` still encode U+0000 as `^00^`. File logical paths already rejected an embedded NUL (`afw_file_path.c`).
+**C-string door:** `afw_utf8_to_utf8_z`, `afw_utf8_z_create`, and `afw_utf8_array_to_utf8_z_with_separator` throw if the length-prefixed bytes contain a `0` (pieces and separator). `afw_utf8_z_array_with_separator` checks the separator the same way; the `utf8_z` pieces are already C strings. A C string cannot hold that value. The length-prefixed concat (`array_to_utf8_with_separator`) does not throw. Do not ban `\0`/`\x00` in the lexer — Adaptive strings are length-prefixed. `forced_safe` / `z_printf` still encode U+0000 as `^00^`. File logical paths already rejected an embedded NUL (`afw_file_path.c`).
 
 ## Code points vs UTF-8
 

--- a/designs/c-naming-and-payloads.md
+++ b/designs/c-naming-and-payloads.md
@@ -65,6 +65,8 @@ Do **not** rename `afw_value_create_managed_<dt>` to `afw_value_create_<dt>` on 
 
 **Gotcha:** a walker that treats `afw_utf8_t->s` as a C string needs a trailing `0`. Old `create` could point at a `z` buffer. New `create` copies **without** a `0`. The RQL origin string uses `create_no_copy` onto `afw_utf8_z_create` for that.
 
+**C-string door:** `afw_utf8_to_utf8_z`, `afw_utf8_z_create`, and `afw_utf8_array_to_utf8_z_with_separator` throw if the length-prefixed bytes contain a `0` (pieces and separator). `afw_utf8_z_array_to_utf8_z_with_separator` checks the separator the same way; the `utf8_z` pieces are already C strings. A C string cannot hold that value. The length-prefixed concat (`array_to_utf8_with_separator`) does not throw. Do not ban `\0`/`\x00` in the lexer — Adaptive strings are length-prefixed. `forced_safe` / `z_printf` still encode U+0000 as `^00^`. File logical paths already rejected an embedded NUL (`afw_file_path.c`).
+
 ## Code points vs UTF-8
 
 Unicode **code-point** tests (identifier, whitespace, Cc) live in **`src/afw/code_point/`** (`afw_code_point.h`). They take an `afw_code_point_t`, not octets. UTF-8 encode/decode stays in `afw_utf8`.

--- a/designs/c-naming-and-payloads.md
+++ b/designs/c-naming-and-payloads.md
@@ -35,9 +35,10 @@ Most scalars are one chunk (`afw_integer_t`). Objects/arrays are a `const` point
 **Rule:** shorter name does more / is safer. Extra words take a guard off (`no_copy`, like `create_unmanaged` on objects). **`p` only if something new lives there.**
 
 - Prefix **`afw_utf8_z_`** when you **have** a C string. Prefix **`afw_utf8_`** when you have length-prefixed `utf8`.
-- **`to_utf8_z` / `z_create`**: result is a C string (throw if the bytes contain a `0`).
 - Mixed predicates spell both types in argument order (`starts_with_utf8_z`).
 - **`from_memory` / `as_memory`**: utf8 ↔ `afw_memory_t`. No `afw_raw_t`.
+
+**Internal** is NFC `afw_utf8_t` (`.s` + `.len`). **External** is not that world. Spell **external C string** or **external octets** when the shape matters. Cross with a named door: `to_utf8_z` / `z_create` (C string, throw if interior `0`), `forced_safe` (encode for logs/names), `as_memory` / write with `len` (octets + size). `afw_utf8_utf8_z_t` is the utf8 + z pair when the buffer is already a C string (literal / `z_create`); generated strings use `afw_s_*` / `afw_z_*`.
 
 `AFW_UTF8_LITERAL` is a trusted C `"…"` initializer. ASCII (including `\n`) is always UTF-8 NFC. `\x` or a non-UTF-8 source file is a programmer error. AFW does not support EBCDIC.
 
@@ -68,7 +69,7 @@ Do **not** rename `afw_value_create_managed_<dt>` to `afw_value_create_<dt>` on 
 
 **Gotcha:** a walker that treats `afw_utf8_t->s` as a C string needs a trailing `0`. Old `create` could point at a `z` buffer. New `create` copies **without** a `0`. The RQL origin string uses `create_no_copy` onto `afw_utf8_z_create` for that.
 
-**C-string door:** `afw_utf8_to_utf8_z`, `afw_utf8_z_create`, and `afw_utf8_array_to_utf8_z_with_separator` throw if the length-prefixed bytes contain a `0` (pieces and separator). `afw_utf8_z_array_with_separator` checks the separator the same way; the `utf8_z` pieces are already C strings. A C string cannot hold that value. The length-prefixed concat (`array_to_utf8_with_separator`) does not throw. Do not ban `\0`/`\x00` in the lexer — Adaptive strings are length-prefixed. `forced_safe` / `z_printf` still encode U+0000 as `^00^`. File logical paths already rejected an embedded NUL (`afw_file_path.c`).
+**External C string:** `afw_utf8_to_utf8_z`, `afw_utf8_z_create`, and `afw_utf8_array_to_utf8_z_with_separator` throw if the length-prefixed bytes contain a `0` (pieces and separator). `afw_utf8_z_array_with_separator` checks the separator the same way. A C string cannot hold that value. Length-prefixed concat (`array_to_utf8_with_separator`) stays internal and does not throw. Do not ban `\0`/`\x00` in the lexer. `forced_safe` / `z_printf` still encode U+0000 as `^00^`. File logical paths already rejected an embedded NUL (`afw_file_path.c`).
 
 ## Code points vs UTF-8
 

--- a/src/afw/adapter/afw_adapter_journal.c
+++ b/src/afw/adapter/afw_adapter_journal.c
@@ -385,7 +385,7 @@ afw_adapter_internal_journal_get_entry(
     /** @fixme Might want to url_decode consumer_id and entry_cursor. */
 
     /* get_first */
-    if (afw_utf8_starts_with_z(object_id, "get_first")) {
+    if (afw_utf8_starts_with_utf8_z(object_id, "get_first")) {
         syntax_z = "get_first";
         option = afw_adapter_journal_option_get_first;
         option_z = "get_first";
@@ -393,7 +393,7 @@ afw_adapter_internal_journal_get_entry(
     }
 
     /* get_by_cursor:<event_cursor> */
-    else if (afw_utf8_starts_with_z(object_id, "get_by_cursor:")) {
+    else if (afw_utf8_starts_with_utf8_z(object_id, "get_by_cursor:")) {
         syntax_z = "get_by_cursor:<event_cursor>";
         option = afw_adapter_journal_option_get_by_cursor;
         option_z = "get_by_cursor";
@@ -405,7 +405,7 @@ afw_adapter_internal_journal_get_entry(
     }
 
     /* get_next_after_cursor:<event_cursor> */
-    else if (afw_utf8_starts_with_z(object_id, "get_next_after_cursor:")) {
+    else if (afw_utf8_starts_with_utf8_z(object_id, "get_next_after_cursor:")) {
         syntax_z = "get_next_after_cursor:<event_cursor>";
         option = afw_adapter_journal_option_get_next_after_cursor;
         option_z = "get_next_after_cursor";
@@ -417,7 +417,7 @@ afw_adapter_internal_journal_get_entry(
     }
 
     /* get_next_for_consumer:<consumer_id> */
-    else if (afw_utf8_starts_with_z(object_id, "get_next_for_consumer:"))
+    else if (afw_utf8_starts_with_utf8_z(object_id, "get_next_for_consumer:"))
     {
         limit_applies = true;
         syntax_z = "get_next_for_consumer:<consumer_id>";
@@ -431,7 +431,7 @@ afw_adapter_internal_journal_get_entry(
     }
 
     /* get_next_for_consumer_after_cursor:<consumer_id>:<event_cursor> */
-    else if (afw_utf8_starts_with_z(object_id,
+    else if (afw_utf8_starts_with_utf8_z(object_id,
         "get_next_for_consumer_after_cursor:"))
     {
         limit_applies = true;
@@ -453,7 +453,7 @@ afw_adapter_internal_journal_get_entry(
     }
 
     /* advance_cursor_for_consumer:<consumer_id> */
-    else if (afw_utf8_starts_with_z(object_id,
+    else if (afw_utf8_starts_with_utf8_z(object_id,
         "advance_cursor_for_consumer:"))
     {
         limit_applies = true;

--- a/src/afw/compile/afw_compile_parse_script.c
+++ b/src/afw/compile/afw_compile_parse_script.c
@@ -2795,7 +2795,7 @@ impl_test_script_get_next_key_value(
             break;
         }
 
-        if (!afw_utf8_starts_with_z(&line, "//?")) {
+        if (!afw_utf8_starts_with_utf8_z(&line, "//?")) {
             AFW_COMPILE_THROW_ERROR_Z("Line must start with '//?'");
         }
 
@@ -2863,7 +2863,7 @@ impl_test_script_get_next_key_value(
                     remaining.len = end - start;
 
                     /* If "...", string is next line to end or "//?" line. */
-                    if (afw_utf8_starts_with_z(&remaining, "...")) {
+                    if (afw_utf8_starts_with_utf8_z(&remaining, "...")) {
                         afw_compile_save_cursor(start_cursor);
                         afw_compile_save_cursor(*string_offset);
                         for (;;) {
@@ -2876,7 +2876,7 @@ impl_test_script_get_next_key_value(
                                     *string_length, parser->p, parser->xctx);
                                 break;
                             }
-                            else if (afw_utf8_starts_with_z(&line, "//?")) {
+                            else if (afw_utf8_starts_with_utf8_z(&line, "//?")) {
                                 afw_compile_restore_cursor(end_cursor);
                                 /* Don't include \n before //? */
                                 *string_length = end_cursor - start_cursor;
@@ -2897,7 +2897,7 @@ impl_test_script_get_next_key_value(
                      * (relative to the test script directory). See
                      * writing-tests.md. File is not whitespace-trimmed.
                      */
-                    else if (afw_utf8_starts_with_z(&remaining, "<<<")) {
+                    else if (afw_utf8_starts_with_utf8_z(&remaining, "<<<")) {
                         afw_size_t value_len;
                         afw_size_t offset;
                         afw_size_t end_trim;

--- a/src/afw/include/afw_common.h
+++ b/src/afw/include/afw_common.h
@@ -694,8 +694,13 @@ typedef struct afw_utf8_s {
 
 
 /**
- * @brief NFC normalized UTF-8 string accessible as afw_utf8_t or afw_utf8_z_t
-*/
+ * @brief Internal utf8 + external C string (same pointer).
+ *
+ * Use when the bytes are already 0-terminated (C literal, `z_create`
+ * result). `.s` is length-prefixed NFC; `.s_z` is the external C string.
+ * No interior 0 in `.s.len` bytes. There is no create for this type.
+ * Generated strings use `afw_s_*` / `afw_z_*` instead.
+ */
 typedef union afw_utf8_utf8_z_s {
     afw_utf8_t s;
     const afw_utf8_z_t *s_z;
@@ -848,7 +853,9 @@ typedef struct afw_key_string_s {
 
 
 /**
- * @brief Typedef for key/string pair that have both utf8 and utf8_z.
+ * @brief Key/string pair, each an internal utf8 + external C string.
+ *
+ * Same contract as `afw_utf8_utf8_z_t` on both sides. VFS map uses this.
  */
 typedef struct afw_key_z_string_z_s {
     union {

--- a/src/afw/include/afw_doxygen.h
+++ b/src/afw/include/afw_doxygen.h
@@ -604,6 +604,10 @@
  * owns the bytes (a pool, a value header, a stack, a literal). Adaptive
  * **values** (`afw_value_*`) are what can `get_reference` / release.
  *
+ * **Internal** is NFC `afw_utf8_t`. **External** (libc, APR, LDAP, logs)
+ * uses a named door: `to_utf8_z` / `z_create`, `forced_safe`, or
+ * `as_memory`.
+ *
  * **Naming (short name does more):**
  *
  * Prefix `afw_utf8_z_` when you **have** a C string. Prefix `afw_utf8_`
@@ -619,8 +623,8 @@
  * | `set` / `z_set` | Caller `afw_utf8_t *` | Copy into `p` + NFC |
  * | `set_no_copy` / `z_set_no_copy` | Caller `afw_utf8_t *` | Point; no `p` |
  * | `clone` | New `const` in `p` | Copy struct + `.s` |
- * | `to_utf8_z` / `z_create` | `utf8_z` | 0-terminated C string; throw if embedded 0 |
- * | `forced_safe` | create/set (always copy) | Encode invalid/Cc as `^hex^`; not NFC; not a value |
+ * | `to_utf8_z` / `z_create` | `utf8_z` | External C string; throw if embedded 0 |
+ * | `forced_safe` | create/set (always copy) | External encode; `^hex^`; not NFC; not a value |
  * | `create_property_name` | New `const` in `p` | Same encode, then NFC (is a name) |
  *
  * `p` only if something new lives there.

--- a/src/afw/include/afw_doxygen.h
+++ b/src/afw/include/afw_doxygen.h
@@ -606,18 +606,24 @@
  *
  * **Naming (short name does more):**
  *
+ * Prefix `afw_utf8_z_` when you **have** a C string. Prefix `afw_utf8_`
+ * when you have length-prefixed `utf8`. Mixed predicates spell both
+ * types in argument order (`starts_with_utf8_z`).
+ *
  * | Door | Dest | Bytes |
  * |------|------|--------|
- * | `create` / `create_z` | New `const` in `p` | Copy + NFC (or throw) |
- * | `create_no_copy` / `_z` | New `const` in `p` | Point at `s`; NFC or throw |
- * | `set` / `set_z` | Caller `afw_utf8_t *` | Copy into `p` + NFC |
- * | `set_no_copy` / `_z` | Caller `afw_utf8_t *` | Point; no `p` |
+ * | `create` | New `const` in `p` | Copy + NFC (or throw) |
+ * | `create_no_copy` | New `const` in `p` | Point at `s`; NFC or throw |
+ * | `z_to_utf8` | New `const` in `p` | Ingest `utf8_z` (copy + NFC) |
+ * | `z_as_utf8` | New `const` in `p` | Ingest `utf8_z` (point) |
+ * | `set` / `z_set` | Caller `afw_utf8_t *` | Copy into `p` + NFC |
+ * | `set_no_copy` / `z_set_no_copy` | Caller `afw_utf8_t *` | Point; no `p` |
  * | `clone` | New `const` in `p` | Copy struct + `.s` |
+ * | `to_utf8_z` / `z_create` | `utf8_z` | 0-terminated C string; throw if embedded 0 |
  * | `forced_safe` | create/set (always copy) | Encode invalid/Cc as `^hex^`; not NFC; not a value |
  * | `create_property_name` | New `const` in `p` | Same encode, then NFC (is a name) |
  *
- * Suffix `_z` = that argument is `0`-terminated. Prefix `z_` = result is
- * `utf8_z`. `p` only if something new lives there.
+ * `p` only if something new lives there.
  *
  * See `afw_utf8.h` and `designs/c-naming-and-payloads.md`.
  */

--- a/src/afw/number/afw_number.c
+++ b/src/afw/number/afw_number.c
@@ -220,25 +220,25 @@ afw_number_parse(
     /* If parse double, allow Infinity, -Infinity, and NaN. */
     if (d) {
         d0 = 0;
-        if (afw_utf8_len_starts_with_z(c, len, AFW_NUMBER_Q_INF)) {
+        if (afw_utf8_len_starts_with_utf8_z(c, len, AFW_NUMBER_Q_INF)) {
             *d = 1 / d0;
             if (is_double) *is_double = true;
             return strlen(AFW_NUMBER_Q_INF);
         }
         
-        else if (afw_utf8_len_starts_with_z(c, len, AFW_NUMBER_Q_INFINITY)) {
+        else if (afw_utf8_len_starts_with_utf8_z(c, len, AFW_NUMBER_Q_INFINITY)) {
             *d = 1 / d0;
             if (is_double) *is_double = true;
             return strlen(AFW_NUMBER_Q_INFINITY);
         }
         
-        else if (afw_utf8_len_starts_with_z(c, len, AFW_NUMBER_Q_NEGATIVE_INF)) {
+        else if (afw_utf8_len_starts_with_utf8_z(c, len, AFW_NUMBER_Q_NEGATIVE_INF)) {
             *d = -1 / d0;
             if (is_double) *is_double = true;
             return strlen(AFW_NUMBER_Q_NEGATIVE_INF);
         }
         
-        else if (afw_utf8_len_starts_with_z(c, len,
+        else if (afw_utf8_len_starts_with_utf8_z(c, len,
             AFW_NUMBER_Q_NEGATIVE_INFINITY))
         {
             *d = -1 / d0;
@@ -246,13 +246,13 @@ afw_number_parse(
             return strlen(AFW_NUMBER_Q_NEGATIVE_INFINITY);
         }
 
-        else if (afw_utf8_len_starts_with_z(c, len, AFW_NUMBER_Q_NAN)) {
+        else if (afw_utf8_len_starts_with_utf8_z(c, len, AFW_NUMBER_Q_NAN)) {
             *d = sqrt(-1);
             if (is_double) *is_double = true;
             return strlen(AFW_NUMBER_Q_NAN);
         }
         
-        else if (afw_utf8_len_starts_with_z(c, len, AFW_NUMBER_Q_NEGATIVE_NAN)) {
+        else if (afw_utf8_len_starts_with_utf8_z(c, len, AFW_NUMBER_Q_NEGATIVE_NAN)) {
             *d = sqrt(-1);
             if (is_double) *is_double = true;
             return strlen(AFW_NUMBER_Q_NEGATIVE_NAN);

--- a/src/afw/object/afw_object.c
+++ b/src/afw/object/afw_object.c
@@ -296,7 +296,7 @@ afw_object_get_property_extended(
     result = NULL;
 
     /* If the property name starts with _meta_, process accordingly. */
-    if (afw_utf8_starts_with_z(property_name_extended,
+    if (afw_utf8_starts_with_utf8_z(property_name_extended,
         AFW_OBJECT_Q_PN_META  "."))
     {
         meta_value = NULL;

--- a/src/afw/object/afw_object_type.c
+++ b/src/afw/object/afw_object_type.c
@@ -189,7 +189,7 @@ afw_object_type_property_type_get_extended(
     /* If the property name starts with _meta_, process accordingly. 
        @fixme not implemented yet
      */
-    if (afw_utf8_starts_with_z(property_name_extended,
+    if (afw_utf8_starts_with_utf8_z(property_name_extended,
         AFW_OBJECT_Q_PN_META  "."))
     {
         meta = NULL;

--- a/src/afw/query_criteria/afw_query_criteria.c
+++ b/src/afw/query_criteria/afw_query_criteria.c
@@ -1966,7 +1966,7 @@ afw_query_criteria_parse_url_encoded_rql_string(
         while (1) {
 
             /* If "sort(", parser sort criteria. It can only occur once. */
-            if (afw_utf8_z_starts_with_z(parser.c, "sort(")) {
+            if (afw_utf8_z_starts_with(parser.c, "sort(")) {
                 if (parser.criteria->first_sort) {
                     AFW_THROW_ERROR_Z(general,
                         "sort() specified multiple times in query string",
@@ -1977,7 +1977,7 @@ afw_query_criteria_parse_url_encoded_rql_string(
             }
 
             /* If "select(", parser select criteria. It can only occur once. */
-            else if (afw_utf8_z_starts_with_z(parser.c, "select(")) {
+            else if (afw_utf8_z_starts_with(parser.c, "select(")) {
                 if (parser.criteria->select) {
                     AFW_THROW_ERROR_Z(general,
                         "select() specified multiple times in query string",
@@ -1988,7 +1988,7 @@ afw_query_criteria_parse_url_encoded_rql_string(
             }
 
             /* If "limit(", parser limit criteria. It can only occur once.
-            else if (afw_utf8_z_starts_with_z(parser.c, "select(")) {
+            else if (afw_utf8_z_starts_with(parser.c, "select(")) {
                 if (parser.criteria->limit) {
                     AFW_THROW_ERROR_Z(general,
                         "limit() specified multiple times in query string",

--- a/src/afw/runtime/afw_runtime.c
+++ b/src/afw/runtime/afw_runtime.c
@@ -494,7 +494,7 @@ impl_check_manifest_cb(
         }
 
         /* Check for entry match. */
-        if (!afw_utf8_starts_with_z(entry, "/afw/")) {
+        if (!afw_utf8_starts_with_utf8_z(entry, "/afw/")) {
             continue;
         }
         s.s = entry->s + 5;

--- a/src/afw/tests/README.md
+++ b/src/afw/tests/README.md
@@ -16,7 +16,8 @@ A few places that are easy to misunderstand:
 - `advanced/` — short orchestrated tests (`orchestration.yaml`) that are
   part of the default run. A few groups are a thin Python `run()` plus
   a checked-in `*_probe.c` (pool wrap, C-array view index, UTF-8 ICU
-  bound). Use that when Adaptive Script cannot reach the hole. Call
+  bound, UTF-8 to C string). Use that when Adaptive Script cannot reach
+  the hole. Call
   `run_c_probe()` from `_afwdev.test.c_probe` — do not copy a `cc`
   line. Start with `afwdev prime-test-c-probe <path>` (a leaf under
   `tests/` or `tests-extra/`).

--- a/src/afw/tests/advanced/utf8_named_doors/utf8_named_doors_probe.c
+++ b/src/afw/tests/advanced/utf8_named_doors/utf8_named_doors_probe.c
@@ -97,8 +97,8 @@ impl_create_set_copy(const afw_pool_t *p, afw_xctx_t *xctx)
         return 1;
     }
 
-    c = afw_utf8_create_z("abc", p, xctx);
-    if (impl_eq(c, "abc", 3, "create_z")) {
+    c = afw_utf8_z_to_utf8("abc", p, xctx);
+    if (impl_eq(c, "abc", 3, "z_to_utf8")) {
         return 1;
     }
 

--- a/src/afw/tests/advanced/utf8_to_utf8_z/utf8_to_utf8_z.py
+++ b/src/afw/tests/advanced/utf8_to_utf8_z/utf8_to_utf8_z.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+to_utf8_z / z_create / array-to-z refuse an embedded 0.
+
+Adaptive strings are length-prefixed, so script can hold U+0000.
+The C-string door is the hole. A probe sets .s/.len by hand.
+"""
+
+from _afwdev.test.c_probe import run_c_probe
+
+
+def run():
+    return run_c_probe(
+        "utf8_to_utf8_z_probe.c",
+        "UTF-8 to C string rejects an embedded NUL",
+        [
+            (
+                "empty",
+                "NULL or zero-length converts to empty C string",
+            ),
+            (
+                "ok",
+                "ordinary utf-8 converts; strlen matches len",
+            ),
+            (
+                "embedded",
+                "embedded 0 in to_utf8_z throws",
+            ),
+            (
+                "z-create",
+                "embedded 0 in z_create throws; ordinary create works",
+            ),
+            (
+                "array-z",
+                "array-to-z throws on piece or separator; utf8 concat keeps NUL",
+            ),
+        ],
+    )

--- a/src/afw/tests/advanced/utf8_to_utf8_z/utf8_to_utf8_z_probe.c
+++ b/src/afw/tests/advanced/utf8_to_utf8_z/utf8_to_utf8_z_probe.c
@@ -1,0 +1,291 @@
+// See the 'COPYING' file in the project root for licensing information.
+/*
+ * Adaptive Framework utf8 to utf8_z probe
+ *
+ * Copyright (c) 2010-2026 Clemson University
+ *
+ */
+
+#include "afw.h"
+
+#include <stdio.h>
+#include <string.h>
+
+/**
+ * @file utf8_to_utf8_z_probe.c
+ * @brief C probe for to_utf8_z / z_create / array-to-z embedded NUL.
+ *
+ * Adaptive strings are length-prefixed. This boots a core environment
+ * and calls the C-string doors with .s/.len set by hand.
+ */
+
+static void
+impl_utf8_set(afw_utf8_t *s, const char *z, afw_size_t len)
+{
+    s->s = (const afw_utf8_octet_t *)z;
+    s->len = len;
+}
+
+static int
+impl_expect_throw(
+    void (*fn)(const afw_pool_t *, afw_xctx_t *),
+    const afw_pool_t *p,
+    afw_xctx_t *xctx,
+    const char *label)
+{
+    int threw;
+
+    threw = 0;
+    AFW_TRY {
+        fn(p, xctx);
+    }
+    AFW_CATCH_UNHANDLED {
+        if (AFW_ERROR_THROWN->code == afw_error_code_general &&
+            AFW_ERROR_THROWN->message_z &&
+            strstr(AFW_ERROR_THROWN->message_z, "Embedded NUL"))
+        {
+            threw = 1;
+        }
+        else {
+            fprintf(stderr, "%s: threw %s\n", label,
+                AFW_ERROR_THROWN->message_z
+                ? AFW_ERROR_THROWN->message_z : "?");
+        }
+    }
+    AFW_ENDTRY;
+
+    if (!threw) {
+        fprintf(stderr, "%s: did not throw\n", label);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+impl_empty(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    afw_utf8_t s;
+    const afw_utf8_z_t *z;
+
+    z = afw_utf8_to_utf8_z(NULL, p, xctx);
+    if (!z || z[0] != 0) {
+        fprintf(stderr, "NULL string: expected empty\n");
+        return 1;
+    }
+
+    impl_utf8_set(&s, "", 0);
+    z = afw_utf8_to_utf8_z(&s, p, xctx);
+    if (!z || z[0] != 0) {
+        fprintf(stderr, "zero len: expected empty\n");
+        return 1;
+    }
+    return 0;
+}
+
+static int
+impl_ok(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    afw_utf8_t s;
+    const afw_utf8_z_t *z;
+
+    impl_utf8_set(&s, "hello", 5);
+    z = afw_utf8_to_utf8_z(&s, p, xctx);
+    if (!z || strlen(z) != 5 || memcmp(z, "hello", 5) != 0) {
+        fprintf(stderr, "ok: bad convert\n");
+        return 1;
+    }
+    return 0;
+}
+
+static const char impl_embedded[] = {
+    'a', 'b', 'c', 0, 'd', 'e', 'f'
+};
+
+static void
+impl_to_z_embedded(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    afw_utf8_t s;
+
+    impl_utf8_set(&s, impl_embedded, sizeof(impl_embedded));
+    (void)afw_utf8_to_utf8_z(&s, p, xctx);
+}
+
+static void
+impl_to_z_single_nul(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    afw_utf8_t s;
+
+    impl_utf8_set(&s, "\0", 1);
+    (void)afw_utf8_to_utf8_z(&s, p, xctx);
+}
+
+static void
+impl_z_create_embedded(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    (void)afw_utf8_z_create(
+        (const afw_utf8_octet_t *)impl_embedded,
+        sizeof(impl_embedded), p, xctx);
+}
+
+static int
+impl_embedded_nul(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    if (impl_expect_throw(impl_to_z_embedded, p, xctx,
+        "to_utf8_z embedded"))
+    {
+        return 1;
+    }
+    return impl_expect_throw(impl_to_z_single_nul, p, xctx,
+        "to_utf8_z single NUL");
+}
+
+static int
+impl_z_create(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    const afw_utf8_z_t *z;
+
+    z = afw_utf8_z_create(
+        (const afw_utf8_octet_t *)"hello", 5, p, xctx);
+    if (!z || strlen(z) != 5 || memcmp(z, "hello", 5) != 0) {
+        fprintf(stderr, "z_create ok: bad convert\n");
+        return 1;
+    }
+
+    return impl_expect_throw(impl_z_create_embedded, p, xctx,
+        "z_create embedded");
+}
+
+static void
+impl_array_z_piece(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    afw_utf8_t hello, bad;
+    const afw_utf8_t *list[3];
+
+    impl_utf8_set(&hello, "hello", 5);
+    impl_utf8_set(&bad, impl_embedded, sizeof(impl_embedded));
+    list[0] = &hello;
+    list[1] = &bad;
+    list[2] = NULL;
+    (void)afw_utf8_array_to_utf8_z_with_separator(list, NULL, p, xctx);
+}
+
+static void
+impl_array_z_sep(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    afw_utf8_t hello, world, sep;
+    const afw_utf8_t *list[3];
+
+    impl_utf8_set(&hello, "hello", 5);
+    impl_utf8_set(&world, "world", 5);
+    impl_utf8_set(&sep, impl_embedded, sizeof(impl_embedded));
+    list[0] = &hello;
+    list[1] = &world;
+    list[2] = NULL;
+    (void)afw_utf8_array_to_utf8_z_with_separator(list, &sep, p, xctx);
+}
+
+static void
+impl_z_array_sep(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    afw_utf8_t sep;
+    const afw_utf8_z_t *list[3];
+
+    impl_utf8_set(&sep, impl_embedded, sizeof(impl_embedded));
+    list[0] = "hello";
+    list[1] = "world";
+    list[2] = NULL;
+    (void)afw_utf8_z_array_to_utf8_z_with_separator(list, &sep, p, xctx);
+}
+
+static int
+impl_array_z(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    afw_utf8_t hello, world, comma, bad;
+    const afw_utf8_t *ok[3];
+    const afw_utf8_t *keep[2];
+    const afw_utf8_t *utf8;
+    const afw_utf8_z_t *z;
+
+    impl_utf8_set(&hello, "hello", 5);
+    impl_utf8_set(&world, "world", 5);
+    impl_utf8_set(&comma, ", ", 2);
+    impl_utf8_set(&bad, impl_embedded, sizeof(impl_embedded));
+
+    ok[0] = &hello;
+    ok[1] = &world;
+    ok[2] = NULL;
+    z = afw_utf8_array_to_utf8_z_with_separator(ok, &comma, p, xctx);
+    if (!z || strcmp(z, "hello, world") != 0) {
+        fprintf(stderr, "array-z ok: got %s\n", z ? z : "(null)");
+        return 1;
+    }
+
+    keep[0] = &bad;
+    keep[1] = NULL;
+    utf8 = afw_utf8_array_to_utf8_with_separator(keep, NULL, p, xctx);
+    if (!utf8 || utf8->len != sizeof(impl_embedded) ||
+        memcmp(utf8->s, impl_embedded, sizeof(impl_embedded)) != 0)
+    {
+        fprintf(stderr, "array utf8: should keep embedded NUL\n");
+        return 1;
+    }
+
+    if (impl_expect_throw(impl_array_z_piece, p, xctx,
+        "array-z piece"))
+    {
+        return 1;
+    }
+    if (impl_expect_throw(impl_array_z_sep, p, xctx,
+        "array-z separator"))
+    {
+        return 1;
+    }
+    return impl_expect_throw(impl_z_array_sep, p, xctx,
+        "z-array separator");
+}
+
+int
+main(int argc, char **argv)
+{
+    const afw_error_t *create_error;
+    afw_xctx_t *xctx;
+    const afw_pool_t *p;
+    const char *case_name;
+    int rc;
+
+    xctx = afw_environment_create(afw_version(), argc,
+        (const char * const *)argv, &create_error);
+    if (!xctx) {
+        fprintf(stderr, "environment create failed\n");
+        return 2;
+    }
+
+    case_name = (argc > 1) ? argv[1] : "";
+    p = afw_pool_create(xctx->p, xctx);
+    rc = 0;
+
+    if (strcmp(case_name, "empty") == 0) {
+        rc = impl_empty(p, xctx);
+    }
+    else if (strcmp(case_name, "ok") == 0) {
+        rc = impl_ok(p, xctx);
+    }
+    else if (strcmp(case_name, "embedded") == 0) {
+        rc = impl_embedded_nul(p, xctx);
+    }
+    else if (strcmp(case_name, "z-create") == 0) {
+        rc = impl_z_create(p, xctx);
+    }
+    else if (strcmp(case_name, "array-z") == 0) {
+        rc = impl_array_z(p, xctx);
+    }
+    else {
+        fprintf(stderr, "usage: utf8_to_utf8_z_probe "
+            "empty|ok|embedded|z-create|array-z\n");
+        rc = 2;
+    }
+
+    afw_pool_release(p, xctx);
+    afw_environment_release(xctx);
+    return rc;
+}

--- a/src/afw/tests/advanced/utf8_to_utf8_z/utf8_to_utf8_z_probe.c
+++ b/src/afw/tests/advanced/utf8_to_utf8_z/utf8_to_utf8_z_probe.c
@@ -194,7 +194,7 @@ impl_z_array_sep(const afw_pool_t *p, afw_xctx_t *xctx)
     list[0] = "hello";
     list[1] = "world";
     list[2] = NULL;
-    (void)afw_utf8_z_array_to_utf8_z_with_separator(list, &sep, p, xctx);
+    (void)afw_utf8_z_array_with_separator(list, &sep, p, xctx);
 }
 
 static int

--- a/src/afw/tests/miscellaneous/unicode_escape_sequence.as
+++ b/src/afw/tests/miscellaneous/unicode_escape_sequence.as
@@ -43,3 +43,19 @@ return "\A" === "A" && "\z" === "z" && "\Q" === "Q";
 //? source: ...
 
 return "\0" === "\u0000" && length("\0") === 1;
+
+//?
+//? test: NullEscape-length-prefixed
+//? description: Embedded NUL stays in the length-prefixed string
+//? expect: true
+//? source: ...
+
+return length("abc\0def") === 7;
+
+//?
+//? test: NullEscape-c-string-boundary
+//? description: Embedded NUL cannot convert to a C string
+//? expect: error
+//? source: ...
+
+return regexp_match("abc\0def", "abc");

--- a/src/afw/utf8/afw_utf8.c
+++ b/src/afw/utf8/afw_utf8.c
@@ -681,6 +681,40 @@ afw_utf8_create_property_name_z(
 }
 
 
+static void
+impl_throw_if_embedded_nul(
+    const afw_utf8_octet_t *s, afw_size_t len, afw_xctx_t *xctx)
+{
+    if (s && len > 0 && memchr(s, 0, len)) {
+        AFW_THROW_ERROR_Z(general,
+            "Embedded NUL in utf-8 string used as C string",
+            xctx);
+    }
+}
+
+
+/*
+ * Convert utf8 to utf8_z in specified pool.
+ */
+AFW_DEFINE(const afw_utf8_z_t *)
+afw_utf8_to_utf8_z(
+    const afw_utf8_t *string, const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    afw_utf8_z_t *result;
+
+    if (!string || string->len == 0) {
+        return impl_z_empty;
+    }
+
+    impl_throw_if_embedded_nul(string->s, string->len, xctx);
+
+    result = afw_pool_malloc(p, string->len + 1, xctx);
+    memcpy(result, string->s, string->len);
+    result[string->len] = 0;
+    return result;
+}
+
+
 /*
  * Create a NFC normalized zero terminated UTF-8 string in specified
  * pool.
@@ -698,6 +732,8 @@ afw_utf8_z_create(
     if (!s || s_len == 0) {
         return impl_z_empty;
     }
+
+    impl_throw_if_embedded_nul(s, s_len, xctx);
 
     /* Allocate memory for string including length byte. */
     s_z = afw_pool_malloc(p, s_len + 1, xctx);
@@ -812,6 +848,29 @@ afw_utf8_printf_v(
 
 
 
+/* Clone a utf-8 string into a specific pool. */
+AFW_DEFINE(const afw_utf8_t *)
+afw_utf8_clone(
+    const afw_utf8_t *string, const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    return (string)
+        ? afw_utf8_create(string->s, string->len, p, xctx)
+        : NULL;
+}
+
+
+/* Set result to a substring of string using byte indexes. */
+AFW_DEFINE(void)
+afw_utf8_substring_byte(
+    afw_utf8_t *result, const afw_utf8_t *string, afw_size_t start,
+    afw_size_t end)
+{
+    if (end > string->len) end = string->len;
+    result->len = (end > start) ? end - start : 0;
+    result->s = (result->len > 0) ? string->s + start : NULL;
+}
+
+
 /* Check to see if a string starts with another string. */
 AFW_DEFINE(afw_boolean_t) afw_utf8_starts_with(
     const afw_utf8_t *string, const afw_utf8_t *starts_with)
@@ -828,6 +887,40 @@ AFW_DEFINE(afw_boolean_t) afw_utf8_starts_with_z(
     afw_size_t len = strlen(starts_with_z);
     return (string->len >= len &&
         memcmp(string->s, starts_with_z, len) == 0);
+}
+
+
+/* Returns true if series of bytes for len s1 starts with s2_z. */
+AFW_DEFINE(afw_boolean_t)
+afw_utf8_len_starts_with_z(
+    const afw_utf8_octet_t *s1, afw_size_t len1, const afw_utf8_z_t *s2_z)
+{
+    while (*s2_z) {
+        if (len1-- <= 0 || *s1 != *s2_z) {
+            return false;
+        }
+        s1++;
+        s2_z++;
+    }
+
+    return true;
+}
+
+
+/* Returns true if zero terminated s1 starts with s2. */
+AFW_DEFINE(afw_boolean_t)
+afw_utf8_z_starts_with_z(
+    const afw_utf8_z_t *s1_z, const afw_utf8_z_t *s2_z)
+{
+    while (*s2_z) {
+        if (!*s1_z || *s1_z != *s2_z) {
+            return false;
+        }
+        s1_z++;
+        s2_z++;
+    }
+
+    return true;
 }
 
 
@@ -1158,6 +1251,44 @@ AFW_DEFINE(afw_boolean_t) afw_utf8_equal_utf8_z(
 }
 
 
+/* Compare two zero terminated utf-8 strings ignoring case. */
+AFW_DEFINE(int)
+afw_utf8_z_compare_ignore_case(
+    const afw_utf8_z_t *s1, const afw_utf8_z_t *s2, afw_xctx_t *xctx)
+{
+    afw_utf8_t a1, a2;
+
+    afw_utf8_set_no_copy_z(&a1, s1, xctx);
+    afw_utf8_set_no_copy_z(&a2, s2, xctx);
+
+    return afw_utf8_compare_ignore_case(&a1, &a2, xctx);
+}
+
+
+/* Compare two zero terminated UTF8 strings to be equal. */
+AFW_DEFINE(afw_boolean_t)
+afw_utf8_z_equal(
+    const afw_utf8_z_t *s1, const afw_utf8_z_t *s2)
+{
+    return (s1 && s2 && (strcmp((const char *)s1, (const char *)s2) == 0
+        || s1 == s2)) ? TRUE : FALSE;
+}
+
+
+/*
+ * Compare two zero terminated UTF8 strings to be equal, ignoring case.
+ *
+ * @fixme See header: needs xctx when XACML no longer uses this.
+ */
+AFW_DEFINE(afw_boolean_t)
+afw_utf8_z_equal_ignore_case(
+    const afw_utf8_z_t *s1, const afw_utf8_z_t *s2)
+{
+    return (strcasecmp((const char *)s1, (const char *)s2) == 0)
+        ? true : false;
+}
+
+
 /* Concatenate zero terminated UTF8 strings. */
 static const afw_utf8_z_t * impl_u8z_concat_v(
     const afw_pool_t *p, afw_xctx_t *xctx, va_list ap)
@@ -1235,6 +1366,22 @@ afw_utf8_z_printf_v(
         z[n] = 0;
         return z;
     }
+}
+
+
+/* Create a utf8_z string using a c format string in specified pool. */
+AFW_DEFINE_ELLIPSIS(const afw_utf8_z_t *)
+afw_utf8_z_printf(
+    const afw_pool_t *p, afw_xctx_t *xctx, const afw_utf8_z_t *format_z, ...)
+{
+    va_list ap;
+    const afw_utf8_z_t *result;
+
+    va_start(ap, format_z);
+    result = afw_utf8_z_printf_v(format_z, ap, p, xctx);
+    va_end(ap);
+
+    return result;
 }
 
 /* Clone a pointer array of utf-8 to specified pool. */
@@ -1344,10 +1491,12 @@ afw_utf8_array_to_utf8_z_with_separator(
     len = 1;
     for (count = 0, c = strings; *c; count++, c++)
     {
+        impl_throw_if_embedded_nul((*c)->s, (*c)->len, xctx);
         len += (*c)->len;
     }
 
     if (separator) {
+        impl_throw_if_embedded_nul(separator->s, separator->len, xctx);
         len += (count - 1) * separator->len;
     }
 
@@ -1391,6 +1540,7 @@ afw_utf8_z_array_to_utf8_z_with_separator(
     }
 
     if (separator) {
+        impl_throw_if_embedded_nul(separator->s, separator->len, xctx);
         len += (count - 1) * separator->len;
     }
 
@@ -1409,6 +1559,26 @@ afw_utf8_z_array_to_utf8_z_with_separator(
     *o = 0;
 
     return result;
+}
+
+
+/* Returns pointer in path_z past last / or \. */
+AFW_DEFINE(const afw_utf8_z_t *)
+afw_utf8_z_file_name_from_path(
+    const afw_utf8_z_t *path_z)
+{
+    const afw_utf8_z_t *file_name;
+    const afw_utf8_z_t *c;
+
+    if (!path_z) return "";
+
+    for (c = file_name = path_z; *c; c++) {
+        if ((*c == '/') || (*c == '\\')) {
+            file_name = c + 1;
+        }
+    }
+
+    return file_name;
 }
 
 

--- a/src/afw/utf8/afw_utf8.c
+++ b/src/afw/utf8/afw_utf8.c
@@ -530,7 +530,7 @@ afw_utf8_create_no_copy(
 
 
 AFW_DEFINE(const afw_utf8_t *)
-afw_utf8_create_no_copy_z(
+afw_utf8_z_as_utf8(
     const afw_utf8_z_t *s_z,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
@@ -557,7 +557,7 @@ afw_utf8_set(
 
 
 AFW_DEFINE(void)
-afw_utf8_set_z(
+afw_utf8_z_set(
     afw_utf8_t *to,
     const afw_utf8_z_t *s_z,
     const afw_pool_t *p,
@@ -596,7 +596,7 @@ afw_utf8_set_no_copy(
 
 
 AFW_DEFINE(void)
-afw_utf8_set_no_copy_z(
+afw_utf8_z_set_no_copy(
     afw_utf8_t *to,
     const afw_utf8_z_t *s_z,
     afw_xctx_t *xctx)
@@ -618,7 +618,7 @@ afw_utf8_create_forced_safe(
 
 
 AFW_DEFINE(const afw_utf8_t *)
-afw_utf8_create_forced_safe_z(
+afw_utf8_z_create_forced_safe(
     const afw_utf8_z_t *s_z,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
@@ -645,7 +645,7 @@ afw_utf8_set_forced_safe(
 
 
 AFW_DEFINE(void)
-afw_utf8_set_forced_safe_z(
+afw_utf8_z_set_forced_safe(
     afw_utf8_t *to,
     const afw_utf8_z_t *s_z,
     const afw_pool_t *p,
@@ -671,7 +671,7 @@ afw_utf8_create_property_name(
 
 
 AFW_DEFINE(const afw_utf8_t *)
-afw_utf8_create_property_name_z(
+afw_utf8_z_create_property_name(
     const afw_utf8_z_t *s_z,
     const afw_pool_t *p,
     afw_xctx_t *xctx)
@@ -881,7 +881,7 @@ AFW_DEFINE(afw_boolean_t) afw_utf8_starts_with(
 
 
 /* Check to see if a string starts with a utf8_z string. */
-AFW_DEFINE(afw_boolean_t) afw_utf8_starts_with_z(
+AFW_DEFINE(afw_boolean_t) afw_utf8_starts_with_utf8_z(
     const afw_utf8_t *string, const afw_utf8_z_t *starts_with_z)
 {
     afw_size_t len = strlen(starts_with_z);
@@ -892,7 +892,7 @@ AFW_DEFINE(afw_boolean_t) afw_utf8_starts_with_z(
 
 /* Returns true if series of bytes for len s1 starts with s2_z. */
 AFW_DEFINE(afw_boolean_t)
-afw_utf8_len_starts_with_z(
+afw_utf8_len_starts_with_utf8_z(
     const afw_utf8_octet_t *s1, afw_size_t len1, const afw_utf8_z_t *s2_z)
 {
     while (*s2_z) {
@@ -909,7 +909,7 @@ afw_utf8_len_starts_with_z(
 
 /* Returns true if zero terminated s1 starts with s2. */
 AFW_DEFINE(afw_boolean_t)
-afw_utf8_z_starts_with_z(
+afw_utf8_z_starts_with(
     const afw_utf8_z_t *s1_z, const afw_utf8_z_t *s2_z)
 {
     while (*s2_z) {
@@ -937,7 +937,7 @@ afw_utf8_ends_with(
 
 /* Check to see if a string ends with a utf8_z string. */
 AFW_DEFINE(afw_boolean_t)
-afw_utf8_ends_with_z(
+afw_utf8_ends_with_utf8_z(
     const afw_utf8_t *string, const afw_utf8_z_t *ends_with_z)
 {
     afw_size_t len = strlen(ends_with_z);
@@ -1258,8 +1258,8 @@ afw_utf8_z_compare_ignore_case(
 {
     afw_utf8_t a1, a2;
 
-    afw_utf8_set_no_copy_z(&a1, s1, xctx);
-    afw_utf8_set_no_copy_z(&a2, s2, xctx);
+    afw_utf8_z_set_no_copy(&a1, s1, xctx);
+    afw_utf8_z_set_no_copy(&a2, s2, xctx);
 
     return afw_utf8_compare_ignore_case(&a1, &a2, xctx);
 }
@@ -1520,7 +1520,7 @@ afw_utf8_array_to_utf8_z_with_separator(
 
 /* Concat array of utf-8 with optional separator to specified pool. */
 AFW_DEFINE(const afw_utf8_z_t *)
-afw_utf8_z_array_to_utf8_z_with_separator(
+afw_utf8_z_array_with_separator(
     const afw_utf8_z_t * const * strings_z,
     const afw_utf8_t * separator,
     const afw_pool_t *p, afw_xctx_t *xctx)

--- a/src/afw/utf8/afw_utf8.h
+++ b/src/afw/utf8/afw_utf8.h
@@ -24,17 +24,29 @@
  * no refcount. Adaptive values (`const afw_value_t *`) are what can hold
  * a lifetime. See @ref afw_utf8 and `designs/c-naming-and-payloads.md`.
  *
- * ## `afw_utf8_t->s` is not a C string
+ * ## Internal vs **external**
  *
- * `.s` is octets for `.len` bytes. There is usually **no** trailing `0` at
- * `s[len]` (new `create`, slices from `substring_byte`, a window into
- * another string). The bytes **may contain U+0000**.
+ * **Internal** is AFW's NFC world: `afw_utf8_t`, `.s` + `.len`. Slices,
+ * hashes, `memcpy`, `stream_write`, curl POSTFIELDS+SIZE. `.s` is octets
+ * for `.len` bytes. There is usually **no** trailing `0` at `s[len]`.
+ * The bytes **may contain U+0000**.
  *
- * Do **not** pass `string->s` to `fopen`, `strlen`, `strcmp`, or any API
- * that expects a 0-terminated C string. Always use `afw_utf8_to_utf8_z`
- * or `afw_utf8_z_create` when you need a `utf8_z` / C string. Those throw
- * if the length-prefixed bytes contain a `0`. Use `.s` and `.len` (or
- * `as_memory`) for length-prefixed work.
+ * **External** is not that world (libc, APR paths, LDAP DNs, libxml
+ * regexp, logs, env names). Say **external C string** or
+ * **external octets** when you need the shape. Cross with a named door:
+ *
+ * | External | Door |
+ * |----------|------|
+ * | C string | `afw_utf8_to_utf8_z` / `z_create` (throw if interior `0`) |
+ * | Encode for logs/names | `forced_safe` (not promised NFC) |
+ * | Octets + size | `as_memory` / write with `len` (NULs are data) |
+ *
+ * Generated literals: `afw_s_*` (internal) and `afw_z_*` (external C
+ * string of the same `"…"`). `afw_utf8_utf8_z_t` is the utf8 + z pair
+ * when the buffer is already a C string (see `afw_common.h`).
+ *
+ * Do **not** pass `string->s` to `fopen`, `strlen`, `strcmp`, or any
+ * external C-string API.
  *
  * ## Naming
  *
@@ -54,8 +66,8 @@
  * | `z_set` / `z_set_no_copy` | Fill yours from a `utf8_z` |
  * | `set` / `set_no_copy` | Fill yours from octets + len |
  * | `clone` | Copy an existing `afw_utf8_t` (struct + bytes) |
- * | `to_utf8_z` / `z_create` | 0-terminated C string (throw if embedded 0) |
- * | `forced_safe` | Always copy; encode invalid/Cc as `^hex^`; not NFC; not a value |
+ * | `to_utf8_z` / `z_create` | External C string (throw if embedded 0) |
+ * | `forced_safe` | External encode; invalid/Cc as `^hex^`; not NFC; not a value |
  * | `create_property_name` | Same encode, then NFC (property name only) |
  *
  * `AFW_UTF8_LITERAL` is a trusted C `"…"` initializer (no check).
@@ -673,15 +685,15 @@ afw_utf8_printf_v(
 
 
 /**
- * @brief Convert utf8 to utf8_z in specified pool.
+ * @brief Convert utf8 to an external C string in specified pool.
  * @param string to convert.
  * @param p pool used for result.
  * @param xctx of caller.
  * @return utf8_z 0 terminated string.
  *
- * Always use this (or `afw_utf8_z_create`) when you need a 0-terminated
- * UTF-8 C string from an `afw_utf8_t`. Do not use `string->s` as a C
- * string: it is not 0-terminated and may contain U+0000.
+ * Always use this (or `afw_utf8_z_create`) at the external C-string
+ * door. Do not use `string->s` as a C string: it is not 0-terminated
+ * and may contain U+0000.
  *
  * The input is assumed to already be valid utf-8. Throws if the
  * length-prefixed bytes contain a 0. A C string cannot represent that
@@ -863,9 +875,9 @@ afw_utf8_substring_byte(
  * @param p pool used for result.
  * @param xctx of caller.
  *
- * Always use this (or `afw_utf8_to_utf8_z`) when you need a 0-terminated
- * UTF-8 C string from length-prefixed octets. Do not use `s` as a C
- * string unless `len` is `AFW_UTF8_Z_LEN` and `s` is already `utf8_z`.
+ * Always use this (or `afw_utf8_to_utf8_z`) at the external C-string
+ * door from length-prefixed octets. Do not use `s` as a C string unless
+ * `len` is `AFW_UTF8_Z_LEN` and `s` is already `utf8_z`.
  *
  * A copy is always required to add a 0 byte.
  *

--- a/src/afw/utf8/afw_utf8.h
+++ b/src/afw/utf8/afw_utf8.h
@@ -41,18 +41,22 @@
  * **Less in the name, more we do.** Extra words take a safety off or pick
  * a non-default policy. **`p` only if something new lives there.**
  *
+ * Prefix **`afw_utf8_z_`** when you **have** a C string. Prefix
+ * **`afw_utf8_`** when you have length-prefixed `utf8`. Mixed predicates
+ * spell both types in argument order (`starts_with_utf8_z`).
+ *
  * | Name | What we do |
  * |------|------------|
- * | `create` / `create_z` | New struct in `p`, **copy** bytes, NFC or throw |
- * | `create_no_copy` / `_z` | New struct in `p`, **point** at `s`, NFC or throw |
- * | `set` / `set_z` | Fill your non-const `afw_utf8_t`, copy into `p` |
- * | `set_no_copy` / `_z` | Fill yours, point; no `p` |
+ * | `create` | New struct in `p`, **copy** octets, NFC or throw |
+ * | `create_no_copy` | New struct in `p`, **point** at `s`, NFC or throw |
+ * | `z_to_utf8` | Ingest `utf8_z` (copy + NFC) |
+ * | `z_as_utf8` | Ingest `utf8_z` (point; already NFC) |
+ * | `z_set` / `z_set_no_copy` | Fill yours from a `utf8_z` |
+ * | `set` / `set_no_copy` | Fill yours from octets + len |
  * | `clone` | Copy an existing `afw_utf8_t` (struct + bytes) |
+ * | `to_utf8_z` / `z_create` | 0-terminated C string (throw if embedded 0) |
  * | `forced_safe` | Always copy; encode invalid/Cc as `^hex^`; not NFC; not a value |
  * | `create_property_name` | Same encode, then NFC (property name only) |
- *
- * Suffix `_z` = that **argument** is `0`-terminated. Prefix `z_` = the
- * **result** is `utf8_z`. Two `_z`s means both.
  *
  * `AFW_UTF8_LITERAL` is a trusted C `"…"` initializer (no check).
  */
@@ -264,12 +268,15 @@ afw_utf8_from_encoding(
 
 
 /**
- * @brief Create utf-8 in p from a 0-terminated C string (copy, NFC or throw).
+ * @brief Ingest a 0-terminated C string: new utf8 in p (copy, NFC or throw).
  * @param s_z 0-terminated octets.
  * @param p pool for the struct and the copy.
  * @param xctx of caller.
+ *
+ * You have a `utf8_z`; you get an `afw_utf8_t`. Inverse of
+ * `afw_utf8_to_utf8_z`.
  */
-#define afw_utf8_create_z(s_z, p, xctx) \
+#define afw_utf8_z_to_utf8(s_z, p, xctx) \
     afw_utf8_nfc(s_z, AFW_UTF8_Z_LEN, afw_utf8_nfc_option_create_copy, \
         p, xctx)
 
@@ -283,8 +290,8 @@ afw_utf8_from_encoding(
  *
  * Extra words take the copy off. p holds the little struct; bytes stay at s
  * and must live as long as the result. Cannot rewrite someone else's memory,
- * so not-NFC throws. `s` is still not a C string unless it already was
- * 0-terminated and you asked for a `utf8_z`.
+ * so not-NFC throws. `s` is still not a C string. Ingest a `utf8_z` with
+ * `afw_utf8_z_as_utf8` / `afw_utf8_z_to_utf8`.
  */
 AFW_DECLARE(const afw_utf8_t *)
 afw_utf8_create_no_copy(
@@ -293,8 +300,13 @@ afw_utf8_create_no_copy(
     const afw_pool_t *p,
     afw_xctx_t *xctx);
 
+/**
+ * @brief Ingest a 0-terminated C string: new utf8 pointing at s_z (no copy).
+ *
+ * `s_z` must already be valid NFC. Inverse of a C string you already own.
+ */
 AFW_DECLARE(const afw_utf8_t *)
-afw_utf8_create_no_copy_z(
+afw_utf8_z_as_utf8(
     const afw_utf8_z_t *s_z,
     const afw_pool_t *p,
     afw_xctx_t *xctx);
@@ -373,7 +385,7 @@ afw_utf8_array_to_utf8_z_with_separator(
  * not, or if the separator contains a 0 byte.
  */
 AFW_DECLARE(const afw_utf8_z_t *)
-afw_utf8_z_array_to_utf8_z_with_separator(
+afw_utf8_z_array_with_separator(
     const afw_utf8_z_t * const * strings_z,
     const afw_utf8_t * separator,
     const afw_pool_t *p, afw_xctx_t *xctx);
@@ -414,8 +426,11 @@ afw_utf8_set(
     const afw_pool_t *p,
     afw_xctx_t *xctx);
 
+/**
+ * @brief Ingest a 0-terminated C string into a preallocated utf8 (copy + NFC).
+ */
 AFW_DECLARE(void)
-afw_utf8_set_z(
+afw_utf8_z_set(
     afw_utf8_t *to,
     const afw_utf8_z_t *s_z,
     const afw_pool_t *p,
@@ -437,8 +452,11 @@ afw_utf8_set_no_copy(
     afw_size_t len,
     afw_xctx_t *xctx);
 
+/**
+ * @brief Ingest a 0-terminated C string into a preallocated utf8 (point).
+ */
 AFW_DECLARE(void)
-afw_utf8_set_no_copy_z(
+afw_utf8_z_set_no_copy(
     afw_utf8_t *to,
     const afw_utf8_z_t *s_z,
     afw_xctx_t *xctx);
@@ -456,8 +474,11 @@ afw_utf8_set_forced_safe(
     const afw_pool_t *p,
     afw_xctx_t *xctx);
 
+/**
+ * @brief Ingest a 0-terminated C string with forced_safe encode (copy).
+ */
 AFW_DECLARE(void)
-afw_utf8_set_forced_safe_z(
+afw_utf8_z_set_forced_safe(
     afw_utf8_t *to,
     const afw_utf8_z_t *s_z,
     const afw_pool_t *p,
@@ -477,8 +498,11 @@ afw_utf8_create_forced_safe(
     const afw_pool_t *p,
     afw_xctx_t *xctx);
 
+/**
+ * @brief Ingest a 0-terminated C string with forced_safe encode (new utf8).
+ */
 AFW_DECLARE(const afw_utf8_t *)
-afw_utf8_create_forced_safe_z(
+afw_utf8_z_create_forced_safe(
     const afw_utf8_z_t *s_z,
     const afw_pool_t *p,
     afw_xctx_t *xctx);
@@ -495,8 +519,11 @@ afw_utf8_create_property_name(
     const afw_pool_t *p,
     afw_xctx_t *xctx);
 
+/**
+ * @brief Ingest a 0-terminated C string as a property name (encode, then NFC).
+ */
 AFW_DECLARE(const afw_utf8_t *)
-afw_utf8_create_property_name_z(
+afw_utf8_z_create_property_name(
     const afw_utf8_z_t *s_z,
     const afw_pool_t *p,
     afw_xctx_t *xctx);
@@ -689,7 +716,7 @@ afw_utf8_starts_with(
  * The input strings are assumed to already be valid utf-8.
  */
 AFW_DECLARE(afw_boolean_t)
-afw_utf8_starts_with_z(
+afw_utf8_starts_with_utf8_z(
     const afw_utf8_t *string, const afw_utf8_z_t *starts_with_z);
 
 
@@ -717,7 +744,7 @@ afw_utf8_ends_with(
  * The input strings are assumed to already be valid utf-8.
  */
 AFW_DECLARE(afw_boolean_t)
-afw_utf8_ends_with_z(
+afw_utf8_ends_with_utf8_z(
     const afw_utf8_t *string, const afw_utf8_z_t *ends_with_z);
 
 
@@ -859,7 +886,7 @@ afw_utf8_z_create(
  * @return true or false.
  */
 AFW_DECLARE(afw_boolean_t)
-afw_utf8_len_starts_with_z(
+afw_utf8_len_starts_with_utf8_z(
     const afw_utf8_octet_t *s1, afw_size_t len1, const afw_utf8_z_t *s2_z);
 
 
@@ -872,7 +899,7 @@ afw_utf8_len_starts_with_z(
  * @return true or false.
  */
 AFW_DECLARE(afw_boolean_t)
-afw_utf8_z_starts_with_z(
+afw_utf8_z_starts_with(
     const afw_utf8_z_t *s1_z, const afw_utf8_z_t *s2_z);
 
 

--- a/src/afw/utf8/afw_utf8.h
+++ b/src/afw/utf8/afw_utf8.h
@@ -24,6 +24,18 @@
  * no refcount. Adaptive values (`const afw_value_t *`) are what can hold
  * a lifetime. See @ref afw_utf8 and `designs/c-naming-and-payloads.md`.
  *
+ * ## `afw_utf8_t->s` is not a C string
+ *
+ * `.s` is octets for `.len` bytes. There is usually **no** trailing `0` at
+ * `s[len]` (new `create`, slices from `substring_byte`, a window into
+ * another string). The bytes **may contain U+0000**.
+ *
+ * Do **not** pass `string->s` to `fopen`, `strlen`, `strcmp`, or any API
+ * that expects a 0-terminated C string. Always use `afw_utf8_to_utf8_z`
+ * or `afw_utf8_z_create` when you need a `utf8_z` / C string. Those throw
+ * if the length-prefixed bytes contain a `0`. Use `.s` and `.len` (or
+ * `as_memory`) for length-prefixed work.
+ *
  * ## Naming
  *
  * **Less in the name, more we do.** Extra words take a safety off or pick
@@ -195,15 +207,10 @@ afw_utf8_from_code_point(afw_utf8_octet_t utf8_z[5], afw_code_point_t cp,
  * @return memory (cast of string).
  *
  * Cast only. Does not copy. The utf8 bytes are already NFC.
+ * The view is pointer + size, not a C string.
  */
-AFW_DEFINE_STATIC_INLINE(const afw_memory_t *)
-afw_utf8_as_memory(
-    const afw_utf8_t *string, const afw_pool_t *p, afw_xctx_t *xctx)
-{
-    (void)p;
-    (void)xctx;
-    return (const afw_memory_t *)string;
-}
+#define afw_utf8_as_memory(string, p, xctx) \
+    ((const afw_memory_t *)(string))
 
 
 /**
@@ -215,13 +222,9 @@ afw_utf8_as_memory(
  *
  * Short name: copy into p and NFC. Invalid utf-8 throws.
  */
-AFW_DEFINE_STATIC_INLINE(const afw_utf8_t *)
-afw_utf8_from_memory(
-    const afw_memory_t *memory, const afw_pool_t *p, afw_xctx_t *xctx)
-{
-    return afw_utf8_nfc((const afw_utf8_octet_t *)memory->ptr, memory->size,
-        afw_utf8_nfc_option_create_copy, p, xctx);
-}
+#define afw_utf8_from_memory(memory, p, xctx) \
+    afw_utf8_nfc((const afw_utf8_octet_t *)(memory)->ptr, (memory)->size, \
+        afw_utf8_nfc_option_create_copy, p, xctx)
 
 
 
@@ -253,7 +256,8 @@ afw_utf8_from_encoding(
  * @return const afw_utf8_t in p.
  *
  * Short name is the safe door: always copy into p. Invalid utf-8 throws.
- * Valid but not NFC is normalized into p.
+ * Valid but not NFC is normalized into p. The copy has no trailing 0;
+ * do not use the result `->s` as a C string.
  */
 #define afw_utf8_create(s, len, p, xctx) \
     afw_utf8_nfc(s, len, afw_utf8_nfc_option_create_copy, p, xctx)
@@ -279,7 +283,8 @@ afw_utf8_from_encoding(
  *
  * Extra words take the copy off. p holds the little struct; bytes stay at s
  * and must live as long as the result. Cannot rewrite someone else's memory,
- * so not-NFC throws.
+ * so not-NFC throws. `s` is still not a C string unless it already was
+ * 0-terminated and you asked for a `utf8_z`.
  */
 AFW_DECLARE(const afw_utf8_t *)
 afw_utf8_create_no_copy(
@@ -343,7 +348,10 @@ afw_utf8_array_to_utf8_with_separator(
  * @return utf8_z 0 terminated string.
  *
  * The input strings must already be valid utf-8.  An error is thrown if it is
- * not.
+ * not, or if a piece or the separator contains a 0 byte.
+ *
+ * Use this (or `to_utf8_z` / `z_create`) when the result must be a
+ * 0-terminated C string. Do not concatenate and then use a piece `->s`.
  */
 AFW_DECLARE(const afw_utf8_z_t *)
 afw_utf8_array_to_utf8_z_with_separator(
@@ -362,7 +370,7 @@ afw_utf8_array_to_utf8_z_with_separator(
  * @return utf8_z 0 terminated string.
  *
  * The input strings must already be valid utf-8.  An error is thrown if it is
- * not.
+ * not, or if the separator contains a 0 byte.
  */
 AFW_DECLARE(const afw_utf8_z_t *)
 afw_utf8_z_array_to_utf8_z_with_separator(
@@ -374,22 +382,17 @@ afw_utf8_z_array_to_utf8_z_with_separator(
 
 /**
  * @brief Clone a utf-8 string into a specific pool.
- * @param string
- * @param len is number of bytes.
+ * @param string to clone, or NULL.
  * @param p pool used for result.
  * @param xctx of caller.
- * @return utf8 string.
+ * @return utf8 string, or NULL if string is NULL.
  *
  * Clone copies the struct and the bytes (same byte policy as create).
+ * The copy has no trailing 0.
  */
-AFW_DEFINE_STATIC_INLINE(const afw_utf8_t *)
+AFW_DECLARE(const afw_utf8_t *)
 afw_utf8_clone(
-    const afw_utf8_t *string, const afw_pool_t *p, afw_xctx_t *xctx)
-{
-    return (string)
-        ? afw_utf8_create(string->s, string->len, p, xctx)
-        : NULL;
-}
+    const afw_utf8_t *string, const afw_pool_t *p, afw_xctx_t *xctx);
 
 
 
@@ -649,23 +652,17 @@ afw_utf8_printf_v(
  * @param xctx of caller.
  * @return utf8_z 0 terminated string.
  *
- * The input strings are assumed to already be valid utf-8.
+ * Always use this (or `afw_utf8_z_create`) when you need a 0-terminated
+ * UTF-8 C string from an `afw_utf8_t`. Do not use `string->s` as a C
+ * string: it is not 0-terminated and may contain U+0000.
+ *
+ * The input is assumed to already be valid utf-8. Throws if the
+ * length-prefixed bytes contain a 0. A C string cannot represent that
+ * value. `forced_safe` / `z_printf` still encode U+0000.
  */
-AFW_DEFINE_STATIC_INLINE(const afw_utf8_z_t *)
+AFW_DECLARE(const afw_utf8_z_t *)
 afw_utf8_to_utf8_z(
-    const afw_utf8_t *string, const afw_pool_t *p, afw_xctx_t *xctx)
-{
-    afw_utf8_z_t * result;
-
-    if (!string || string->len == 0) {
-        return "";
-    }
-
-    result = afw_pool_malloc(p, string->len + 1, xctx);
-    memcpy(result, string->s, string->len);
-    result[string->len] = 0;
-    return result;
-}
+    const afw_utf8_t *string, const afw_pool_t *p, afw_xctx_t *xctx);
 
 
 /**
@@ -817,33 +814,36 @@ afw_utf8_parse_csv(
  *    end of string, substring will include all bytes up to end
  *    of string.
  *
+ * Result points into `string` (no copy). There is no trailing 0 at
+ * `result->s[result->len]`. Do not use `result->s` as a C string.
+ *
  * If string might contain codepoints > 127, you should use
  * afw_utf8_substring().
  */
-AFW_DEFINE_STATIC_INLINE(void)
+AFW_DECLARE(void)
 afw_utf8_substring_byte(
     afw_utf8_t *result, const afw_utf8_t *string, afw_size_t start,
-    afw_size_t end)
-{
-    if (end > string->len) end = string->len;
-    result->len = (end > start) ? end - start : 0;
-    result->s = (result->len > 0) ? string->s + start : NULL;
-}
+    afw_size_t end);
 
 
-/* -- The following are primarily zero terminate utf-8 string functions. -- */
+/* -- Zero-terminated utf-8 (`utf8_z` / C string) -- */
 
 /**
- * @brief Create a NFC Normalized zero terminated UTF-8 string in specified
+ * @brief Create a NFC normalized 0-terminated UTF-8 string in specified
  *    pool.
  * @param s pointer to utf-8 characters.
  * @param len is number of bytes.
  * @param p pool used for result.
  * @param xctx of caller.
  *
+ * Always use this (or `afw_utf8_to_utf8_z`) when you need a 0-terminated
+ * UTF-8 C string from length-prefixed octets. Do not use `s` as a C
+ * string unless `len` is `AFW_UTF8_Z_LEN` and `s` is already `utf8_z`.
+ *
  * A copy is always required to add a 0 byte.
  *
- * An error is thrown if s is not valid utf-8.
+ * Throws if s is not valid utf-8, or if the length-prefixed bytes
+ * contain a 0 (a C string cannot represent that value).
  */
 AFW_DECLARE(const afw_utf8_z_t *)
 afw_utf8_z_create(
@@ -858,20 +858,9 @@ afw_utf8_z_create(
  * @param s2_z 0 terminated string.
  * @return true or false.
  */
-AFW_DEFINE_STATIC_INLINE(afw_boolean_t)
+AFW_DECLARE(afw_boolean_t)
 afw_utf8_len_starts_with_z(
-    const afw_utf8_octet_t *s1, afw_size_t len1, const afw_utf8_z_t *s2_z)
-{
-    while (*s2_z) {
-        if (len1-- <= 0 || *s1 != *s2_z) {
-            return false;
-        }
-        s1++;
-        s2_z++;
-    }
-
-    return true;
-}
+    const afw_utf8_octet_t *s1, afw_size_t len1, const afw_utf8_z_t *s2_z);
 
 
 /**
@@ -882,38 +871,17 @@ afw_utf8_len_starts_with_z(
  * @param s2_z 0 terminated string.
  * @return true or false.
  */
-AFW_DEFINE_STATIC_INLINE(afw_boolean_t)
+AFW_DECLARE(afw_boolean_t)
 afw_utf8_z_starts_with_z(
-    const afw_utf8_z_t *s1_z, const afw_utf8_z_t *s2_z)
-{
-    while (*s2_z) {
-        if (!*s1_z || *s1_z != *s2_z) {
-            return false;
-        }
-        s1_z++;
-        s2_z++;
-    }
-
-    return true;
-}
+    const afw_utf8_z_t *s1_z, const afw_utf8_z_t *s2_z);
 
 
 /**
  * @brief Compare two zero terminated utf-8 strings ignoring case.
- *
- * 
  */
-AFW_DEFINE_STATIC_INLINE(int)
+AFW_DECLARE(int)
 afw_utf8_z_compare_ignore_case(
-    const afw_utf8_z_t *s1, const afw_utf8_z_t *s2, afw_xctx_t *xctx)
-{
-    afw_utf8_t a1, a2;
-
-    afw_utf8_set_no_copy_z(&a1, s1, xctx);
-    afw_utf8_set_no_copy_z(&a2, s2, xctx);
-
-    return afw_utf8_compare_ignore_case(&a1, &a2, xctx);
-}
+    const afw_utf8_z_t *s1, const afw_utf8_z_t *s2, afw_xctx_t *xctx);
 
 
 /** @fixme Need to fix comments below and polish comments above. */
@@ -922,13 +890,9 @@ afw_utf8_z_compare_ignore_case(
  * Compare two zero terminated UTF8 strings to be equal.
  * Strings should already be normalized (NFC, etc.)
  */
-AFW_DEFINE_STATIC_INLINE(afw_boolean_t)
+AFW_DECLARE(afw_boolean_t)
 afw_utf8_z_equal(
-    const afw_utf8_z_t *s1, const afw_utf8_z_t *s2)
-{
-    return (s1 && s2 && (strcmp((const char *)s1, (const char *)s2) == 0
-        || s1 == s2)) ? TRUE : FALSE;
-}
+    const afw_utf8_z_t *s1, const afw_utf8_z_t *s2);
 
 
 /**
@@ -940,12 +904,9 @@ afw_utf8_z_equal(
  * when XACML is chanced not to use this.  New version has xctx so
  * error can be thrown if string is not UTF8 or too large.
  */
-AFW_DEFINE_STATIC_INLINE(afw_boolean_t)
+AFW_DECLARE(afw_boolean_t)
 afw_utf8_z_equal_ignore_case(
-    const afw_utf8_z_t *s1, const afw_utf8_z_t *s2)
-{
-    return (strcasecmp((const char *)s1, (const char *)s2) == 0) ? true : false;
-}
+    const afw_utf8_z_t *s1, const afw_utf8_z_t *s2);
 
 
 
@@ -977,42 +938,18 @@ afw_utf8_z_printf_v(
 /**
  * Create a utf8_z string using a c format string in specified pool.
  */
-AFW_DEFINE_STATIC_INLINE(const afw_utf8_z_t *)
+AFW_DECLARE_ELLIPSIS(const afw_utf8_z_t *)
 afw_utf8_z_printf(
-    const afw_pool_t *p, afw_xctx_t *xctx, const afw_utf8_z_t *format_z, ...)
-{
-    va_list ap;
-    const afw_utf8_z_t *result;
-
-    va_start(ap, format_z);
-    result = afw_utf8_z_printf_v(format_z, ap, p, xctx);
-    va_end(ap);
-
-    return result;
-};
+    const afw_pool_t *p, afw_xctx_t *xctx, const afw_utf8_z_t *format_z, ...);
 
 
 
 /**
  * Returns pointer in path_z past last / or \.
  */
-AFW_DEFINE_STATIC_INLINE(const afw_utf8_z_t *)
+AFW_DECLARE(const afw_utf8_z_t *)
 afw_utf8_z_file_name_from_path(
-    const afw_utf8_z_t *path_z)
-{
-    const afw_utf8_z_t *file_name;
-    const afw_utf8_z_t *c;
-
-    if (!path_z) return "";
-
-    for (c = file_name = path_z; *c; c++) {
-        if ((*c == '/') || (*c == '\\')) {
-            file_name = c + 1;
-        }
-    }
-
-    return file_name;
-}
+    const afw_utf8_z_t *path_z);
 
 
 /**

--- a/src/afw_lmdb/afw_lmdb_internal.c
+++ b/src/afw_lmdb/afw_lmdb_internal.c
@@ -1387,7 +1387,7 @@ int afw_lmdb_internal_reader_list_cb(
     afw_lmdb_internal_reader_list_cb_ctx * context = (afw_lmdb_internal_reader_list_cb_ctx *)ctx;
     const afw_utf8_t *message;
 
-    message = afw_utf8_create_z(msg, context->pool, context->xctx);
+    message = afw_utf8_z_to_utf8(msg, context->pool, context->xctx);
     *(context->list) = afw_utf8_create(
     message->s, message->len, context->pool, context->xctx);
 

--- a/src/afw_lmdb/afw_lmdb_metadata.c
+++ b/src/afw_lmdb/afw_lmdb_metadata.c
@@ -89,7 +89,7 @@ const afw_array_t * afw_lmdb_metadata_retrieve_objects(
 afw_boolean_t afw_lmdb_metadata_handles(const afw_utf8_t *object_type_id)
 {
     if (object_type_id  && (
-        afw_utf8_starts_with_z(object_type_id,
+        afw_utf8_starts_with_utf8_z(object_type_id,
             AFW_LMDB_Q_OBJECT_TYPE_SYNTHETIC_PREFIX)
         ))
     {

--- a/whats-new.md
+++ b/whats-new.md
@@ -38,7 +38,7 @@ In-tree extensions and the `afw` / `afwfcgi` commands built with the same `./afw
 | Old installed headers / mixed binaries | Rebuild once. Prune stale names under the include prefix (`afw_*_internal.h`, old `afw_function_bindings.h`, `afw_declare_helpers.h`, …). |
 | `#include` of core internals or package `*_declare_helpers.h` | `#include "afw.h"`. Core **`AFW_DECLARE` / `AFW_DEFINE` / `AFW_BEGIN_DECLARES`** live in **`afw_common.h`**. Package `*_declare_helpers.h` is **not generated**. |
 | Type name `afw_iterator` as the old opaque cursor | That name is the new **keyless** iterator. Legacy cursor is **`afw_iterator_old`**. [#153](#utf-8-code-point-sequences-issue-153) |
-| `afw_utf8_create` / `create_copy` / `from_utf8_z` / `from_raw` | **`create` always copies** (old `create_copy`). Point without copy is **`create_no_copy`**. `from_utf8_z` → **`create_z`**. `from_raw` / `as_raw` → **`from_memory` / `as_memory`**. Env/request names that are not UTF-8 are **`^` + hex + `^`**, not `_NONUTF8_` + whole-name hex. [UTF-8 doors](#utf-8-create-set-and-forced_safe) |
+| `afw_utf8_create` / `create_copy` / `from_utf8_z` / `from_raw` | **`create` always copies** (old `create_copy`). Point without copy is **`create_no_copy`**. `from_utf8_z` → **`utf8_z_to_utf8`** (copy) or **`utf8_z_as_utf8`** (point). `from_raw` / `as_raw` → **`from_memory` / `as_memory`**. Env/request names that are not UTF-8 are **`^` + hex + `^`**, not `_NONUTF8_` + whole-name hex. [UTF-8 doors](#utf-8-create-set-and-forced_safe) |
 
 **Details:** [libafw C API cleanup](#libafw-c-api-cleanup-release-ready-surface).
 
@@ -486,9 +486,11 @@ C `afw_utf8_t` doors now say **who owns the little struct** and **whether `.s` i
 |-----|-----|
 | `afw_utf8_create_copy` | **`afw_utf8_create`** (always copy into `p`, NFC or throw) |
 | `afw_utf8_create` (point if already NFC) | **`afw_utf8_create_no_copy`** (struct in `p`, `.s` stays yours; not-NFC throws) |
-| `afw_utf8_from_utf8_z` | **`afw_utf8_create_z`** (copy) or **`create_no_copy_z`** |
+| `afw_utf8_from_utf8_z` | **`afw_utf8_z_to_utf8`** (copy) or **`afw_utf8_z_as_utf8`** (point) |
 | `afw_utf8_from_raw` / `as_raw` | **`afw_utf8_from_memory` / `as_memory`** |
-| Hand-set `.s` / `.len` | **`afw_utf8_set`** (copy into `p`) or **`set_no_copy`** (point; no `p`) |
+| Hand-set `.s` / `.len` | **`afw_utf8_set`** (copy into `p`) or **`set_no_copy`** (point; no `p`). From a C string: **`afw_utf8_z_set`** / **`afw_utf8_z_set_no_copy`**. |
+| `afw_utf8_starts_with_z` / `ends_with_z` | **`afw_utf8_starts_with_utf8_z`** / **`ends_with_utf8_z`** |
+| `afw_utf8_z_starts_with_z` | **`afw_utf8_z_starts_with`** |
 
 `afw_memory_t` uses the same verbs (no NFC). There is no `afw_raw_t`.
 


### PR DESCRIPTION
Adaptive strings stay length-prefixed and may hold U+0000. A C string cannot. `afw_utf8_to_utf8_z` and `afw_utf8_z_create` (and the array-to-z joins) now throw if the length-prefixed bytes contain a `0`. Do not use `afw_utf8_t->s` as a C string. Internal work stays `.s` + `.len`.

**External** is the name for leaving NFC utf8: C string via `to_utf8_z` / `z_create`; encode via `forced_safe`; octets + size via `as_memory` / write.

Ingest from a C string is prefixed `afw_utf8_z_`: `z_to_utf8` (copy), `z_as_utf8` (point), `z_set` / `z_set_no_copy`. Mixed predicates spell both types in argument order (`starts_with_utf8_z`). `whats-new` maps original names (`from_utf8_z`, …) to these finals.

Remaining utf8.h inlines are real functions (tiny casts stay macros). C probe `utf8_to_utf8_z` plus script cases in `unicode_escape_sequence.as`.

Not in this PR: `printf` / `AFW_UTF8_FMT` still stop at a `0` before `forced_safe`.