### PR TITLE
Track the crypto test files directory so open_file writes succeed

### DIFF
--- a/src/afw_crypto/tests/environments/crypto/files/.gitignore
+++ b/src/afw_crypto/tests/environments/crypto/files/.gitignore
@@ -1,0 +1,4 @@
+# Runtime files created by crypto_seal_unseal.as and
+# crypto_bind_parameters_template.as (git does not track empty directories).
+*
+!.gitignore


### PR DESCRIPTION
## Why

`afwdev test` copies `src/afw_crypto/tests/environments/crypto/` into the work dir. `rootFilePaths` maps `data` to `files/`. Git does not keep that directory when it is empty, so clones fail `open_file` writes:

- `easy_seal_file_roundtrip` / `hard_line_file_format`
- `bindParameters_template_file_sealed_blob`

ENOENT: `/tmp/afwdev_test_output/afw_crypto.tests.crypto/files/...`

## Change

Add a `.gitignore` placeholder under `files/`, same pattern as file-journal and stream_file test dirs.

## Test

`afwdev test --srcdir-pattern afw_crypto --show-all` — 17 passed, 17 total.