### PR TITLE
Pin adapter metrics and properties until the caller pool is released

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Project guidance for coding agents lives in the tool-agnostic hub:
 
 **Read @AGENTS.md first** (mission, system map, build/test loop, knowledge map, optional pattern for working an issue with an AI partner). Auto-loaded below via the `@`-import on this line — you don't need to open it separately.
 
-**Before you edit C or invent a design:** read @designs/knowledge-atlas.md's **How the C surface fits** section (also auto-loaded below), then the topic row for the area you are in. Those pads are not optional background — they hold pairing knowledge that **is not obvious from the code** (create vs evaluate, GET vs POST `/afw`, face delete tombstones, lock-safe load ≠ lifetime, stale `afwfcgi` after install, #28 decided-not, …). Symptom first? [`designs/agent-support.md`](designs/agent-support.md). Open with “what do you think?” unless you already share a plan.
+**Before you edit C or invent a design:** read @designs/knowledge-atlas.md's **How the C surface fits** section (also auto-loaded below), then the topic row for the area you are in. Those pads are not optional background — they hold pairing knowledge that **is not obvious from the code** (create vs evaluate, GET vs POST `/afw`, face delete tombstones, metrics pin until caller pool cleanup, stale `afwfcgi` after install, #28 decided-not, …). Symptom first? [`designs/agent-support.md`](designs/agent-support.md). Open with “what do you think?” unless you already share a plan.
 
 This file preloads `AGENTS.md` and `designs/knowledge-atlas.md` (via the `@`-imports above). It does **not** preload the rest of `designs/` or `.cursor/rules/` — you have to open those.
 

--- a/beta-backlog.md
+++ b/beta-backlog.md
@@ -93,7 +93,7 @@ delete the remote `mgg-develop` name when nobody needs the tip.
 ### Session wrap-up — 2026-08-09 (#149 phase 1 + afwdev harness)
 
 - **#149 closed** (2026-08-09): phases 1–3 via PRs [#160](https://github.com/afw-org/afw/pull/160), [#161](https://github.com/afw-org/afw/pull/161), [#162](https://github.com/afw-org/afw/pull/162) (`ad78aa62`).
