### PR TITLE
UTF-8 leftovers: ignore-case offsets, printf, throw-path, ICU wrap

### DIFF
--- a/.cursor/rules/afw-tests.mdc
+++ b/.cursor/rules/afw-tests.mdc
@@ -137,7 +137,7 @@ valgrind with `valgrind.suppress`). A standalone `valgrind` on a
 probe that **throws**, without that file, can trip libunwind in
 `afw_os_backtrace`; that is not an overread in the code under test.
 Judge the probe by its exit code and by the helper's valgrind wrap.
-The UTF-8 / error-struct side of a throw is issue **#206**.
+Error-object `backtrace` is `forced_safe` then NFC (issue **#206**).
 
 When fixing a C/runtime bug, add `.as` coverage that fails without the fix
 unless the hole is C-only (then the probe above):

--- a/designs/afw-philosophy-and-core-model.md
+++ b/designs/afw-philosophy-and-core-model.md
@@ -228,7 +228,7 @@ generate/ metadata + interface XML
 
 **Errors:** `get_info()` → contextual → exact span in that unit’s `full_source`. Nested compile+eval prints each source as the stack changes. `decompile()` is compiled-form Adaptive (recompilable when supported), not original pretty source. `stringify()` is JSON of an evaluated value. Listing is the human tree.
 
-**Print / untrusted bytes:** `forced_safe` makes viewable UTF-8 (`^hex^` for invalid/Cc, `^^` for caret) — not NFC, not a value. Property names at env/FCGI boundaries: same encode, then NFC (`create_property_name`).
+**Print / untrusted bytes:** `forced_safe` makes viewable UTF-8 (`^hex^` for invalid/Cc, `^^` for caret) — not NFC, not a value. `afw_utf8_printf` / `z_printf` always encode that way (logs and traces, not data files). Property names at env/FCGI boundaries: same encode, then NFC (`create_property_name`).
 
 ---
 

--- a/designs/agent-support.md
+++ b/designs/agent-support.md
@@ -114,7 +114,7 @@ Shape: **symptom → layer → probe → code / doc entry**.
 - **Wrong bound then narrow** — a field stored as signed 32-bit must be checked against the signed max, not the unsigned max. Sibling fields in the same parse are the hint.
 - **Release the existing, not the incoming** — replace/clear must drop the object already stored. The generic associative-array impl already did; the memory object impl released the argument (NULL on clear).
 - **malloc(n) then write `[n]`** — a NULL-terminated copy needs `n + 1` slots. Count first, allocate one extra, then terminate.
-- **UNSAFE ICU walk** — `U8_NEXT_UNSAFE` / `U8_APPEND_UNSAFE` trust well-formed UTF-8 and have no bound. Hand-set `.s`/`.len` can truncate a multi-byte sequence. Current ICU names the bounded macros `U8_NEXT` / `U8_APPEND` (there is no `*_SAFE`). Throw on `c < 0` / append error, same as `afw_utf8_nfc`. Validating constructors are not the only door. `compare_ignore_case` lockstep leftover is [#206](https://github.com/afw-org/afw/issues/206).
+- **UNSAFE ICU walk** — `U8_NEXT_UNSAFE` / `U8_APPEND_UNSAFE` trust well-formed UTF-8 and have no bound. Hand-set `.s`/`.len` can truncate a multi-byte sequence. Current ICU names the bounded macros `U8_NEXT` / `U8_APPEND` (there is no `*_SAFE`). Throw on `c < 0` / append error, same as `afw_utf8_nfc`. Validating constructors are not the only door. `compare_ignore_case` walks each string with its own offset ([#206](https://github.com/afw-org/afw/issues/206)).
 - **Last-element quicksort** — Lomuto + last pivot is O(n) stack on already-sorted input. Recurse the smaller partition, loop the larger. Time can still be O(n²); the stack is what that bounds.
 
 **Wrong path:** deep-cloning whole adapters/registries to “fix” one bad lifetime; treating short-test green as long-run proof.
@@ -143,7 +143,7 @@ Shape: **symptom → layer → probe → code / doc entry**.
 
 **Valgrind hang lesson:** parallel valgrind can park the pool if one worker blocks forever (e.g. `Session("local").close()` → `wait()`). Harness now times out/kills; if wall time is absurd with idle CPU, check for a stuck worker before assuming “just slow.”
 
-**Throwing C probe + valgrind:** Start with `afwdev prime-test-c-probe <path>`. `run_c_probe()` (`_afwdev.test.c_probe`) compiles a checked-in `*_probe.c` and runs named cases. `afwdev test --env-mode valgrind` wraps those binaries with `valgrind.suppress` (libunwind noise in `afw_os_backtrace` on a throw is suppressed). Standalone valgrind without that file can still report the noise; that is not an overread. Judge the probe by exit code and by the helper wrap. Recipe: handbook **Writing Tests**, [`c-probes.md`](c-probes.md). Error-struct / backtrace as `afw_utf8_t` is [#206](https://github.com/afw-org/afw/issues/206).
+**Throwing C probe + valgrind:** Start with `afwdev prime-test-c-probe <path>`. `run_c_probe()` (`_afwdev.test.c_probe`) compiles a checked-in `*_probe.c` and runs named cases. `afwdev test --env-mode valgrind` wraps those binaries with `valgrind.suppress` (libunwind noise in `afw_os_backtrace` on a throw is suppressed). Standalone valgrind without that file can still report the noise; that is not an overread. Judge the probe by exit code and by the helper wrap. Recipe: handbook **Writing Tests**, [`c-probes.md`](c-probes.md). Error-object `backtrace` is `forced_safe` then NFC ([#206](https://github.com/afw-org/afw/issues/206)).
 
 ---
 

--- a/designs/c-naming-and-payloads.md
+++ b/designs/c-naming-and-payloads.md
@@ -50,7 +50,7 @@ Most scalars are one chunk (`afw_integer_t`). Objects/arrays are a `const` point
 | **`forced_safe`** | `^` + uppercase hex + `^` (runs); `^^` = caret | **No** | **No** |
 | **`create_property_name`** | Same encode | Then NFC | **Yes** — a name |
 
-Valid UTF-8 text passes through encode. Unicode **Cc** (`afw_code_point_is_control`) and invalid UTF-8 bytes are hex. **Whitespace/EOL** (`afw_code_point_is_whitespace_or_eol`) stays text. `forced_safe` always **copies**. `printf` / `z_printf` use it.
+Valid UTF-8 text passes through encode. Unicode **Cc** (`afw_code_point_is_control`) and invalid UTF-8 bytes are hex. **Whitespace/EOL** (`afw_code_point_is_whitespace_or_eol`) stays text. `forced_safe` always **copies**. `printf` / `z_printf` always run the assembled result through it — **viewable text**, not a data-file writer.
 
 Env / FCGI names: only three `create_property_name` callers. Documented in object types + `whats-new`.
 
@@ -75,7 +75,9 @@ Do **not** rename `afw_value_create_managed_<dt>` to `afw_value_create_<dt>` on 
 
 Unicode **code-point** tests (identifier, whitespace, Cc) live in **`src/afw/code_point/`** (`afw_code_point.h`). They take an `afw_code_point_t`, not octets. UTF-8 encode/decode stays in `afw_utf8`.
 
-ICU: `afw_utf8.c` (NFC, to_lower) and `afw_code_point.c` (properties). `u_errorName` still in env register.
+ICU: `afw_utf8.c` (NFC, to_lower, `afw_utf8_icu_error_name_z`) and `afw_code_point.c` (properties). Env decoder uses that wrap.
+
+`afw_utf8_printf` / `z_printf`: own formatter; `AFW_UTF8_FMT` (`%.*s`) copies n bytes (interior `0` is data), then `forced_safe` the assembled buffer. libc `printf` with the same specifier still stops at `0`. Do not use these to write data files or round-trip octets — `.s` + `.len` / `as_memory`.
 
 ## Related
 

--- a/designs/c-probes.md
+++ b/designs/c-probes.md
@@ -2,7 +2,7 @@
 
 **Audience:** maintainers / assistants.  
 **Issue:** [#207](https://github.com/afw-org/afw/issues/207).  
-**Not** [#206](https://github.com/afw-org/afw/issues/206) (NFC / ICU / error-struct `afw_utf8_t` on the throw path).
+**Not** [#206](https://github.com/afw-org/afw/issues/206) (named utf8 doors / ignore-case offsets / error-object backtrace).
 
 **Origin:** Grok (xAI) designed `run_c_probe()` for #207 in August 2026, pairing on AFW. The helper, the valgrind wrap, and the decision not to skip backtrace on a throw are that sitting. Signed in `_afwdev/test/c_probe.py` (`who()`).
 
@@ -45,7 +45,7 @@ A throw calls `afw_os_backtrace` (except memory errors). libunwind then trips Me
 
 Standalone valgrind on the compiled binary, without that file, can still report the noise. Judge the probe by exit code and by the helper wrap.
 
-**Decided not:** skip backtrace on every probe throw (`AFW_NO_BACKTRACE` or similar). That would hide the throw path from Memcheck. The UTF-8 / error-struct side of `afw_os_backtrace` stays on #206.
+**Decided not:** skip backtrace on every probe throw (`AFW_NO_BACKTRACE` or similar). That would hide the throw path from Memcheck. Error-object `backtrace` is `forced_safe` then NFC ([#206](https://github.com/afw-org/afw/issues/206)).
 
 Python-mode files are loaded under a unique module name (not a shared `test`). Two `.py` files in one process no longer inherit `run()` from each other.
 

--- a/designs/knowledge-atlas.md
+++ b/designs/knowledge-atlas.md
@@ -347,7 +347,7 @@ After install, **restart afwfcgi** if attach tools talk to a long-lived process.
 | Array semantics | `array-semantics.md` | Shipped (#39) |
 | Converts | `conversion-functions.md` | Shipped with #39 wave |
 | UTF-8 / memory C doors | [`c-naming-and-payloads.md`](c-naming-and-payloads.md) | `create` copies; `no_copy` points; `forced_safe` `^hex^`; `src/afw/code_point/` |
-| UTF-8 code points (script) | `utf8-code-point-sequences.md` | #153 oriented; #190 empty-match `replace`; `to_lower` / ignore-case compare use bounded `U8_NEXT` / `U8_APPEND`; ignore-case lockstep leftover is [#206](https://github.com/afw-org/afw/issues/206) |
+| UTF-8 code points (script) | `utf8-code-point-sequences.md` | #153 oriented; #190 empty-match `replace`; `to_lower` / ignore-case compare use bounded `U8_NEXT` / `U8_APPEND` and independent offsets ([#206](https://github.com/afw-org/afw/issues/206)) |
 | Mutable faces | `issue-17-mutable-object-faces.md` | Closed PR #150 |
 | Expression property names | `issue-38-…` | Closed |
 | Meta on wire | `issue-138-…` | Design/status in pad |

--- a/designs/lineage-and-library-floor.md
+++ b/designs/lineage-and-library-floor.md
@@ -53,8 +53,7 @@ Keep ICU (`unicode/*.h`, `U8_*`, `u_*`, `unorm2_*`) in **`src/afw/utf8/`** (NFC,
 
 | Place | Use |
 |-------|-----|
-| `src/afw/utf8/afw_utf8.c` | `U8_*`, `unorm2_*`, `u_str*`, `u_tolower`, NFC quick check |
+| `src/afw/utf8/afw_utf8.c` | `U8_*`, `unorm2_*`, `u_str*`, `u_tolower`, NFC, `u_errorName` wrap |
 | `src/afw/code_point/afw_code_point.c` | `u_hasBinaryProperty` / `u_charType` |
-| `src/afw/environment/afw_environment_register_core.c` | `u_errorName` for the ICU error-code decoder |
 
-`u_errorName` can wait for an `afw_utf8_*` wrap. [#206](https://github.com/afw-org/afw/issues/206).
+Env ICU decoder calls `afw_utf8_icu_error_name_z()`. [#206](https://github.com/afw-org/afw/issues/206).

--- a/designs/utf8-code-point-sequences.md
+++ b/designs/utf8-code-point-sequences.md
@@ -50,7 +50,7 @@ Specialized hot paths (e.g. **substring**) may stay hand-tuned; they must share 
 | `starts_with` / `ends_with` | Full-string byte compare (OK for complete valid UTF-8 strings) |
 | **`replace`**, **split** (non-empty separator), **`afw_utf8_contains`** | **Fixed** — search advances by code point (still `memcmp` of full needle) |
 | Empty-match **`replace`** | **Fixed (#190)** — insert at each code-point boundary (including start and end); `limit = -1` must terminate |
-| **`to_lower` / `compare_ignore_case`** | **Bound (P4)** — `U8_NEXT` / `U8_APPEND`; throw on truncated. Compare still walks both strings from the same byte offset `i` (OK for ASCII; wrong for mixed-width like `"A"` vs `"À"`). Leftover owned by [#206](https://github.com/afw-org/afw/issues/206). |
+| **`to_lower` / `compare_ignore_case`** | **Bound (P4)** — `U8_NEXT` / `U8_APPEND`; throw on truncated. Compare walks each string with its own offset (mixed-width ignore-case, e.g. `"iX"` vs `"İX"`). [#206](https://github.com/afw-org/afw/issues/206). |
 | XACML bag formals | **Not** code-point expand (bag-of-one scalar); see `as_array_sequence` notes |
 
 ## Goals

--- a/src/afw/environment/afw_environment_register_core.c
+++ b/src/afw/environment/afw_environment_register_core.c
@@ -13,7 +13,6 @@
  */
 
 #include "afw_internal.h"
-#include <unicode/utypes.h>
 #include <string.h>
 #include <errno.h>
 
@@ -45,7 +44,9 @@ static const afw_utf8_z_t * impl_rv_decoder_z_apr(int rv,
 static const afw_utf8_z_t * impl_rv_decoder_z_icu(int rv,
     afw_utf8_z_t *wa, afw_size_t wa_size)
 {
-    return u_errorName(rv);
+    (void)wa;
+    (void)wa_size;
+    return afw_utf8_icu_error_name_z(rv);
 }
 
 

--- a/src/afw/error/afw_error.c
+++ b/src/afw/error/afw_error.c
@@ -750,8 +750,17 @@ afw_error_print(FILE *fp, const afw_error_t *error)
     }
 
     if (error->backtrace) {
-        rv = fprintf(fp, "\nbacktrace:\n" AFW_UTF8_FMT "\n",
-            AFW_UTF8_FMT_ARG(error->backtrace));
+        rv = fputs("\nbacktrace:\n", fp);
+        if (rv < 0) goto return_rv;
+        if (error->backtrace->len > 0 && error->backtrace->s) {
+            if (fwrite(error->backtrace->s, 1, error->backtrace->len,
+                fp) != error->backtrace->len)
+            {
+                rv = -1;
+                goto return_rv;
+            }
+        }
+        rv = fputc('\n', fp);
         if (rv < 0) goto return_rv;
     }
 
@@ -839,6 +848,23 @@ impl_add_contextual(
 }
 
 
+/* Adaptive string for a diagnostic utf8: forced_safe, then NFC. */
+static const afw_utf8_t *
+impl_utf8_forced_safe_value(
+    const afw_utf8_t *s,
+    const afw_pool_t *p,
+    afw_xctx_t *xctx)
+{
+    const afw_utf8_t *encoded;
+
+    if (!s) {
+        return NULL;
+    }
+    encoded = afw_utf8_create_forced_safe(s->s, s->len, p, xctx);
+    return afw_utf8_create(encoded->s, encoded->len, p, xctx);
+}
+
+
 /* Add error info to an existing object. */
 AFW_DECLARE(void)
 afw_error_add_to_object(
@@ -888,7 +914,9 @@ afw_error_add_to_object(
             xctx->env->flag_index_response_error_backtrace, xctx))
     {
         afw_object_set_property_as_string(object,
-            afw_s_backtrace, error->backtrace, xctx);
+            afw_s_backtrace,
+            impl_utf8_forced_safe_value(error->backtrace, p, xctx),
+            xctx);
     }
 
     /* Evaluation backtrace. */
@@ -898,7 +926,9 @@ afw_error_add_to_object(
         evaluation_backtrace = impl_evaluation_backtrace(error, p, xctx);
         if (evaluation_backtrace) {
             afw_object_set_property_as_string(object,
-                afw_s_backtraceEvaluation, evaluation_backtrace, xctx);
+                afw_s_backtraceEvaluation,
+                impl_utf8_forced_safe_value(evaluation_backtrace, p, xctx),
+                xctx);
         }
     }
 

--- a/src/afw/include/afw_common.h
+++ b/src/afw/include/afw_common.h
@@ -738,6 +738,9 @@ typedef struct afw_utf8_array_s {
 
 /**
  * @brief Format string specifier used for afw_utf8_t.
+ *
+ * With libc printf this is `%.*s` and still stops at an interior 0.
+ * `afw_utf8_printf` / `z_printf` copy n bytes, then `forced_safe`.
  */
 #define AFW_UTF8_FMT "%.*s"
 

--- a/src/afw/tests/advanced/utf8_icu_bound/utf8_icu_bound.py
+++ b/src/afw/tests/advanced/utf8_icu_bound/utf8_icu_bound.py
@@ -28,6 +28,10 @@ def run():
                 "compare_ignore_case of valid UTF-8",
             ),
             (
+                "compare-mixed-width",
+                "compare_ignore_case independent offsets (iX vs İX)",
+            ),
+            (
                 "compare-truncated",
                 "compare_ignore_case of a truncated sequence throws",
             ),

--- a/src/afw/tests/advanced/utf8_icu_bound/utf8_icu_bound_probe.c
+++ b/src/afw/tests/advanced/utf8_icu_bound/utf8_icu_bound_probe.c
@@ -168,6 +168,47 @@ impl_compare_valid(const afw_pool_t *p, afw_xctx_t *xctx)
 }
 
 static int
+impl_compare_mixed_width(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    afw_utf8_t a;
+    afw_utf8_t b;
+    int cmp;
+
+    (void)p;
+    /* "iX" vs "İX" (U+0130). Same ignore-case; İ is two bytes. */
+    impl_utf8_set(&a, "iX", 2);
+    impl_utf8_set(&b, "\xC4\xB0X", 3);
+    cmp = afw_utf8_compare_ignore_case(&a, &b, xctx);
+    if (cmp != 0) {
+        fprintf(stderr, "compare mixed: iX vs IX -> %d\n", cmp);
+        return 1;
+    }
+    cmp = afw_utf8_compare_ignore_case(&b, &a, xctx);
+    if (cmp != 0) {
+        fprintf(stderr, "compare mixed: IX vs iX -> %d\n", cmp);
+        return 1;
+    }
+
+    impl_utf8_set(&a, "i", 1);
+    impl_utf8_set(&b, "\xC4\xB0", 2);
+    cmp = afw_utf8_compare_ignore_case(&a, &b, xctx);
+    if (cmp != 0) {
+        fprintf(stderr, "compare mixed: i vs I -> %d\n", cmp);
+        return 1;
+    }
+
+    impl_utf8_set(&a, "A", 1);
+    impl_utf8_set(&b, "\xC3\x80", 2);
+    cmp = afw_utf8_compare_ignore_case(&a, &b, xctx);
+    if (cmp == 0) {
+        fprintf(stderr, "compare mixed: A vs A-grave equal\n");
+        return 1;
+    }
+
+    return 0;
+}
+
+static int
 impl_compare_truncated(const afw_pool_t *p, afw_xctx_t *xctx)
 {
     afw_utf8_t a;
@@ -182,6 +223,10 @@ impl_compare_truncated(const afw_pool_t *p, afw_xctx_t *xctx)
     impl_utf8_set(&a, "a", 1);
     impl_utf8_set(&b, "\xC3", 1);
     rc |= impl_expect_throw(&a, &b, false, p, xctx, "compare s2");
+    /* Equal prefix, truncated remainder. */
+    impl_utf8_set(&a, "a", 1);
+    impl_utf8_set(&b, "a\xC3", 2);
+    rc |= impl_expect_throw(&a, &b, false, p, xctx, "compare remainder");
     return rc;
 }
 
@@ -214,13 +259,17 @@ main(int argc, char **argv)
     else if (strcmp(case_name, "compare-valid") == 0) {
         rc = impl_compare_valid(p, xctx);
     }
+    else if (strcmp(case_name, "compare-mixed-width") == 0) {
+        rc = impl_compare_mixed_width(p, xctx);
+    }
     else if (strcmp(case_name, "compare-truncated") == 0) {
         rc = impl_compare_truncated(p, xctx);
     }
     else {
         fprintf(stderr, "usage: utf8_icu_bound_probe "
             "to_lower-valid|to_lower-truncated|"
-            "compare-valid|compare-truncated\n");
+            "compare-valid|compare-mixed-width|"
+            "compare-truncated\n");
         rc = 2;
     }
 

--- a/src/afw/tests/advanced/utf8_named_doors/utf8_named_doors.py
+++ b/src/afw/tests/advanced/utf8_named_doors/utf8_named_doors.py
@@ -34,6 +34,18 @@ def run():
                 "printf uses forced_safe",
             ),
             (
+                "printf-nul",
+                "AFW_UTF8_FMT copies n bytes including interior 0",
+            ),
+            (
+                "error-backtrace",
+                "error object backtrace is forced_safe then NFC",
+            ),
+            (
+                "icu-error-name",
+                "icu error name wrap, no unicode include in env",
+            ),
+            (
                 "from-memory",
                 "as_memory / from_memory",
             ),

--- a/src/afw/tests/advanced/utf8_named_doors/utf8_named_doors_probe.c
+++ b/src/afw/tests/advanced/utf8_named_doors/utf8_named_doors_probe.c
@@ -241,6 +241,94 @@ impl_printf_safe(const afw_pool_t *p, afw_xctx_t *xctx)
 }
 
 static int
+impl_printf_nul(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    const afw_utf8_t *c;
+    afw_utf8_t s;
+    char in[3];
+    const afw_utf8_z_t *z;
+
+    in[0] = 'a';
+    in[1] = 0;
+    in[2] = 'b';
+    s.s = (const afw_utf8_octet_t *)in;
+    s.len = 3;
+    c = afw_utf8_printf(p, xctx, "x=" AFW_UTF8_FMT,
+        AFW_UTF8_FMT_ARG(&s));
+    if (impl_eq(c, "x=a^00^b", 8, "printf nul")) {
+        return 1;
+    }
+
+    c = afw_utf8_printf(p, xctx, "n=%d x=" AFW_UTF8_FMT, 3,
+        AFW_UTF8_FMT_ARG(&s));
+    if (impl_eq(c, "n=3 x=a^00^b", 12, "printf mixed")) {
+        return 1;
+    }
+
+    z = afw_utf8_z_printf(p, xctx, "x=" AFW_UTF8_FMT,
+        AFW_UTF8_FMT_ARG(&s));
+    if (!z || strcmp((const char *)z, "x=a^00^b") != 0) {
+        fprintf(stderr, "z_printf nul: got %s\n", z ? (const char *)z : "?");
+        return 1;
+    }
+    return 0;
+}
+
+static int
+impl_error_backtrace(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    afw_utf8_t fake;
+    char in[3];
+    const afw_object_t *obj;
+    const afw_utf8_t *got;
+    int rc;
+
+    in[0] = 'x';
+    in[1] = (char)0xff;
+    in[2] = 'y';
+    fake.s = (const afw_utf8_octet_t *)in;
+    fake.len = 3;
+
+    afw_flag_set(afw_s_a_flag_response_error_backtrace, true, xctx);
+
+    rc = 0;
+    AFW_TRY {
+        AFW_THROW_ERROR_Z(general, "probe", xctx);
+    }
+    AFW_CATCH_UNHANDLED {
+        xctx->error->backtrace = &fake;
+        obj = afw_error_to_object(xctx->error, p, xctx);
+        got = afw_object_get_property_as_string(
+            obj, afw_s_backtrace, p, xctx);
+        if (!got || got->len != 6 ||
+            memcmp(got->s, "x^FF^y", 6) != 0)
+        {
+            fprintf(stderr, "error backtrace: got len=%lu\n",
+                (unsigned long)(got ? got->len : 0));
+            rc = 1;
+        }
+    }
+    AFW_ENDTRY;
+    return rc;
+}
+
+static int
+impl_icu_error_name(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    const afw_utf8_z_t *z;
+
+    (void)p;
+    (void)xctx;
+    z = afw_utf8_icu_error_name_z(0);
+    if (!z || strcmp((const char *)z, "U_ZERO_ERROR") != 0) {
+        fprintf(stderr, "icu error name: got %s\n",
+            z ? (const char *)z : "?");
+        return 1;
+    }
+    return 0;
+}
+
+static int
 impl_from_memory(const afw_pool_t *p, afw_xctx_t *xctx)
 {
     const afw_utf8_t hello = AFW_UTF8_LITERAL("hello");
@@ -294,13 +382,23 @@ main(int argc, char **argv)
     else if (strcmp(case_name, "printf-safe") == 0) {
         rc = impl_printf_safe(p, xctx);
     }
+    else if (strcmp(case_name, "printf-nul") == 0) {
+        rc = impl_printf_nul(p, xctx);
+    }
+    else if (strcmp(case_name, "error-backtrace") == 0) {
+        rc = impl_error_backtrace(p, xctx);
+    }
+    else if (strcmp(case_name, "icu-error-name") == 0) {
+        rc = impl_icu_error_name(p, xctx);
+    }
     else if (strcmp(case_name, "from-memory") == 0) {
         rc = impl_from_memory(p, xctx);
     }
     else {
         fprintf(stderr, "usage: utf8_named_doors_probe "
             "create-set-copy|no-copy|forced-safe|property-name|"
-            "printf-safe|from-memory\n");
+            "printf-safe|printf-nul|error-backtrace|icu-error-name|"
+            "from-memory\n");
         rc = 2;
     }
 

--- a/src/afw/tests/miscellaneous/eq_ignore_case.as
+++ b/src/afw/tests/miscellaneous/eq_ignore_case.as
@@ -1,0 +1,35 @@
+#!/usr/bin/env -S afw --syntax test_script
+//?
+//? testScript: eq_ignore_case.as
+//? customPurpose: Part of miscellaneous category tests
+//? description: eq_ignore_case mixed-width UTF-8 (issue #206 leftover)
+//? sourceType: script
+//?
+//? test: ascii
+//? description: ASCII ignore-case still matches
+//? expect: 0
+//? source: ...
+
+assert(eq_ignore_case("AbC", "aBc") === true);
+assert(eq_ignore_case("abc", "abd") === false);
+return 0;
+
+//?
+//? test: dotted-i-mixed-width
+//? description: iX vs İX — U+0130 is two bytes, i is one (issue #206)
+//? expect: 0
+//? source: ...
+
+assert(eq_ignore_case("i", "\u0130") === true);
+assert(eq_ignore_case("iX", "\u0130X") === true);
+assert(eq_ignore_case("\u0130X", "iX") === true);
+return 0;
+
+//?
+//? test: a-vs-agrave
+//? description: A vs À are not ignore-case equal
+//? expect: 0
+//? source: ...
+
+assert(eq_ignore_case("A", "\u00c0") === false);
+return 0;

--- a/src/afw/utf8/afw_utf8.c
+++ b/src/afw/utf8/afw_utf8.c
@@ -17,6 +17,9 @@
 #include <unicode/uchar.h>
 #include <unicode/unorm2.h>
 #include <unicode/ustring.h>
+#include <unicode/utypes.h>
+#include <string.h>
+#include <stddef.h>
 
 static const afw_utf8_z_t * impl_z_empty = "";
 
@@ -71,6 +74,17 @@ afw_utf8_from_code_point(afw_utf8_octet_t utf8_z[5], afw_code_point_t cp,
     U8_APPEND((afw_octet_t *)utf8_z, i, 4, cp, isError);
     utf8_z[i] = 0;
     return (isError == FALSE);
+}
+
+
+/* ICU UErrorCode name as a static ASCII C string. Never throws. */
+AFW_DEFINE(const afw_utf8_z_t *)
+afw_utf8_icu_error_name_z(int rv)
+{
+    const char *s;
+
+    s = u_errorName((UErrorCode)rv);
+    return s ? (const afw_utf8_z_t *)s : impl_z_empty;
 }
 
 
@@ -813,21 +827,233 @@ AFW_DEFINE(const afw_utf8_t *) afw_utf8_concat_v(
 
 
 
+/*
+ * AFW_UTF8_FMT is "%.*s". libc %.*s stops at an interior 0. Copy n
+ * bytes, then forced_safe the assembled buffer (length, not strlen).
+ * Viewable text (logs, errors, traces), not a data-file writer.
+ *
+ * va_arg lives in this function. Do not pass ap to apr_pvsprintf
+ * mid-walk (the list is then indeterminate).
+ */
+#define IMPL_PSPRINTF(val) \
+    ((star_width && star_prec) \
+        ? apr_psprintf(apr_p, spec, aw, aprec, (val)) \
+        : star_width \
+            ? apr_psprintf(apr_p, spec, aw, (val)) \
+            : star_prec \
+                ? apr_psprintf(apr_p, spec, aprec, (val)) \
+                : apr_psprintf(apr_p, spec, (val)))
+
+static void
+impl_format_to_writer(
+    const afw_writer_t *w,
+    const afw_utf8_z_t *format_z,
+    va_list ap,
+    const afw_pool_t *p,
+    afw_xctx_t *xctx)
+{
+    apr_pool_t *apr_p;
+    const afw_utf8_z_t *f;
+    const afw_utf8_z_t *start;
+    const afw_utf8_z_t *piece;
+    const char *s;
+    char spec[64];
+    char conv;
+    char lenmod;
+    int star_width;
+    int star_prec;
+    int aw;
+    int aprec;
+    int n;
+    afw_size_t spec_len;
+
+    apr_p = afw_pool_get_apr_pool(p);
+    f = format_z;
+    while (*f) {
+        if (*f != '%') {
+            start = f;
+            while (*f && *f != '%') {
+                f++;
+            }
+            afw_writer_write(w, start, (afw_size_t)(f - start), xctx);
+            continue;
+        }
+        if (f[1] == '%') {
+            afw_writer_write(w, "%", 1, xctx);
+            f += 2;
+            continue;
+        }
+        /* AFW_UTF8_FMT: copy n bytes, including interior 0. */
+        if (f[1] == '.' && f[2] == '*' && f[3] == 's') {
+            n = va_arg(ap, int);
+            s = va_arg(ap, const char *);
+            if (n > 0 && s) {
+                afw_writer_write(w, s, (afw_size_t)n, xctx);
+            }
+            f += 4;
+            continue;
+        }
+        start = f;
+        f++;
+        star_width = 0;
+        star_prec = 0;
+        lenmod = 0;
+        while (*f && strchr("-+ #0'", *f)) {
+            f++;
+        }
+        if (*f == '*') {
+            star_width = 1;
+            f++;
+        }
+        else {
+            while (*f >= '0' && *f <= '9') {
+                f++;
+            }
+        }
+        if (*f == '.') {
+            f++;
+            if (*f == '*') {
+                star_prec = 1;
+                f++;
+            }
+            else {
+                while (*f >= '0' && *f <= '9') {
+                    f++;
+                }
+            }
+        }
+        if (*f == 'h') {
+            lenmod = 'h';
+            f++;
+            if (*f == 'h') {
+                f++;
+            }
+        }
+        else if (*f == 'l') {
+            lenmod = 'l';
+            f++;
+            if (*f == 'l') {
+                lenmod = 'L';
+                f++;
+            }
+        }
+        else if (*f && strchr("Lztjq", *f)) {
+            lenmod = *f;
+            f++;
+        }
+        if (!*f) {
+            afw_writer_write(w, start, (afw_size_t)(f - start), xctx);
+            break;
+        }
+        conv = *f++;
+        spec_len = (afw_size_t)(f - start);
+        if (spec_len == 0 || spec_len >= sizeof(spec)) {
+            afw_writer_write(w, start, spec_len, xctx);
+            continue;
+        }
+        memcpy(spec, start, spec_len);
+        spec[spec_len] = 0;
+        aw = 0;
+        aprec = 0;
+        if (star_width) {
+            aw = va_arg(ap, int);
+        }
+        if (star_prec) {
+            aprec = va_arg(ap, int);
+        }
+        piece = NULL;
+        if (conv == 's') {
+            s = va_arg(ap, const char *);
+            piece = IMPL_PSPRINTF(s);
+        }
+        else if (conv == 'c') {
+            n = va_arg(ap, int);
+            piece = IMPL_PSPRINTF(n);
+        }
+        else if (conv == 'p') {
+            piece = IMPL_PSPRINTF(va_arg(ap, void *));
+        }
+        else if (strchr("di", conv)) {
+            if (lenmod == 'L' || lenmod == 'j' || lenmod == 'q') {
+                piece = IMPL_PSPRINTF(va_arg(ap, long long));
+            }
+            else if (lenmod == 'l') {
+                piece = IMPL_PSPRINTF(va_arg(ap, long));
+            }
+            else if (lenmod == 'z' || lenmod == 't') {
+                piece = IMPL_PSPRINTF(va_arg(ap, ptrdiff_t));
+            }
+            else {
+                piece = IMPL_PSPRINTF(va_arg(ap, int));
+            }
+        }
+        else if (strchr("uoxX", conv)) {
+            if (lenmod == 'L' || lenmod == 'j' || lenmod == 'q') {
+                piece = IMPL_PSPRINTF(va_arg(ap, unsigned long long));
+            }
+            else if (lenmod == 'l') {
+                piece = IMPL_PSPRINTF(va_arg(ap, unsigned long));
+            }
+            else if (lenmod == 'z' || lenmod == 't') {
+                piece = IMPL_PSPRINTF(va_arg(ap, afw_size_t));
+            }
+            else {
+                piece = IMPL_PSPRINTF(va_arg(ap, unsigned));
+            }
+        }
+        else if (strchr("fFeEgGaA", conv)) {
+            if (lenmod == 'L') {
+                piece = IMPL_PSPRINTF(va_arg(ap, long double));
+            }
+            else {
+                piece = IMPL_PSPRINTF(va_arg(ap, double));
+            }
+        }
+        if (piece) {
+            afw_writer_write_z(w, piece, xctx);
+        }
+        else {
+            afw_writer_write(w, start, spec_len, xctx);
+        }
+    }
+}
+
+#undef IMPL_PSPRINTF
+
+
+static const afw_utf8_t *
+impl_printf_forced_safe(
+    const afw_utf8_z_t *format_z,
+    va_list ap,
+    const afw_pool_t *p,
+    afw_xctx_t *xctx)
+{
+    const afw_writer_t *w;
+    afw_utf8_t assembled;
+    const afw_utf8_t *safe;
+
+    w = afw_utf8_writer_create(NULL, p, xctx);
+    impl_format_to_writer(w, format_z, ap, p, xctx);
+    afw_utf8_writer_current_string(w, &assembled, xctx);
+    safe = afw_utf8_create_forced_safe(
+        assembled.s, assembled.len, p, xctx);
+    afw_writer_release(w, xctx);
+    return safe;
+}
+
+
 /* Create a string using a c format string. */
 AFW_DEFINE_ELLIPSIS(const afw_utf8_t *)
 afw_utf8_printf(
     const afw_pool_t *p, afw_xctx_t *xctx, const afw_utf8_z_t *format, ...)
 {
     va_list arg;
-    const afw_utf8_z_t *s;
+    const afw_utf8_t *result;
 
-    /* Use apr_pvsprint() to produce c string. */
     va_start(arg, format);
-    s = apr_pvsprintf(afw_pool_get_apr_pool(p), format, arg);
+    result = impl_printf_forced_safe(format, arg, p, xctx);
     va_end(arg);
-
-    /* Format output may contain anything %s handed us. */
-    return afw_utf8_create_forced_safe(s, AFW_UTF8_Z_LEN, p, xctx);
+    return result;
 }
 
 
@@ -837,13 +1063,7 @@ afw_utf8_printf_v(
     const afw_utf8_z_t *format, va_list arg,
     const afw_pool_t *p, afw_xctx_t *xctx)
 {
-    const afw_utf8_z_t *s;
-
-    /* Use apr_pvsprint() to produce c string. */
-    s = apr_pvsprintf(afw_pool_get_apr_pool(p), format, arg);
-
-    /* Format output may contain anything %s handed us. */
-    return afw_utf8_create_forced_safe(s, AFW_UTF8_Z_LEN, p, xctx);
+    return impl_printf_forced_safe(format, arg, p, xctx);
 }
 
 
@@ -1197,9 +1417,8 @@ AFW_DEFINE(int) afw_utf8_compare_ignore_case(
     const afw_utf8_t *s1, const afw_utf8_t *s2, afw_xctx_t *xctx)
 {
     UChar32 c1, c2;
-    int32_t i, len, i2, len1, len2;
+    int32_t i1, i2, len1, len2;
     const uint8_t *cs1, *cs2;
-    int result;
 
     /* ICU only supports 32 bit non-negative lengths. */
     if (s1->len > AFW_INT32_MAX ||
@@ -1213,31 +1432,38 @@ AFW_DEFINE(int) afw_utf8_compare_ignore_case(
     cs2 = (const uint8_t *)s2->s;
     len1 = (int32_t)s1->len;
     len2 = (int32_t)s2->len;
-    len = (len1 <= len2) ? len1 : len2;
-    result = 0;
-    for (i = 0; i < len;) {
-        /*
-         * U8_NEXT increments i. Don't use i in the first call so the
-         * offset stays correct for both the loop and the other string.
-         */
-        i2 = i;
-        U8_NEXT(cs1, i2, len1, c1);
-        U8_NEXT(cs2, i, len2, c2);
+    i1 = 0;
+    i2 = 0;
+
+    while (i1 < len1 && i2 < len2) {
+        U8_NEXT(cs1, i1, len1, c1);
+        U8_NEXT(cs2, i2, len2, c2);
         if (c1 < 0 || c2 < 0) {
             AFW_THROW_ERROR_Z(general, "Not valid UTF-8", xctx);
         }
         c1 = u_tolower(c1);
         c2 = u_tolower(c2);
-        if (c1 == c2) continue;
-        result = (int)(c1 > c2) ? 1 : -1;
-        break;
+        if (c1 != c2) {
+            return (c1 > c2) ? 1 : -1;
+        }
     }
 
-    if (result == 0 && s1->len != s2->len) {
-        result = (s1->len > s2->len) ? 1 : -1;
+    while (i1 < len1) {
+        U8_NEXT(cs1, i1, len1, c1);
+        if (c1 < 0) {
+            AFW_THROW_ERROR_Z(general, "Not valid UTF-8", xctx);
+        }
+        return 1;
+    }
+    while (i2 < len2) {
+        U8_NEXT(cs2, i2, len2, c2);
+        if (c2 < 0) {
+            AFW_THROW_ERROR_Z(general, "Not valid UTF-8", xctx);
+        }
+        return -1;
     }
 
-    return result;
+    return 0;
 }
 
 
@@ -1343,29 +1569,18 @@ afw_utf8_z_printf_v(
     const afw_pool_t *p,
     afw_xctx_t *xctx)
 {
-    afw_utf8_z_t *result;
+    const afw_utf8_t *safe;
+    afw_utf8_z_t *z;
+    afw_size_t n;
 
-    result = apr_pvsprintf(afw_pool_get_apr_pool(p), format_z, ap);
-
-    if (!result) {
-        AFW_THROW_MEMORY_ERROR(xctx);
+    safe = impl_printf_forced_safe(format_z, ap, p, xctx);
+    n = safe->len;
+    z = afw_pool_malloc(p, n + 1, xctx);
+    if (n > 0) {
+        memcpy(z, safe->s, n);
     }
-
-    /* Encode, then copy with a trailing 0. Do not NFC. */
-    {
-        const afw_utf8_t *safe;
-        afw_utf8_z_t *z;
-        afw_size_t n;
-
-        safe = afw_utf8_create_forced_safe(result, AFW_UTF8_Z_LEN, p, xctx);
-        n = safe->len;
-        z = afw_pool_malloc(p, n + 1, xctx);
-        if (n > 0) {
-            memcpy(z, safe->s, n);
-        }
-        z[n] = 0;
-        return z;
-    }
+    z[n] = 0;
+    return z;
 }
 
 

--- a/src/afw/utf8/afw_utf8.h
+++ b/src/afw/utf8/afw_utf8.h
@@ -190,6 +190,18 @@ afw_utf8_from_code_point(afw_utf8_octet_t utf8_z[5], afw_code_point_t cp,
 
 
 /**
+ * @brief ICU UErrorCode name as a static C string (ASCII).
+ * @param rv ICU error code (UErrorCode as int).
+ * @return Static name such as `U_ZERO_ERROR`. Never throws.
+ *
+ * Wraps `u_errorName`. Call this instead of including ICU unicode
+ * headers outside `utf8/` and `code_point/`.
+ */
+AFW_DECLARE(const afw_utf8_z_t *)
+afw_utf8_icu_error_name_z(int rv);
+
+
+/**
  * @brief Determine if series of bytes is valid utf-8.
  * @param s pointer to bytes to be tested.
  * @param len is number of bytes.
@@ -660,7 +672,12 @@ afw_utf8_line_count_and_max_column(
  * @param ... arguments for format_z.
  * @return utf8 string.
  *
- * Format output goes through create_forced_safe so a bad %s does not throw.
+ * Assembles with AFW's formatter, then create_forced_safe so a bad %s
+ * does not throw. `AFW_UTF8_FMT` (`%.*s`) copies n bytes, including an
+ * interior 0; libc printf still stops at 0.
+ *
+ * Viewable text (logs, errors, traces). Not a data-file writer: do not
+ * use this to round-trip octets. Write `.s` + `.len` or `as_memory`.
  */
 AFW_DECLARE_ELLIPSIS(const afw_utf8_t *)
 afw_utf8_printf(
@@ -676,7 +693,8 @@ afw_utf8_printf(
  * @param xctx of caller.
  * @return utf8 string.
  *
- * Format output goes through create_forced_safe so a bad %s does not throw.
+ * Same as afw_utf8_printf: assemble, then forced_safe. Viewable text,
+ * not a data-file writer.
  */
 AFW_DECLARE(const afw_utf8_t *)
 afw_utf8_printf_v(
@@ -967,6 +985,9 @@ afw_utf8_z_query_string_to_object(
 
 /**
  * Create a utf8_z string using a c format string and va_list in specified pool.
+ *
+ * Same formatter as afw_utf8_printf, then forced_safe, then a trailing 0.
+ * Viewable text, not a data-file writer.
  */
 AFW_DECLARE(const afw_utf8_z_t *)
 afw_utf8_z_printf_v(
@@ -976,6 +997,8 @@ afw_utf8_z_printf_v(
 
 /**
  * Create a utf8_z string using a c format string in specified pool.
+ *
+ * Same as afw_utf8_z_printf_v. Viewable text, not a data-file writer.
  */
 AFW_DECLARE_ELLIPSIS(const afw_utf8_z_t *)
 afw_utf8_z_printf(

--- a/whats-new.md
+++ b/whats-new.md
@@ -39,6 +39,7 @@ In-tree extensions and the `afw` / `afwfcgi` commands built with the same `./afw
 | `#include` of core internals or package `*_declare_helpers.h` | `#include "afw.h"`. Core **`AFW_DECLARE` / `AFW_DEFINE` / `AFW_BEGIN_DECLARES`** live in **`afw_common.h`**. Package `*_declare_helpers.h` is **not generated**. |
 | Type name `afw_iterator` as the old opaque cursor | That name is the new **keyless** iterator. Legacy cursor is **`afw_iterator_old`**. [#153](#utf-8-code-point-sequences-issue-153) |
 | `afw_utf8_create` / `create_copy` / `from_utf8_z` / `from_raw` | **`create` always copies** (old `create_copy`). Point without copy is **`create_no_copy`**. `from_utf8_z` → **`utf8_z_to_utf8`** (copy) or **`utf8_z_as_utf8`** (point). `from_raw` / `as_raw` → **`from_memory` / `as_memory`**. Env/request names that are not UTF-8 are **`^` + hex + `^`**, not `_NONUTF8_` + whole-name hex. [UTF-8 doors](#utf-8-create-set-and-forced_safe) |
+| `afw_utf8_printf` / `z_printf` to write a data file | Don't. Those formatters always **`forced_safe`** the result (viewable text, `^hex^` for bad runs). For octets, write `.s` + `.len` or **`as_memory`**. |
 
 **Details:** [libafw C API cleanup](#libafw-c-api-cleanup-release-ready-surface).
 
@@ -74,7 +75,7 @@ sections end with [↑ Highlights](#highlights) to return here.
 | [**C builders / afwdev**](#c-api-docs-and-full-package-builds-issue-1) ([#1](https://github.com/afw-org/afw/issues/1)) | Richer C API Doxygen, package **0.12.2**, `afwdev build --fulldev` |
 | [**Value / memory (α/β)**](#value-lifetime--memory-management-issue-2--alphabeta) ([#2](https://github.com/afw-org/afw/issues/2)) | Permanent scalar reuse, dual-face object/array values, safer managed object value release; **`afw_pool_release` returns pool or NULL**; managed object faces pin base |
 | [**`stringify` / `decompile` / listing**](#stringify-decompile-compiler-listing-and-binary-text) ([#18](https://github.com/afw-org/afw/issues/18)) | **`stringify`** pure JSON (+ replacer); **`decompile`** Adaptive compiled form; **compile listing** human tree+symbols; **`decode_to_string`** UTF-8 from octets |
-| [**UTF-8 create / set / forced_safe**](#utf-8-create-set-and-forced_safe) | C doors: short **`create`/`set` copy**; **`no_copy`** points; **`forced_safe`** encodes invalid runs as `^hex^`. Env/request names use that encode (not `_NONUTF8_` + whole-name hex) |
+| [**UTF-8 create / set / forced_safe**](#utf-8-create-set-and-forced_safe) | C doors: short **`create`/`set` copy**; **`no_copy`** points; **`forced_safe`** encodes invalid runs as `^hex^`. Env/request names use that encode (not `_NONUTF8_` + whole-name hex). **`afw_utf8_printf`** is its own formatter: `AFW_UTF8_FMT` copies n bytes (interior `0` is data), then the whole result is **`forced_safe`** — viewable text, not a data-file writer |
 | [**UTF-8 in JSON / Fiddle**](#utf-8-in-json-results-and-python-local-mode) | Multi-byte UTF-8 survives **`stringify`**, Fiddle results, and other JSON emitters (signed-char octet bug) |
 | [**Python `Session("local")`**](#utf-8-in-json-results-and-python-local-mode) | Local FIFO client uses **binary octet** framing so large/UTF-8 responses no longer hang |
 | [**Param / catch Patterns**](#function-parameter-and-catch-patterns-issue-140) ([#140](https://github.com/afw-org/afw/issues/140)) | Function/lambda params + `catch` Patterns; Expression defaults; call-site `f(...arr)`; computed/string keys; type syntax for later checking |
@@ -494,11 +495,15 @@ C `afw_utf8_t` doors now say **who owns the little struct** and **whether `.s` i
 
 `afw_memory_t` uses the same verbs (no NFC). There is no `afw_raw_t`.
 
-**`forced_safe`** (create/set, always copy): valid UTF-8 text passes through; `^` becomes `^^`; Unicode control (Cc) and invalid UTF-8 **runs** become `^` + uppercase hex + `^`. Tab/LF/CR and other whitespace/EOL stay as text. Result is valid UTF-8, **not** promised NFC, **not** an Adaptive value. `printf` / `z_printf` use this so a bad `%s` does not throw.
+**`forced_safe`** (create/set, always copy): valid UTF-8 text passes through; `^` becomes `^^`; Unicode control (Cc) and invalid UTF-8 **runs** become `^` + uppercase hex + `^`. Tab/LF/CR and other whitespace/EOL stay as text. Result is valid UTF-8, **not** promised NFC, **not** an Adaptive value.
 
-**`create_property_name`**: same encode, then NFC. Used for process env and FCGI/CGI request parameter names.
+**`afw_utf8_printf` / `z_printf`** assemble with their own formatter, then **`forced_safe` the whole result**. That is the point: a bad `%s` or a truncated path in an error message does not NFC-throw, and an interior `0` in an `afw_utf8_t` is not a C-string terminator. `AFW_UTF8_FMT` (`%.*s`) copies **n bytes** (including U+0000); libc `printf` with the same specifier still stops at `0`. Use these for **viewable** text (logs, error objects, traces). Do **not** use them to write data files or round-trip octets — write `.s` + `.len` or **`as_memory`**.
+
+**`create_property_name`**: same encode as `forced_safe`, then NFC. Used for process env and FCGI/CGI request parameter names.
 
 `AFW_UTF8_LITERAL` is still a trusted C `"…"` initializer (no check). ASCII including `\n` is always UTF-8 NFC.
+
+`eq_ignore_case` walks each string with its own code-point offset (mixed-width such as `"iX"` vs `"İX"`). Error-object `backtrace` is `forced_safe` then NFC.
 
 [↑ Highlights](#highlights)
 


### PR DESCRIPTION
Leftover list on #206 after named doors (#213) and the C-string door (#214).

`compare_ignore_case` walks each string with its own code-point offset. Mixed-width ignore-case matches (`iX` vs `İX`). Truncated remainder throws.

`afw_utf8_printf` / `z_printf` assemble with their own formatter, then `forced_safe` the whole result. `AFW_UTF8_FMT` (`%.*s`) copies n bytes, including an interior `0`. That is **viewable text** (logs, errors, traces), not a data-file writer — write `.s` + `.len` or `as_memory` for octets. libc `printf` / `apr_psprintf` with the same specifier still stop at `0`.

Error-object `backtrace` is `forced_safe` then NFC before it becomes a string property. FILE dump uses `fwrite`. Env ICU decoder calls `afw_utf8_icu_error_name_z()`; `unicode/` headers stay in `utf8/` and `code_point/`.

C probes: `utf8_icu_bound` mixed-width, `utf8_named_doors` printf-nul / error-backtrace / icu-error-name. Script: `src/afw/tests/miscellaneous/eq_ignore_case.as`. `whats-new` highlights the printf.

`afwdev test -j` was 20 srcdirs, 4130 passed. Valgrind on the UTF-8 leftover tests passed.

Not in this PR: N1 (concat `.len` then `to_utf8_z` on LDAP filters and file dir paths).

Related: #206.