### PR TITLE
Remove stale expression/hybrid mock catalog entries (#63)

### DIFF
--- a/src/afw_test/javascript/src/__mocks__/retrieve_objects/afw/_AdaptiveDataType_.json
+++ b/src/afw_test/javascript/src/__mocks__/retrieve_objects/afw/_AdaptiveDataType_.json
@@ -112,25 +112,6 @@
         },
         {
             "_meta_": {
-                "path": "/afw/_AdaptiveDataType_/expression",
-                "objectId": "expression",
-                "objectType": "_AdaptiveDataType_"
-            },
-            "scalar": false,
-            "relationalCompares": false,
-            "ldapOid": "1.3.6.1.4.1.1466.115.121.1.15{64512}",
-            "jsonPrimitive": "string",
-            "jsonImpliesDataType": false,
-            "evaluated": true,
-            "directReturn": false,
-            "description": "Data type expression holds the source for an adaptive expression.",
-            "dataTypeParameterType": "evaluatedDataType",
-            "dataType": "script",
-            "cType": "afw_utf8_t",
-            "brief": "An adaptive expression"
-        },
-        {
-            "_meta_": {
                 "path": "/afw/_AdaptiveDataType_/dayTimeDuration",
                 "objectId": "dayTimeDuration",
                 "objectType": "_AdaptiveDataType_"
@@ -417,24 +398,6 @@
             "dataType": "boolean",
             "cType": "afw_boolean_t",
             "brief": "A boolean value"
-        },
-        {
-            "_meta_": {
-                "path": "/afw/_AdaptiveDataType_/hybrid",
-                "objectId": "hybrid",
-                "objectType": "_AdaptiveDataType_"
-            },
-            "scalar": false,
-            "relationalCompares": false,
-            "jsonPrimitive": "varies",
-            "jsonImpliesDataType": false,
-            "evaluated": true,
-            "directReturn": true,
-            "description": "Data type hybrid can be a string containing the source for an adaptive expression tuple, an adaptive script, or an adaptive template.  It can also be a literal (evaluated value) such as boolean, double, integer, list, object, or string.\n\nIf the value is a string that begins with a square bracket ('['), the string is the source for an expressionTuple.  If the value is a string that begins with a shebang ('#!'), the string is the source for a script.  If not either of these, but the string contains a substitution ( ${...} ), the string is a source for a template.  In other cases, the string is a string literal.",
-            "dataTypeParameterType": "evaluatedDataType",
-            "dataType": "template",
-            "cType": "const afw_value_t *",
-            "brief": "A hybrid value"
         },
         {
             "_meta_": {

--- a/src/afw_test/javascript/src/__mocks__/retrieve_objects/afw/_AdaptiveFunctionCategory_.json
+++ b/src/afw_test/javascript/src/__mocks__/retrieve_objects/afw/_AdaptiveFunctionCategory_.json
@@ -23,17 +23,6 @@
         },
         {
             "_meta_": {
-                "path": "/afw/_AdaptiveFunctionCategory_/expression",
-                "objectId": "expression",
-                "objectType": "_AdaptiveFunctionCategory_"
-            },
-            "description": "These function are related to data type expression.\n\nThe \"<expression>\" in function ids in this category is optional. If omitted, the function will be called polymorphically based of the data type of the first parameter.",
-            "dataTypeCategory": true,
-            "category": "expression",
-            "brief": "Data type expression related functions"
-        },
-        {
-            "_meta_": {
                 "path": "/afw/_AdaptiveFunctionCategory_/dayTimeDuration",
                 "objectId": "dayTimeDuration",
                 "objectType": "_AdaptiveFunctionCategory_"

--- a/src/afw_test/javascript/src/layouts/objectTypes/ObjectResponsive/PropertyResponsive.test.js
+++ b/src/afw_test/javascript/src/layouts/objectTypes/ObjectResponsive/PropertyResponsive.test.js
@@ -245,9 +245,6 @@ const TestArray = (wrapper) => {
                     
                 expect(onChanged).toHaveBeenLastCalledWith(expect.objectContaining({ eventId: "onChildChanged", value: testValues[0] }));
 
-                //if (dataType === "hybrid")
-                //    await waitFor(() => expect(mswPostCallback).toHaveBeenCalled());   
-                
                 if (expectedReadonlyTestValues)
                     await waitFor(() => expect(screen.getAllByText(expectedReadonlyTestValues[0])).toHaveLength(1));
                 else
@@ -305,10 +302,7 @@ const TestArray = (wrapper) => {
         
                     expect(onChanged).toHaveBeenLastCalledWith(expect.objectContaining({ eventId: "onChildChanged", value: testValues[1] }));
                 }
-                
-                //if (dataType === "hybrid")
-                //    await waitFor(() => expect(mswPostCallback).toHaveBeenCalled());                
-                
+
                 if (expectedReadonlyTestValues) {
                     await waitFor(() => expect(screen.getAllByText(expectedReadonlyTestValues[0])).toHaveLength(1));
                     if (expectedReadonlyTestValues.length > 1)
@@ -470,10 +464,7 @@ const Test = (wrapper) => {
                     { wrapper }
                 );   
 
-                //if (dataType === "hybrid")
-                //    await waitFor(() => expect(mswPostCallback).toHaveBeenCalled());
-    
-                await waitFor(() => expect(screen.getByLabelText(label)).toBeInTheDocument()); 
+                await waitFor(() => expect(screen.getByLabelText(label)).toBeInTheDocument());
             });
 
             test("Calls onChanged after input changes", async () => {
@@ -499,9 +490,6 @@ const Test = (wrapper) => {
                     { wrapper }
                 );   
 
-                //if (dataType === "hybrid")
-                //    await waitFor(() => expect(mswPostCallback).toHaveBeenCalled());
-    
                 const input = screen.getByLabelText(label);
                 await waitFor(() => expect(input).toBeInTheDocument());
                 await waitFor(() => expect(input.value).toBe(expectedTestValues[0]));
@@ -544,9 +532,6 @@ const Test = (wrapper) => {
                     );   
                 });
 
-                //if (dataType === "hybrid")
-                //    await waitFor(() => expect(mswPostCallback).toHaveBeenCalled());
-    
                 const input = screen.getByLabelText(label);
                 await waitFor(() => expect(input).toBeInTheDocument());
                 await waitFor(() => expect(input.value).toBe(expectedTestValues[0]));


### PR DESCRIPTION
## Summary
- Core removal of the `expression` and `hybrid` data types was already done in PR #66 (2023), but the hand-maintained JS test mocks under `src/afw_test/javascript` never got updated to match.
- Removes the stale `expression`/`hybrid` entries from `_AdaptiveDataType_.json` and the stale `expression` entry from `_AdaptiveFunctionCategory_.json`.
- Removes dead commented-out `//if (dataType === "hybrid")` branches in `PropertyResponsive.test.js` (5 occurrences).

Closes #63.

## Test plan
- [x] Verified both edited JSON mocks parse (`python3 -c "json.load(...)"`)
- [x] Rebuilt `@afw/test` (`npm run build --prefix src/afw_test/javascript`) so consumers pick up the mock changes
- [x] `npm run test:mui` (same command CI's `integration.yml` runs) — 11 suites passed, 567 passed / 7 skipped (pre-existing, unrelated), 0 failures
- [ ] `test:admin` not run (admin app deps not installed in this environment; nothing there directly references the edited mocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)