-  - Architecture pads; `_AdaptiveRuntimeValueAccessor_` registry; lock+copy **referenceCount**; objectOptions pool fix on permanent shells; lock-safe live **metrics/properties**.
+  - Architecture pads; `_AdaptiveRuntimeValueAccessor_` registry; lock+copy **referenceCount**; objectOptions pool fix on permanent shells; live **metrics/properties** pinned until the caller pool is released.
   - Tests: `catalog-value-accessors`, `tests-extra` lifecycle + blast; object_options envreg cases.
   - Residuals (full-registry materialize size, long-running pool pressure) under **#2**.
 - **afwdev follow-ons** (with #160 / after **#159**): `--tests-path`/`-T`, `--output`/`--output-format`, **#61** exceptions (closed).

--- a/designs/agent-support.md
+++ b/designs/agent-support.md
@@ -102,7 +102,7 @@ Shape: **symptom → layer → probe → code / doc entry**.
 
 - **Create vs evaluate** — do not mix (`afw-script-eval`). `argv[0]` at create is the callee expression; `x->function` is harvest at evaluate.  
 - **New get, old delete** — look-through / face / view added on read; mutate/delete/count still the old impl. Faces: delete is a local NULL tombstone (`issue-17`).  
-- **Sibling already learned it** — `split()` empty separator vs `replace()` empty match; `create_array()` cap vs `read(n)`; `copies_under_lock` vs live metrics.  
+- **Sibling already learned it** — `split()` empty separator vs `replace()` empty match; `create_array()` cap vs `read(n)`; `copies_under_lock` vs live metrics (metrics/properties pin the instance until the caller pool is cleaned up; they are not a deep snapshot).  
 - **Two impls of one interface** — memory array index uses `>= count`; C-array view used `> count` (gate: `tests/advanced/array_view_index/`).  
 - **Script integer → malloc / spin / C stack** — APR pools often abort on huge alloc; empty match + “replace all” never advances; type and destructure parse have a nesting limit (`AFW_COMPILE_PARSE_NESTING_MAX`); other grammars may not.  
 - **Type names are declared before use** — like script values, not hoisted. Self-ref in the same `type` / `interface` body is allowed. Unknown names are a compile error even with typeCheck off.  

--- a/designs/knowledge-atlas.md
+++ b/designs/knowledge-atlas.md
@@ -47,7 +47,7 @@ generate/  →  generated/  →  env registries (afw_environment_t)
 
 | Area | Pointers |
 |------|----------|
-| Env / runtime catalog / accessors | #149 pads; atlas §5; **#2 leftover:** live metrics after unlock |
+| Env / runtime catalog / accessors | #149 pads; atlas §5; metrics/properties pin until caller pool cleanup |
 | Hosts / stop | #158; atlas §6 |
 | Memory / faces / `create_array` | #2 pad; #17 faces; atlas §3 |
 | Types | #28 pad + `typescript-differences.md`; #186 parse nesting; #188 names declared before use |
@@ -174,7 +174,7 @@ generate/  →  generated/  →  env registries (afw_environment_t)
 | **Day rules** | `afw-environment`, `afw-environment-variables`, `afw-core-services` (runtime section) |
 | **Deep pads** | [`runtime-objects-and-environment.md`](runtime-objects-and-environment.md) (architecture), [`runtime-value-accessors.md`](runtime-value-accessors.md) (catalog snapshot), [`runtime-catalog-lifetime.md`](runtime-catalog-lifetime.md) (discovery notes) |
 | **Probe** | Typed `retrieve_objects` / GET `/afw/_Adaptive…_/`; `/afw/_AdaptiveRuntimeValueAccessor_/`; **do not** stop permanent `adapter-afw` / `adapter-conf`; prefer typed retrieve over full `current` materialize |
-| **Open** | Residuals under **#2**; metrics/properties live pointer after unlock (lock-safe load ≠ lifetime); more adapters may need terminating checks; attach lifecycle for orchestrated leaves not fully built |
+| **Open** | Residuals under **#2** (managed object/array, long-running escape). Metrics/properties pin the instance until the caller pool is cleaned up (not a deep snapshot; not a managed wrapper). Runtime objects still map over live data; const graphs are fine. A later #2 option is clone-into-requestor-pool **under the lock** so changing data need only live long enough to copy. More adapters may need terminating checks; attach lifecycle for orchestrated leaves not fully built |
 | **Gap** | Live-stack / action probes now in `agent-support`. Architecture pad remains the deep map. |
 
 **Registry discovery (condensed)**

--- a/designs/runtime-objects-and-environment.md
+++ b/designs/runtime-objects-and-environment.md
@@ -2,7 +2,7 @@
 
 **Audience:** maintainers and AI assistants; useful secondary reading for extension/command authors.  
 **Not** published handbook or end-user docs.  
-**Status:** architecture reference for **[#149](https://github.com/afw-org/afw/issues/149)** (child of **[#2 Memory management](https://github.com/afw-org/afw/issues/2)**). Phases 1–3 shipped (accessor registry, lock+copy `referenceCount`, objectOptions pool fix, lock-safe live metrics/properties). Pad remains the map for #2-adjacent follow-on.  
+**Status:** architecture reference for **[#149](https://github.com/afw-org/afw/issues/149)** (child of **[#2 Memory management](https://github.com/afw-org/afw/issues/2)**). Phases 1–3 shipped (accessor registry, lock+copy `referenceCount`, objectOptions pool fix, live metrics/properties). Metrics/properties also pin the instance until the caller pool is released. Pad remains the map for #2-adjacent follow-on.  
 **Related pads:** [`runtime-catalog-lifetime.md`](runtime-catalog-lifetime.md) (discovery notes; may be superseded by this file for architecture), [`memory-management.md`](memory-management.md) (#2 umbrella).  
 **Related issues (separate tracks):** [#49](https://github.com/afw-org/afw/issues/49) `maxObjects`, [#127](https://github.com/afw-org/afw/issues/127) progressive retrieve release, [#17](https://github.com/afw-org/afw/issues/17) faces (different lifetime problem).
 
@@ -500,7 +500,8 @@ High signal for #149 (adjust as inventory proceeds):
 4. ~~Phase 1 PR to `mgg-develop`~~ — [PR #160](https://github.com/afw-org/afw/pull/160) merged 2026-08-09 (`32ff0706`).  
 5. ~~EnvironmentRegistry/`current` + rich objectOptions “must have a pool” (§14.7).~~ **fixed** PR **#161**.  
 6. ~~metrics / properties: document-R + lock-safe pointer load~~ — `adapter_metrics` loads under lock; new `adapter_properties`; OT prose. **No** deep metrics snapshot (product accepts live-while-active).  
-   **Residual:** the lock only makes the **pointer load** safe. After `AFW_LOCK_END` the accessor does not hold an adapter/session reference. A concurrent stop can still destroy the pool behind the live object. `returnsLiveReference` plus “only valid while you hold a session” is a contract the API does not enforce. Same shape on `adapter_properties`. Follow-on under **#2**: copy under lock, or hold `afw_adapter_get_reference` for the value’s life — discuss first.  
+   **Pin for the caller pool (not #2):** after the pointer load, the accessor increments the instance `reference_count` and registers `afw_adapter_release` on `p`. Stop/replace drains until that pool is cleaned up. Counters still live. Values are unmanaged; do not cache them past `p`. Direct GET of `_AdaptiveAdapterMetrics_` does not go through this accessor.  
+   **Later (#2, not this pin):** runtime objects still **map over active data**. Const graphs are fine. Some live mapped objects may instead need a copy into the requestor’s pool **while the lock is still held** (clone as properties are read, or a memory object of copied values). That shortens how long changing/disappearing data must stay pinned. That is not how runtime objects work today; inventory other properties/types before assuming the pin is enough everywhere.  
 7. **Out of #149 / under #2 if needed:** services/logs custom paths; deeper escape/leak work.
 
 When decisions stabilize, promote invariants into `.cursor/rules` or developer docs and thin the pads.
@@ -538,7 +539,7 @@ Views reshape presentation; **#149 still reasons about the base object + accesso
 
 - **Active** instance accepts new `get_reference` traffic.
 - On replace/stop: old anchor copy chained on **`stopping`**; new active installed; old drains until **reference_count → 0** then destroy.
-- Runtime OT `_AdaptiveAdapter_` maps the anchor. Accessors **`stopping_adapter_instances`** and **`adapter_reference_count`** **lock + copy** into the request pool. **`metrics` / `properties`** remain **live while active** (documented on the OT; product choice — not full-clone on get). Parallel pattern for authorization handlers (`authorization_handler_reference_count`, stopping_*).
+- Runtime OT `_AdaptiveAdapter_` maps the anchor. Accessors **`stopping_adapter_instances`** and **`adapter_reference_count`** **lock + copy** into the request pool. **`metrics` / `properties`** remain **live while active** (not a full clone) and **pin the instance** until the caller pool is cleaned up. Parallel pattern for authorization handlers (`authorization_handler_reference_count`, stopping_*).
 
 Service control for probes: `service_get` / `service_start` / `service_stop` / `service_restart`. Prefer **files / vfs / lmdb** (etc.). Do **not** stop permanent **adapter-afw** / **adapter-conf** (can strand the host).
 
@@ -585,7 +586,7 @@ Adapter types normalize **object stores** behind one object API (provisioning). 
 | **service_startup** / **service_status** | no | memcpy enum → permanent utf8 name string | **S** (enum) + **P** (name) | |
 | **stopping_adapter_instances** | **yes** `adapter_id_anchor_lock` | count + copy refcounts into array on `p` | **S** | **Reference implementation for #149** |
 | **stopping_authorization_handler_instances** | **yes** rw lock | same pattern | **S** | |
-| **adapter_metrics** | no | unmanaged object value wrapping `adapter->impl->metrics_object` | **R/L** | Pointer into instance; OK while instance refcount holds; dangling after destroy |
+| **adapter_metrics** | no | unmanaged object value wrapping `adapter->impl->metrics_object` | **R/L** | Pointer into instance; accessor pins instance until `p` cleanup |
 | **adapter_additional_metrics** | no | may call adapter for extra metrics object on `p` | **R** / varies | |
 | **applicable_flags** | no | builds array of flag id values on `p` | **S** (array); flag ids **P** | |
 | **null_terminated_array_of_*** | no | builds array view/wrappers on `p` | often **S** shell + **P** element ptrs | Function metadata tables (permanent) |
@@ -612,8 +613,8 @@ Plus **18** `onGetValueCFunctionName` model `current::` callbacks (xctx model st
 | adapterId | indirect | **E** | id in env/anchor; stable for process life of id registration |
 | serviceId | indirect | **E** | same |
 | referenceCount | **adapter_reference_count** | **P (snapshot)** | lock + copy integer under `adapter_id_anchor_lock` |
-| properties | default (object *) | **R/L** | copies **pointer** to properties object into value; object lives with adapter/conf lifetime; **NULL when fully stopped** |
-| metrics | adapter_metrics | **R/L** | pointer to metrics runtime object on instance; **NULL when no active adapter** |
+| properties | adapter_properties | **R/L** | pointer to properties object; pin until `p` cleanup; **NULL when fully stopped** |
+| metrics | adapter_metrics | **R/L** | pointer to metrics runtime object on instance; pin until `p` cleanup; **NULL when no active adapter** |
 | stopping | stopping_adapter_instances | **S** | lock+copy; empty/absent when no draining instances |
 
 **Live probes (full AFWDev afwfcgi, 2026-08-08):**
@@ -643,7 +644,7 @@ Plus **18** `onGetValueCFunctionName` model `current::` callbacks (xctx model st
 ### 14.5 Candidate fixes
 
 1. **referenceCount (adapter + auth):** done — lock + copy.  
-2. **metrics / properties:** chose **(a) document-R + lock-safe pointer load** — not deep snapshot. `adapter_metrics` loads active adapter under `adapter_id_anchor_lock`; `adapter_properties` loads properties under the same lock; both `returnsLiveReference`.  
+2. **metrics / properties:** live-while-active (not a deep snapshot) plus instance pin until caller pool cleanup. `adapter_metrics` / `adapter_properties` load under `adapter_id_anchor_lock`, increment the instance refcount, wrap the live object, release on `p` cleanup. Both `returnsLiveReference`.  
 3. **Keep** stopping_* as the gold standard for true multi-instance drain snapshots.  
 4. Optional later (not #149 close-out): mid-drain `stopping[]` test with concurrent session holder.
 

--- a/designs/runtime-value-accessors.md
+++ b/designs/runtime-value-accessors.md
@@ -37,7 +37,7 @@ editing the tables below. Property meaning:
 | `returnsLiveReference` | Adaptive value may alias live env/instance state |
 
 **Snapshot date:** 2026-08-08  
-**Core entry count:** 23
+**Core entry count:** 24
 
 ## Summary table
 
@@ -45,6 +45,7 @@ editing the tables below. Property meaning:
 |-----|-------|-----------------|----------------------|
 | `adapter_additional_metrics` | Call adapter get_additional_metrics() | no | no |
 | `adapter_metrics` | Return live adapter metrics object | no | yes |
+| `adapter_properties` | Live adapter anchor properties object (pointer under lock) | no | yes |
 | `adapter_reference_count` | Snapshot adapter anchor reference_count under lock | yes | no |
 | `afw_components_extension_loaded` | Ensure afw_components extension is loaded | no | no |
 | `applicable_flags` | Build array of applicable flag ids for a flag | no | no |
@@ -70,7 +71,7 @@ editing the tables below. Property meaning:
 ### By lifetime class (quick filter)
 
 - **copiesUnderLock:** `adapter_reference_count`, `authorization_handler_reference_count`, `stopping_adapter_instances`, `stopping_authorization_handler_instances`
-- **returnsLiveReference:** `adapter_metrics`, `default`, `indirect`, `null_terminated_array_of_objects`, `null_terminated_array_of_values`, `value`
+- **returnsLiveReference:** `adapter_metrics`, `adapter_properties`, `default`, `indirect`, `null_terminated_array_of_objects`, `null_terminated_array_of_values`, `value`
 - **Neither (typically scalar/copy into `p`):** `adapter_additional_metrics`, `afw_components_extension_loaded`, `applicable_flags`, `compile_type`, `data_type_id`, `null_terminated_array_of_internal`, `null_terminated_array_of_pointers`, `null_terminated_array_of_utf8_z_key_value_pair_objects`, `octet`, `service_startup`, `service_status`, `size`, `uint32`
 
 ## Full descriptions
@@ -87,7 +88,14 @@ editing the tables below. Property meaning:
 - **Brief:** Return live adapter metrics object
 - **copiesUnderLock:** `false`
 - **returnsLiveReference:** `true`
-- **Description:** internal is a pointer to const afw_adapter_t * on an anchor. Under `adapter_id_anchor_lock`, loads `metrics_object` and wraps it after the lock (no deep copy). Live environment state (`returnsLiveReference`). The lock makes the pointer load safe, not the object’s life after unlock — do not cache across stop/replace unless a session (or other) reference keeps the instance. Same leftover as `adapter_properties`.
+- **Description:** internal is a pointer to const afw_adapter_t * on an anchor. Under `adapter_id_anchor_lock`, loads `metrics_object` and wraps it after the lock (no deep copy). Live environment state (`returnsLiveReference`): counters may change while held. The accessor increments the instance reference count and releases it when `p` is cleaned up, so a concurrent stop drains instead of destroying the pool behind the object. Do not cache beyond that pool.
+
+### `adapter_properties`
+
+- **Brief:** Live adapter anchor properties object (pointer under lock)
+- **copiesUnderLock:** `false`
+- **returnsLiveReference:** `true`
+- **Description:** internal is a pointer to const afw_object_t * properties on an `afw_adapter_id_anchor_t`. Under `adapter_id_anchor_lock`, loads the properties pointer and wraps it without deep copy. NULL when no properties. Same pin as `adapter_metrics`. Typically absent on the active anchor after full stop.
 
 ### `adapter_reference_count`
 

--- a/generated/schemas/afw/_AdaptiveAdapter_.json
+++ b/generated/schemas/afw/_AdaptiveAdapter_.json
@@ -3,8 +3,8 @@
     "$defs": {
         "_AdaptiveAdapterMetrics_": {
             "additionalProperties": false,
-            "description": "Live metrics object for this adapter instance (`valueAccessor` adapter_metrics). Active adapter pointer is loaded under adapter_id_anchor_lock; metrics contents are not deep-copied. Counters may change while held. Only valid while the adapter remains active (or while a session ref keeps the instance). Do not cache across stop/replace. NULL when no active instance.",
-            "markdownDescription": "Live metrics object for this adapter instance (`valueAccessor` adapter_metrics). Active adapter pointer is loaded under adapter_id_anchor_lock; metrics contents are not deep-copied. Counters may change while held. Only valid while the adapter remains active (or while a session ref keeps the instance). Do not cache across stop/replace. NULL when no active instance.",
+            "description": "Live metrics object for this adapter instance (`valueAccessor` adapter_metrics). Active adapter pointer is loaded under adapter_id_anchor_lock; metrics contents are not deep-copied. Counters may change while held. The accessor holds an instance reference until the caller pool is released, so a concurrent stop drains instead of destroying the object. Do not cache beyond that pool. NULL when no active instance.",
+            "markdownDescription": "Live metrics object for this adapter instance (`valueAccessor` adapter_metrics). Active adapter pointer is loaded under adapter_id_anchor_lock; metrics contents are not deep-copied. Counters may change while held. The accessor holds an instance reference until the caller pool is released, so a concurrent stop drains instead of destroying the object. Do not cache beyond that pool. NULL when no active instance.",
             "properties": {
                 "_meta_": {
                     "additionalProperties": true,
@@ -152,14 +152,14 @@
                             "$ref": "#/$defs/_AdaptiveAdapterMetrics_"
                         }
                     ],
-                    "description": "Live metrics object for this adapter instance (`valueAccessor` adapter_metrics). Active adapter pointer is loaded under adapter_id_anchor_lock; metrics contents are not deep-copied. Counters may change while held. Only valid while the adapter remains active (or while a session ref keeps the instance). Do not cache across stop/replace. NULL when no active instance.",
-                    "markdownDescription": "**Metrics**\n\nLive metrics object for this adapter instance (`valueAccessor` adapter_metrics). Active adapter pointer is loaded under adapter_id_anchor_lock; metrics contents are not deep-copied. Counters may change while held. Only valid while the adapter remains active (or while a session ref keeps the instance). Do not cache across stop/replace. NULL when no active instance.",
+                    "description": "Live metrics object for this adapter instance (`valueAccessor` adapter_metrics). Active adapter pointer is loaded under adapter_id_anchor_lock; metrics contents are not deep-copied. Counters may change while held. The accessor holds an instance reference until the caller pool is released, so a concurrent stop drains instead of destroying the object. Do not cache beyond that pool. NULL when no active instance.",
+                    "markdownDescription": "**Metrics**\n\nLive metrics object for this adapter instance (`valueAccessor` adapter_metrics). Active adapter pointer is loaded under adapter_id_anchor_lock; metrics contents are not deep-copied. Counters may change while held. The accessor holds an instance reference until the caller pool is released, so a concurrent stop drains instead of destroying the object. Do not cache beyond that pool. NULL when no active instance.",
                     "title": "Metrics",
                     "type": "object"
                 },
                 "properties": {
-                    "description": "Live object with selected conf properties plus runtime properties for this adapter instance (`valueAccessor` adapter_properties). Pointer loaded under adapter_id_anchor_lock; not deep-copied on get. Valid while registration/conf properties remain; typically absent after full stop.",
-                    "markdownDescription": "**Properties**\n\nLive object with selected conf properties plus runtime properties for this adapter instance (`valueAccessor` adapter_properties). Pointer loaded under adapter_id_anchor_lock; not deep-copied on get. Valid while registration/conf properties remain; typically absent after full stop.",
+                    "description": "Live object with selected conf properties plus runtime properties for this adapter instance (`valueAccessor` adapter_properties). Pointer loaded under adapter_id_anchor_lock; not deep-copied on get. The accessor holds an instance reference until the caller pool is released, so a concurrent stop drains instead of destroying the object. Typically absent on the active anchor after full stop.",
+                    "markdownDescription": "**Properties**\n\nLive object with selected conf properties plus runtime properties for this adapter instance (`valueAccessor` adapter_properties). Pointer loaded under adapter_id_anchor_lock; not deep-copied on get. The accessor holds an instance reference until the caller pool is released, so a concurrent stop drains instead of destroying the object. Typically absent on the active anchor after full stop.",
                     "title": "Properties",
                     "type": "object"
                 },
@@ -205,14 +205,14 @@
                             "$ref": "#/$defs/_AdaptiveAdapterMetrics_"
                         }
                     ],
-                    "description": "Live metrics object for this adapter instance (`valueAccessor` adapter_metrics). Active adapter pointer is loaded under adapter_id_anchor_lock; metrics contents are not deep-copied. Counters may change while held. Only valid while the adapter remains active (or while a session ref keeps the instance). Do not cache across stop/replace. NULL when no active instance.",
-                    "markdownDescription": "**Metrics**\n\nLive metrics object for this adapter instance (`valueAccessor` adapter_metrics). Active adapter pointer is loaded under adapter_id_anchor_lock; metrics contents are not deep-copied. Counters may change while held. Only valid while the adapter remains active (or while a session ref keeps the instance). Do not cache across stop/replace. NULL when no active instance.",
+                    "description": "Live metrics object for this adapter instance (`valueAccessor` adapter_metrics). Active adapter pointer is loaded under adapter_id_anchor_lock; metrics contents are not deep-copied. Counters may change while held. The accessor holds an instance reference until the caller pool is released, so a concurrent stop drains instead of destroying the object. Do not cache beyond that pool. NULL when no active instance.",
+                    "markdownDescription": "**Metrics**\n\nLive metrics object for this adapter instance (`valueAccessor` adapter_metrics). Active adapter pointer is loaded under adapter_id_anchor_lock; metrics contents are not deep-copied. Counters may change while held. The accessor holds an instance reference until the caller pool is released, so a concurrent stop drains instead of destroying the object. Do not cache beyond that pool. NULL when no active instance.",
                     "title": "Metrics",
                     "type": "object"
                 },
                 "properties": {
-                    "description": "Live object with selected conf properties plus runtime properties for this adapter instance (`valueAccessor` adapter_properties). Pointer loaded under adapter_id_anchor_lock; not deep-copied on get. Valid while registration/conf properties remain; typically absent after full stop.",
-                    "markdownDescription": "**Properties**\n\nLive object with selected conf properties plus runtime properties for this adapter instance (`valueAccessor` adapter_properties). Pointer loaded under adapter_id_anchor_lock; not deep-copied on get. Valid while registration/conf properties remain; typically absent after full stop.",
+                    "description": "Live object with selected conf properties plus runtime properties for this adapter instance (`valueAccessor` adapter_properties). Pointer loaded under adapter_id_anchor_lock; not deep-copied on get. The accessor holds an instance reference until the caller pool is released, so a concurrent stop drains instead of destroying the object. Typically absent on the active anchor after full stop.",
+                    "markdownDescription": "**Properties**\n\nLive object with selected conf properties plus runtime properties for this adapter instance (`valueAccessor` adapter_properties). Pointer loaded under adapter_id_anchor_lock; not deep-copied on get. The accessor holds an instance reference until the caller pool is released, so a concurrent stop drains instead of destroying the object. Typically absent on the active anchor after full stop.",
                     "title": "Properties",
                     "type": "object"
                 },
@@ -268,14 +268,14 @@
                     "$ref": "#/$defs/_AdaptiveAdapterMetrics_"
                 }
             ],
-            "description": "Live metrics object for this adapter instance (`valueAccessor` adapter_metrics). Active adapter pointer is loaded under adapter_id_anchor_lock; metrics contents are not deep-copied. Counters may change while held. Only valid while the adapter remains active (or while a session ref keeps the instance). Do not cache across stop/replace. NULL when no active instance.",
-            "markdownDescription": "**Metrics**\n\nLive metrics object for this adapter instance (`valueAccessor` adapter_metrics). Active adapter pointer is loaded under adapter_id_anchor_lock; metrics contents are not deep-copied. Counters may change while held. Only valid while the adapter remains active (or while a session ref keeps the instance). Do not cache across stop/replace. NULL when no active instance.",
+            "description": "Live metrics object for this adapter instance (`valueAccessor` adapter_metrics). Active adapter pointer is loaded under adapter_id_anchor_lock; metrics contents are not deep-copied. Counters may change while held. The accessor holds an instance reference until the caller pool is released, so a concurrent stop drains instead of destroying the object. Do not cache beyond that pool. NULL when no active instance.",
+            "markdownDescription": "**Metrics**\n\nLive metrics object for this adapter instance (`valueAccessor` adapter_metrics). Active adapter pointer is loaded under adapter_id_anchor_lock; metrics contents are not deep-copied. Counters may change while held. The accessor holds an instance reference until the caller pool is released, so a concurrent stop drains instead of destroying the object. Do not cache beyond that pool. NULL when no active instance.",
             "title": "Metrics",
             "type": "object"
         },
         "properties": {
-            "description": "Live object with selected conf properties plus runtime properties for this adapter instance (`valueAccessor` adapter_properties). Pointer loaded under adapter_id_anchor_lock; not deep-copied on get. Valid while registration/conf properties remain; typically absent after full stop.",
-            "markdownDescription": "**Properties**\n\nLive object with selected conf properties plus runtime properties for this adapter instance (`valueAccessor` adapter_properties). Pointer loaded under adapter_id_anchor_lock; not deep-copied on get. Valid while registration/conf properties remain; typically absent after full stop.",
+            "description": "Live object with selected conf properties plus runtime properties for this adapter instance (`valueAccessor` adapter_properties). Pointer loaded under adapter_id_anchor_lock; not deep-copied on get. The accessor holds an instance reference until the caller pool is released, so a concurrent stop drains instead of destroying the object. Typically absent on the active anchor after full stop.",
+            "markdownDescription": "**Properties**\n\nLive object with selected conf properties plus runtime properties for this adapter instance (`valueAccessor` adapter_properties). Pointer loaded under adapter_id_anchor_lock; not deep-copied on get. The accessor holds an instance reference until the caller pool is released, so a concurrent stop drains instead of destroying the object. Typically absent on the active anchor after full stop.",
             "title": "Properties",
             "type": "object"
         },

--- a/src/afw/generate/objects/_AdaptiveObjectType_/_AdaptiveAdapter_.json
+++ b/src/afw/generate/objects/_AdaptiveObjectType_/_AdaptiveAdapter_.json
@@ -25,7 +25,7 @@
             "brief": "Adapter metrics",
             "dataType": "object",
             "dataTypeParameter": "_AdaptiveAdapterMetrics_",
-            "description": "Live metrics object for this adapter instance (`valueAccessor` adapter_metrics). Active adapter pointer is loaded under adapter_id_anchor_lock; metrics contents are not deep-copied. Counters may change while held. Only valid while the adapter remains active (or while a session ref keeps the instance). Do not cache across stop/replace. NULL when no active instance.",
+            "description": "Live metrics object for this adapter instance (`valueAccessor` adapter_metrics). Active adapter pointer is loaded under adapter_id_anchor_lock; metrics contents are not deep-copied. Counters may change while held. The accessor holds an instance reference until the caller pool is released, so a concurrent stop drains instead of destroying the object. Do not cache beyond that pool. NULL when no active instance.",
             "label": "Metrics",
             "runtime": {
                 "memberName": "adapter",
@@ -35,7 +35,7 @@
         "properties": {
             "brief": "Properties associated with adapter",
             "dataType": "object",
-            "description": "Live object with selected conf properties plus runtime properties for this adapter instance (`valueAccessor` adapter_properties). Pointer loaded under adapter_id_anchor_lock; not deep-copied on get. Valid while registration/conf properties remain; typically absent after full stop.",
+            "description": "Live object with selected conf properties plus runtime properties for this adapter instance (`valueAccessor` adapter_properties). Pointer loaded under adapter_id_anchor_lock; not deep-copied on get. The accessor holds an instance reference until the caller pool is released, so a concurrent stop drains instead of destroying the object. Typically absent on the active anchor after full stop.",
             "label": "Properties",
             "runtime": {
                 "memberName": "properties",

--- a/src/afw/generated/afw_const_objects.c
+++ b/src/afw/generated/afw_const_objects.c
@@ -4240,7 +4240,7 @@ impl_44_property_dataTypeParameter = {
 static const afw_runtime_property_t
 impl_44_property_description = {
     &afw_self_s_description,
-    &afw_self_v_zz__717fbf3050bf.pub
+    &afw_self_v_zz__f40d437fd517.pub
 };
 
 static const afw_runtime_property_t
@@ -4421,7 +4421,7 @@ impl_46_property_dataType = {
 static const afw_runtime_property_t
 impl_46_property_description = {
     &afw_self_s_description,
-    &afw_self_v_zz__baa3d7c8c8fe.pub
+    &afw_self_v_zz__b9eefb386513.pub
 };
 
 static const afw_runtime_property_t

--- a/src/afw/generated/afw_strings.c
+++ b/src/afw/generated/afw_strings.c
@@ -28755,12 +28755,6 @@ afw_self_v_zz__70e75e2bba42 = {
 };
 
 const afw_value_string_t
-afw_self_v_zz__717fbf3050bf = {
-    {&afw_value_permanent_string_inf},
-    AFW_UTF8_LITERAL(AFW_Q_zz__717fbf3050bf)
-};
-
-const afw_value_string_t
 afw_self_v_zz__718cc0701c67 = {
     {&afw_value_permanent_string_inf},
     AFW_UTF8_LITERAL(AFW_Q_zz__718cc0701c67)
@@ -51567,6 +51561,12 @@ afw_self_v_zz__b9b169af57d0 = {
 };
 
 const afw_value_string_t
+afw_self_v_zz__b9eefb386513 = {
+    {&afw_value_permanent_string_inf},
+    AFW_UTF8_LITERAL(AFW_Q_zz__b9eefb386513)
+};
+
+const afw_value_string_t
 afw_self_v_zz__ba2c6045bfb9 = {
     {&afw_value_permanent_string_inf},
     AFW_UTF8_LITERAL(AFW_Q_zz__ba2c6045bfb9)
@@ -51582,12 +51582,6 @@ const afw_value_string_t
 afw_self_v_zz__baa327556a1e = {
     {&afw_value_permanent_string_inf},
     AFW_UTF8_LITERAL(AFW_Q_zz__baa327556a1e)
-};
-
-const afw_value_string_t
-afw_self_v_zz__baa3d7c8c8fe = {
-    {&afw_value_permanent_string_inf},
-    AFW_UTF8_LITERAL(AFW_Q_zz__baa3d7c8c8fe)
 };
 
 const afw_value_string_t
@@ -55416,6 +55410,12 @@ const afw_value_string_t
 afw_self_v_zz__f40a3ae56edf = {
     {&afw_value_permanent_string_inf},
     AFW_UTF8_LITERAL(AFW_Q_zz__f40a3ae56edf)
+};
+
+const afw_value_string_t
+afw_self_v_zz__f40d437fd517 = {
+    {&afw_value_permanent_string_inf},
+    AFW_UTF8_LITERAL(AFW_Q_zz__f40d437fd517)
 };
 
 const afw_value_string_t

--- a/src/afw/generated/afw_strings_internal.h
+++ b/src/afw/generated/afw_strings_internal.h
@@ -25925,32 +25925,6 @@ extern const afw_value_string_t \
 
 
 /** @brief #define for string in quotes */
-#define AFW_Q_zz__717fbf3050bf \
-    "Live metrics object for this adapter instance (`valueAccessor` adapter_metrics). Active adapter pointer is loaded under adapter_id_anchor_lock; metrics contents are not deep-copied. Counters may change while held. Only valid while the adapter remains active (or while a session ref keeps the instance). Do not cache across stop/replace. NULL when no active instance."
-
-/** @brief 'afw_utf8_t' for AFW_Q_zz__717fbf3050bf */
-#define afw_s_zz__717fbf3050bf \
-    (&afw_self_v_zz__717fbf3050bf.internal)
-
-/** @brief 'afw_utf8_t' for AFW_Q_zz__717fbf3050bf */
-#define afw_self_s_zz__717fbf3050bf \
-    (afw_self_v_zz__717fbf3050bf.internal)
-
-/** @brief 'afw_value_string_t' for AFW_Q_zz__717fbf3050bf */
-extern const afw_value_string_t \
-    afw_self_v_zz__717fbf3050bf;
-
-/** @brief 'afw_utf8_z_t *' for AFW_Q_zz__717fbf3050bf */
-#define afw_z_zz__717fbf3050bf \
-    (afw_self_v_zz__717fbf3050bf.internal.s)
-
-/** @brief 'const afw_value_t *' for AFW_Q_zz__717fbf3050bf */
-#define afw_v_zz__717fbf3050bf \
-    (&afw_self_v_zz__717fbf3050bf.pub)
-
-
-
-/** @brief #define for string in quotes */
 #define AFW_Q_zz__718cc0701c67 \
     "This object can be changed, unless denied by authorization policy or by the adapter"
 
@@ -124777,6 +124751,32 @@ extern const afw_value_string_t \
 
 
 /** @brief #define for string in quotes */
+#define AFW_Q_zz__b9eefb386513 \
+    "Live object with selected conf properties plus runtime properties for this adapter instance (`valueAccessor` adapter_properties). Pointer loaded under adapter_id_anchor_lock; not deep-copied on get. The accessor holds an instance reference until the caller pool is released, so a concurrent stop drains instead of destroying the object. Typically absent on the active anchor after full stop."
+
+/** @brief 'afw_utf8_t' for AFW_Q_zz__b9eefb386513 */
+#define afw_s_zz__b9eefb386513 \
+    (&afw_self_v_zz__b9eefb386513.internal)
+
+/** @brief 'afw_utf8_t' for AFW_Q_zz__b9eefb386513 */
+#define afw_self_s_zz__b9eefb386513 \
+    (afw_self_v_zz__b9eefb386513.internal)
+
+/** @brief 'afw_value_string_t' for AFW_Q_zz__b9eefb386513 */
+extern const afw_value_string_t \
+    afw_self_v_zz__b9eefb386513;
+
+/** @brief 'afw_utf8_z_t *' for AFW_Q_zz__b9eefb386513 */
+#define afw_z_zz__b9eefb386513 \
+    (afw_self_v_zz__b9eefb386513.internal.s)
+
+/** @brief 'const afw_value_t *' for AFW_Q_zz__b9eefb386513 */
+#define afw_v_zz__b9eefb386513 \
+    (&afw_self_v_zz__b9eefb386513.pub)
+
+
+
+/** @brief #define for string in quotes */
 #define AFW_Q_zz__ba2c6045bfb9 \
     "Process current working directory snapshot at environment create. Not updated if the process later changes directory."
 
@@ -124851,32 +124851,6 @@ extern const afw_value_string_t \
 /** @brief 'const afw_value_t *' for AFW_Q_zz__baa327556a1e */
 #define afw_v_zz__baa327556a1e \
     (&afw_self_v_zz__baa327556a1e.pub)
-
-
-
-/** @brief #define for string in quotes */
-#define AFW_Q_zz__baa3d7c8c8fe \
-    "Live object with selected conf properties plus runtime properties for this adapter instance (`valueAccessor` adapter_properties). Pointer loaded under adapter_id_anchor_lock; not deep-copied on get. Valid while registration/conf properties remain; typically absent after full stop."
-
-/** @brief 'afw_utf8_t' for AFW_Q_zz__baa3d7c8c8fe */
-#define afw_s_zz__baa3d7c8c8fe \
-    (&afw_self_v_zz__baa3d7c8c8fe.internal)
-
-/** @brief 'afw_utf8_t' for AFW_Q_zz__baa3d7c8c8fe */
-#define afw_self_s_zz__baa3d7c8c8fe \
-    (afw_self_v_zz__baa3d7c8c8fe.internal)
-
-/** @brief 'afw_value_string_t' for AFW_Q_zz__baa3d7c8c8fe */
-extern const afw_value_string_t \
-    afw_self_v_zz__baa3d7c8c8fe;
-
-/** @brief 'afw_utf8_z_t *' for AFW_Q_zz__baa3d7c8c8fe */
-#define afw_z_zz__baa3d7c8c8fe \
-    (afw_self_v_zz__baa3d7c8c8fe.internal.s)
-
-/** @brief 'const afw_value_t *' for AFW_Q_zz__baa3d7c8c8fe */
-#define afw_v_zz__baa3d7c8c8fe \
-    (&afw_self_v_zz__baa3d7c8c8fe.pub)
 
 
 
@@ -141465,6 +141439,32 @@ extern const afw_value_string_t \
 /** @brief 'const afw_value_t *' for AFW_Q_zz__f40a3ae56edf */
 #define afw_v_zz__f40a3ae56edf \
     (&afw_self_v_zz__f40a3ae56edf.pub)
+
+
+
+/** @brief #define for string in quotes */
+#define AFW_Q_zz__f40d437fd517 \
+    "Live metrics object for this adapter instance (`valueAccessor` adapter_metrics). Active adapter pointer is loaded under adapter_id_anchor_lock; metrics contents are not deep-copied. Counters may change while held. The accessor holds an instance reference until the caller pool is released, so a concurrent stop drains instead of destroying the object. Do not cache beyond that pool. NULL when no active instance."
+
+/** @brief 'afw_utf8_t' for AFW_Q_zz__f40d437fd517 */
+#define afw_s_zz__f40d437fd517 \
+    (&afw_self_v_zz__f40d437fd517.internal)
+
+/** @brief 'afw_utf8_t' for AFW_Q_zz__f40d437fd517 */
+#define afw_self_s_zz__f40d437fd517 \
+    (afw_self_v_zz__f40d437fd517.internal)
+
+/** @brief 'afw_value_string_t' for AFW_Q_zz__f40d437fd517 */
+extern const afw_value_string_t \
+    afw_self_v_zz__f40d437fd517;
+
+/** @brief 'afw_utf8_z_t *' for AFW_Q_zz__f40d437fd517 */
+#define afw_z_zz__f40d437fd517 \
+    (afw_self_v_zz__f40d437fd517.internal.s)
+
+/** @brief 'const afw_value_t *' for AFW_Q_zz__f40d437fd517 */
+#define afw_v_zz__f40d437fd517 \
+    (&afw_self_v_zz__f40d437fd517.pub)
 
 
 

--- a/src/afw/generated/objects/_AdaptiveObjectType_/_AdaptiveAdapter_.json
+++ b/src/afw/generated/objects/_AdaptiveObjectType_/_AdaptiveAdapter_.json
@@ -25,7 +25,7 @@
             "brief": "Adapter metrics",
             "dataType": "object",
             "dataTypeParameter": "_AdaptiveAdapterMetrics_",
-            "description": "Live metrics object for this adapter instance (`valueAccessor` adapter_metrics). Active adapter pointer is loaded under adapter_id_anchor_lock; metrics contents are not deep-copied. Counters may change while held. Only valid while the adapter remains active (or while a session ref keeps the instance). Do not cache across stop/replace. NULL when no active instance.",
+            "description": "Live metrics object for this adapter instance (`valueAccessor` adapter_metrics). Active adapter pointer is loaded under adapter_id_anchor_lock; metrics contents are not deep-copied. Counters may change while held. The accessor holds an instance reference until the caller pool is released, so a concurrent stop drains instead of destroying the object. Do not cache beyond that pool. NULL when no active instance.",
             "label": "Metrics",
             "runtime": {
                 "memberName": "adapter",
@@ -35,7 +35,7 @@
         "properties": {
             "brief": "Properties associated with adapter",
             "dataType": "object",
-            "description": "Live object with selected conf properties plus runtime properties for this adapter instance (`valueAccessor` adapter_properties). Pointer loaded under adapter_id_anchor_lock; not deep-copied on get. Valid while registration/conf properties remain; typically absent after full stop.",
+            "description": "Live object with selected conf properties plus runtime properties for this adapter instance (`valueAccessor` adapter_properties). Pointer loaded under adapter_id_anchor_lock; not deep-copied on get. The accessor holds an instance reference until the caller pool is released, so a concurrent stop drains instead of destroying the object. Typically absent on the active anchor after full stop.",
             "label": "Properties",
             "runtime": {
                 "memberName": "properties",

--- a/src/afw/runtime/afw_runtime_value_accessor.c
+++ b/src/afw/runtime/afw_runtime_value_accessor.c
@@ -682,6 +682,75 @@ afw_runtime_value_accessor_uint32(
 }
 
 
+/* --- adapter live-object pin (metrics / properties) ---------------------- */
+
+static void
+impl_release_adapter_cleanup(
+    void *data, void *data2, const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    (void)data2;
+    (void)p;
+
+    if (data) {
+        afw_adapter_release((const afw_adapter_t *)data, xctx);
+    }
+}
+
+/*
+ * Caller holds adapter_id_anchor_lock. Increment the instance's anchor
+ * count so stop/replace drains instead of destroying while p still holds
+ * a live metrics/properties object. Skip when p is the instance pool
+ * (same lifetime — extra pin would release during destroy).
+ */
+static const afw_adapter_t *
+impl_pin_adapter_for_pool_lock_held(
+    const afw_adapter_t *instance,
+    const afw_pool_t *p,
+    afw_xctx_t *xctx)
+{
+    afw_adapter_id_anchor_t *anchor;
+
+    if (!instance || p == instance->p) {
+        return NULL;
+    }
+
+    for (
+        anchor = (afw_adapter_id_anchor_t *)
+            afw_environment_get_adapter_id(&instance->adapter_id, xctx);
+        anchor;
+        anchor = anchor->stopping)
+    {
+        if (anchor->adapter == instance) {
+            anchor->reference_count++;
+            return instance;
+        }
+    }
+
+    return NULL;
+}
+
+static void
+impl_register_adapter_pin_cleanup(
+    const afw_adapter_t *held,
+    const afw_pool_t *p,
+    afw_xctx_t *xctx)
+{
+    if (!held) {
+        return;
+    }
+
+    AFW_TRY {
+        afw_pool_register_cleanup_before(
+            p, (void *)held, NULL, impl_release_adapter_cleanup, xctx);
+    }
+    AFW_CATCH_UNHANDLED {
+        afw_adapter_release(held, xctx);
+        AFW_ERROR_RETHROW;
+    }
+    AFW_ENDTRY;
+}
+
+
 /* --- adapter_metrics ----------------------------------------------------- */
 
 static const afw_utf8_t
@@ -697,10 +766,11 @@ impl_description_adapter_metrics =
         "active adapter and returns an object value wrapping "
         "adapter->impl->metrics_object without deep-copying metrics. NULL when "
         "no active adapter. The metrics object is live environment state "
-        "(returnsLiveReference): counters may change while held and the "
-        "object is only valid while the adapter remains active (or while you "
-        "hold a session reference that keeps the instance alive). Do not "
-        "cache across service stop/replace.");
+        "(returnsLiveReference): counters may change while held. The accessor "
+        "increments the instance reference count and releases it when p is "
+        "cleaned up, so a concurrent stop drains instead of destroying the "
+        "pool behind the object. Do not cache beyond the pool that produced "
+        "the value.");
 
 static const afw_runtime_value_accessor_info_t
 impl_info_adapter_metrics = {
@@ -718,6 +788,7 @@ afw_runtime_value_accessor_adapter_metrics(
     const void *internal, const afw_pool_t *p, afw_xctx_t *xctx)
 {
     const afw_adapter_t *adapter;
+    const afw_adapter_t *held;
     const afw_object_t *metrics_object;
 
     (void)prop;
@@ -727,13 +798,20 @@ afw_runtime_value_accessor_adapter_metrics(
     }
 
     metrics_object = NULL;
+    held = NULL;
     AFW_LOCK_BEGIN(xctx->env->adapter_id_anchor_lock) {
         adapter = *(const afw_adapter_t * const *)internal;
         if (adapter && adapter->impl) {
             metrics_object = adapter->impl->metrics_object;
+            if (metrics_object) {
+                held = impl_pin_adapter_for_pool_lock_held(
+                    adapter, p, xctx);
+            }
         }
     }
     AFW_LOCK_END;
+
+    impl_register_adapter_pin_cleanup(held, p, xctx);
 
     return (metrics_object)
         ? afw_value_create_unmanaged_object(metrics_object, p, xctx)
@@ -755,8 +833,11 @@ impl_description_adapter_properties =
         "afw_adapter_id_anchor_t. Under adapter_id_anchor_lock, loads the "
         "properties pointer and returns an object value wrapping it without "
         "deep copy. NULL when no properties. Live environment state "
-        "(returnsLiveReference): valid while the adapter registration / "
-        "conf properties remain; typically cleared or replaced on stop.");
+        "(returnsLiveReference). Same pin as adapter_metrics: the accessor "
+        "increments the instance reference count and releases it when p is "
+        "cleaned up, so a concurrent stop drains instead of destroying the "
+        "pool behind the object. Typically absent on the active anchor after "
+        "full stop.");
 
 static const afw_runtime_value_accessor_info_t
 impl_info_adapter_properties = {
@@ -773,19 +854,35 @@ afw_runtime_value_accessor_adapter_properties(
     const afw_runtime_object_map_property_t * prop,
     const void *internal, const afw_pool_t *p, afw_xctx_t *xctx)
 {
+    const afw_adapter_id_anchor_t *anchor;
+    const afw_adapter_t *adapter;
+    const afw_adapter_t *held;
     const afw_object_t *properties;
-
-    (void)prop;
 
     if (!internal) {
         return NULL;
     }
 
     properties = NULL;
+    adapter = NULL;
+    held = NULL;
     AFW_LOCK_BEGIN(xctx->env->adapter_id_anchor_lock) {
         properties = *(const afw_object_t * const *)internal;
+        if (properties && prop &&
+            prop->offset != (afw_size_t)-1)
+        {
+            anchor = (const afw_adapter_id_anchor_t *)(
+                (const char *)internal - prop->offset);
+            adapter = anchor->adapter;
+            if (adapter) {
+                held = impl_pin_adapter_for_pool_lock_held(
+                    adapter, p, xctx);
+            }
+        }
     }
     AFW_LOCK_END;
+
+    impl_register_adapter_pin_cleanup(held, p, xctx);
 
     return (properties)
         ? afw_value_create_unmanaged_object(properties, p, xctx)

--- a/src/afw/runtime/afw_runtime_value_accessor.h
+++ b/src/afw/runtime/afw_runtime_value_accessor.h
@@ -377,7 +377,8 @@ afw_runtime_value_accessor_uint32(
  * @return object value wrapping metrics_object, or NULL if no active adapter.
  *
  * Loads the adapter pointer under adapter_id_anchor_lock. Result is still a
- * live reference (not a deep snapshot of counters).
+ * live reference (not a deep snapshot of counters). Pins the instance until
+ * p is cleaned up so stop/replace cannot destroy the pool behind the object.
  */
 const afw_value_t *
 afw_runtime_value_accessor_adapter_metrics(
@@ -391,6 +392,8 @@ afw_runtime_value_accessor_adapter_metrics(
  * @param p is pool to use.
  * @param xctx of caller.
  * @return object value wrapping properties, or NULL.
+ *
+ * Pins the instance until p is cleaned up, same as adapter_metrics.
  */
 const afw_value_t *
 afw_runtime_value_accessor_adapter_properties(

--- a/src/afw/tests/advanced/catalog-value-accessors/afw.conf
+++ b/src/afw/tests/advanced/catalog-value-accessors/afw.conf
@@ -1,8 +1,20 @@
-/* Minimal conf: request handler only — runtime catalog via built-in afw adapter. */
+/* Runtime catalog via built-in afw adapter, plus a stoppable file adapter
+ * so metrics/properties pin-across-stop can run in this leaf.
+ */
 [
     {
         type                : "requestHandler",
         uriPrefix           : "/",
         requestHandlerType  : "adapter"
+    },
+
+    {
+        type                : "adapter",
+        adapterType         : "file",
+        adapterId           : "file",
+        description         : "stoppable file adapter for metrics pin test",
+        root                : "objects/",
+        filenameSuffix      : ".json",
+        contentType         : "json"
     }
 ]

--- a/src/afw/tests/advanced/catalog-value-accessors/hold_metrics_across_stop.as
+++ b/src/afw/tests/advanced/catalog-value-accessors/hold_metrics_across_stop.as
@@ -1,0 +1,29 @@
+// Hold live metrics/properties, stop the instance, still read them.
+// The accessors pin the instance on the request pool so stop drains.
+const a = get_object("afw", "_AdaptiveAdapter_", "file");
+assert(a !== null && a !== undefined);
+assert(a.adapterId === "file");
+const metrics = a.metrics;
+const props = a.properties;
+assert(metrics !== null && metrics !== undefined,
+    "metrics present while adapter active");
+assert(props !== null && props !== undefined,
+    "properties present while adapter active");
+const getCount = metrics.getObjectCount;
+assert(getCount !== null && getCount !== undefined);
+assert(props.adapterId === "file");
+
+const stopped = service_stop("adapter-file");
+assert(stopped !== null && stopped !== undefined);
+
+assert(metrics.getObjectCount === getCount,
+    "held metrics stay readable after stop");
+assert(props.adapterId === "file",
+    "held properties stay readable after stop");
+
+const after = get_object("afw", "_AdaptiveAdapter_", "file");
+assert(after.metrics === null || after.metrics === undefined,
+    "active metrics gone after stop");
+assert(after.properties === null || after.properties === undefined,
+    "active properties gone after stop");
+return props.adapterId;

--- a/src/afw/tests/advanced/catalog-value-accessors/objects/README.txt
+++ b/src/afw/tests/advanced/catalog-value-accessors/objects/README.txt
@@ -1,0 +1,1 @@
+Placeholder so the file adapter root exists for catalog-value-accessors.

--- a/src/afw/tests/advanced/catalog-value-accessors/orchestration.yaml
+++ b/src/afw/tests/advanced/catalog-value-accessors/orchestration.yaml
@@ -28,3 +28,7 @@ tests:
   - name: test_script hybrid step
     sourceType: test_script
     sourcePath: step_catalog_sane.as
+  - name: hold metrics and properties across service_stop
+    sourceType: script
+    sourcePath: hold_metrics_across_stop.as
+    expect: file

--- a/whats-new.md
+++ b/whats-new.md
@@ -90,7 +90,7 @@ sections end with [↑ Highlights](#highlights) to return here.
 | [**Orchestrated tests**](#orchestrated-tests-issue-157) ([#157](https://github.com/afw-org/afw/issues/157)) | Hermetic multi-step leaves via `orchestration.yaml` (hosts `afwfcgi` / `local`); `//? expect-stdout` / `expect-stderr`; opt-in `tests-extra/` |
 | [**afwdev test recipe flags**](#afwdev-test-recipe-flags) | `-T` / `--tests-path`, `--output` / `--output-format` for machine summaries |
 | [**Graceful process stop**](#graceful-process-stop-sigtermsigint-issue-158) ([#158](https://github.com/afw-org/afw/issues/158)) | **`afwfcgi`** honors **SIGTERM/SIGINT** (stop accept, drain workers, unlink Unix listen path); **`afw`** sets **`terminating`**; mid-request I/O can throw **503 Server Terminating** |
-| [**Runtime catalog / accessors**](#runtime-catalog--accessors-issue-149) ([#149](https://github.com/afw-org/afw/issues/149)) | Lock+copy **`referenceCount`**; accessor registry; rich objectOptions on permanent shells fixed; **metrics/properties** live-while-active with lock-safe pointer load |
+| [**Runtime catalog / accessors**](#runtime-catalog--accessors-issue-149) ([#149](https://github.com/afw-org/afw/issues/149)) | Lock+copy **`referenceCount`**; accessor registry; rich objectOptions on permanent shells fixed; **metrics/properties** live-while-active, instance pinned until the caller pool is released |
 | [**Error codes**](#error-codes-trycatch-and-http-issue-33) ([#33](https://github.com/afw-org/afw/issues/33)) | Review of `e.id` / HTTP map; script `throw` … `id "not_found"` (and similar) sets the catch object and HTTP status |
 | [**Multi `let` / `const`**](#multi-let-and-const-issue-62) ([#62](https://github.com/afw-org/afw/issues/62)) | Several names on one `let` / `const`; C-style `for` init; `x = y = 1;` chain; script result is set by assignment, `return`, and a call that is not void; loop labels |
 | [**Compiler literals**](#compiler-literals-issue-106) ([#106](https://github.com/afw-org/afw/issues/106)) | `#doubleMax`, `#integerMax`, `#pi`, `#infinity`, and related `#` names fold to those values at compile |
@@ -298,9 +298,9 @@ Child of **[#2](https://github.com/afw-org/afw/issues/2)** memory work. Focused 
 | **`referenceCount` on catalog adapter / auth handler objects** | Snapshot under the existing anchor lock |
 | **`_AdaptiveRuntimeValueAccessor_`** | First-class registry objects (lock-copy / live-reference contracts) |
 | **Rich objectOptions on permanent / const shells** | `metaFull+normalize` (etc.) on **`EnvironmentRegistry/current`** no longer throws **Object must have a pool** (mutable propertyTypes on the view pool) |
-| **`metrics` / `properties` on `_AdaptiveAdapter_`** | Live-while-active: pointer loaded under **adapter_id_anchor_lock** (`adapter_metrics` / `adapter_properties`); not a deep snapshot of counters or conf |
+| **`metrics` / `properties` on `_AdaptiveAdapter_`** | Live-while-active: pointer loaded under **adapter_id_anchor_lock** (`adapter_metrics` / `adapter_properties`); not a deep snapshot of counters or conf. Getting either property holds the instance until that request/caller pool is released, so a concurrent **service stop** drains instead of destroying the object |
 
-If you hold Adaptive values from `/afw/…` adapter objects across **service stop**, treat **metrics** / **properties** as valid only while the instance is active (or you hold a session ref); **`referenceCount`** is a safe integer snapshot. Full-registry materialize size and long-running pool pressure remain under **[#2](https://github.com/afw-org/afw/issues/2)**.
+If you hold Adaptive values from `/afw/…` adapter objects across **service stop**, **metrics** / **properties** obtained through `_AdaptiveAdapter_` stay valid for the pool that produced them (the instance stays in the stopping chain until that pool is cleaned up). **`referenceCount`** is still a safe integer snapshot. Caching those objects past the request is unmanaged — full-registry materialize size and long-running pool pressure remain under **[#2](https://github.com/afw-org/afw/issues/2)**.
 
 [↑ Highlights](#highlights)
 


### PR DESCRIPTION
Leftover of [#149](https://github.com/afw-org/afw/issues/149): `adapter_metrics` / `adapter_properties` loaded a live pointer under `adapter_id_anchor_lock`, then dropped the lock without holding the instance. A concurrent `service_stop` could destroy the pool behind the object.

This pin uses the existing adapter drain protocol. Under the lock, increment the instance `reference_count`; release it when the caller pool is cleaned up. Counters stay live-while-active (not a deep snapshot, not managed object wrappers). Values remain unmanaged — do not cache them past that pool.

Gate: `src/afw/tests/advanced/catalog-value-accessors/hold_metrics_across_stop.as` (hold metrics/properties, stop the file adapter, still read them). `./afwdev build --cdev` then that leaf passed.

Runtime objects still map over live C data. Const graphs are already safe. Other live properties may need the same kind of help; a later [#2](https://github.com/afw-org/afw/issues/2) option is clone into the requestor pool **while the lock is held**, so changing data only has to live long enough to copy. Direct GET of `_AdaptiveAdapterMetrics_` does not go through this accessor.

cc @JeremyGrieshop