### PR TITLE
Clarify leftover utf8 name peels are not unfinished wrap work

### DIFF
--- a/src/afw/context/afw_context.c
+++ b/src/afw/context/afw_context.c
@@ -598,7 +598,7 @@ afw_context_variable_definitions_compile_and_add_based_on_qualifiers_object(
     while ((object = afw_object_old_get_next_property_as_object(
         objects, &iterator, &qualifier_id, xctx)))
     {
-        /* Qualifier ids stay utf8 on this API; as_utf8 at that door. */
+        /* These APIs take utf8 qualifier ids, not object-key values. */
         qualifier_id_utf8 = afw_object_string_property_name_as_utf8(
             qualifier_id, xctx);
         detail_source_location = afw_utf8_printf(

--- a/src/afw/environment/afw_environment_variables_object.c
+++ b/src/afw/environment/afw_environment_variables_object.c
@@ -231,7 +231,7 @@ impl_afw_object_get_property(
      * populated via load_all / iterate (raw name is not a C string key).
      */
     value = NULL;
-    /* getenv is a C-string API; as_utf8 at that door. */
+    /* getenv wants a C string. Not an object-key conversion. */
     property_name_utf8 = afw_object_string_property_name_as_utf8(
         property_name, xctx);
     property_name_z = afw_utf8_z_create(

--- a/src/afw/function/afw_function_compiler.c
+++ b/src/afw/function/afw_function_compiler.c
@@ -489,7 +489,7 @@ impl_stringify_prepare_object(
         if (!next) {
             break;
         }
-        /* Stringify replacer still takes utf8; as_utf8 at that door. */
+        /* Replacer allow-list and callback take utf8, not a name value. */
         property_name_utf8 = afw_object_string_property_name_as_utf8(
             property_name, ctx->xctx);
         if (!impl_stringify_name_allowed(ctx, property_name_utf8)) {

--- a/src/afw/model/afw_model_compile.c
+++ b/src/afw/model/afw_model_compile.c
@@ -843,7 +843,7 @@ afw_model_compile(
         object_type = afw_object_old_get_next_property_as_object(
             objectTypes, &iterator, &property_name, xctx);
         if (!object_type) break;
-        /* objectType ids stay utf8 hash keys; as_utf8 at that door. */
+        /* objectType ids are utf8 hash keys, not object property names. */
         property_name_utf8 = afw_object_string_property_name_as_utf8(
             property_name, xctx);
         model_object_type = impl_object_type_compile(model,

--- a/src/afw/model/afw_model_internal.h
+++ b/src/afw/model/afw_model_internal.h
@@ -207,16 +207,16 @@ struct afw_model_internal_object_type_s {
     /** @brief NULL terminated list of descendants. */
     const afw_model_object_type_t * *descendants;
 
-    /** @brief descriptionPropertyName. */
+    /** @brief descriptionPropertyName (utf8 config peel, not a key). */
     const afw_utf8_t *description_property_name;
 
-    /** @brief descriptionPropertyName value. */
+    /** @brief descriptionPropertyName as stored on the model object. */
     const afw_value_t *description_property_name_value;
 
-    /** @brief objectIdPropertyName. */
+    /** @brief objectIdPropertyName (utf8 config peel, not a key). */
     const afw_utf8_t *object_id_property_name;
 
-    /** @brief objectIdPropertyName value. */
+    /** @brief objectIdPropertyName as stored on the model object. */
     const afw_value_t *object_id_property_name_value;
 
     /** @brief NULL terminated list of property types for this object type. */

--- a/src/afw/object/afw_object_meta.c
+++ b/src/afw/object/afw_object_meta.c
@@ -90,7 +90,7 @@ afw_object_meta_add_needed_object_type(
         objectTypes = afw_object_create_embedded(meta,
             afw_v_objectTypes, xctx);
     }
-    /* Object type ids stay utf8; intern the name into objectTypes. */
+    /* objectType id used as a key here; the id itself stays utf8. */
     afw_object_set_property_as_object(objectTypes,
         afw_value_create_unmanaged_string(
             object_type->meta.id, objectTypes->p, xctx),

--- a/src/afw_ldap/afw_ldap_adapter_session.c
+++ b/src/afw_ldap/afw_ldap_adapter_session.c
@@ -378,7 +378,7 @@ impl_afw_adapter_session_add_object(
     while ((value = afw_object_get_next_property(object,
         &iterator, &property_name, xctx)))
     {
-        /* LDAP C APIs still take utf8 / C strings; as_utf8 at that door. */
+        /* LDAP lookup / mod_type take utf8, not a property-name value. */
         property_name_utf8 = afw_object_string_property_name_as_utf8(
             property_name, xctx);
         attribute = afw_ldap_metadata_get_object_type_attribute(

--- a/src/afw_ldap/afw_ldap_metadata.c
+++ b/src/afw_ldap/afw_ldap_metadata.c
@@ -917,7 +917,7 @@ impl_add_parents_and_property_types(
                 property_types_object, &iterator, &property_name, xctx))
             )
         {
-            /* Attribute types stay utf8 hash keys; as_utf8 at that door. */
+            /* Attribute-type hash is utf8 (s, len), not a name value. */
             property_name_utf8 = afw_object_string_property_name_as_utf8(
                 property_name, xctx);
             attribute_type = apr_hash_get(metadata->attribute_types,


### PR DESCRIPTION
## Summary

Comment-only follow-up to PR #222. The wrap FIXMEs were already removed; leftover peels still read like open work (`as_utf8 at that door`). Reworded to say **why** they stay utf8:

- getenv, stringify replacer, qualifier-id APIs, LDAP lookup/hash, objectType hash keys, objectTypes key
- Model `descriptionPropertyName` / `objectIdPropertyName` header notes (utf8 config peels, not keys)

No C behavior change. Do not close umbrella #2.

## Tests

Comment-only; no rebuild required beyond what already landed on `develop` for #222.