### PR TITLE
fix(curl): check curl_easy_setopt return for MAIL_FROM and MAIL_RCPT

### DIFF
--- a/src/afw_curl/afw_curl_internal.c
+++ b/src/afw_curl/afw_curl_internal.c
@@ -1567,7 +1567,7 @@ afw_curl_internal_smtp_send(
             AFW_THROW_ERROR_RV_Z(general, curl, res, "Error in curl_easy_setopt()", xctx);
 
         /* set the required (by us) from address */
-        curl_easy_setopt(curl, CURLOPT_MAIL_FROM, afw_utf8_to_utf8_z(mail_from, xctx->p, xctx));
+        res = curl_easy_setopt(curl, CURLOPT_MAIL_FROM, afw_utf8_to_utf8_z(mail_from, xctx->p, xctx));
         if (res != CURLE_OK)
             AFW_THROW_ERROR_RV_Z(general, curl, res, "Error in curl_easy_setopt()", xctx);
 
@@ -1582,8 +1582,10 @@ afw_curl_internal_smtp_send(
             value = afw_array_get_next_value(mail_recipients, &iterator, pool, xctx);
         }
 
-        curl_easy_setopt(curl, CURLOPT_MAIL_RCPT, recipients);
-        
+        res = curl_easy_setopt(curl, CURLOPT_MAIL_RCPT, recipients);
+        if (res != CURLE_OK)
+            AFW_THROW_ERROR_RV_Z(general, curl, res, "Error in curl_easy_setopt()", xctx);
+
         /* set any options, that may have been specified */
         afw_curl_internal_options(curl, options, NULL, NULL, NULL, pool, xctx);
 


### PR DESCRIPTION
## Summary

- C3 (private C audit board): `curl_easy_setopt(curl, CURLOPT_MAIL_FROM, ...)` in `afw_curl_internal_smtp_send` never assigned its return value to `res`. The following `if (res != CURLE_OK)` check was silently checking stale state left over from the `CURLOPT_URL` setopt above it -- a failed mail-from setopt was swallowed and execution proceeded toward `curl_easy_perform()` as if it had succeeded.
- Same sitting, same shape, right below it: `curl_easy_setopt(curl, CURLOPT_MAIL_RCPT, recipients)`'s return wasn't checked at all. Fixed alongside C3 rather than as a separate card since it's the identical pattern in the same function.
- Both realistically only fail via `CURLE_NOT_BUILT_IN` (libcurl built without SMTP support), so there's no dedicated failure-injection regression test -- not something togglable against the installed libcurl at runtime.

## Test plan

- [x] `./afwdev build --cdev`
- [x] `afwdev test --srcdir-pattern afw_curl -j` -- 41/41 passed, including the `smtp_send` regression tests added for C1 (confirms the happy path through both setopt calls is unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)