### PR TITLE
fix(curl): check apr_brigade_length/flatten returns in parse_response

### DIFF
--- a/src/afw_curl/afw_curl_internal.c
+++ b/src/afw_curl/afw_curl_internal.c
@@ -537,18 +537,27 @@ afw_curl_internal_parse_response(
     afw_memory_t * response_body = NULL;
 
     if (response && response->response) {
+        apr_status_t rv;
         apr_off_t len;
         apr_size_t size;
 
         response_body = afw_xctx_calloc_type(afw_memory_t, xctx);
 
         /* the response field is an APR Bucket Brigade that needs to be flattened */
-        apr_brigade_length(response->response, 1, &len);
+        rv = apr_brigade_length(response->response, 1, &len);
+        if (rv != APR_SUCCESS || len < 0) {
+            AFW_THROW_ERROR_RV_Z(general, apr, rv,
+                "apr_brigade_length() failed.", xctx);
+        }
         size = (apr_size_t) len;
         response_body->ptr = apr_palloc(afw_pool_get_apr_pool(pool), size);
-        response_body->size = size;
 
-        apr_brigade_flatten(response->response, (char *)response_body->ptr, &size);
+        rv = apr_brigade_flatten(response->response, (char *)response_body->ptr, &size);
+        if (rv != APR_SUCCESS) {
+            AFW_THROW_ERROR_RV_Z(general, apr, rv,
+                "apr_brigade_flatten() failed.", xctx);
+        }
+        response_body->size = size;
     }
 
     return response_body;


### PR DESCRIPTION
## Summary

- C2 (private C audit board): `apr_brigade_length()` in `afw_curl_internal_parse_response` had its return value discarded. On failure the length can come back `-1`, and `size = (apr_size_t) len` wraps that to near-`SIZE_MAX`, driving `apr_palloc()` to request a huge allocation and `apr_brigade_flatten()` to write into it.
- Same sitting, same function, folded into this card: `apr_brigade_flatten()`'s return was also discarded, and `response_body->size` was set from the pre-flatten *requested* size rather than what flatten actually wrote -- on a partial flatten, `response_body->size` would overstate how many bytes are valid (an OOB-read risk for callers reading that many bytes from `response_body->ptr`). Now `response_body->size` is set from flatten's actual output, after checking its return.
- Both now throw via the `apr` error-decoder pattern already used elsewhere in the tree (`AFW_THROW_ERROR_RV_Z(general, apr, rv, ...)`). Safe to throw here -- this function is called from every `http_*` function, each already wrapped in its own `AFW_TRY`.

## Test plan

- [x] `./afwdev build --cdev`
- [x] `afwdev test --srcdir-pattern afw_curl -j` (offline) -- 41/41 passed
- [x] `TEST_CURL_HTTPBIN=1 afwdev test --srcdir-pattern afw_curl -j` (live network, confirmed available in this environment) -- 39/41 passed, exercising the fixed `parse_response` directly against real httpbin.org responses via get/post/put/patch/delete and their `*_callbacks` variants. The 2 remaining failures are a pre-existing `wwww.httpbin.org` typo in `http_head.as`/`http_options.as`, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)