### PR TITLE
Fix heap/tracker free-list livelock on second free (#2)

### DIFF
--- a/src/afw/pool/afw_pool_heap.c
+++ b/src/afw/pool/afw_pool_heap.c
@@ -384,7 +384,37 @@ impl_create_for_subpool(
  * First-fit on an address-ordered doubly-linked free list. Always
  * insert on free; coalesce with neighbors when adjacent. Remainder
  * too small to hold a chunk is taken with the allocation.
+ *
+ * Size is APR-aligned; the low bit is in-use. A second free of the
+ * same chunk (heap free of a tracker alloc, then last-release) must
+ * not insert again — that cycles next and livelocks first-fit.
  */
+#define AFW_POOL_HEAP_INUSE ((afw_size_t)1)
+
+static afw_size_t
+impl_chunk_bytes(const afw_pool_heap_chunk_t *chunk)
+{
+    return chunk->size & ~AFW_POOL_HEAP_INUSE;
+}
+
+static afw_boolean_t
+impl_chunk_in_use(const afw_pool_heap_chunk_t *chunk)
+{
+    return (chunk->size & AFW_POOL_HEAP_INUSE) ? true : false;
+}
+
+static void
+impl_chunk_mark_in_use(afw_pool_heap_chunk_t *chunk, afw_size_t bytes)
+{
+    chunk->size = bytes | AFW_POOL_HEAP_INUSE;
+}
+
+static void
+impl_chunk_mark_free(afw_pool_heap_chunk_t *chunk, afw_size_t bytes)
+{
+    chunk->size = bytes & ~AFW_POOL_HEAP_INUSE;
+}
+
 static void
 impl_chunk_unlink(
     afw_pool_heap_chunk_t **head,
@@ -401,6 +431,34 @@ impl_chunk_unlink(
     }
     chunk->prev = NULL;
     chunk->next = NULL;
+}
+
+/*
+ * Heap free_memory(p=heap) of a tracker allocation does not go
+ * through tracker free, so unlink from the owning tracker here.
+ */
+static void
+impl_unlink_from_child_trackers(
+    AFW_POOL_SELF_T *heap,
+    afw_pool_heap_chunk_t *block)
+{
+    afw_pool_internal_self_t *t;
+
+    if (block->prev) {
+        block->prev->next = block->next;
+        if (block->next) {
+            block->next->prev = block->prev;
+        }
+        block->prev = NULL;
+        block->next = NULL;
+        return;
+    }
+    for (t = heap->first_child; t; t = t->next_sibling) {
+        if (t->first_allocated_memory == block) {
+            impl_chunk_unlink(&t->first_allocated_memory, block);
+            return;
+        }
+    }
 }
 
 
@@ -431,34 +489,67 @@ impl_alloc_memory(
 
     curr = NULL;
     if (self->free_memory_head) {
-        for (curr = self->free_memory_head->first;
-            curr && curr->size < *actual_size;
-            curr = curr->next);
+        afw_pool_heap_chunk_t *slow;
+        afw_pool_heap_chunk_t *fast;
+
+        slow = self->free_memory_head->first;
+        fast = slow;
+        for (curr = slow;
+            curr && impl_chunk_bytes(curr) < *actual_size;
+            curr = curr->next)
+        {
+            if (fast) {
+                fast = fast->next;
+            }
+            if (fast) {
+                fast = fast->next;
+            }
+            if (fast && fast == curr) {
+                AFW_THROW_ERROR_Z(general,
+                    "heap free-list cycle",
+                    xctx);
+            }
+        }
     }
 
     if (curr) {
+        afw_size_t curr_bytes;
+
+        curr_bytes = impl_chunk_bytes(curr);
         prev = curr->prev;
         next = curr->next;
         impl_chunk_unlink(&self->free_memory_head->first, curr);
-        if (curr->size - *actual_size >= sizeof(afw_pool_heap_chunk_t))
+        if (curr_bytes - *actual_size >= sizeof(afw_pool_heap_chunk_t))
         {
             rest = (afw_pool_heap_chunk_t *)
                 (((char *)curr) + *actual_size);
-            rest->size = curr->size - *actual_size;
+            impl_chunk_mark_free(rest, curr_bytes - *actual_size);
             rest->prev = prev;
-            rest->next = next;
             if (prev) {
                 prev->next = rest;
             }
             else {
                 self->free_memory_head->first = rest;
             }
-            if (next) {
-                next->prev = rest;
+            if (next &&
+                ((char *)rest) + impl_chunk_bytes(rest) == (char *)next)
+            {
+                impl_chunk_mark_free(rest,
+                    impl_chunk_bytes(rest) + impl_chunk_bytes(next));
+                rest->next = next->next;
+                if (next->next) {
+                    next->next->prev = rest;
+                }
+            }
+            else {
+                rest->next = next;
+                if (next) {
+                    next->prev = rest;
+                }
             }
         }
         else {
-            *actual_size = curr->size;
+            *actual_size = curr_bytes;
         }
     }
 
@@ -487,10 +578,14 @@ impl_free_memory(
     afw_pool_heap_chunk_t *prev;
     afw_pool_heap_chunk_t *curr;
 
-    (void)xctx;
-
     freeing = (afw_pool_heap_chunk_t *)address;
-    freeing->size = size;
+    if (!impl_chunk_in_use(freeing)) {
+        /* Running xctx, not self: self may already be in teardown. */
+        AFW_THROW_ERROR_Z(general,
+            "afw_pool_free_memory: memory already freed",
+            xctx);
+    }
+    impl_chunk_mark_free(freeing, size);
     freeing->prev = NULL;
     freeing->next = NULL;
 
@@ -514,9 +609,10 @@ impl_free_memory(
     }
 
     if (curr &&
-        ((char *)freeing) + freeing->size == (char *)curr)
+        ((char *)freeing) + impl_chunk_bytes(freeing) == (char *)curr)
     {
-        freeing->size += curr->size;
+        impl_chunk_mark_free(freeing,
+            impl_chunk_bytes(freeing) + impl_chunk_bytes(curr));
         freeing->next = curr->next;
         if (curr->next) {
             curr->next->prev = freeing;
@@ -524,9 +620,10 @@ impl_free_memory(
     }
 
     if (prev &&
-        ((char *)prev) + prev->size == (char *)freeing)
+        ((char *)prev) + impl_chunk_bytes(prev) == (char *)freeing)
     {
-        prev->size += freeing->size;
+        impl_chunk_mark_free(prev,
+            impl_chunk_bytes(prev) + impl_chunk_bytes(freeing));
         prev->next = freeing->next;
         if (freeing->next) {
             freeing->next->prev = prev;
@@ -564,7 +661,7 @@ impl_malloc_user(
     IMPL_PRINT_DEBUG_INFO_FZ(detail, "alloc %s " AFW_SIZE_T_FMT,
         reused ? "reuse" : "apr", size);
     block = (afw_pool_heap_chunk_t *)mem;
-    block->size = actual_size;
+    impl_chunk_mark_in_use(block, actual_size);
     block->prev = NULL;
     block->next = NULL;
     impl_account_alloc(self, actual_size, xctx);
@@ -717,11 +814,17 @@ impl_afw_pool_free_memory(
         return;
     }
     block = AFW_POOL_HEAP_CHUNK(address);
+    if (!impl_chunk_in_use(block)) {
+        AFW_THROW_ERROR_Z(general,
+            "afw_pool_free_memory: memory already freed",
+            xctx);
+    }
     IMPL_PRINT_DEBUG_INFO_FZ(
         detail, "free %p " AFW_SIZE_T_FMT,
-        address, block->size);
-    impl_account_free(self, block->size, xctx);
-    impl_free_memory(self, block, block->size, xctx);
+        address, impl_chunk_bytes(block));
+    impl_unlink_from_child_trackers(self, block);
+    impl_account_free(self, impl_chunk_bytes(block), xctx);
+    impl_free_memory(self, block, impl_chunk_bytes(block), xctx);
 }
 
 /*
@@ -791,7 +894,6 @@ impl_subpool_afw_pool_destroy(
     afw_xctx_t *xctx)
 {
     afw_pool_heap_chunk_t *memory;
-    afw_pool_heap_chunk_t *next;
     afw_pool_internal_self_t *child;
     afw_pool_cleanup_t *e;
 
@@ -827,13 +929,15 @@ impl_subpool_afw_pool_destroy(
         apr_pool_destroy(self->public_apr_p);
     }
 
-    /* Return all allocated memory to the parent. */
-    for (memory = self->first_allocated_memory;
-        memory;
-        memory = next)
-    {
-        next = memory->next;
-        impl_free_memory(self, memory, memory->size, xctx);
+    /* Return remaining in-use chunks. Unlink first so next is still
+     * the allocated-list link, not a free-list link. */
+    while (self->first_allocated_memory) {
+        memory = self->first_allocated_memory;
+        impl_chunk_unlink(&self->first_allocated_memory, memory);
+        if (impl_chunk_in_use(memory)) {
+            impl_free_memory(self, memory, impl_chunk_bytes(memory),
+                xctx);
+        }
     }
 
     impl_account_destroy(self, xctx);
@@ -924,13 +1028,18 @@ impl_subpool_afw_pool_free_memory(
         return;
     }
     block = AFW_POOL_HEAP_CHUNK(address);
+    if (!impl_chunk_in_use(block)) {
+        AFW_THROW_ERROR_Z(general,
+            "afw_pool_free_memory: memory already freed",
+            xctx);
+    }
     IMPL_PRINT_DEBUG_INFO_FZ(
         detail, "free %p " AFW_SIZE_T_FMT,
-        address, block->size);
+        address, impl_chunk_bytes(block));
 
-    impl_account_free(self, block->size, xctx);
+    impl_account_free(self, impl_chunk_bytes(block), xctx);
     impl_chunk_unlink(&self->first_allocated_memory, block);
-    impl_free_memory(self, block, block->size, xctx);
+    impl_free_memory(self, block, impl_chunk_bytes(block), xctx);
 }
 
 

--- a/src/afw/tests/advanced/pool_heap/pool_heap.py
+++ b/src/afw/tests/advanced/pool_heap/pool_heap.py
@@ -87,6 +87,15 @@ def run():
                 "nonadjacent_reuse",
                 "non-adjacent frees land on the free list and reuse",
             ),
+            (
+                "for_clone_churn",
+                "tracker calloc ~56 after mixed optional free and "
+                "tracker last-release does not hang",
+            ),
+            (
+                "double_free_throws",
+                "second free_memory throws on the running xctx",
+            ),
         ],
         extra_cflags=("-I", _pool_src()),
         extra_ldflags=("-lapr-1",),

--- a/src/afw/tests/advanced/pool_heap/pool_heap_probe.c
+++ b/src/afw/tests/advanced/pool_heap/pool_heap_probe.c
@@ -11,6 +11,8 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <signal.h>
+#include <unistd.h>
 
 /**
  * @file pool_heap_probe.c
@@ -31,6 +33,9 @@
 #define IMPL_SIZE_MEDIUM ((afw_size_t)64)
 #define IMPL_SIZE_SLIGHT ((afw_size_t)56)
 #define IMPL_SIZE_LARGE  ((afw_size_t)200)
+#define IMPL_SIZE_SCOPE  ((afw_size_t)56)
+#define IMPL_CHURN_ITERS 2000
+#define IMPL_FREE_WALK_CAP 100000
 
 static afw_size_t
 impl_in_use(afw_xctx_t *xctx)
@@ -511,6 +516,51 @@ impl_tracker_parent(afw_xctx_t *xctx)
     return 0;
 }
 
+static int
+impl_double_free_throws(afw_xctx_t *xctx)
+{
+    const afw_pool_t *heap;
+    void *a;
+    int threw;
+    int unexpected;
+
+    heap = afw_pool_heap_create(xctx->p, xctx);
+    a = afw_pool_malloc(heap, IMPL_SIZE_MEDIUM, xctx);
+    memset(a, 0x77, IMPL_SIZE_MEDIUM);
+    afw_pool_free_memory(heap, a, xctx);
+
+    threw = 0;
+    unexpected = 0;
+    AFW_TRY {
+        afw_pool_free_memory(heap, a, xctx);
+    }
+    AFW_CATCH_UNHANDLED {
+        if (AFW_ERROR_THROWN->code == afw_error_code_general &&
+            AFW_ERROR_THROWN->message_z &&
+            strstr(AFW_ERROR_THROWN->message_z, "already freed"))
+        {
+            threw = 1;
+        }
+        else {
+            unexpected = 1;
+            fprintf(stderr, "double_free_throws: threw %s\n",
+                AFW_ERROR_THROWN->message_z
+                    ? AFW_ERROR_THROWN->message_z : "?");
+        }
+    }
+    AFW_ENDTRY;
+
+    afw_pool_release(heap, xctx);
+
+    if (unexpected) {
+        return 1;
+    }
+    if (!threw) {
+        return impl_fail("double_free_throws", "did not throw");
+    }
+    return 0;
+}
+
 /*
  * get_apr_pool() is a door for leftover APR calls, not the heap store.
  * Heap returns its reservoir for now. Tracker creates a child of that
@@ -676,6 +726,126 @@ impl_nonadjacent_reuse(afw_xctx_t *xctx)
     return 0;
 }
 
+/*
+ * Walk the heap free list. A cycle or a walk that never ends is the
+ * first-fit livelock (tracker calloc of ~56 while many smaller
+ * fragments are on the list).
+ */
+static int
+impl_free_list_walk_ok(
+    afw_pool_internal_self_t *heap_self,
+    const char *label)
+{
+    afw_pool_heap_chunk_t *slow;
+    afw_pool_heap_chunk_t *fast;
+    afw_size_t steps;
+
+    if (!heap_self->free_memory_head) {
+        return 0;
+    }
+    slow = heap_self->free_memory_head->first;
+    fast = slow;
+    steps = 0;
+    while (slow) {
+        steps++;
+        if (steps > IMPL_FREE_WALK_CAP) {
+            fprintf(stderr,
+                "%s: free-list walk exceeded " AFW_SIZE_T_FMT
+                " nodes (cycle or unbounded)\n",
+                label, (afw_size_t)IMPL_FREE_WALK_CAP);
+            return 1;
+        }
+        if (fast) {
+            fast = fast->next;
+        }
+        if (fast) {
+            fast = fast->next;
+        }
+        if (fast && fast == slow) {
+            fprintf(stderr, "%s: free-list next cycle at %p\n",
+                label, (void *)slow);
+            return 1;
+        }
+        slow = slow->next;
+    }
+    return 0;
+}
+
+/*
+ * C-style for clone: new tracker, calloc ~56 (scope), mixed-size
+ * optional frees on the shared heap, last-release. Then another
+ * tracker calloc of 56 — the gdb hang from boxing.
+ *
+ * The hang is a cycle: a tracker-allocated chunk is returned to the
+ * heap free list (optional free with the heap as p) without unlinking
+ * from the tracker. Last-release then walks memory->next as if it
+ * were still the allocated list.
+ */
+static void
+impl_churn_alarm(int sig)
+{
+    (void)sig;
+    fprintf(stderr,
+        "for_clone_churn: timed out (free-list walk likely hung)\n");
+    _exit(1);
+}
+
+static int
+impl_for_clone_churn(afw_xctx_t *xctx)
+{
+    const afw_pool_t *heap;
+    const afw_pool_t *tracker;
+    afw_pool_internal_self_t *heap_self;
+    void *scope;
+    void *small;
+    afw_size_t i;
+    afw_size_t small_size;
+    static const afw_size_t small_sizes[] = { 16, 24, 32, 40, 48 };
+
+    heap = afw_pool_heap_create(xctx->p, xctx);
+    heap_self = impl_self(heap);
+    signal(SIGALRM, impl_churn_alarm);
+    alarm(15);
+
+    for (i = 0; i < IMPL_CHURN_ITERS; i++) {
+        if (impl_free_list_walk_ok(heap_self, "for_clone_churn before calloc"))
+        {
+            alarm(0);
+            return 1;
+        }
+        tracker = afw_pool_heap_tracker_create(heap, xctx);
+        scope = afw_pool_calloc(tracker, IMPL_SIZE_SCOPE, xctx);
+        memset(scope, 0xa5, IMPL_SIZE_SCOPE);
+
+        small_size = small_sizes[i % 5];
+        /* Allocate on the tracker, return the chunk on the heap free
+         * list without the tracker unlink. Last-release must not
+         * livelock (next is already a free-list link). */
+        small = afw_pool_malloc(tracker, small_size, xctx);
+        memset(small, 0x5a, small_size);
+        afw_pool_free_memory(heap, small, xctx);
+
+        afw_pool_release(tracker, xctx);
+
+        if (impl_free_list_walk_ok(heap_self, "for_clone_churn")) {
+            alarm(0);
+            return 1;
+        }
+    }
+
+    tracker = afw_pool_heap_tracker_create(heap, xctx);
+    scope = afw_pool_calloc(tracker, IMPL_SIZE_SCOPE, xctx);
+    memset(scope, 0xa5, IMPL_SIZE_SCOPE);
+    if (impl_free_list_walk_ok(heap_self, "for_clone_churn after calloc")) {
+        alarm(0);
+        return 1;
+    }
+    afw_pool_release(tracker, xctx);
+    afw_pool_release(heap, xctx);
+    alarm(0);
+    return 0;
+}
+
 int
 main(int argc, char **argv)
 {
@@ -730,12 +900,19 @@ main(int argc, char **argv)
     else if (strcmp(case_name, "nonadjacent_reuse") == 0) {
         rc = impl_nonadjacent_reuse(xctx);
     }
+    else if (strcmp(case_name, "for_clone_churn") == 0) {
+        rc = impl_for_clone_churn(xctx);
+    }
+    else if (strcmp(case_name, "double_free_throws") == 0) {
+        rc = impl_double_free_throws(xctx);
+    }
     else {
         fprintf(stderr, "usage: pool_heap_probe "
             "heap_malloc_free|tracker_malloc|tracker_optional_free|"
             "tracker_last_release|tracker_header|mixed_sizes|"
             "heap_whole_block|general_free_noop|tracker_parent|"
-            "get_apr_pool|deregister_cleanup|nonadjacent_reuse\n");
+            "get_apr_pool|deregister_cleanup|nonadjacent_reuse|"
+            "for_clone_churn|double_free_throws\n");
         rc = 2;
     }
 


### PR DESCRIPTION
Related to #2. Does not close the umbrella.

First-fit in `impl_alloc_memory` could spin at 100% CPU when `next` cycled. That happened if a tracker-allocated chunk was returned with `free_memory` on the heap (no tracker unlink) and last-release then walked `memory->next` as if it were still the allocated list.

- In-use bit on chunk size. First free still puts the chunk on the heap free list.
- Second free throws on the **running `xctx`**, not the pool being freed.
- Heap `free_memory` unlinks from a child tracker if the chunk is still listed.
- Last-release unlinks from the allocated list before insert.
- Alloc walk detects a cycle and throws (backstop).
- Split remainder coalesces with the following free node when adjacent.

Gate: `src/afw/tests/advanced/pool_heap/` `for_clone_churn` and `double_free_throws`. Existing 12 cases stay green.

Verified: pool_heap 14/14 including valgrind; `afwdev test -j` (4226 passed on the livelock fix; 14/14 after throw-on-second-free).

Not this PR: boxing `scope_clone` still passes `scope->p` (tracker) into `slot_store`. That is `issue-2-managed-p` (use `eval_p` / heap for assigned slots).

Co-Authored-By: Grok 4.6 <noreply@x.ai>