### PR TITLE
fix(lmdb): honor limit in journal consumer scan loops

### DIFF
--- a/src/afw_lmdb/afw_lmdb_journal.c
+++ b/src/afw_lmdb/afw_lmdb_journal.c
@@ -354,7 +354,7 @@ afw_lmdb_journal_get_next_for_consumer_after_cursor(
         peer, afw_v_consumeFilter, xctx);
 
     /* Scan our journal until we find an applicable entry, or hit our limit */
-    for (i = 0; (i < limit) || !found;  i++) {
+    for (i = 0; (limit == 0 || i < limit) && !found;  i++) {
         entry = afw_lmdb_adapter_journal_get_entry_object(self,
             session, adapter, dbiJournal, txn, cursor, xctx);
 
@@ -480,7 +480,7 @@ impl_afw_adapter_journal_get_next_for_consumer(
         cursor = 1;
 
     /* Scan our journal until we find an applicable entry, or hit our limit */
-    for (i = 0; (i < limit) || !found;  i++) {
+    for (i = 0; (limit == 0 || i < limit) && !found;  i++) {
         entry = afw_lmdb_adapter_journal_get_entry_object(self,
             session, adapter, dbiJournal, txn, cursor, xctx);
 
@@ -612,7 +612,7 @@ afw_lmdb_journal_advance_cursor_for_consumer(
         cursor = 1;
 
     /* Scan our journal until we find an applicable entry, or hit our limit */
-    for (i = 0; (i < limit) || !found;  i++) {
+    for (i = 0; (limit == 0 || i < limit) && !found;  i++) {
         entry = afw_lmdb_adapter_journal_get_entry_object(self,
             session, adapter, dbiJournal, txn, cursor, xctx);
 


### PR DESCRIPTION
## Summary

- LJ1 (private C audit board): `for (i = 0; (i < limit) || !found; i++)` reduces to `!found` once `i >= limit`, so the scan kept going regardless of `limit`, stopping only when a match was found or the journal was exhausted. Same copy-pasted loop in all three consumer-scan functions (`get_next_for_consumer_after_cursor`, `get_next_for_consumer`, `advance_cursor_for_consumer`). All three run inside a genuine LMDB write transaction even though they're semantically reads, and LMDB allows only one writer per environment at a time -- an unbounded scan (a consumer with a narrow or never-matching filter against a large journal) can stall every other write in the adapter for as long as it runs.
- Not a plain `&&` swap: `limit` defaults to `0` when a caller omits it (`afw_function_journal.c:118,365,446`), and the interface XML documents the parameter as "Limit or 0" -- under the current `||` logic, `limit == 0` already behaves as "unlimited", almost certainly the intended default rather than an accident. A literal `i < limit && !found` swap would make every omitted-limit call scan zero entries. Fixed as `(limit == 0 || i < limit) && !found` instead: preserves `0` as unlimited, and actually bounds the scan the moment a caller passes a positive limit.

No regression test in this PR. Tracing a live repro through the normal adaptive-function API surfaced a separate, pre-existing bug: `afw_lmdb_adapter_journal_get_peer_object`/`update_peer` key the "Primary" database by a bare 16-byte UUID, but generic `add_object` (the only way to create a `_AdaptiveProvisioningPeer_` object -- no special-casing for that type exists anywhere in `afw_lmdb`) keys it `{object_type_id}{uuid}`. A peer created the normal way is invisible to the consumer-scan functions, which blocks constructing a live test through the standard API. Left alone, separate scope from this fix -- likely why the audit rated LJ1 "Plausible" rather than "Confirmed".

## Test plan

- [x] `./afwdev build --cdev`
- [x] `afwdev test --srcdir-pattern afw_lmdb -j` -- full suite green (existing journal tests exercise `get_first`/`get_by_cursor`/`get_next_after_cursor`, unaffected since they don't use the consumer-filter scan loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)