### PR TITLE
fix(lmdb): clear currTxn on commit/release; make explicit begin_transaction reentrant-safe

### DIFF
--- a/src/afw_lmdb/afw_lmdb_index.c
+++ b/src/afw_lmdb/afw_lmdb_index.c
@@ -174,8 +174,8 @@ impl_afw_adapter_impl_index_open(
     const afw_pool_t * pool,
     afw_xctx_t *xctx)
 {
-    const afw_lmdb_adapter_t *adapter = self->adapter;   
-    const afw_lmdb_adapter_session_t * session = NULL;     
+    const afw_lmdb_adapter_t *adapter = self->adapter;
+    const afw_lmdb_adapter_session_t * session = self->session;
     const afw_utf8_t *database;
     unsigned int flags;
 

--- a/src/afw_lmdb/afw_lmdb_internal.c
+++ b/src/afw_lmdb/afw_lmdb_internal.c
@@ -1270,14 +1270,30 @@ afw_lmdb_transaction_t * afw_lmdb_transaction_create(
 
     self->session = (afw_adapter_session_t *)session;
 
-    /* 
+    /*
+     * If a transaction is already active for this session (e.g. the
+     * implicit per-request transaction begun by add_object/modify_object/
+     * delete_object/replace_object, or an outer explicit transaction),
+     * reuse it. LMDB only allows a single write transaction per thread;
+     * calling mdb_txn_begin() again here would self-deadlock on LMDB's
+     * writer mutex. This handle does not own the transaction, so
+     * commit()/release() on it become no-ops -- only the owner's
+     * commit/release actually ends the transaction.
+     */
+    if (session->transaction) {
+        self->txn = session->transaction->txn;
+        self->owner = false;
+        return self;
+    }
+
+    /*
         Anytime we need to begin a transaction, we must first obtain
         a database lock to prevent another transactions from opening
-        databases. 
+        databases.
      */
     apr_thread_rwlock_rdlock(session->adapter->dbLock);
 
-    afw_trace_z(1, session->adapter->pub.trace_flag_index, 
+    afw_trace_z(1, session->adapter->pub.trace_flag_index,
         NULL, "LMDB Begin read transaction.", xctx);
 
     rc = mdb_txn_begin(session->adapter->dbEnv, NULL, 0, &self->txn);
@@ -1292,6 +1308,7 @@ afw_lmdb_transaction_t * afw_lmdb_transaction_create(
             "Unable to begin transaction.", xctx);
     }
 
+    self->owner = true;
     session->transaction = self;
     session->currTxn = self->txn;
 
@@ -1310,6 +1327,15 @@ impl_afw_adapter_transaction_release (
     afw_lmdb_adapter_session_t * session =
         (afw_lmdb_adapter_session_t *)self->session;
 
+    /*
+     * A non-owning handle (reentrant reuse of an already-active session
+     * transaction) does not release -- the owner is still using it.
+     */
+    if (!self->owner) {
+        self->txn = NULL;
+        return;
+    }
+
     /* if our session still has an active transaction going, abort it */
     if (session->transaction) {
         mdb_txn_abort(self->txn);
@@ -1321,6 +1347,7 @@ impl_afw_adapter_transaction_release (
 
     self->txn = NULL;
     session->transaction = NULL;
+    session->currTxn = NULL;
 }
 
 /*
@@ -1335,6 +1362,15 @@ impl_afw_adapter_transaction_commit (
     afw_lmdb_adapter_session_t * session =
         (afw_lmdb_adapter_session_t *)self->session;
     int rc;
+
+    /*
+     * A non-owning handle (reentrant reuse of an already-active session
+     * transaction) does not commit -- the owner will, when it releases.
+     */
+    if (!self->owner) {
+        self->txn = NULL;
+        return;
+    }
 
     rc = mdb_txn_commit(self->txn);
     if (rc) {
@@ -1352,6 +1388,7 @@ impl_afw_adapter_transaction_commit (
     /* clear our session transaction to prevent further commits */
     self->txn = NULL;
     session->transaction = NULL;
+    session->currTxn = NULL;
 }
 
 /*

--- a/src/afw_lmdb/afw_lmdb_internal.h
+++ b/src/afw_lmdb/afw_lmdb_internal.h
@@ -70,6 +70,12 @@ typedef struct afw_lmdb_transaction_s {
     afw_adapter_transaction_t pub;
     afw_adapter_session_t *session;
     MDB_txn *txn;
+    /*
+     * false when this handle was created while a transaction was already
+     * active on the session (reentrant reuse) -- it does not own the
+     * underlying MDB_txn and must not begin/commit/abort/release it.
+     */
+    afw_boolean_t owner;
 } afw_lmdb_transaction_t;
 
 /* defines the data used to remember our open transaction handle */
@@ -433,7 +439,7 @@ do { \
                 AFW_THROW_ERROR_RV_Z(general, lmdb_internal, this_rc, \
                     "Unable to commit transaction.", this_xctx); \
             } \
-            afw_trace_z(1, this_session->adapter->pub.trace_flag_index, \
+            afw_trace_z(1, this_adapter->pub.trace_flag_index, \
                 NULL, "LMDB Transaction committed.", this_xctx); \
         } \
     }
@@ -452,7 +458,7 @@ do { \
                 AFW_THROW_ERROR_RV_Z(general, lmdb_internal, this_rc, \
                     "Unable to abort transaction.", this_xctx); \
             } \
-            afw_trace_z(1, this_session->adapter->pub.trace_flag_index, \
+            afw_trace_z(1, this_adapter->pub.trace_flag_index, \
                 NULL, "LMDB Transaction aborted.", this_xctx); \
         } \
     }
@@ -467,7 +473,7 @@ do { \
             if (this_txn && !this_txnHandled) { \
                 mdb_txn_abort(this_txn); \
                 this_txnHandled = true; \
-                afw_trace_z(1, this_session->adapter->pub.trace_flag_index, \
+                afw_trace_z(1, this_adapter->pub.trace_flag_index, \
                     NULL, "LMDB Transaction aborted.", this_xctx); \
             } \
             if (this_session) \

--- a/src/afw_lmdb/tests/adapter/index_current.as
+++ b/src/afw_lmdb/tests/adapter/index_current.as
@@ -8,7 +8,7 @@
 //? test: index_current_object
 //? description: index_create value/filter scripts use current::object (issue #54)
 //? skip: true
-//? skipReason: FIXME: LMDB index_create txn/save_config and retroactive hang; unskip when create path is fixed (#57)
+//? skipReason: FIXME: retroactive index_create's retrieve_objects(object_type_id=NULL) crashes in the generic adapter wrapper (afw_adapter_impl.c impl_afw_adapter_session_retrieve_objects, building ctx.resource_id via AFW_UTF8_FMT_ARG on a NULL object_type_id when impl_request is also NULL) -- core adapter bug, not LMDB-specific; unskip when that's fixed
 //? expect: 0
 //? source: ...
 #!/usr/bin/env afw


### PR DESCRIPTION
## Summary

- L1 (private C audit board): `session->currTxn` was set by `afw_lmdb_transaction_create` but never cleared by `impl_afw_adapter_transaction_commit`/`_release` (only `session->transaction` was). `AFW_LMDB_BEGIN_TRANSACTION`'s reentrant-reuse branch trusts any non-NULL `currTxn` and skips both `mdb_txn_begin()` and the `dbLock` acquisition, so once a transaction's explicit `commit()`/`release()` ran, the next LMDB operation on that session reused the already-freed `MDB_txn` with no lock held -- a use-after-free.
- Chasing a live regression for that fix (`index_create` is the only current caller that does explicit begin/commit/release outside the per-request auto-commit path) turned up two more bugs in the same neighborhood, fixed alongside:
  - `impl_afw_adapter_impl_index_open` hardcoded `session = NULL` instead of `self->session`, defeating `AFW_LMDB_BEGIN_TRANSACTION`'s own reentrant check and causing a guaranteed self-deadlock on the write rwlock whenever an implicit transaction (e.g. from an earlier `add_object` in the same request) was already open.
  - `AFW_LMDB_COMMIT_TRANSACTION`/`ABORT_TRANSACTION`/`END_TRANSACTION` traced via `this_session->adapter` unconditionally, even though the code right above already treats `this_session` as possibly NULL -- a guaranteed NULL deref on any call with a NULL session. Traces now go through `this_adapter`, which every call site already guarantees.
  - `afw_lmdb_transaction_create` (the explicit `begin_transaction()` used by `index_create`) had no reentrancy awareness at all: it called `mdb_txn_begin()` unconditionally, self-deadlocking on LMDB's writer mutex whenever an implicit transaction was already open. It now reuses an already-active session transaction as a non-owning handle; `commit()`/`release()` on a non-owning handle are no-ops, mirroring the ownership pattern `AFW_LMDB_BEGIN_TRANSACTION` already uses via `this_txnOwner`.
- `index_current.as` stays skipped: past these fixes it now reaches a fourth, unrelated bug in the generic adapter wrapper (`afw_adapter_impl.c` `impl_afw_adapter_session_retrieve_objects` builds `ctx.resource_id` via `AFW_UTF8_FMT_ARG` on a NULL `object_type_id` when `impl_request` is also NULL). Not LMDB-specific and out of scope here; `skipReason` updated to point at it directly.

## Note on branch age

This branch was built ~a day before opening this PR, off an older `develop`. 27 commits have landed since (including a large property-name-as-value refactor), but none touch the files this PR changes (`afw_lmdb_internal.c`/`.h`, `afw_lmdb_index.c`, `tests/adapter/index_current.as`).

## Test plan

- [x] `./afwdev build --cdev`
- [x] `afwdev test --srcdir-pattern afw_lmdb -j` -- full suite green, including the existing `nested_retrieve_during_dump.as` regression for the MDB_BAD_RSLOT fix that originally introduced the reentrant-reuse macro
- [x] Full repo suite green apart from 2 pre-existing, unrelated `afw_crypto` failures (also present on unmodified `develop` at the time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)