### PR TITLE
fix(adapter): retrieve_objects NULL object_type_id crash + LMDB indexer stale txn (#232)

### DIFF
--- a/.cursor/rules/afw-adapter-index.mdc
+++ b/.cursor/rules/afw-adapter-index.mdc
@@ -1,5 +1,5 @@
 ---
-description: Adapter index interface (core helpers + LMDB) — definitions, current:: eval, create/txn residuals (#54, #57)
+description: Adapter index interface (core helpers + LMDB) — definitions, current:: eval, retroactive create/remove (#54, #57, #232)
 globs: src/afw/adapter/afw_adapter_impl_index*,src/afw/function/afw_function_indexes.c,src/afw/generate/objects/_AdaptiveFunctionGenerate_/index_*.json,src/afw_lmdb/afw_lmdb_index*,src/afw_lmdb/afw_lmdb_adapter_session.c,src/afw_lmdb/tests/adapter/**
 alwaysApply: false
 ---
@@ -51,12 +51,17 @@ Migration for old scripts: `object` / `variable_get("object")` → `current::obj
 
 CRUD + dump retrieve work with **empty** `indexDefinitions` (indexer walk is no-op). Tests under `tests/adapter/` / `tests/journal/` do **not** require indexes.
 
-## Known residuals (do not “fix” as #54 alone)
+## Retroactive create/remove — fixed residuals (#229, #232)
 
-- Session indexer often has **`txn == NULL`** → `update_index_definitions` / `save_config` can **EINVAL**.
-- **Retroactive** `index_create` (full retrieve under write txn) can **hang**.
-- Smoke `tests/adapter/index_current.as` is **skipped** until create path is fixed; track with **#57**.
-- Qualifier stack **requires** non-empty qualifier name on push (empty “unqualified qualifier” rejected).
+Three stacked bugs used to make retroactive `index_create` / filtered `index_remove` unusable; all are now fixed and `tests/adapter/index_current.as` runs (unskipped):
+
+- **Reentrant LMDB transactions** (#229): `AFW_LMDB_BEGIN_TRANSACTION`'s reentrant-reuse branch and `afw_lmdb_transaction_create` (session `begin_transaction()`) now correctly share/reuse an already-active session transaction instead of self-deadlocking or reusing a freed `MDB_txn` after commit/release.
+- **NULL `object_type_id` scan-all-types crash** (#232): the generic adapter wrapper (`afw_adapter_impl.c` `impl_afw_adapter_session_retrieve_objects`) built its diagnostic `resource_id` via `AFW_UTF8_FMT_ARG` on a possibly-NULL `object_type_id` — a real SIGSEGV, not a catchable error, hit by any `retrieve_objects(object_type_id: NULL)` call with no `impl_request` (retroactive `index_create`, and `index_remove`'s per-objectType drop loop, which was also passing a literal `NULL` instead of its loop variable). Fixed: `AFW_UTF8_FMT_OPTIONAL_ARG` + pass the loop variable.
+- **Session indexer's stale `self->txn`** (#232): `impl_afw_adapter_impl_index_add` / `_delete` / `_replace` / `_drop` / `update_index_definitions` in `afw_lmdb_index.c` read `self->txn`, which is hardcoded `NULL` for every session-backed indexer (only the one-off adapter-level indexer construction sets it) and is **never** refreshed — so any write during a live transaction (retroactive scan under `index_create`'s explicit `begin_transaction`, or a normal per-request implicit txn) passed a NULL `MDB_txn` to `mdb_put`/`mdb_del`/`mdb_drop`, failing with `EINVAL`. Fixed by falling back to the session's active transaction via the same reentrant-safe `AFW_LMDB_BEGIN_TRANSACTION`/`AFW_LMDB_GET_TRANSACTION` macros `impl_afw_adapter_impl_index_open` already used correctly — that function is the reference pattern for any *new* write path added to this file.
+
+Also found and fixed while unskipping the test: `current::object.get("propName")` is **not valid** AFW — objects have no `.get()` method. Use `property_get(current::object, "propName")`.
+
+Remaining, unrelated: qualifier stack **requires** non-empty qualifier name on push (empty “unqualified qualifier” rejected).
 
 ## Key files
 
@@ -69,4 +74,4 @@ CRUD + dump retrieve work with **empty** `indexDefinitions` (indexer walk is no-
 | `src/afw_lmdb/README.md` | Operator `index_create` example |
 | `beta-backlog.md` | Maintainer notes / beta residuals |
 
-Related: `afw-qualified-variables`, `afw-extensions` (lmdb), `afw-adaptive-script`, issue **#54** / **#57**.
+Related: `afw-qualified-variables`, `afw-extensions` (lmdb), `afw-adaptive-script`, issues **#54** / **#57** / **#229** / **#232**.

--- a/src/afw/adapter/afw_adapter_impl.c
+++ b/src/afw/adapter/afw_adapter_impl.c
@@ -1001,7 +1001,7 @@ impl_afw_adapter_session_retrieve_objects(
         ctx.resource_id = afw_utf8_printf(p, xctx,
             "/" AFW_UTF8_FMT "/" AFW_UTF8_FMT,
             AFW_UTF8_FMT_ARG(&adapter->adapter_id),
-            AFW_UTF8_FMT_ARG(object_type_id));
+            AFW_UTF8_FMT_OPTIONAL_ARG(object_type_id));
     }
     ctx.action_id_value = afw_authorization_action_id_query;
 

--- a/src/afw/adapter/afw_adapter_impl_index.c
+++ b/src/afw/adapter/afw_adapter_impl_index.c
@@ -846,7 +846,8 @@ AFW_DEFINE(const afw_object_t *) afw_adapter_impl_index_remove(
                 ctx.mode = afw_adapter_impl_index_mode_delete;
 
                 /** @fixme xctx->p, session->p, or pool?  */
-                afw_adapter_session_retrieve_objects(session, NULL, NULL,
+                afw_adapter_session_retrieve_objects(session, NULL,
+                    object_type_id,
                     NULL, &ctx, afw_adapter_impl_index_cb, NULL,
                     /** @fixme is pool correct? */ pool, xctx);
             }

--- a/src/afw_lmdb/afw_lmdb_index.c
+++ b/src/afw_lmdb/afw_lmdb_index.c
@@ -136,28 +136,61 @@ impl_afw_adapter_impl_index_update_index_definitions (
     const afw_object_t * indexDefinitions,
     afw_xctx_t *xctx)
 {
+    const afw_lmdb_adapter_t *adapter = self->adapter;
     const afw_lmdb_adapter_session_t *session = self->session;
-    const afw_adapter_t *adapter = (afw_adapter_t *)self->session->adapter;    
     const afw_pool_t *pool;
-    MDB_txn *txn = self->txn;
+    MDB_txn *txn;
 
     /* clone this object with our adapter's memory pool */
-    pool = adapter->p;
+    pool = adapter->pub.p;
 
-    /* lock the adapter */
-    AFW_ADAPTER_IMPL_LOCK_WRITE_BEGIN(adapter) {
-        afw_object_set_property_as_object(
-            session->adapter->internalConfig, afw_lmdb_v_indexDefinitions, 
-            afw_object_create_clone(
-                indexDefinitions, pool, xctx),
-            xctx);
+    /*
+     * self->txn is only set for the one-off adapter-level indexer
+     * (afw_lmdb_adapter_impl_index_create() called with an explicit txn).
+     * A session-backed indexer's self->txn is always NULL -- the live
+     * transaction for this session lives on the session itself (either an
+     * explicit begin_transaction(), or the implicit per-request txn), so
+     * fall back to it via the same reentrant-safe macro impl_index_open
+     * uses, rather than passing a stale NULL txn to save_config.
+     */
+    if (self->txn == NULL) {
+        AFW_LMDB_BEGIN_TRANSACTION(adapter, session, 0, false, xctx) {
+            txn = AFW_LMDB_GET_TRANSACTION();
 
-        /* now write out our new config */
-        afw_lmdb_internal_save_config(session->adapter, 
-            session->adapter->internalConfig, txn, xctx);
+            /* lock the adapter */
+            AFW_ADAPTER_IMPL_LOCK_WRITE_BEGIN(((afw_adapter_t *)adapter)) {
+                afw_object_set_property_as_object(
+                    session->adapter->internalConfig, afw_lmdb_v_indexDefinitions,
+                    afw_object_create_clone(
+                        indexDefinitions, pool, xctx),
+                    xctx);
+
+                /* now write out our new config */
+                afw_lmdb_internal_save_config(session->adapter,
+                    session->adapter->internalConfig, txn, xctx);
+            }
+            AFW_ADAPTER_IMPL_LOCK_WRITE_END;
+
+            AFW_LMDB_COMMIT_TRANSACTION();
+        }
+        AFW_LMDB_END_TRANSACTION();
+    } else {
+        txn = self->txn;
+
+        /* lock the adapter */
+        AFW_ADAPTER_IMPL_LOCK_WRITE_BEGIN(((afw_adapter_t *)adapter)) {
+            afw_object_set_property_as_object(
+                session->adapter->internalConfig, afw_lmdb_v_indexDefinitions,
+                afw_object_create_clone(
+                    indexDefinitions, pool, xctx),
+                xctx);
+
+            /* now write out our new config */
+            afw_lmdb_internal_save_config(session->adapter,
+                session->adapter->internalConfig, txn, xctx);
+        }
+        AFW_ADAPTER_IMPL_LOCK_WRITE_END;
     }
-   
-    AFW_ADAPTER_IMPL_LOCK_WRITE_END;
 }
 
 /*
@@ -224,8 +257,9 @@ afw_rc_t impl_afw_adapter_impl_index_add(
     const afw_pool_t * pool,
     afw_xctx_t *xctx)
 {
+    const afw_lmdb_adapter_t *adapter = self->adapter;
     const afw_lmdb_adapter_session_t *session = self->session;
-    afw_rc_t rc;
+    afw_rc_t rc = 0;
     MDB_txn * txn;
     MDB_dbi dbi;
     MDB_val key, data;
@@ -235,7 +269,7 @@ afw_rc_t impl_afw_adapter_impl_index_add(
 
     /* we will get an error if we try to add a key of length 0 */
     /** @fixme this basically avoids indexing an empty string, so
-    we should determine if this is an error condition or not 
+    we should determine if this is an error condition or not
      */
     if (value->len == 0) {
         return 0;
@@ -244,37 +278,68 @@ afw_rc_t impl_afw_adapter_impl_index_add(
     database = afw_lmdb_index_database(
         object_type_id, indexKey, pool, xctx);
 
-    /* use the transaction on our session interface */
-    txn = self->txn;
-
-    dbi = afw_lmdb_internal_open_database(session->adapter, 
-        txn, database, MDB_DUPSORT|MDB_CREATE, pool, xctx);
-
     uuid = afw_uuid_from_utf8(object_id, pool, xctx);
 
-    afw_lmdb_internal_set_key(&raw, 
+    afw_lmdb_internal_set_key(&raw,
         object_type_id, uuid, pool, xctx);
-    
+
     key.mv_data = (void*)value->s;
     key.mv_size = value->len;
 
     data.mv_data = (void*)raw.ptr;
     data.mv_size = raw.size;
 
-    if (unique) {
-        rc = mdb_put(txn, dbi, &key, &data, MDB_NOOVERWRITE);
-        if (rc != 0) {
-            AFW_THROW_ERROR_RV_Z(general, lmdb, rc, 
-                "Unable to add unique index value.", xctx);
+    /*
+     * self->txn is only set for the one-off adapter-level indexer; a
+     * session-backed indexer's self->txn is always NULL, so fall back to
+     * the session's active transaction via the same reentrant-safe macro
+     * impl_index_open uses.
+     */
+    if (self->txn == NULL) {
+        AFW_LMDB_BEGIN_TRANSACTION(adapter, session, 0, false, xctx) {
+            txn = AFW_LMDB_GET_TRANSACTION();
+
+            dbi = afw_lmdb_internal_open_database(session->adapter,
+                txn, database, MDB_DUPSORT|MDB_CREATE, pool, xctx);
+
+            if (unique) {
+                rc = mdb_put(txn, dbi, &key, &data, MDB_NOOVERWRITE);
+                if (rc != 0) {
+                    AFW_THROW_ERROR_RV_Z(general, lmdb, rc,
+                        "Unable to add unique index value.", xctx);
+                }
+            } else {
+                rc = mdb_put(txn, dbi, &key, &data, MDB_NODUPDATA);
+                if (rc != 0 && rc != MDB_KEYEXIST) {
+                    AFW_THROW_ERROR_RV_Z(general, lmdb, rc,
+                        "Unable to add index value.", xctx);
+                }
+            }
+
+            AFW_LMDB_COMMIT_TRANSACTION();
         }
+        AFW_LMDB_END_TRANSACTION();
     } else {
-        rc = mdb_put(txn, dbi, &key, &data, MDB_NODUPDATA);
-        if (rc != 0 && rc != MDB_KEYEXIST) {
-            AFW_THROW_ERROR_RV_Z(general, lmdb, rc, 
-                "Unable to add index value.", xctx);
+        txn = self->txn;
+
+        dbi = afw_lmdb_internal_open_database(session->adapter,
+            txn, database, MDB_DUPSORT|MDB_CREATE, pool, xctx);
+
+        if (unique) {
+            rc = mdb_put(txn, dbi, &key, &data, MDB_NOOVERWRITE);
+            if (rc != 0) {
+                AFW_THROW_ERROR_RV_Z(general, lmdb, rc,
+                    "Unable to add unique index value.", xctx);
+            }
+        } else {
+            rc = mdb_put(txn, dbi, &key, &data, MDB_NODUPDATA);
+            if (rc != 0 && rc != MDB_KEYEXIST) {
+                AFW_THROW_ERROR_RV_Z(general, lmdb, rc,
+                    "Unable to add index value.", xctx);
+            }
         }
     }
- 
+
     return rc;
 }
 
@@ -290,18 +355,19 @@ afw_rc_t impl_afw_adapter_impl_index_delete(
     const afw_pool_t *pool,
     afw_xctx_t *xctx)
 {
+    const afw_lmdb_adapter_t *adapter = self->adapter;
     const afw_lmdb_adapter_session_t *session = self->session;
     MDB_val key, data;
     MDB_dbi dbi;
-    MDB_txn *txn = self->txn;
+    MDB_txn *txn;
     const afw_utf8_t *database;
     const afw_uuid_t *uuid;
-    afw_rc_t rc;
+    afw_rc_t rc = 0;
     afw_memory_t raw;
 
     /* we will get an error if we try to delete a key of length 0 */
     /** @fixme this basically avoids indexing an empty string, so
-    we should determine if this is an error condition or not 
+    we should determine if this is an error condition or not
      */
     if (value->len == 0) {
         return 0;
@@ -309,9 +375,6 @@ afw_rc_t impl_afw_adapter_impl_index_delete(
 
     database = afw_lmdb_index_database(
         object_type_id, indexKey, pool, xctx);
-   
-    dbi = afw_lmdb_internal_open_database(session->adapter, 
-        txn, database, MDB_DUPSORT, pool, xctx);
 
     uuid = afw_uuid_from_utf8(object_id, pool, xctx);
 
@@ -325,10 +388,39 @@ afw_rc_t impl_afw_adapter_impl_index_delete(
     data.mv_data = (void*)raw.ptr;
     data.mv_size = raw.size;
 
-    rc = mdb_del(txn, dbi, &key, &data);
-    if (rc != 0 && rc != MDB_NOTFOUND) {
-        AFW_THROW_ERROR_RV_Z(general, lmdb, rc, 
-            "Unable to delete index value.", xctx);
+    /*
+     * self->txn is only set for the one-off adapter-level indexer; a
+     * session-backed indexer's self->txn is always NULL, so fall back to
+     * the session's active transaction via the same reentrant-safe macro
+     * impl_index_open uses.
+     */
+    if (self->txn == NULL) {
+        AFW_LMDB_BEGIN_TRANSACTION(adapter, session, 0, false, xctx) {
+            txn = AFW_LMDB_GET_TRANSACTION();
+
+            dbi = afw_lmdb_internal_open_database(session->adapter,
+                txn, database, MDB_DUPSORT, pool, xctx);
+
+            rc = mdb_del(txn, dbi, &key, &data);
+            if (rc != 0 && rc != MDB_NOTFOUND) {
+                AFW_THROW_ERROR_RV_Z(general, lmdb, rc,
+                    "Unable to delete index value.", xctx);
+            }
+
+            AFW_LMDB_COMMIT_TRANSACTION();
+        }
+        AFW_LMDB_END_TRANSACTION();
+    } else {
+        txn = self->txn;
+
+        dbi = afw_lmdb_internal_open_database(session->adapter,
+            txn, database, MDB_DUPSORT, pool, xctx);
+
+        rc = mdb_del(txn, dbi, &key, &data);
+        if (rc != 0 && rc != MDB_NOTFOUND) {
+            AFW_THROW_ERROR_RV_Z(general, lmdb, rc,
+                "Unable to delete index value.", xctx);
+        }
     }
 
     return rc;
@@ -347,54 +439,109 @@ afw_rc_t impl_afw_adapter_impl_index_replace(
     const afw_pool_t *pool,
     afw_xctx_t *xctx)
 {
+    const afw_lmdb_adapter_t *adapter = self->adapter;
     const afw_lmdb_adapter_session_t *session = self->session;
     MDB_val key, data;
     MDB_dbi dbi;
-    MDB_txn *txn = self->txn;
+    MDB_txn *txn;
     const afw_utf8_t *database;
     const afw_uuid_t *uuid;
     afw_memory_t raw;
-    afw_rc_t rc;
+    afw_rc_t rc = 0;
 
     database = afw_lmdb_index_database(
         object_type_id, indexKey, pool, xctx);
-    
-    dbi = afw_lmdb_internal_open_database(session->adapter, 
-        txn, database, MDB_DUPSORT, pool, xctx);
 
-    memset(&key, 0, sizeof(MDB_val));
-    key.mv_data = (void *)old_value->s;
-    key.mv_size = old_value->len;
+    /*
+     * self->txn is only set for the one-off adapter-level indexer; a
+     * session-backed indexer's self->txn is always NULL, so fall back to
+     * the session's active transaction via the same reentrant-safe macro
+     * impl_index_open uses.
+     */
+    if (self->txn == NULL) {
+        AFW_LMDB_BEGIN_TRANSACTION(adapter, session, 0, false, xctx) {
+            txn = AFW_LMDB_GET_TRANSACTION();
 
-    memset(&data, 0, sizeof(MDB_val));
-    uuid = afw_uuid_from_utf8(object_id, pool, xctx);
+            dbi = afw_lmdb_internal_open_database(session->adapter,
+                txn, database, MDB_DUPSORT, pool, xctx);
 
-    afw_lmdb_internal_set_key(&raw, object_type_id, uuid, pool, xctx);
+            memset(&key, 0, sizeof(MDB_val));
+            key.mv_data = (void *)old_value->s;
+            key.mv_size = old_value->len;
 
-    data.mv_data = (void*)raw.ptr;
-    data.mv_size = raw.size;
+            memset(&data, 0, sizeof(MDB_val));
+            uuid = afw_uuid_from_utf8(object_id, pool, xctx);
 
-    /* remove the old value */
-    rc = mdb_del(txn, dbi, &key, &data);
-    if (rc != 0) {
-        AFW_THROW_ERROR_RV_Z(general, lmdb, rc, 
-            "Unable to remove old index value.", xctx);
+            afw_lmdb_internal_set_key(&raw, object_type_id, uuid, pool, xctx);
+
+            data.mv_data = (void*)raw.ptr;
+            data.mv_size = raw.size;
+
+            /* remove the old value */
+            rc = mdb_del(txn, dbi, &key, &data);
+            if (rc != 0) {
+                AFW_THROW_ERROR_RV_Z(general, lmdb, rc,
+                    "Unable to remove old index value.", xctx);
+            }
+
+            memset(&key, 0, sizeof(MDB_val));
+            key.mv_data = (void *)new_value->s;
+            key.mv_size = new_value->len;
+
+            memset(&data, 0, sizeof(MDB_val));
+            uuid = afw_uuid_from_utf8(object_id, pool, xctx);
+
+            afw_lmdb_internal_set_key(&raw, object_type_id, uuid, pool, xctx);
+
+            data.mv_data = (void*)raw.ptr;
+            data.mv_size = raw.size;
+
+            /* now write the new value */
+            rc = mdb_put(txn, dbi, &key, &data, MDB_NODUPDATA);
+
+            AFW_LMDB_COMMIT_TRANSACTION();
+        }
+        AFW_LMDB_END_TRANSACTION();
+    } else {
+        txn = self->txn;
+
+        dbi = afw_lmdb_internal_open_database(session->adapter,
+            txn, database, MDB_DUPSORT, pool, xctx);
+
+        memset(&key, 0, sizeof(MDB_val));
+        key.mv_data = (void *)old_value->s;
+        key.mv_size = old_value->len;
+
+        memset(&data, 0, sizeof(MDB_val));
+        uuid = afw_uuid_from_utf8(object_id, pool, xctx);
+
+        afw_lmdb_internal_set_key(&raw, object_type_id, uuid, pool, xctx);
+
+        data.mv_data = (void*)raw.ptr;
+        data.mv_size = raw.size;
+
+        /* remove the old value */
+        rc = mdb_del(txn, dbi, &key, &data);
+        if (rc != 0) {
+            AFW_THROW_ERROR_RV_Z(general, lmdb, rc,
+                "Unable to remove old index value.", xctx);
+        }
+
+        memset(&key, 0, sizeof(MDB_val));
+        key.mv_data = (void *)new_value->s;
+        key.mv_size = new_value->len;
+
+        memset(&data, 0, sizeof(MDB_val));
+        uuid = afw_uuid_from_utf8(object_id, pool, xctx);
+
+        afw_lmdb_internal_set_key(&raw, object_type_id, uuid, pool, xctx);
+
+        data.mv_data = (void*)raw.ptr;
+        data.mv_size = raw.size;
+
+        /* now write the new value */
+        rc = mdb_put(txn, dbi, &key, &data, MDB_NODUPDATA);
     }
-
-    memset(&key, 0, sizeof(MDB_val));
-    key.mv_data = (void *)new_value->s;
-    key.mv_size = new_value->len;
-
-    memset(&data, 0, sizeof(MDB_val));
-    uuid = afw_uuid_from_utf8(object_id, pool, xctx);
-
-    afw_lmdb_internal_set_key(&raw, object_type_id, uuid, pool, xctx);
-
-    data.mv_data = (void*)raw.ptr;
-    data.mv_size = raw.size;
-
-    /* now write the new value */
-    rc = mdb_put(txn, dbi, &key, &data, MDB_NODUPDATA);
 
     return rc;
 }
@@ -410,20 +557,44 @@ impl_afw_adapter_impl_index_drop (
     const afw_pool_t  * pool,
     afw_xctx_t       * xctx)
 {
+    const afw_lmdb_adapter_t *adapter = self->adapter;
     const afw_lmdb_adapter_session_t *session = self->session;
     const afw_utf8_t *database;
     MDB_dbi dbi;
-    MDB_txn *txn = self->txn;
-    afw_rc_t rc;
+    MDB_txn *txn;
+    afw_rc_t rc = 0;
 
     database = afw_lmdb_index_database(
         object_type_id, key, pool, xctx);
 
-    dbi = afw_lmdb_internal_open_database(session->adapter, 
-        txn, database, MDB_DUPSORT|MDB_CREATE, pool, xctx);
+    /*
+     * self->txn is only set for the one-off adapter-level indexer; a
+     * session-backed indexer's self->txn is always NULL, so fall back to
+     * the session's active transaction via the same reentrant-safe macro
+     * impl_index_open uses.
+     */
+    if (self->txn == NULL) {
+        AFW_LMDB_BEGIN_TRANSACTION(adapter, session, 0, false, xctx) {
+            txn = AFW_LMDB_GET_TRANSACTION();
 
-    /* (1) means delete it from the environment and close the DB handle */
-    rc = mdb_drop(txn, dbi, 1);
+            dbi = afw_lmdb_internal_open_database(session->adapter,
+                txn, database, MDB_DUPSORT|MDB_CREATE, pool, xctx);
+
+            /* (1) means delete it from the environment and close the DB handle */
+            rc = mdb_drop(txn, dbi, 1);
+
+            AFW_LMDB_COMMIT_TRANSACTION();
+        }
+        AFW_LMDB_END_TRANSACTION();
+    } else {
+        txn = self->txn;
+
+        dbi = afw_lmdb_internal_open_database(session->adapter,
+            txn, database, MDB_DUPSORT|MDB_CREATE, pool, xctx);
+
+        /* (1) means delete it from the environment and close the DB handle */
+        rc = mdb_drop(txn, dbi, 1);
+    }
 
     return rc;
 }

--- a/src/afw_lmdb/tests/adapter/index_current.as
+++ b/src/afw_lmdb/tests/adapter/index_current.as
@@ -7,17 +7,9 @@
 //?
 //? test: index_current_object
 //? description: index_create value/filter scripts use current::object (issue #54)
-//? skip: true
-//? skipReason: FIXME: retroactive index_create's retrieve_objects(object_type_id=NULL) crashes in the generic adapter wrapper (afw_adapter_impl.c impl_afw_adapter_session_retrieve_objects, building ctx.resource_id via AFW_UTF8_FMT_ARG on a NULL object_type_id when impl_request is also NULL) -- core adapter bug, not LMDB-specific; unskip when that's fixed
 //? expect: 0
 //? source: ...
 #!/usr/bin/env afw
-
-/*
- * When unskipped: seed objects, index_create with value/filter using
- * current::object (and related), assert num_indexed >= 1, online add,
- * index_list contains key, cleanup.
- */
 
 const ot: string = "_AdaptiveObject_";
 
@@ -37,9 +29,9 @@ add_object("lmdb", ot, {
 const created: object = index_create(
     "lmdb",
     "surnameByDept",
-    "current::object.get(\"surname\")",
+    "property_get(current::object, \"surname\")",
     [ot],
-    "eq(current::object.get(\"department\"), \"ENG\")",
+    "eq(property_get(current::object, \"department\"), \"ENG\")",
     undefined,
     true,
     false


### PR DESCRIPTION
## Summary

- Fixes #232: `impl_afw_adapter_session_retrieve_objects()` built its diagnostic `resource_id` via `AFW_UTF8_FMT_ARG` on a possibly-NULL `object_type_id` (scan-all-types is a normal, documented case for internal C callers with no `impl_request`) — a straight SIGSEGV, not a catchable error. Swapped to the existing `AFW_UTF8_FMT_OPTIONAL_ARG` macro.
- `afw_adapter_impl_index_remove()`'s per-objectType drop loop passed a literal `NULL` instead of its `object_type_id` loop variable, scanning every object type on every iteration instead of the one being dropped.
- Getting the previously-skipped `index_current.as` to actually pass surfaced a second, deeper bug (the real blocker for #57): `impl_afw_adapter_impl_index_add`/`_delete`/`_replace`/`_drop` and `update_index_definitions` in `afw_lmdb_index.c` read `self->txn`, which is hardcoded `NULL` for every session-backed indexer and never refreshed. Any write during a live transaction (retroactive `index_create`'s scan, or a normal per-request implicit txn) passed a NULL `MDB_txn` to `mdb_put`/`mdb_del`/`mdb_drop`, failing with `EINVAL`. Fixed by falling back to the session's active transaction via the same reentrant-safe `AFW_LMDB_BEGIN_TRANSACTION`/`AFW_LMDB_GET_TRANSACTION` macros `impl_afw_adapter_impl_index_open` already used correctly.
- Also fixed the test script itself: `current::object.get("propName")` isn't valid AFW (objects have no `.get()` method) — corrected to `property_get(current::object, "propName")`.
- Updated `.cursor/rules/afw-adapter-index.mdc`'s residuals section to match current state.

The public `retrieve_objects()` Adaptive function is unaffected and still requires `objectType` (`AFW_FUNCTION_EVALUATE_REQUIRED_DATA_TYPE_PARAMETER`) — verified live that omitting it still throws `argument_error`. Only the internal C interface method, called directly by `index_create`/`index_remove`, allows NULL.

## Test plan

- [x] `afwdev test --srcdir-pattern afw_lmdb -j` — 9/9 passed, `index_current.as` unskipped and green
- [x] `afwdev test -j` (full repo suite) — 4210 passed, 0 failed
- [x] Manually verified `retrieve_objects("lmdb")` (no objectType) still throws `argument_error` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>