### PR TITLE
Name the AI partner on commits and PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ Prefer **git** for durable shared truth (designs, rules, handbook, tests, living
 4. When chat is stuck, **close the loop live** (`afw`, `afwfcgi`, runtime objects on `adapterId=afw`, the code the partner named).  
 5. If you decide to work it: ask for a **feature branch** off the right base (often `develop`), then implement in **small verticals** you both agree (build/test as you go). A useful cadence for wrap-ups and exploratory edges: **flexible plan, one step, then re-decide** — share a living candidate order; finish one step; then **“what do you think we should do next?”** and adapt (see [`designs/mantras-and-working-style.md`](designs/mantras-and-working-style.md)).  
 6. **Commit / push when you ask** for a checkpoint — not as a silent default after every edit (unless you agree otherwise for a stretch).  
-7. When ready: **“Open a PR”** against the target branch; you still own review.  
+7. When ready: **“Open a PR”** against the target branch; you still own review. **Name the partner** on the commit and PR (`Co-Authored-By` trailer, a Generated-with line) — same visibility a human co-author would get. Silent human-only authorship of partner work is the wrong default.  
 8. After a real click, leave a **thin map** in git if it will help the next person (atlas row, playbook note, or short pad) — issue ids as pointers only.
 
 Support without an issue: steps 1–4 are enough (symptom → discuss → live probe → optional map).

--- a/designs/ai-partner-lessons.md
+++ b/designs/ai-partner-lessons.md
@@ -84,6 +84,7 @@ Use any subset; none of this is mandatory for the team.
 - **Discuss → plan → execute when agreed** on multi-step hard work (especially memory / long-running lifetime).  
 - **Flexible plan, one step, then re-decide** — living candidate order, not a locked script; after a step, ask **“what do you think we should do next?”** and adapt (see mantras pad *Partnership habits*). Good for issue wrap-ups and residual passes.  
 - **Hold commits and PRs until asked** in a pairing session, unless you agree otherwise for a stretch.  
+- **Name the partner on the commit and PR.** `Co-Authored-By` trailer plus a Generated-with line on the PR body. Same visibility a human co-author would get. Silent human-only authorship of partner work is the wrong default.  
 - Keep **language tests** (`afwdev test -j`) as the correctness gate; keep **load / soak** as a separate lab (`tests-extra/` / `-T`, firehose) — do not redefine the gate as soak.  
 - **Never hand-edit `generated/`** — metadata is the single source of truth.  
 - Prefer **plain language** in chat and maintainer notes when a short phrase is enough.  
@@ -165,7 +166,10 @@ to “implement everything on `develop`.”
    for a stretch (see *Practical defaults* above).  
 7. **When the vertical is ready for review:**  
    **“Open a PR against `develop`”** (or your target branch). Review the
-   diff yourself; treat the partner’s draft description as a starting point.  
+   diff yourself; treat the partner’s draft description as a starting point.
+   Name the partner as a co-author on the commit and PR (`Co-Authored-By`,
+   a Generated-with line). Do not ship the work as silent human-only
+   authorship.  
 8. **After a real click** (shipped behavior or a durable mental model), add or
    update a **short map** in `designs/` (atlas row, playbook note, or thin pad)
    if the next person would care — issue ids as pointers only. User-facing


### PR DESCRIPTION
@JeremyGrieshop

## Summary

Partner work was shipping as silent human-only authorship. Name the partner on the commit and PR (`Co-Authored-By` trailer, a Generated-with line) — same visibility a human co-author would get.

Touched `AGENTS.md` (pairing pattern step 7) and `designs/ai-partner-lessons.md` (practical default + session shape). Docs only.

## Tests

Docs only; no rebuild.

Generated with Grok