### PR TITLE
fix(curl): bound READFUNCTION copies to libcurl's offered buffer size

### DIFF
--- a/src/afw_curl/afw_curl_internal.c
+++ b/src/afw_curl/afw_curl_internal.c
@@ -212,47 +212,75 @@ afw_curl_internal_request_cb(
     afw_curl_internal_script_cb_t * reader = appdata->reader;
     const afw_value_t *return_value;
     const afw_memory_t *payload;
+    size_t capacity;
+    size_t remaining;
+    size_t n;
 
-    if ((size == 0) || (nitems == 0) || ((size * nitems) < 1)) {
+    capacity = size * nitems;
+    if ((size == 0) || (nitems == 0) || (capacity < 1)) {
         return 0;
     }
-    
+
     /* check to see if a callback was provided by adaptive script */
     if (reader && reader->callback)
     {
-        reader->argv[0] = reader->callback;
-        reader->argv[1] = reader->userData;
-        reader->argv[2] = afw_value_create_unmanaged_integer(
-            size, appdata->pool, appdata->xctx);
-        reader->argv[3] = afw_value_create_unmanaged_integer(
-            nitems, appdata->pool, appdata->xctx);
-        if (!reader->call) {
-            reader->call = afw_value_call_create(reader->contextual,
-                3, &reader->argv[0], false, appdata->pool, appdata->xctx);
-        }
-        return_value = afw_value_evaluate(reader->call, 
-            appdata->pool, appdata->xctx);
+        /* drain any bytes left over from a previous script call first */
+        if (!appdata->pending_payload) {
+            reader->argv[0] = reader->callback;
+            reader->argv[1] = reader->userData;
+            reader->argv[2] = afw_value_create_unmanaged_integer(
+                size, appdata->pool, appdata->xctx);
+            reader->argv[3] = afw_value_create_unmanaged_integer(
+                nitems, appdata->pool, appdata->xctx);
+            if (!reader->call) {
+                reader->call = afw_value_call_create(reader->contextual,
+                    3, &reader->argv[0], false, appdata->pool, appdata->xctx);
+            }
+            return_value = afw_value_evaluate(reader->call,
+                appdata->pool, appdata->xctx);
 
-        /* copy the bytes returned into buffer (null indicates end of data) */
-        if (afw_value_is_null(return_value)) {
-            return 0;
+            /* copy the bytes returned into buffer (null indicates end of data) */
+            if (afw_value_is_null(return_value)) {
+                return 0;
+            }
+
+            payload = afw_value_as_hexBinary(return_value, appdata->xctx);
+            if (payload->size == 0) {
+                return 0;
+            }
+
+            appdata->pending_payload = payload;
+            appdata->pending_offset = 0;
         }
 
-        payload = afw_value_as_hexBinary(return_value, appdata->xctx);
-        memcpy(buffer, payload->ptr, payload->size);
-        
-        return payload->size;
+        remaining = appdata->pending_payload->size - appdata->pending_offset;
+        n = (remaining < capacity) ? remaining : capacity;
+
+        memcpy(buffer,
+            appdata->pending_payload->ptr + appdata->pending_offset, n);
+        appdata->pending_offset += n;
+
+        /* fully drained -- next call evaluates the script again */
+        if (appdata->pending_offset == appdata->pending_payload->size) {
+            appdata->pending_payload = NULL;
+            appdata->pending_offset = 0;
+        }
+
+        return n;
     }
 
     else
     {
-        if (appdata->bytes_sent == appdata->payload->len)
+        remaining = appdata->payload->len - appdata->bytes_sent;
+        if (remaining == 0)
             return 0;
-    
-        memcpy(buffer, appdata->payload->s, appdata->payload->len); 
-        appdata->bytes_sent = appdata->payload->len;
 
-        return appdata->bytes_sent;
+        n = (remaining < capacity) ? remaining : capacity;
+
+        memcpy(buffer, appdata->payload->s + appdata->bytes_sent, n);
+        appdata->bytes_sent += n;
+
+        return n;
     }
 }
 afw_curl_internal_write_cb_t *

--- a/src/afw_curl/afw_curl_internal.h
+++ b/src/afw_curl/afw_curl_internal.h
@@ -52,6 +52,14 @@ typedef struct afw_curl_internal_read_cb_s {
     size_t                            bytes_sent;
     afw_curl_internal_script_cb_t   * header;
     afw_curl_internal_script_cb_t   * reader;
+    /*
+     * Bytes from the reader script's last returned chunk that did not fit
+     * in the buffer libcurl offered on that call, still waiting to be
+     * drained across subsequent callback invocations before the script is
+     * called again.
+     */
+    const afw_memory_t              * pending_payload;
+    size_t                             pending_offset;
     const afw_pool_t                * pool;
     afw_xctx_t                      * xctx;
 } afw_curl_internal_read_cb_t;

--- a/src/afw_curl/tests/smtp/config.py
+++ b/src/afw_curl/tests/smtp/config.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+import os
+import re
+import socket
+import threading
+
+# test configuration settings
+Environment = "curl"
+
+# Minimal local SMTP stub for smtp_send() regression tests (C1: curl upload
+# READFUNCTION heap overflow). Runs for the lifetime of this test group,
+# accepting one connection per smtp_send() call. It reads the expected
+# payload length out of the MAIL FROM address (e.g. "stub-len-500000@..."),
+# so each test case is self-contained without extra coordination, and
+# rejects (SMTP 5xx) if the bytes actually received during DATA don't match
+# -- which surfaces in the .as test as a thrown error from smtp_send().
+_server_socket = None
+_server_thread = None
+_stop_event = None
+
+
+def _read_line(conn):
+    buf = b""
+    while not buf.endswith(b"\r\n"):
+        chunk = conn.recv(1)
+        if not chunk:
+            break
+        buf += chunk
+    return buf
+
+
+def _handle_connection(conn):
+    conn.settimeout(20)
+
+    def send(s):
+        conn.sendall(s.encode())
+
+    send("220 localhost ESMTP stub\r\n")
+
+    expected_len = None
+    while True:
+        line = _read_line(conn)
+        if not line:
+            return
+        upper = line.upper()
+        if upper.startswith(b"MAIL FROM"):
+            m = re.search(rb"stub-len-(\d+)@", line)
+            if m:
+                expected_len = int(m.group(1))
+            send("250 OK\r\n")
+        elif upper.startswith(b"DATA"):
+            send("354 End data with <CR><LF>.<CR><LF>\r\n")
+            break
+        else:
+            send("250 OK\r\n")
+
+    terminator = b"\r\n.\r\n"
+    data = b""
+    while terminator not in data:
+        chunk = conn.recv(65536)
+        if not chunk:
+            return
+        data += chunk
+    body = data[:data.index(terminator)]
+
+    if expected_len is not None and len(body) == expected_len:
+        send("250 OK: queued\r\n")
+    else:
+        send("554 Transaction failed: length mismatch (expected {}, got {})\r\n"
+             .format(expected_len, len(body)))
+
+    _read_line(conn)  # QUIT
+    send("221 Bye\r\n")
+
+
+def _serve():
+    while not _stop_event.is_set():
+        try:
+            _server_socket.settimeout(0.5)
+            conn, _ = _server_socket.accept()
+        except socket.timeout:
+            continue
+        except OSError:
+            break
+        try:
+            _handle_connection(conn)
+        except Exception:
+            pass
+        finally:
+            conn.close()
+
+
+def before_all():
+    global _server_socket, _server_thread, _stop_event
+
+    _server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    _server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    _server_socket.bind(("127.0.0.1", 0))
+    _server_socket.listen(5)
+
+    # port 0 lets the OS assign a free port; publish it to the .as tests
+    os.environ["AFW_CURL_TEST_SMTP_PORT"] = str(_server_socket.getsockname()[1])
+
+    _stop_event = threading.Event()
+    _server_thread = threading.Thread(target=_serve, daemon=True)
+    _server_thread.start()
+
+
+def after_all():
+    global _server_socket, _server_thread, _stop_event
+
+    if _stop_event:
+        _stop_event.set()
+    if _server_socket:
+        _server_socket.close()
+    if _server_thread:
+        _server_thread.join(timeout=5)

--- a/src/afw_curl/tests/smtp/smtp_send_upload.as
+++ b/src/afw_curl/tests/smtp/smtp_send_upload.as
@@ -1,0 +1,51 @@
+#!/usr/bin/env -S afw --syntax test_script
+//?
+//? testScript: smtp_send_upload.as
+//? customPurpose: Part of afw_curl tests
+//? description: Regression for C1 -- curl upload READFUNCTION ignored the buffer size libcurl offered, overflowing its buffer. Runs against a local SMTP stub (see config.py) that verifies the exact byte count received.
+//? sourceType: script
+//?
+//? test: smtp_upload_small
+//? description: Baseline sanity -- a payload well under any read buffer, single READFUNCTION call. Confirms the stub/harness itself works.
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+const bodyLen = 50;
+let body = "A";
+while (length(body) < bodyLen) {
+    body += body;
+}
+body = substring(body, 0, bodyLen);
+
+smtp_send(
+    "smtp://127.0.0.1:" + string(integer(environment::AFW_CURL_TEST_SMTP_PORT)),
+    "stub-len-" + string(bodyLen) + "@example.com",
+    ["recipient@example.com"],
+    body
+);
+
+return 0;
+
+
+//? test: smtp_upload_multi_buffer
+//? description: Payload far larger than libcurl's internal upload buffer, forcing multiple READFUNCTION invocations. This is the case that crashed before the C1 fix.
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+const bodyLen = 500000;
+let body = "A";
+while (length(body) < bodyLen) {
+    body += body;
+}
+body = substring(body, 0, bodyLen);
+
+smtp_send(
+    "smtp://127.0.0.1:" + string(integer(environment::AFW_CURL_TEST_SMTP_PORT)),
+    "stub-len-" + string(bodyLen) + "@example.com",
+    ["recipient@example.com"],
+    body
+);
+
+return 0;


### PR DESCRIPTION
## Summary

- C1 (private C audit board): `afw_curl_internal_request_cb` (the `CURLOPT_READFUNCTION` callback) `memcpy`'d the full request payload -- or the full script-returned `hexBinary` chunk -- into libcurl's buffer, ignoring the `size*nitems` capacity libcurl actually offered on that call. Fixed by tracking a byte cursor and copying `min(remaining, size*nitems)` per call, draining across multiple invocations per libcurl's documented contract.
- Live path: `smtp_send()` is the only caller wired to this code (HTTP POST/PUT use `CURLOPT_POSTFIELDS`, a different libcurl path not affected), and any mail body larger than libcurl's internal upload buffer (64KB by default) overflowed it.
- Also fixed the scripted `readFunction` branch, which has the same bug but is currently dead code -- nothing in the tree wires a non-NULL reader for uploads yet (unlike the response `writer`/`header` callbacks, which are). Same fix shape, added since it's clearly meant to be used.
- Added a permanent regression test (`src/afw_curl/tests/smtp/`) -- there was no `smtp/` test directory and nothing exercised this code path before. A local raw-socket SMTP stub (started in `config.py` `before_all`, OS-assigned port to avoid collisions under `-j`) verifies the exact byte count received for a payload sized to force multiple `READFUNCTION` calls.

## Test plan

- [x] `./afwdev build --cdev`
- [x] `afwdev test --srcdir-pattern afw_curl -j` -- 41/41 passed
- [x] Confirmed the regression test actually catches the bug: temporarily checked out the pre-fix files (parent commit) and rebuilt -- old code segfaults deterministically (SIGSEGV) on the multi-buffer case, no valgrind needed, `afwdev test` reports it as a clean process-death failure; fixed code passes cleanly and repeatably
- [x] Confirmed with valgrind on the pre-fix code directly: `Invalid write of size 8 ... 0 bytes after a block of size 65,536 alloc'd` at the old `memcpy` call
- [x] Full repo suite: `afwdev test -j` -- 4130 passed, only 2 pre-existing unrelated `afw_crypto` failures (confirmed present on unmodified `develop` too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)