### PR TITLE
Join LDAP filters and file paths with concat, then to_utf8_z

### DIFF
--- a/designs/c-naming-and-payloads.md
+++ b/designs/c-naming-and-payloads.md
@@ -79,6 +79,8 @@ ICU: `afw_utf8.c` (NFC, to_lower, `afw_utf8_icu_error_name_z`) and `afw_code_poi
 
 `afw_utf8_printf` / `z_printf`: own formatter; `AFW_UTF8_FMT` (`%.*s`) copies n bytes (interior `0` is data), then `forced_safe` the assembled buffer. libc `printf` with the same specifier still stops at `0`. Do not use these to write data files or round-trip octets — `.s` + `.len` / `as_memory`.
 
+LDAP filters and file-adapter paths (dir open, journal, object files): **concat `.len`**, then **`to_utf8_z`**. Do not glue those with `AFW_UTF8_FMT` / `apr_psprintf`.
+
 ## Related
 
 - [`memory-management.md`](memory-management.md) — #2 pools / escape (do not fold this pad into it).

--- a/src/afw/file/afw_file.c
+++ b/src/afw/file/afw_file.c
@@ -28,6 +28,11 @@
 static const afw_utf8_t impl_factory_description =
 AFW_UTF8_LITERAL("Adapter type for accessing objects contained in files.");
 
+static const afw_utf8_t impl_s_journal_dir = AFW_UTF8_LITERAL(
+    AFW_OBJECT_Q_OBJECT_TYPE_ID_JOURNAL_ENTRY "/");
+static const afw_utf8_t impl_s_journal_lock = AFW_UTF8_LITERAL(
+    AFW_OBJECT_Q_OBJECT_TYPE_ID_JOURNAL_ENTRY "/journal_lock");
+
 /* File adapter factory instance. */
 static const afw_adapter_factory_t impl_adapter_factory =
 {
@@ -59,7 +64,11 @@ afw_file_insure_full_path(const afw_utf8_t *path,
     }
     len = strlen(full_path_z);
     if (len > 0 && full_path_z[len - 1] != '/') {
-        full_path = afw_utf8_printf(p, xctx, "%s/", full_path_z);
+        afw_utf8_t base;
+
+        base.s = (const afw_utf8_octet_t *)full_path_z;
+        base.len = len;
+        full_path = afw_utf8_concat(p, xctx, &base, afw_s_a_slash, NULL);
     }
     else {
         full_path = afw_utf8_create(full_path_z, AFW_UTF8_Z_LEN, p, xctx);
@@ -333,14 +342,14 @@ afw_file_adapter_create_cede_p(
         p, xctx);
 
     /* Make path for journal directory. */
-    self->journal_dir_path_z = afw_utf8_z_printf(p, xctx,
-        AFW_UTF8_FMT AFW_OBJECT_Q_OBJECT_TYPE_ID_JOURNAL_ENTRY "/",
-        AFW_UTF8_FMT_ARG(self->root));
+    self->journal_dir_path_z = afw_utf8_to_utf8_z(
+        afw_utf8_concat(p, xctx, self->root, &impl_s_journal_dir, NULL),
+        p, xctx);
 
     /* Make path to journal lock file. */
-    self->journal_lock_file_path_z = afw_utf8_z_printf(p, xctx,
-        AFW_UTF8_FMT AFW_OBJECT_Q_OBJECT_TYPE_ID_JOURNAL_ENTRY "/journal_lock",
-        AFW_UTF8_FMT_ARG(self->root));
+    self->journal_lock_file_path_z = afw_utf8_to_utf8_z(
+        afw_utf8_concat(p, xctx, self->root, &impl_s_journal_lock, NULL),
+        p, xctx);
 
     self->journal_rw_lock = afw_lock_create_rw_and_register(
         afw_s_a_lock_file_journal_anchor,
@@ -433,12 +442,14 @@ impl_get_full_path(
     const afw_utf8_t * object_id,
     const afw_pool_t *p, afw_xctx_t *xctx)
 {
-    return afw_utf8_printf(p, xctx,
-        AFW_UTF8_FMT AFW_UTF8_FMT "/" AFW_UTF8_FMT AFW_UTF8_FMT,
-        AFW_UTF8_FMT_ARG(adapter->root),
-        AFW_UTF8_FMT_ARG(object_type_id),
-        AFW_UTF8_FMT_ARG(object_id),
-        AFW_UTF8_FMT_ARG(adapter->filename_suffix));
+    return afw_utf8_concat(p, xctx,
+        adapter->root,
+        object_type_id,
+        afw_s_a_slash,
+        object_id,
+        adapter->filename_suffix
+            ? adapter->filename_suffix : afw_s_a_empty_string,
+        NULL);
 }
 
 
@@ -483,11 +494,11 @@ impl_afw_adapter_session_retrieve_objects(
     const afw_utf8_t *object_id;
     afw_size_t len;
 
-    /* Open ObjectType's directory. */
-    dirname_z = apr_psprintf(afw_pool_get_apr_pool(p),
-        AFW_UTF8_FMT AFW_UTF8_FMT "/",
-        AFW_UTF8_FMT_ARG(adapter->root),
-        AFW_UTF8_FMT_ARG(object_type_id));
+    /* Open ObjectType's directory. Concat .len, then C-string door. */
+    dirname_z = afw_utf8_to_utf8_z(
+        afw_utf8_concat(p, xctx,
+            adapter->root, object_type_id, afw_s_a_slash, NULL),
+        p, xctx);
     rv = apr_dir_open(&dir, dirname_z, afw_pool_get_apr_pool(p));
 
     /* If not found, return no objects. */
@@ -543,13 +554,14 @@ impl_afw_adapter_session_retrieve_objects(
         /* Determine object_id and full_path. */
         object_id = afw_utf8_create(finfo.name, len, obj_p, xctx);
         
-        /** @fixme: Mike filename_suffix could be NULL here */
-        full_path = afw_utf8_printf(obj_p, xctx,
-            AFW_UTF8_FMT AFW_UTF8_FMT "/" AFW_UTF8_FMT AFW_UTF8_FMT,
-            AFW_UTF8_FMT_ARG(adapter->root),
-            AFW_UTF8_FMT_ARG(object_type_id),
-            AFW_UTF8_FMT_ARG(object_id),
-            AFW_UTF8_FMT_OPTIONAL_ARG(adapter->filename_suffix));
+        full_path = afw_utf8_concat(obj_p, xctx,
+            adapter->root,
+            object_type_id,
+            afw_s_a_slash,
+            object_id,
+            adapter->filename_suffix
+                ? adapter->filename_suffix : afw_s_a_empty_string,
+            NULL);
 
         /*
          * Load file to memory and convert to object &self->pub.  Ceed control

--- a/src/afw/file/afw_file_journal.c
+++ b/src/afw/file/afw_file_journal.c
@@ -12,6 +12,7 @@
  */
 
 #include "afw_internal.h"
+#include <apr_strings.h>
 
 
 
@@ -33,6 +34,28 @@ typedef struct afw_adapter_journal_lock_s {
     unsigned char filler;          /* filler - ignore                  */
 } afw_adapter_journal_lock_t;
 
+
+static const afw_utf8_t impl_s_path_to_first = AFW_UTF8_LITERAL(
+    AFW_OBJECT_Q_OBJECT_TYPE_ID_JOURNAL_ENTRY
+    "/path_to_first_journal_file");
+static const afw_utf8_t impl_s_journal_slash = AFW_UTF8_LITERAL(
+    AFW_OBJECT_Q_OBJECT_TYPE_ID_JOURNAL_ENTRY "/");
+
+static const afw_utf8_z_t *
+impl_journal_path_z(
+    const afw_utf8_t *root,
+    const afw_utf8_z_t *tail_z,
+    const afw_pool_t *p,
+    afw_xctx_t *xctx)
+{
+    afw_utf8_t tail;
+
+    tail.s = (const afw_utf8_octet_t *)tail_z;
+    tail.len = tail_z ? strlen((const char *)tail_z) : 0;
+    return afw_utf8_to_utf8_z(
+        afw_utf8_concat(p, xctx, root, &impl_s_journal_slash, &tail, NULL),
+        p, xctx);
+}
 
 const afw_adapter_journal_inf_t * afw_file_internal_get_journal_inf()
 {
@@ -179,12 +202,16 @@ impl_open_and_retrieve_peer_object(
     apr_status_t rv;
     afw_size_t len;
 
-    *full_peer_path_z = afw_utf8_z_printf(p, xctx,
-        AFW_UTF8_FMT AFW_OBJECT_Q_OBJECT_TYPE_ID_PROVISIONING_PEER
-        "/" AFW_UTF8_FMT AFW_UTF8_FMT,
-        AFW_UTF8_FMT_ARG(adapter->root),
-        AFW_UTF8_FMT_ARG(consumer_id),
-        AFW_UTF8_FMT_OPTIONAL_ARG(adapter->filename_suffix));
+    *full_peer_path_z = afw_utf8_to_utf8_z(
+        afw_utf8_concat(p, xctx,
+            adapter->root,
+            AFW_OBJECT_S_OBJECT_TYPE_ID_PROVISIONING_PEER,
+            afw_s_a_slash,
+            consumer_id,
+            adapter->filename_suffix
+                ? adapter->filename_suffix : afw_s_a_empty_string,
+            NULL),
+        p, xctx);
 
     AFW_ERROR_FOOTPRINT("apr_stat()");
     rv = apr_stat(&finfo, *full_peer_path_z, APR_FINFO_SIZE,
@@ -376,10 +403,8 @@ impl_afw_adapter_journal_add_entry_internal(
     first_entry = rv == APR_EOF;
     if (!first_entry && rv != APR_SUCCESS) goto error_lock_apr;
     if (first_entry) {
-        first_entry_save_path = afw_utf8_printf(xctx->p, xctx,
-            AFW_UTF8_FMT AFW_OBJECT_Q_OBJECT_TYPE_ID_JOURNAL_ENTRY
-            "/path_to_first_journal_file",
-            AFW_UTF8_FMT_ARG(adapter->root));
+        first_entry_save_path = afw_utf8_concat(xctx->p, xctx,
+            adapter->root, &impl_s_path_to_first, NULL);
         temp_raw.ptr = (const afw_byte_t *)relative_entry_path_z;
         temp_raw.size = strlen(relative_entry_path_z);
         afw_file_from_memory(first_entry_save_path, &temp_raw,
@@ -404,11 +429,14 @@ impl_afw_adapter_journal_add_entry_internal(
         || lock.hour    != now.tm_hour)
         )
     {
-        old_full_entry_path_z = afw_utf8_z_printf(p, xctx,
-            AFW_UTF8_FMT AFW_OBJECT_Q_OBJECT_TYPE_ID_JOURNAL_ENTRY
-            "/y%02d%02d/m%02d/d%02d/h%02d",
-            AFW_UTF8_FMT_ARG(adapter->root),
-            lock.century, lock.year, lock.month, lock.day, lock.hour);
+        char ymdh[32];
+
+        apr_snprintf(ymdh, sizeof(ymdh),
+            "y%02d%02d/m%02d/d%02d/h%02d",
+            lock.century, lock.year, lock.month, lock.day,
+            lock.hour);
+        old_full_entry_path_z = impl_journal_path_z(
+            adapter->root, ymdh, p, xctx);
     }
 
     /* Update lock struct. */
@@ -423,20 +451,20 @@ impl_afw_adapter_journal_add_entry_internal(
     lock.usec    = afw_endian_native_to_big_uint32(now.tm_usec);
 
     /* Path to file that will hold event. */
-    full_entry_path_z = afw_utf8_z_printf(p, xctx,
-        AFW_UTF8_FMT AFW_OBJECT_Q_OBJECT_TYPE_ID_JOURNAL_ENTRY "/%s",
-        AFW_UTF8_FMT_ARG(adapter->root), relative_entry_path_z);
+    full_entry_path_z = impl_journal_path_z(
+        adapter->root, relative_entry_path_z, p, xctx);
 
     /*
      * If switching journal file or first entry, make sure all directories
      * exist.
      */
     if (old_full_entry_path_z || first_entry) {
-        full_entry_dir_path_z = afw_utf8_z_printf(p, xctx,
-            AFW_UTF8_FMT AFW_OBJECT_Q_OBJECT_TYPE_ID_JOURNAL_ENTRY
-            "/y%02d%02d/m%02d/d%02d/",
-            AFW_UTF8_FMT_ARG(adapter->root),
+        char ymd[24];
+
+        apr_snprintf(ymd, sizeof(ymd), "y%02d%02d/m%02d/d%02d/",
             lock.century, lock.year, lock.month, lock.day);
+        full_entry_dir_path_z = impl_journal_path_z(
+            adapter->root, ymd, p, xctx);
         AFW_ERROR_FOOTPRINT("apr_dir_make_recursive()");
         rv = apr_dir_make_recursive(full_entry_dir_path_z,
             APR_FPROT_OS_DEFAULT, apr_p);
@@ -769,10 +797,8 @@ impl_afw_adapter_journal_get_entry_internal(
         const afw_utf8_z_t *first_entry_save_path_z;
         apr_finfo_t first_finfo;
 
-        first_entry_save_path = afw_utf8_printf(xctx->p, xctx,
-            AFW_UTF8_FMT AFW_OBJECT_Q_OBJECT_TYPE_ID_JOURNAL_ENTRY
-            "/path_to_first_journal_file",
-            AFW_UTF8_FMT_ARG(adapter->root));
+        first_entry_save_path = afw_utf8_concat(xctx->p, xctx,
+            adapter->root, &impl_s_path_to_first, NULL);
         first_entry_save_path_z = afw_utf8_to_utf8_z(
             first_entry_save_path, p, xctx);
         AFW_ERROR_FOOTPRINT("apr_stat()");

--- a/src/afw/tests/advanced/utf8_to_utf8_z/utf8_to_utf8_z.py
+++ b/src/afw/tests/advanced/utf8_to_utf8_z/utf8_to_utf8_z.py
@@ -35,5 +35,9 @@ def run():
                 "array-z",
                 "array-to-z throws on piece or separator; utf8 concat keeps NUL",
             ),
+            (
+                "concat-z",
+                "concat .len then to_utf8_z throws if a piece has 0",
+            ),
         ],
     )

--- a/src/afw/tests/advanced/utf8_to_utf8_z/utf8_to_utf8_z_probe.c
+++ b/src/afw/tests/advanced/utf8_to_utf8_z/utf8_to_utf8_z_probe.c
@@ -244,6 +244,44 @@ impl_array_z(const afw_pool_t *p, afw_xctx_t *xctx)
         "z-array separator");
 }
 
+static void
+impl_concat_z_embedded(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    afw_utf8_t root;
+    afw_utf8_t type;
+    const afw_utf8_t *joined;
+
+    impl_utf8_set(&root, "root/", 5);
+    impl_utf8_set(&type, impl_embedded, sizeof(impl_embedded));
+    joined = afw_utf8_concat(p, xctx, &root, &type, NULL);
+    (void)afw_utf8_to_utf8_z(joined, p, xctx);
+}
+
+static int
+impl_concat_z(const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    afw_utf8_t root;
+    afw_utf8_t type;
+    afw_utf8_t slash;
+    afw_utf8_t id;
+    const afw_utf8_t *joined;
+    const afw_utf8_z_t *z;
+
+    impl_utf8_set(&root, "root/", 5);
+    impl_utf8_set(&type, "Type", 4);
+    impl_utf8_set(&slash, "/", 1);
+    impl_utf8_set(&id, "id", 2);
+    joined = afw_utf8_concat(p, xctx, &root, &type, &slash, &id, NULL);
+    z = afw_utf8_to_utf8_z(joined, p, xctx);
+    if (!z || strcmp(z, "root/Type/id") != 0) {
+        fprintf(stderr, "concat-z ok: got %s\n", z ? z : "(null)");
+        return 1;
+    }
+
+    return impl_expect_throw(impl_concat_z_embedded, p, xctx,
+        "concat-z embedded");
+}
+
 int
 main(int argc, char **argv)
 {
@@ -279,9 +317,12 @@ main(int argc, char **argv)
     else if (strcmp(case_name, "array-z") == 0) {
         rc = impl_array_z(p, xctx);
     }
+    else if (strcmp(case_name, "concat-z") == 0) {
+        rc = impl_concat_z(p, xctx);
+    }
     else {
         fprintf(stderr, "usage: utf8_to_utf8_z_probe "
-            "empty|ok|embedded|z-create|array-z\n");
+            "empty|ok|embedded|z-create|array-z|concat-z\n");
         rc = 2;
     }
 

--- a/src/afw_ldap/afw_ldap_adapter_session.c
+++ b/src/afw_ldap/afw_ldap_adapter_session.c
@@ -22,6 +22,23 @@
 #define AFW_ADAPTER_SESSION_SELF_T afw_ldap_internal_adapter_session_t
 #include "afw_adapter_session_impl_declares.h"
 
+static const afw_utf8_t impl_s_objectclass_eq =
+    AFW_UTF8_LITERAL("objectclass=");
+static const afw_utf8_t impl_s_structural_eq =
+    AFW_UTF8_LITERAL("structuralobjectclass=");
+static const afw_utf8_t impl_s_objectclass_star =
+    AFW_UTF8_LITERAL("objectclass=*");
+static const afw_utf8_t impl_s_and_wrap_open =
+    AFW_UTF8_LITERAL("(&(");
+static const afw_utf8_t impl_s_close_open =
+    AFW_UTF8_LITERAL(")(");
+static const afw_utf8_t impl_s_close2 =
+    AFW_UTF8_LITERAL("))");
+static const afw_utf8_t impl_s_open_structural =
+    AFW_UTF8_LITERAL("(structuralobjectclass=");
+static const afw_utf8_t impl_s_close =
+    AFW_UTF8_LITERAL(")");
+
 
 afw_ldap_internal_adapter_session_t *
 afw_ldap_internal_adapter_session_create(
@@ -109,33 +126,31 @@ impl_afw_adapter_session_retrieve_objects(
         }
     }
 
-    /* Determine filter_z. */
+    /* Determine filter_z. Concat .len, then C-string door (throw on 0). */
     if (object_type_id) {
         escaped_type = afw_ldap_internal_filter_escape(
             object_type_id, p, xctx);
         /* Check to see if the user wants inherited object types to be returned */
         if (AFW_OBJECT_OPTION_IS(impl_request->options, includeDescendentObjectTypes)) {
-            filter_class = afw_utf8_printf(p, xctx,
-                "objectclass=" AFW_UTF8_FMT,
-                AFW_UTF8_FMT_ARG(escaped_type));
+            filter_class = afw_utf8_concat(p, xctx,
+                &impl_s_objectclass_eq, escaped_type, NULL);
         } else {
-            filter_class = afw_utf8_printf(p, xctx,
-                "structuralobjectclass=" AFW_UTF8_FMT,
-                AFW_UTF8_FMT_ARG(escaped_type));
+            filter_class = afw_utf8_concat(p, xctx,
+                &impl_s_structural_eq, escaped_type, NULL);
         }
     } else {
-        filter_class = afw_utf8_printf(p, xctx, "objectclass=*");
+        filter_class = &impl_s_objectclass_star;
     }
     if (criteria && criteria->filter) {
         filter = afw_ldap_internal_expression_from_query_criteria(
             self, criteria->filter, xctx);
-        filter = afw_utf8_printf(p, xctx,
-            "(&(" AFW_UTF8_FMT ")(" AFW_UTF8_FMT "))",
-            AFW_UTF8_FMT_ARG(filter_class), AFW_UTF8_FMT_ARG(filter));
+        filter = afw_utf8_concat(p, xctx,
+            &impl_s_and_wrap_open, filter_class,
+            &impl_s_close_open, filter, &impl_s_close2, NULL);
     } else {
         filter = filter_class;
     }
-    filter_z = afw_utf8_z_create(filter->s, filter->len, p, xctx);
+    filter_z = afw_utf8_to_utf8_z(filter, p, xctx);
 
     /* Start search. */
     msgid = ldap_search(self->ld, base_z, LDAP_SCOPE_SUBTREE,
@@ -252,9 +267,10 @@ impl_afw_adapter_session_get_object(
     ldap_scope = LDAP_SCOPE_BASE;
     escaped_type = afw_ldap_internal_filter_escape(
         object_type_id, p, xctx);
-    filter_z = apr_psprintf(afw_pool_get_apr_pool(xctx->p),
-        "(structuralobjectclass=" AFW_UTF8_FMT ")",
-        AFW_UTF8_FMT_ARG(escaped_type));
+    filter_z = afw_utf8_to_utf8_z(
+        afw_utf8_concat(p, xctx,
+            &impl_s_open_structural, escaped_type, &impl_s_close, NULL),
+        p, xctx);
     rv = ldap_search_s(self->ld, (char *)dn_z, ldap_scope, (char *)filter_z,
         afw_ldap_internal_allattrs, 0, &res);
     if (res) {

--- a/src/afw_ldap/afw_ldap_internal.c
+++ b/src/afw_ldap/afw_ldap_internal.c
@@ -21,6 +21,19 @@ char * afw_ldap_internal_allattrs[] = { "+", "*", NULL };
 
 static const int impl_zero = 0;
 
+static const afw_utf8_t impl_s_eq = AFW_UTF8_LITERAL("=");
+static const afw_utf8_t impl_s_lt = AFW_UTF8_LITERAL("<");
+static const afw_utf8_t impl_s_le = AFW_UTF8_LITERAL("<=");
+static const afw_utf8_t impl_s_gt = AFW_UTF8_LITERAL(">");
+static const afw_utf8_t impl_s_ge = AFW_UTF8_LITERAL(">=");
+static const afw_utf8_t impl_s_ne_open = AFW_UTF8_LITERAL("!(");
+static const afw_utf8_t impl_s_close = AFW_UTF8_LITERAL(")");
+static const afw_utf8_t impl_s_and_open = AFW_UTF8_LITERAL("&(");
+static const afw_utf8_t impl_s_or_open = AFW_UTF8_LITERAL("|(");
+static const afw_utf8_t impl_s_or_and_open = AFW_UTF8_LITERAL("|(&(");
+static const afw_utf8_t impl_s_close_open = AFW_UTF8_LITERAL(")(");
+static const afw_utf8_t impl_s_close2_open = AFW_UTF8_LITERAL("))(");
+
 
 LDAPMessage *
 afw_ldap_internal_search_s(
@@ -533,40 +546,29 @@ afw_ldap_internal_expression_from_filter_entry(
 
     switch (entry->op_id) {
         case afw_query_criteria_filter_op_id_eq:
-            filter_expression = afw_utf8_printf(xctx->p, xctx,
-                AFW_UTF8_FMT "=" AFW_UTF8_FMT,
-                AFW_UTF8_FMT_ARG(property_name), 
-                AFW_UTF8_FMT_ARG(property_value));
+            filter_expression = afw_utf8_concat(xctx->p, xctx,
+                property_name, &impl_s_eq, property_value, NULL);
             break;
         case afw_query_criteria_filter_op_id_ne:
-            filter_expression = afw_utf8_printf(xctx->p, xctx,
-                "!(" AFW_UTF8_FMT "=" AFW_UTF8_FMT ")",
-                AFW_UTF8_FMT_ARG(property_name), 
-                AFW_UTF8_FMT_ARG(property_value));
+            filter_expression = afw_utf8_concat(xctx->p, xctx,
+                &impl_s_ne_open, property_name, &impl_s_eq,
+                property_value, &impl_s_close, NULL);
             break;
         case afw_query_criteria_filter_op_id_lt:
-            filter_expression = afw_utf8_printf(xctx->p, xctx,
-                AFW_UTF8_FMT "<" AFW_UTF8_FMT,
-                AFW_UTF8_FMT_ARG(property_name), 
-                AFW_UTF8_FMT_ARG(property_value));
+            filter_expression = afw_utf8_concat(xctx->p, xctx,
+                property_name, &impl_s_lt, property_value, NULL);
             break;
         case afw_query_criteria_filter_op_id_le:
-            filter_expression = afw_utf8_printf(xctx->p, xctx,
-                AFW_UTF8_FMT "<=" AFW_UTF8_FMT,
-                AFW_UTF8_FMT_ARG(property_name), 
-                AFW_UTF8_FMT_ARG(property_value));
+            filter_expression = afw_utf8_concat(xctx->p, xctx,
+                property_name, &impl_s_le, property_value, NULL);
             break;
         case afw_query_criteria_filter_op_id_gt:
-            filter_expression = afw_utf8_printf(xctx->p, xctx,
-                AFW_UTF8_FMT ">" AFW_UTF8_FMT,
-                AFW_UTF8_FMT_ARG(property_name), 
-                AFW_UTF8_FMT_ARG(property_value));
+            filter_expression = afw_utf8_concat(xctx->p, xctx,
+                property_name, &impl_s_gt, property_value, NULL);
             break;
         case afw_query_criteria_filter_op_id_ge:
-            filter_expression = afw_utf8_printf(xctx->p, xctx,
-                AFW_UTF8_FMT ">=" AFW_UTF8_FMT,
-                AFW_UTF8_FMT_ARG(property_name), 
-                AFW_UTF8_FMT_ARG(property_value));
+            filter_expression = afw_utf8_concat(xctx->p, xctx,
+                property_name, &impl_s_ge, property_value, NULL);
             break;
         default:
             AFW_THROW_ERROR_Z(query_too_complex,
@@ -607,10 +609,10 @@ impl_expression_from_query_criteria(
             session, entry->on_false, xctx);
 
         /* (|(&(filter_expression)(on_true))(on_false)) */
-        filter_expression = afw_utf8_printf(xctx->p, xctx,
-            "|(&(" AFW_UTF8_FMT ")(" AFW_UTF8_FMT "))(" AFW_UTF8_FMT ")",
-            AFW_UTF8_FMT_ARG(filter_expression), 
-            AFW_UTF8_FMT_ARG(on_true), AFW_UTF8_FMT_ARG(on_false));
+        filter_expression = afw_utf8_concat(xctx->p, xctx,
+            &impl_s_or_and_open, filter_expression,
+            &impl_s_close_open, on_true,
+            &impl_s_close2_open, on_false, &impl_s_close, NULL);
     }
 
     /* (entry AND on_true) */
@@ -620,9 +622,9 @@ impl_expression_from_query_criteria(
             session, entry->on_true, xctx);
 
         /* (&(filter_expression)(on_true)) */
-        filter_expression = afw_utf8_printf(xctx->p, xctx, "&(" AFW_UTF8_FMT ")(" AFW_UTF8_FMT ")",
-            filter_expression->len, filter_expression->s,
-            on_true->len, on_true->s);
+        filter_expression = afw_utf8_concat(xctx->p, xctx,
+            &impl_s_and_open, filter_expression,
+            &impl_s_close_open, on_true, &impl_s_close, NULL);
     }
 
     /* (entry OR on_false) */
@@ -632,10 +634,9 @@ impl_expression_from_query_criteria(
             session, entry->on_false, xctx);
 
         /* (|(filter_expression)(on_false)) */
-        filter_expression = afw_utf8_printf(xctx->p, xctx,
-            "|(" AFW_UTF8_FMT ")(" AFW_UTF8_FMT ")",
-            AFW_UTF8_FMT_ARG(filter_expression),
-            AFW_UTF8_FMT_ARG(on_false));
+        filter_expression = afw_utf8_concat(xctx->p, xctx,
+            &impl_s_or_open, filter_expression,
+            &impl_s_close_open, on_false, &impl_s_close, NULL);
     }
 
     return filter_expression;

--- a/whats-new.md
+++ b/whats-new.md
@@ -505,6 +505,8 @@ C `afw_utf8_t` doors now say **who owns the little struct** and **whether `.s` i
 
 `eq_ignore_case` walks each string with its own code-point offset (mixed-width such as `"iX"` vs `"İX"`). Error-object `backtrace` is `forced_safe` then NFC.
 
+LDAP filters and file-adapter paths that used to glue pieces with `AFW_UTF8_FMT` now **concat `.len`**, then **`to_utf8_z`**. An interior `0` throws at that door instead of becoming a truncated or `^00^`-encoded path/filter.
+
 [↑ Highlights](#highlights)
 
 ---


### PR DESCRIPTION
N1 remainder after #214 (C-string door throws on an interior `0`) and #215 (`printf` is viewable text).

LDAP filters and file-adapter paths that glued pieces with `AFW_UTF8_FMT` / `apr_psprintf` now **concat `.len`**, then **`to_utf8_z`**. An interior `0` throws instead of a truncated or `^00^` filter/path.

LDAP retrieve/get-object and the filter expression tree. File full path, retrieve dirname, journal dir/lock/entry paths. Number-only journal names (`y%04d/m%02d/…`) stay printf. Logs stay display-only.

Probe `concat-z` in `utf8_to_utf8_z`: join a piece with an embedded `0`, then `to_utf8_z` throws. `afwdev test -j` was 20 srcdirs, 4131 passed.

Not in this PR: VFS host-path joins that still use `z_printf` + FMT (same family, optional follow-on).