### PR TITLE
fix(ubjson): off-by-one read, signed-length overflow, unbounded recursion

### DIFF
--- a/src/afw_ubjson/afw_ubjson_to_value.c
+++ b/src/afw_ubjson/afw_ubjson_to_value.c
@@ -18,6 +18,9 @@
             to UBJSON, back to JSON, we lose special characters. */
 
 
+/* Matches cJSON's CJSON_NESTING_LIMIT default. */
+#define AFW_UBJSON_MAX_DEPTH 1000
+
 typedef struct afw_ubjson_parser_s {
     const afw_memory_t *input;
     const unsigned char *ptr;
@@ -27,6 +30,7 @@ typedef struct afw_ubjson_parser_s {
     const afw_value_t *property_name;
     const afw_pool_t *p;
     afw_boolean_t cede_p;
+    unsigned int depth;
 } afw_ubjson_parser_t;
 
 
@@ -62,7 +66,7 @@ size_t afw_ubjson_parse_length(
 static unsigned char afw_ubjson_peek_byte(
     afw_ubjson_parser_t *parser, afw_xctx_t *xctx)
 {
-    if (parser->cursor > parser->input->size) {
+    if (parser->cursor >= parser->input->size) {
         AFW_THROW_ERROR_Z(general, "Error: expected end of document.", xctx);
     }
 
@@ -74,7 +78,7 @@ static unsigned char afw_ubjson_next_byte(
 {
     unsigned char c;
 
-    if (parser->cursor > parser->input->size) {
+    if (parser->cursor >= parser->input->size) {
         AFW_THROW_ERROR_Z(general, "Error: expected end of document.", xctx);
     }
 
@@ -87,10 +91,10 @@ static unsigned char afw_ubjson_next_byte(
 }
 
 static void afw_ubjson_next_bytes(
-    afw_ubjson_parser_t *parser, unsigned char *buf, 
+    afw_ubjson_parser_t *parser, unsigned char *buf,
     size_t len, afw_xctx_t *xctx)
 {
-    if (parser->cursor + len > parser->input->size) {
+    if (len > parser->input->size - parser->cursor) {
         AFW_THROW_ERROR_Z(general, "Error: expected end of document.", xctx);
     }
 
@@ -104,7 +108,7 @@ size_t afw_ubjson_parse_length(
 {
     unsigned char c;
     afw_c_types_t c_type;
-    size_t d;
+    afw_int64_t d;
 
     c = afw_ubjson_next_byte(parser, xctx);
 
@@ -132,12 +136,23 @@ size_t afw_ubjson_parse_length(
             break;
 
         default:
-            AFW_THROW_ERROR_RV_Z(general, ubjson_marker, c, 
+            AFW_THROW_ERROR_RV_Z(general, ubjson_marker, c,
                 "Error: invalid numeric type for string length", xctx);
             break;
     }
 
-    return d;
+    /*
+     * A negative length marker (e.g. INT8 = -1) would otherwise
+     * sign-extend when returned as size_t, producing a value near
+     * SIZE_MAX that can overflow the cursor+len bounds checks at call
+     * sites and drive a massive out-of-bounds read.
+     */
+    if (d < 0) {
+        AFW_THROW_ERROR_Z(general,
+            "Error: negative length not allowed.", xctx);
+    }
+
+    return (size_t)d;
 }
 
 const afw_value_t * afw_ubjson_parse_number(
@@ -220,8 +235,8 @@ const afw_utf8_t * afw_ubjson_parse_string(
 
     len = afw_ubjson_parse_length(parser, xctx);
 
-    if (parser->cursor + len > parser->input->size) {
-        AFW_THROW_ERROR_Z(general, 
+    if (len > parser->input->size - parser->cursor) {
+        AFW_THROW_ERROR_Z(general,
             "Error: string length exceeds input.", xctx);
     }
 
@@ -249,6 +264,11 @@ const afw_array_t * afw_ubjson_parse_array(
     const afw_value_t *value;
     char c;
     char type = 0;
+
+    if (++parser->depth > AFW_UBJSON_MAX_DEPTH) {
+        AFW_THROW_ERROR_Z(general,
+            "Error: maximum nesting depth exceeded.", xctx);
+    }
 
     list = afw_array_create_generic(parser->p, xctx);
 
@@ -279,6 +299,8 @@ const afw_array_t * afw_ubjson_parse_array(
 
     afw_ubjson_next_byte(parser, xctx);
 
+    parser->depth--;
+
     /* Return. */
     return list;
 }
@@ -303,6 +325,11 @@ const afw_object_t * afw_ubjson_parse_object(
     const afw_object_t *saved_embedding_object;
     const afw_value_t *saved_property_name;
     const afw_object_t *_meta_;
+
+    if (++parser->depth > AFW_UBJSON_MAX_DEPTH) {
+        AFW_THROW_ERROR_Z(general,
+            "Error: maximum nesting depth exceeded.", xctx);
+    }
 
     /* Create new memory object.*/
     AFW_OBJECT_CREATE_ENTITY_OR_EMBEDDED(obj,
@@ -376,6 +403,8 @@ const afw_object_t * afw_ubjson_parse_object(
     /* Set parser->embedding_object to previous value and return object. */
     parser->embedding_object = saved_embedding_object;
     parser->property_name = saved_property_name;
+
+    parser->depth--;
 
     return obj;
 }
@@ -489,6 +518,7 @@ const afw_value_t * afw_ubjson_to_value(
     parser.p = p;
     parser.path = path;
     parser.cede_p = false;
+    parser.depth = 0;
 
     value = afw_ubjson_parse_value(&parser, 0, xctx);
 
@@ -519,6 +549,7 @@ afw_ubjson_to_object(
     parser.property_name = NULL;
     parser.p = (cede_p) ? p : afw_pool_create(p, xctx);
     parser.cede_p = true;
+    parser.depth = 0;
     parser.path = afw_object_path_make(
         adapter_id, object_type_id, object_id, parser.p, xctx);
 

--- a/src/afw_ubjson/tests/environments/ubjson-parser/afw.conf
+++ b/src/afw_ubjson/tests/environments/ubjson-parser/afw.conf
@@ -1,0 +1,10 @@
+[
+    {
+        "adapterId": "ubjson",
+        "type": "adapter",
+        "adapterType": "file",
+        "root": "objects/",
+        "filenameSuffix": ".ubjson",
+        "contentType": "ubjson"
+    }
+]

--- a/src/afw_ubjson/tests/parser/config.py
+++ b/src/afw_ubjson/tests/parser/config.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+import glob
+import os
+import struct
+
+# test configuration settings
+Environment = "ubjson-parser"
+
+# UBJSON marker bytes (see src/afw_ubjson/afw_ubjson.h).
+MARKER_INT8 = b"i"
+MARKER_STRING = b"S"
+MARKER_ARRAY_OPEN = b"["
+MARKER_ARRAY_CLOSE = b"]"
+MARKER_OBJECT_OPEN = b"{"
+MARKER_OBJECT_CLOSE = b"}"
+
+# Depth chosen to match cJSON's CJSON_NESTING_LIMIT default (see
+# AFW_UBJSON_MAX_DEPTH in afw_ubjson_to_value.c).
+MAX_DEPTH = 1000
+
+
+def ubjson_key(name):
+    """Encode a UBJSON object key: <int8 length><raw bytes>, no marker."""
+    raw = name.encode("utf-8")
+    return MARKER_INT8 + struct.pack(">b", len(raw)) + raw
+
+
+def ubjson_string(value):
+    """Encode a UBJSON string value: S<int8 length><raw bytes>."""
+    raw = value.encode("utf-8")
+    return MARKER_STRING + MARKER_INT8 + struct.pack(">b", len(raw)) + raw
+
+
+def write_fixture(name, body):
+    path = os.path.join("objects", "Test", name + ".ubjson")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(body)
+
+
+def build_fixtures():
+    # valid: a well-formed { "a": "hi" } object -- baseline sanity, would
+    # pass before and after the fix.
+    valid = (
+        MARKER_OBJECT_OPEN
+        + ubjson_key("a")
+        + ubjson_string("hi")
+        + MARKER_OBJECT_CLOSE
+    )
+    write_fixture("valid", valid)
+
+    # u1_truncated: the same object with the closing '}' cut off. Once the
+    # parser's cursor reaches the (now shorter) end of input, the pre-fix
+    # `cursor > size` check let cursor == size through and read one byte
+    # past the buffer instead of throwing.
+    write_fixture("u1_truncated", valid[:-1])
+
+    # u2_negative_length: object with one key "a" whose string value's
+    # length marker is INT8 = -1. Pre-fix, this sign-extends to a huge
+    # size_t, the cursor+len bounds check overflows back into range, and
+    # afw_utf8_create() is called with len close to SIZE_MAX -- effectively
+    # "read to the end of the address space".
+    u2 = (
+        MARKER_OBJECT_OPEN
+        + ubjson_key("a")
+        + MARKER_STRING
+        + MARKER_INT8
+        + struct.pack(">b", -1)
+    )
+    write_fixture("u2_negative_length", u2)
+
+    # u3_deep_nesting: { "a": [[[[...]]]] } with well beyond MAX_DEPTH
+    # levels of array nesting. Pre-fix, parse_value/parse_array recurse
+    # with no depth limit at all and exhaust the C stack.
+    levels = MAX_DEPTH * 5
+    u3 = (
+        MARKER_OBJECT_OPEN
+        + ubjson_key("a")
+        + MARKER_ARRAY_OPEN * levels
+        + MARKER_ARRAY_CLOSE * levels
+        + MARKER_OBJECT_CLOSE
+    )
+    write_fixture("u3_deep_nesting", u3)
+
+
+def cleanup():
+    for f in glob.glob(os.path.join("objects", "Test", "*.ubjson")):
+        os.remove(f)
+
+
+def before_all():
+    cleanup()
+    build_fixtures()
+
+
+def after_all():
+    cleanup()

--- a/src/afw_ubjson/tests/parser/ubjson_parser.as
+++ b/src/afw_ubjson/tests/parser/ubjson_parser.as
@@ -1,0 +1,35 @@
+#!/usr/bin/env -S afw --syntax test_script
+//?
+//? testScript: ubjson_parser.as
+//? customPurpose: Part of afw_ubjson tests
+//? description: Regression for U1/U2 -- UBJSON parser off-by-one read and signed-length overflow bypassing bounds checks. Fixtures are crafted raw UBJSON bytes (see config.py), read through a file adapter with contentType ubjson -- the same afw_content_type_raw_to_object path a POST with Content-Type: application/ubjson reaches via afw_request_body_to_value. U3 (unbounded recursion) is in its own file, ubjson_parser_depth.as -- pre-fix it parses to completion instead of throwing, and the resulting deeply-nested value breaks the test runner's own JSON response decoding, which would otherwise hide these cases' results.
+//? sourceType: script
+//?
+//? test: ubjson_valid_object_parses
+//? description: Baseline sanity -- a well-formed object parses correctly.
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+const obj = get_object("ubjson", "Test", "valid");
+assert(obj.a === "hi", "expected well-formed UBJSON object to parse correctly");
+
+return 0;
+
+
+//? test: ubjson_u1_truncated_throws
+//? description: U1 -- truncated input (missing closing brace) must throw the specific end-of-document error, not silently read past the buffer.
+//? expect: error:Error: expected end of document.
+//? source: ...
+#!/usr/bin/env afw
+
+get_object("ubjson", "Test", "u1_truncated");
+
+
+//? test: ubjson_u2_negative_length_throws
+//? description: U2 -- a negative length marker must throw the specific rejection error, not sign-extend into a massive out-of-bounds read.
+//? expect: error:Error: negative length not allowed.
+//? source: ...
+#!/usr/bin/env afw
+
+get_object("ubjson", "Test", "u2_negative_length");

--- a/src/afw_ubjson/tests/parser/ubjson_parser_depth.as
+++ b/src/afw_ubjson/tests/parser/ubjson_parser_depth.as
@@ -1,0 +1,14 @@
+#!/usr/bin/env -S afw --syntax test_script
+//?
+//? testScript: ubjson_parser_depth.as
+//? customPurpose: Part of afw_ubjson tests
+//? description: Regression for U3 -- UBJSON parser unbounded recursion. Kept separate from ubjson_parser.as because pre-fix this case doesn't throw at all -- it parses a deeply-nested value to completion, and returning that from the test blows past the test runner's own JSON decoder recursion limit, which would otherwise mask the other cases' results in the same run.
+//? sourceType: script
+//?
+//? test: ubjson_u3_deep_nesting_throws
+//? description: U3 -- deeply nested arrays must throw the specific max-depth error instead of exhausting the C stack (or, pre-fix, parsing to completion with no limit at all).
+//? expect: error:Error: maximum nesting depth exceeded.
+//? source: ...
+#!/usr/bin/env afw
+
+get_object("ubjson", "Test", "u3_deep_nesting");


### PR DESCRIPTION
## Summary

U1/U2/U3 (private C audit board) are all in the same recursive-descent UBJSON parser and reachable from a plain remote request -- the `ubjson` content type registers as `application/ubjson`, and `afw_request_body_to_value` (called directly from `afw_request_handler_adapter.c`) dispatches request bodies to it by `Content-Type`. Both cards previously noted the live entry point was unclear; it isn't obscure, it's the ordinary HTTP body path.

- **U1** (off-by-one): `afw_ubjson_peek_byte`/`next_byte` checked `cursor > size`, letting `cursor == size` through and reading one byte past the input buffer. Now `cursor >= size`.
- **U2** (signed→unsigned overflow): `afw_ubjson_parse_length` read INT8/INT16/INT32 length markers into signed fields and returned them as `size_t`. A negative marker (e.g. `INT8 = -1`) sign-extends to near `SIZE_MAX`; the `cursor+len` bounds checks at both call sites then overflow back into range, and `afw_utf8_create` runs with a length near `SIZE_MAX`. Confirmed with gdb that this corrupts the parser's own cursor/ptr (which then overflow-wrap on `+= len`, landing back in range and failing on a later read instead of crashing outright -- still a genuine out-of-bounds read, fully attacker-controlled). Fixed at the single source (`parse_length` rejects negative values) rather than each call site, covering both current call sites and the two "optimized count" sites that currently discard the value but would inherit the bug if ever wired up. Also switched both bounds checks to the overflow-safe `len > size - cursor` form.
- **U3** (unbounded recursion): `parse_value`/`parse_array`/`parse_object` mutually recurse with no depth limit. Added a depth counter, capped at 1000 -- matching cJSON's `CJSON_NESTING_LIMIT` default, the same protection AFW's own core JSON path gets for free via cJSON; this hand-written parser had nothing equivalent.

Added `src/afw_ubjson/tests/parser/` -- no `afw_ubjson` tests existed at all before this. Fixtures are crafted raw UBJSON bytes read through a `file` adapter configured with `contentType: ubjson` (generated at runtime in `config.py` rather than committing crafted binary blobs).

## Test plan

- [x] `./afwdev build --cdev`
- [x] `afwdev test --srcdir-pattern afw_ubjson -j` -- 4/4 passed
- [x] Verified each case discriminates old vs. fixed code: temporarily reverted the fix, rebuilt, and confirmed pre-fix U1/U2 throw different, incidental errors (U3 parses to completion with no limit at all -- its return value is deep enough to blow past the test runner's own JSON-decoder recursion limit, which is why it's a separate test file from U1/U2, otherwise that failure masks their individual results in the same run); post-fix all four cases (including a well-formed baseline) pass with the exact intended error messages
- [x] Full repo suite: `afwdev test -j` -- 4148 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)