### PR TITLE
docs: #2 lifetime table matches wrapper holds

### DIFF
--- a/.cursor/rules/afw-value-memory.mdc
+++ b/.cursor/rules/afw-value-memory.mdc
@@ -8,7 +8,7 @@ alwaysApply: false
 
 Use when changing value lifetime, reference count, create/allocate APIs, data type bindings, const objects/strings, pools/scopes, or debugging leaks for **long-running scripts**.
 
-**Campaign map:** [`designs/issue-2-lifetime.md`](../../designs/issue-2-lifetime.md) (slot protocol landed; pool split on `issue-2-pool-heap`). When they disagree, the pad is where #2 is going.
+**Campaign map:** [`designs/issue-2-lifetime.md`](../../designs/issue-2-lifetime.md) (slots, pool split, #35 store-time bind, wrapper overlay holds + create-at-0). When they disagree, the pad is where #2 is going.
 
 ## Pool and scope model
 
@@ -16,7 +16,7 @@ Use when changing value lifetime, reference count, create/allocate APIs, data ty
 - **Heap / heap tracker:** single-thread only. One compiled_value evaluate creates a heap, scopes use trackers, wrap **releases** the heap (a closure hold may keep it). **No reparent** on destroy; parent cascade destroys children.
 - `managed_p`: job pools and heap set self; others inherit. Managed object/array: `afw_pool_create(p->managed_p)`.
 - `compiled_value` owns a dedicated compile pool; evaluation scratch is the heap.
-- Scope create/activate/deactivate: reference count on scopes; `closure_binding` holds the scope; last-release walks `symbol_values`. Store-time bind for literals and nested assign is **#35**.
+- Scope create/activate/deactivate: reference count on scopes; `closure_binding` holds the scope; last-release walks `symbol_values`. Store-time bind for literals and nested assign is **#35**. Closure create-at-0; face overlay `set` is the hold for `o.fn = function…`.
 - Short scripts: pool + scope bulk free is enough. **Long-running** needs correct managed escape paths (below).
 
 ## Lifetimes (inf chooses policy)

--- a/designs/issue-2-lifetime.md
+++ b/designs/issue-2-lifetime.md
@@ -230,19 +230,17 @@ This pass is specified with **`xctx->p` as the usual ancestor**. Adapter caches,
 
 ## What the tree does today (so we do not lie)
 
-| Area | Today | This story |
-|------|--------|------------|
-| Memory objects | Managed/unmanaged/`cede_p`; dual-face inf matches; create subpool | Keep; create at 0; assign holds |
-| Memory arrays | Options ignored; unmanaged face; `release` no-op | Match objects; `create_array` on-ramp (in progress on this branch) |
-| Value create object/array | Extra heap header (`create_unmanaged_*`) | Borrow dual face; `add_reference` on instance |
-| `wrap_literal_*` | Unmanaged memory face in `x->p` | Same shape; 0→1 holds base; compiled base permanent-like |
-| Adapter get/retrieve | `impl_script_face_object` → unmanaged memory face | Script-aware wrapper when we have it |
-| Assign | `impl_assign` stores pointer; `symbol_set_value` stores pointer | `release` old, `add_reference` new |
-| Scope last `release` | Pool + parent lexical; **no** slot walk | Walk slots then pool |
-| `script_result` | xctx pointer, save/restore | Hidden **frame** slot; assign to caller at block end **before** callee walk |
-| `for` clone | `memcpy` slot pointers; FIXME | Per-slot `add_reference` |
-| Scalar managed/unmanaged infs | Generated pair + slice | Product: permanent / temp / `xctx->p` box |
-| Pools | General APR + heap/tracker (`issue-2-pool-heap`) | Landed; first-fit later |
+| Area | Today (after #235) | Notes |
+|------|-------------------|--------|
+| Memory objects | Managed/unmanaged/`cede_p`; dual-face inf matches | Generic store-as-is; faces overlay-`slot_store` |
+| Memory arrays | Options honored; `get_reference`/`release`; script constructors are faces | Remaining-element walk is pool cleanup |
+| Value create object/array | Dual face preferred (`as_value`); extra header still exists | Unmanaged object/array values hold the instance |
+| `wrap_literal_*` | Unmanaged memory face | 0→1 holds base; overlay walk on pool cleanup |
+| Adapter get/retrieve | `impl_script_face_object` → unmanaged memory face | Memory face is the script-aware stand-in |
+| Assign | `slot_store` | Scope last-`release` walks slots then pool |
+| `script_result` | xctx pointer, save/restore | Still not a real frame slot |
+| `for` clone | Per-slot `add_reference` | C-style `for` clone can drop instance RC to 0 while live — do not walk overlay on that event |
+| Pools | General APR + heap/tracker | First-fit later |
 
 ---
 


### PR DESCRIPTION
Generated with Grok.

Follow-on to #235: stop lying in the campaign map's today table. No code.

Related to https://github.com/afw-org/afw/issues/2. Does not close it.

@JeremyGrieshop