### PR TITLE
fix(curl): wire script callbacks for PUT/PATCH/DELETE/HEAD/OPTIONS + smtp_send (#108)

### DIFF
--- a/src/afw_curl/afw_curl_function_http.c
+++ b/src/afw_curl/afw_curl_function_http.c
@@ -451,14 +451,14 @@ afw_curl_function_execute_http_head(
 
     /* Optional headers */
     headers = NULL;
-    if (AFW_FUNCTION_PARAMETER_IS_PRESENT(3)) {
-        AFW_FUNCTION_EVALUATE_REQUIRED_DATA_TYPE_PARAMETER(headers, 3, array);
+    if (AFW_FUNCTION_PARAMETER_IS_PRESENT(2)) {
+        AFW_FUNCTION_EVALUATE_REQUIRED_DATA_TYPE_PARAMETER(headers, 2, array);
     }
 
     /* Optional options */
     options = NULL;
-    if (AFW_FUNCTION_PARAMETER_IS_PRESENT(4)) {
-        AFW_FUNCTION_EVALUATE_REQUIRED_DATA_TYPE_PARAMETER(options, 4, object);
+    if (AFW_FUNCTION_PARAMETER_IS_PRESENT(3)) {
+        AFW_FUNCTION_EVALUATE_REQUIRED_DATA_TYPE_PARAMETER(options, 3, object);
     }
 
     /* use internal routine to do the HEAD */
@@ -524,14 +524,14 @@ afw_curl_function_execute_http_options(
 
     /* Optional headers */
     headers = NULL;
-    if (AFW_FUNCTION_PARAMETER_IS_PRESENT(3)) {
-        AFW_FUNCTION_EVALUATE_REQUIRED_DATA_TYPE_PARAMETER(headers, 3, array);
+    if (AFW_FUNCTION_PARAMETER_IS_PRESENT(2)) {
+        AFW_FUNCTION_EVALUATE_REQUIRED_DATA_TYPE_PARAMETER(headers, 2, array);
     }
 
     /* Optional options */
     options = NULL;
-    if (AFW_FUNCTION_PARAMETER_IS_PRESENT(4)) {
-        AFW_FUNCTION_EVALUATE_REQUIRED_DATA_TYPE_PARAMETER(options, 4, object);
+    if (AFW_FUNCTION_PARAMETER_IS_PRESENT(3)) {
+        AFW_FUNCTION_EVALUATE_REQUIRED_DATA_TYPE_PARAMETER(options, 3, object);
     }
 
     /* use internal routine to do the OPTIONS */

--- a/src/afw_curl/afw_curl_internal.c
+++ b/src/afw_curl/afw_curl_internal.c
@@ -917,7 +917,7 @@ afw_curl_internal_http_delete(
         header->contextual = contextual;
 
         /* set any options, that may have been specified */
-        afw_curl_internal_options(curl, options, header, NULL, writer, pool, xctx);
+        afw_curl_internal_options(curl, options, NULL, writer, header, pool, xctx);
 
         /* set the error buffer as empty before performing a request */
         errbuf = afw_pool_calloc(pool, CURL_ERROR_SIZE, xctx);
@@ -928,8 +928,8 @@ afw_curl_internal_http_delete(
             AFW_THROW_ERROR_RV_Z(general, curl, res, "Error in curl_easy_setopt()", xctx);
 
         /* setup our response callbacks to handle data send back from the server */
-        response = afw_curl_internal_register_response_callbacks(curl, 
-            NULL, NULL, pool, xctx);
+        response = afw_curl_internal_register_response_callbacks(curl,
+            header, writer, pool, xctx);
 
         /* Perform the request, res will get the return code */
         res = curl_easy_perform(curl);
@@ -1078,7 +1078,7 @@ afw_curl_internal_http_put(
 
         /* setup our response callbacks to handle data send back from the server */
         response = afw_curl_internal_register_response_callbacks(curl, 
-            NULL, NULL, pool, xctx);
+            header, writer, pool, xctx);
 
         /* Perform the request, res will get the return code */
         res = curl_easy_perform(curl);
@@ -1227,7 +1227,7 @@ afw_curl_internal_http_patch(
 
         /* setup our response callbacks to handle data send back from the server */
         response = afw_curl_internal_register_response_callbacks(curl, 
-            NULL, NULL, pool, xctx);
+            header, writer, pool, xctx);
 
         /* Perform the request, res will get the return code */
         res = curl_easy_perform(curl);
@@ -1346,7 +1346,7 @@ afw_curl_internal_http_head(
         header->contextual = contextual;
 
         /* set any options, that may have been specified */
-        afw_curl_internal_options(curl, options, header, NULL, writer, pool, xctx);
+        afw_curl_internal_options(curl, options, NULL, writer, header, pool, xctx);
 
         /* set the error buffer as empty before performing a request */
         errbuf = afw_pool_calloc(pool, CURL_ERROR_SIZE, xctx);
@@ -1358,7 +1358,7 @@ afw_curl_internal_http_head(
 
         /* setup our response callbacks to handle data send back from the server */
         response = afw_curl_internal_register_response_callbacks(curl, 
-            NULL, NULL, pool, xctx);
+            header, writer, pool, xctx);
 
         /* Perform the request, res will get the return code */
         res = curl_easy_perform(curl);
@@ -1479,7 +1479,7 @@ afw_curl_internal_http_options(
         header->contextual = contextual;
 
         /* set any options, that may have been specified */
-        afw_curl_internal_options(curl, options, header, NULL, writer, pool, xctx);
+        afw_curl_internal_options(curl, options, NULL, writer, header, pool, xctx);
 
         /* set the error buffer as empty before performing a request */
         errbuf = afw_pool_calloc(pool, CURL_ERROR_SIZE, xctx);
@@ -1491,7 +1491,7 @@ afw_curl_internal_http_options(
 
         /* setup our response callbacks to handle data send back from the server */
         response = afw_curl_internal_register_response_callbacks(curl, 
-            NULL, NULL, pool, xctx);
+            header, writer, pool, xctx);
 
         /* Perform the request, res will get the return code */
         res = curl_easy_perform(curl);

--- a/src/afw_curl/afw_curl_internal.c
+++ b/src/afw_curl/afw_curl_internal.c
@@ -1564,6 +1564,7 @@ afw_curl_internal_smtp_send(
     struct curl_slist * recipients = NULL;
     const afw_iterator_old_t * iterator;
     const afw_value_t * value;
+    afw_curl_internal_script_cb_t * reader = NULL;
 
     curl = curl_easy_init();
     AFW_TRY {
@@ -1595,11 +1596,15 @@ afw_curl_internal_smtp_send(
         if (res != CURLE_OK)
             AFW_THROW_ERROR_RV_Z(general, curl, res, "Error in curl_easy_setopt()", xctx);
 
+        reader = afw_pool_calloc_type(pool,
+            afw_curl_internal_script_cb_t, xctx);
+        reader->contextual = contextual;
+
         /* set any options, that may have been specified */
-        afw_curl_internal_options(curl, options, NULL, NULL, NULL, pool, xctx);
+        afw_curl_internal_options(curl, options, reader, NULL, NULL, pool, xctx);
 
         /* send the body of the email, using a callback */
-        afw_curl_internal_register_request_callbacks(curl, payload, NULL, pool, xctx);
+        afw_curl_internal_register_request_callbacks(curl, payload, reader, pool, xctx);
 
         /* Perform the request, res will get the return code */
         res = curl_easy_perform(curl);

--- a/src/afw_curl/tests/http/config.py
+++ b/src/afw_curl/tests/http/config.py
@@ -1,3 +1,109 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
+import json
+import os
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+# test configuration settings
 Environment = "curl"
+
+# Minimal local HTTP stub for http_* function regression tests, standing in
+# for httpbin.org so the suite runs deterministically, offline, and on every
+# `afwdev test` invocation instead of only when TEST_CURL_HTTPBIN is set.
+# Runs for the lifetime of this test group (see before_all / after_all
+# below); its port is published to the .as tests via AFW_CURL_TEST_HTTP_PORT.
+# Mirrors the smtp stub in tests/smtp/config.py.
+#
+# Behavior:
+#   - GET/POST/PUT/PATCH/DELETE echo the request back as a JSON body
+#     ({"method", "path", "headers", "data", and "json" when the request's
+#     Content-Type contains "json"}), so tests can assert on request/response
+#     round-tripping the same way the old httpbin.org-based tests did.
+#   - HEAD/OPTIONS send headers only, per HTTP semantics.
+#   - A path of "/status/<code>" forces that response code.
+
+_server = None
+_server_thread = None
+
+
+class _Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, format, *args):
+        pass
+
+    def _status_from_path(self):
+        if self.path.startswith("/status/"):
+            try:
+                return int(self.path[len("/status/"):])
+            except ValueError:
+                pass
+        return 200
+
+    def _read_body(self):
+        length = int(self.headers.get("Content-Length", 0) or 0)
+        return self.rfile.read(length) if length else b""
+
+    def _respond(self, with_body):
+        code = self._status_from_path()
+        raw = self._read_body()
+
+        self.close_connection = True
+
+        payload = b""
+        if with_body:
+            body = {
+                "method": self.command,
+                "path": self.path,
+                "headers": dict(self.headers.items()),
+            }
+            if raw:
+                body["data"] = raw.decode("utf-8", errors="replace")
+                if "json" in self.headers.get("Content-Type", ""):
+                    try:
+                        body["json"] = json.loads(raw)
+                    except ValueError:
+                        pass
+            payload = json.dumps(body).encode("utf-8")
+
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.send_header("X-Afw-Test", "stub")
+        self.end_headers()
+        if payload:
+            self.wfile.write(payload)
+
+    def do_GET(self):
+        self._respond(with_body=True)
+
+    do_POST = do_GET
+    do_PUT = do_GET
+    do_PATCH = do_GET
+    do_DELETE = do_GET
+
+    def do_HEAD(self):
+        self._respond(with_body=False)
+
+    do_OPTIONS = do_HEAD
+
+
+def before_all():
+    global _server, _server_thread
+
+    _server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    os.environ["AFW_CURL_TEST_HTTP_PORT"] = str(_server.server_address[1])
+
+    _server_thread = threading.Thread(target=_server.serve_forever, daemon=True)
+    _server_thread.start()
+
+
+def after_all():
+    global _server, _server_thread
+
+    if _server:
+        _server.shutdown()
+        _server.server_close()
+    if _server_thread:
+        _server_thread.join(timeout=5)

--- a/src/afw_curl/tests/http/http_delete.as
+++ b/src/afw_curl/tests/http/http_delete.as
@@ -24,67 +24,110 @@ http_delete("http://xyz");
 
 
 //? test: http_delete_http_cleartext
-//? description: Call http_delete with httpbin.org
+//? description: Call http_delete against the local HTTP stub (see config.py)
 //? expect: 200
 //? source: ...
 #!/usr/bin/env afw
 
-// only do live HTTP requests, if configured to do so
-if (environment::TEST_CURL_HTTPBIN === undefined) {
-    return 200;
-}
-
-const response = http_delete("http://www.httpbin.org/delete");
+const response = http_delete(
+    "http://127.0.0.1:" + string(integer(environment::AFW_CURL_TEST_HTTP_PORT)) + "/delete"
+);
 
 return response.response_code;
 
 
 //? test: http_delete_200
-//? description: Call http_delete with 200 rc
+//? description: Call http_delete with 200 rc against a real TLS endpoint
 //? expect: 200
 //? source: ...
 #!/usr/bin/env afw
 
-// only do live HTTP requests, if configured to do so
+// requires a real TLS endpoint; only run if configured to do so
 if (environment::TEST_CURL_HTTPBIN === undefined) {
     return 200;
 }
 
 const response = http_delete("https://www.httpbin.org/delete",,
-    { 
-        "sslVerifyPeer": true, 
+    {
+        "sslVerifyPeer": true,
         "sslVerifyHost": true
     });
 
 return response.response_code;
 
 //? test: http_delete_404
-//? description: Call http_delete with 404 rc
+//? description: Call http_delete against the local HTTP stub, forcing a 404
 //? expect: 404
 //? source: ...
 #!/usr/bin/env afw
 
-// only do live HTTP requests, if configured to do so
-if (environment::TEST_CURL_HTTPBIN === undefined) {
-    return 404;
-}
-
-const response = http_delete("https://www.httpbin.org/status/404");
+const response = http_delete(
+    "http://127.0.0.1:" + string(integer(environment::AFW_CURL_TEST_HTTP_PORT)) + "/status/404"
+);
 
 return response.response_code;
 
 
 //? test: http_delete_500
-//? description: Call http_delete with 500 rc
+//? description: Call http_delete against the local HTTP stub, forcing a 500
 //? expect: 500
 //? source: ...
 #!/usr/bin/env afw
 
-// only do live HTTP requests, if configured to do so
-if (environment::TEST_CURL_HTTPBIN === undefined) {
-    return 500;
+const response = http_delete(
+    "http://127.0.0.1:" + string(integer(environment::AFW_CURL_TEST_HTTP_PORT)) + "/status/500"
+);
+
+return response.response_code;
+
+
+//? test: http_delete_callbacks
+//? description: Call http_delete with callbacks against the local HTTP stub
+//? expect: 200
+//? source: ...
+#!/usr/bin/env afw
+
+let userData = {
+    "payload": "",
+    "headers": []
+};
+
+function writer(buffer, userData) {
+    const str = decode_to_string(buffer);
+    const len = length(str);
+
+    if (userData.payload !== undefined)
+        userData["payload"] += str;
+    else
+        userData["payload"] = str;
+
+    return len;
 }
 
-const response = http_delete("https://www.httpbin.org/status/500");
+function headers(header, userData) {
+    const len = length(header);
+
+    if (len > 0) {
+        add_entries(userData.headers, header);
+    }
+
+    return len;
+}
+
+const options = {
+    "headerFunction": headers,
+    "headerUserData": userData,
+    "writeFunction": writer,
+    "writeUserData": userData,
+};
+
+const response = http_delete(
+    "http://127.0.0.1:" + string(integer(environment::AFW_CURL_TEST_HTTP_PORT)) + "/delete",
+    undefined,
+    options
+);
+
+assert(length(userData.headers) > 0);
+assert(length(userData.payload) > 0);
 
 return response.response_code;

--- a/src/afw_curl/tests/http/http_get.as
+++ b/src/afw_curl/tests/http/http_get.as
@@ -23,18 +23,14 @@ http_get();
 http_get("http://xyz");
 
 //? test: http_get
-//? description: Call http_get
+//? description: Call http_get against the local HTTP stub (see config.py)
 //? expect: 200
 //? source: ...
 #!/usr/bin/env afw
 
-
-// only do live HTTP requests, if configured to do so
-if (environment::TEST_CURL_HTTPBIN === undefined) {
-    return 200;
-}
-
-const response = http_get("http://www.httpbin.org/get");
+const response = http_get(
+    "http://127.0.0.1:" + string(integer(environment::AFW_CURL_TEST_HTTP_PORT)) + "/get"
+);
 
 /* make sure we get at least the 200 OK header back */
 assert(includes(response.headers, "HTTP/1.1 200 OK\r\n"));
@@ -43,20 +39,20 @@ return response.response_code;
 
 
 //? test: http_get_secure
-//? description: Call http_get secure
+//? description: Call http_get secure against a real TLS endpoint
 //? expect: 200
 //? source: ...
 #!/usr/bin/env afw
 
-// only do live HTTP requests, if configured to do so
+// requires a real TLS endpoint; only run if configured to do so
 if (environment::TEST_CURL_HTTPBIN === undefined) {
     return 200;
 }
 
-const response = http_get("https://www.httpbin.org/get", 
+const response = http_get("https://www.httpbin.org/get",
     undefined,
-    { 
-        "sslVerifyPeer": true, 
+    {
+        "sslVerifyPeer": true,
         "sslVerifyHost": true
     });
 
@@ -64,34 +60,26 @@ return response.response_code;
 
 
 //? test: http_get_400
-//? description: Call http_get secure
+//? description: Call http_get against the local HTTP stub, forcing a 400
 //? expect: 400
 //? source: ...
 #!/usr/bin/env afw
 
-// only do live HTTP requests, if configured to do so
-if (environment::TEST_CURL_HTTPBIN === undefined) {
-    return 400;
-}
-
-const response = http_get("https://www.httpbin.org/status/400");
+const response = http_get(
+    "http://127.0.0.1:" + string(integer(environment::AFW_CURL_TEST_HTTP_PORT)) + "/status/400"
+);
 
 return response.response_code;
 
 
 //? test: http_get_callbacks
-//? description: Call http_get with callbacks
+//? description: Call http_get with callbacks against the local HTTP stub
 //? expect: 200
 //? source: ...
 #!/usr/bin/env afw
 
-// only do live HTTP requests, if configured to do so
-if (environment::TEST_CURL_HTTPBIN === undefined) {
-    return 200;
-}
-
 // fixme: if I don't set the "payload" property first,
-// then I get a valgrind/memory error; need to 
+// then I get a valgrind/memory error; need to
 // check memory pools
 let userData = {
     "payload": "",
@@ -105,7 +93,7 @@ function writer(buffer, userData) {
     // here, we could read the string and do something
     if (userData.payload !== undefined)
         userData["payload"] += str;
-    else 
+    else
         userData["payload"] = str;
 
     return len;
@@ -129,7 +117,7 @@ const options = {
 };
 
 const response = http_get(
-    "http://www.httpbin.org/get", 
+    "http://127.0.0.1:" + string(integer(environment::AFW_CURL_TEST_HTTP_PORT)) + "/get",
     undefined,
     options
 );

--- a/src/afw_curl/tests/http/http_head.as
+++ b/src/afw_curl/tests/http/http_head.as
@@ -24,16 +24,49 @@ http_head("http://xyz");
 
 
 //? test: http_head
-//? description: Call http_head with https://api.reqbin.com/
+//? description: Call http_head against the local HTTP stub (see config.py)
 //? expect: 200
 //? source: ...
 #!/usr/bin/env afw
 
-// only do live HTTP requests, if configured to do so
-if (environment::TEST_CURL_HTTPBIN === undefined) {
-    return 200;
+const response = http_head(
+    "http://127.0.0.1:" + string(integer(environment::AFW_CURL_TEST_HTTP_PORT)) + "/get"
+);
+
+return response.response_code;
+
+
+//? test: http_head_callbacks
+//? description: Call http_head with a headerFunction callback against the local HTTP stub
+//? expect: 200
+//? source: ...
+#!/usr/bin/env afw
+
+let userData = {
+    "headers": []
+};
+
+function headers(header, userData) {
+    const len = length(header);
+
+    if (len > 0) {
+        add_entries(userData.headers, header);
+    }
+
+    return len;
 }
 
-const response = http_head("http://wwww.httpbin.org/get");
+const options = {
+    "headerFunction": headers,
+    "headerUserData": userData,
+};
+
+const response = http_head(
+    "http://127.0.0.1:" + string(integer(environment::AFW_CURL_TEST_HTTP_PORT)) + "/get",
+    undefined,
+    options
+);
+
+assert(length(userData.headers) > 0);
 
 return response.response_code;

--- a/src/afw_curl/tests/http/http_options.as
+++ b/src/afw_curl/tests/http/http_options.as
@@ -24,16 +24,49 @@ http_options("http://xyz");
 
 
 //? test: http_options
-//? description: Call http_options with https://api.reqbin.com/
+//? description: Call http_options against the local HTTP stub (see config.py)
 //? expect: 200
 //? source: ...
 #!/usr/bin/env afw
 
-// only do live HTTP requests, if configured to do so
-if (environment::TEST_CURL_HTTPBIN === undefined) {
-    return 200;
+const response = http_options(
+    "http://127.0.0.1:" + string(integer(environment::AFW_CURL_TEST_HTTP_PORT)) + "/get"
+);
+
+return response.response_code;
+
+
+//? test: http_options_callbacks
+//? description: Call http_options with a headerFunction callback against the local HTTP stub
+//? expect: 200
+//? source: ...
+#!/usr/bin/env afw
+
+let userData = {
+    "headers": []
+};
+
+function headers(header, userData) {
+    const len = length(header);
+
+    if (len > 0) {
+        add_entries(userData.headers, header);
+    }
+
+    return len;
 }
 
-const response = http_options("http://wwww.httpbin.org/get");
+const options = {
+    "headerFunction": headers,
+    "headerUserData": userData,
+};
+
+const response = http_options(
+    "http://127.0.0.1:" + string(integer(environment::AFW_CURL_TEST_HTTP_PORT)) + "/get",
+    undefined,
+    options
+);
+
+assert(length(userData.headers) > 0);
 
 return response.response_code;

--- a/src/afw_curl/tests/http/http_patch.as
+++ b/src/afw_curl/tests/http/http_patch.as
@@ -24,67 +24,114 @@ http_patch("http://xyz", "");
 
 
 //? test: http_patch_http_cleartext
-//? description: Call http_patch with httpbin.org
+//? description: Call http_patch against the local HTTP stub (see config.py)
 //? expect: 200
 //? source: ...
 #!/usr/bin/env afw
 
-// only do live HTTP requests, if configured to do so
-if (environment::TEST_CURL_HTTPBIN === undefined) {
-    return 200;
-}
-
-const response = http_patch("http://www.httpbin.org/patch", "xyz");
+const response = http_patch(
+    "http://127.0.0.1:" + string(integer(environment::AFW_CURL_TEST_HTTP_PORT)) + "/patch",
+    "xyz"
+);
 
 return response.response_code;
 
 
 //? test: http_patch_200
-//? description: Call http_patch with 200 rc
+//? description: Call http_patch with 200 rc against a real TLS endpoint
 //? expect: 200
 //? source: ...
 #!/usr/bin/env afw
 
-// only do live HTTP requests, if configured to do so
+// requires a real TLS endpoint; only run if configured to do so
 if (environment::TEST_CURL_HTTPBIN === undefined) {
     return 200;
 }
 
 const response = http_patch("https://www.httpbin.org/patch","xyz",,
-    { 
-        "sslVerifyPeer": true, 
+    {
+        "sslVerifyPeer": true,
         "sslVerifyHost": true
     });
 
 return response.response_code;
 
 //? test: http_patch_404
-//? description: Call http_patch with 404 rc
+//? description: Call http_patch against the local HTTP stub, forcing a 404
 //? expect: 404
 //? source: ...
 #!/usr/bin/env afw
 
-// only do live HTTP requests, if configured to do so
-if (environment::TEST_CURL_HTTPBIN === undefined) {
-    return 404;
-}
-
-const response = http_patch("https://www.httpbin.org/status/404", "xyz");
+const response = http_patch(
+    "http://127.0.0.1:" + string(integer(environment::AFW_CURL_TEST_HTTP_PORT)) + "/status/404",
+    "xyz"
+);
 
 return response.response_code;
 
 
 //? test: http_patch_500
-//? description: Call http_patch with 500 rc
+//? description: Call http_patch against the local HTTP stub, forcing a 500
 //? expect: 500
 //? source: ...
 #!/usr/bin/env afw
 
-// only do live HTTP requests, if configured to do so
-if (environment::TEST_CURL_HTTPBIN === undefined) {
-    return 500;
+const response = http_patch(
+    "http://127.0.0.1:" + string(integer(environment::AFW_CURL_TEST_HTTP_PORT)) + "/status/500",
+    "xyz"
+);
+
+return response.response_code;
+
+
+//? test: http_patch_callbacks
+//? description: Call http_patch with callbacks against the local HTTP stub
+//? expect: 200
+//? source: ...
+#!/usr/bin/env afw
+
+let userData = {
+    "payload": "",
+    "headers": []
+};
+
+function writer(buffer, userData) {
+    const str = decode_to_string(buffer);
+    const len = length(str);
+
+    if (userData.payload !== undefined)
+        userData["payload"] += str;
+    else
+        userData["payload"] = str;
+
+    return len;
 }
 
-const response = http_patch("https://www.httpbin.org/status/500", "xyz");
+function headers(header, userData) {
+    const len = length(header);
+
+    if (len > 0) {
+        add_entries(userData.headers, header);
+    }
+
+    return len;
+}
+
+const options = {
+    "headerFunction": headers,
+    "headerUserData": userData,
+    "writeFunction": writer,
+    "writeUserData": userData,
+};
+
+const response = http_patch(
+    "http://127.0.0.1:" + string(integer(environment::AFW_CURL_TEST_HTTP_PORT)) + "/patch",
+    "xyz",
+    undefined,
+    options
+);
+
+assert(length(userData.headers) > 0);
+assert(length(userData.payload) > 0);
 
 return response.response_code;

--- a/src/afw_curl/tests/http/http_post.as
+++ b/src/afw_curl/tests/http/http_post.as
@@ -31,37 +31,35 @@ http_post("http://xyz");
 http_post("http://xyz", "");
 
 //? test: http_post_http_cleartext
-//? description: Call http_post over cleartext
+//? description: Call http_post against the local HTTP stub (see config.py)
 //? expect: 200
 //? source: ...
 #!/usr/bin/env afw
 
-// only do live HTTP requests, if configured to do so
-if (environment::TEST_CURL_HTTPBIN === undefined) {
-    return 200;
-}
-
-const response = http_post("http://www.httpbin.org/post", "");
+const response = http_post(
+    "http://127.0.0.1:" + string(integer(environment::AFW_CURL_TEST_HTTP_PORT)) + "/post",
+    ""
+);
 
 return response.response_code;
 
 
 //? test: http_post_google_secure
-//? description: Call http_post with 200 rc
+//? description: Call http_post with 200 rc against a real TLS endpoint
 //? expect: 200
 //? source: ...
 #!/usr/bin/env afw
 
-// only do live HTTP requests, if configured to do so
+// requires a real TLS endpoint; only run if configured to do so
 if (environment::TEST_CURL_HTTPBIN === undefined) {
     return 200;
 }
 
-const response = http_post("https://www.httpbin.org/post", 
+const response = http_post("https://www.httpbin.org/post",
     "xyz",
     undefined,
-    { 
-        "sslVerifyPeer": true, 
+    {
+        "sslVerifyPeer": true,
         "sslVerifyHost": true
     });
 
@@ -69,15 +67,10 @@ return response.response_code;
 
 
 //? test: http_post_json
-//? description: Call http_post with json data
+//? description: Call http_post with json data against the local HTTP stub
 //? expect: 200
 //? source: ...
 #!/usr/bin/env afw
-
-// only do live HTTP requests, if configured to do so
-if (environment::TEST_CURL_HTTPBIN === undefined) {
-    return 200;
-}
 
 const postData = {
     "foo": "bar"
@@ -90,7 +83,7 @@ const postHeaders = [
 
 
 const response = http_post(
-    "http://www.httpbin.org/post", 
+    "http://127.0.0.1:" + string(integer(environment::AFW_CURL_TEST_HTTP_PORT)) + "/post",
     string(postData),
     postHeaders
 );
@@ -100,7 +93,6 @@ assert(length(response.response) > 0);
 
 const decoded = compile(json(decode_to_string(base64Binary(response.response))));
 
-// Note: response format from httpbin.org could change in the future
 assert(decoded.headers.Accept === "application/json");
 assert(decoded.json.foo === "bar");
 
@@ -108,18 +100,13 @@ return response.response_code;
 
 
 //? test: http_post_callbacks
-//? description: Call http_post with callbacks
+//? description: Call http_post with callbacks against the local HTTP stub
 //? expect: 200
 //? source: ...
 #!/usr/bin/env afw
 
-// only do live HTTP requests, if configured to do so
-if (environment::TEST_CURL_HTTPBIN === undefined) {
-    return 200;
-}
-
 // fixme: if I don't set the "payload" property first,
-// then I get a valgrind/memory error; need to 
+// then I get a valgrind/memory error; need to
 // check memory pools
 let userData = {
     "payload": "",
@@ -133,7 +120,7 @@ function writer(buffer, userData) {
     // here, we could read the string and do something
     if (userData.payload !== undefined)
         userData["payload"] += str;
-    else 
+    else
         userData["payload"] = str;
 
     return len;
@@ -166,9 +153,9 @@ const options = {
 };
 
 const response = http_post(
-    "http://www.httpbin.org/post", 
+    "http://127.0.0.1:" + string(integer(environment::AFW_CURL_TEST_HTTP_PORT)) + "/post",
     string(postData),
-    postHeaders,    
+    postHeaders,
     options
 );
 

--- a/src/afw_curl/tests/http/http_put.as
+++ b/src/afw_curl/tests/http/http_put.as
@@ -24,67 +24,114 @@ http_put("http://xyz", "");
 
 
 //? test: http_put_http_cleartext
-//? description: Call http_put with httpbin.org
+//? description: Call http_put against the local HTTP stub (see config.py)
 //? expect: 200
 //? source: ...
 #!/usr/bin/env afw
 
-// only do live HTTP requests, if configured to do so
-if (environment::TEST_CURL_HTTPBIN === undefined) {
-    return 200;
-}
-
-const response = http_put("http://www.httpbin.org/put", "xyz");
+const response = http_put(
+    "http://127.0.0.1:" + string(integer(environment::AFW_CURL_TEST_HTTP_PORT)) + "/put",
+    "xyz"
+);
 
 return response.response_code;
 
 
 //? test: http_put_200
-//? description: Call http_put with 200 rc
+//? description: Call http_put with 200 rc against a real TLS endpoint
 //? expect: 200
 //? source: ...
 #!/usr/bin/env afw
 
-// only do live HTTP requests, if configured to do so
+// requires a real TLS endpoint; only run if configured to do so
 if (environment::TEST_CURL_HTTPBIN === undefined) {
     return 200;
 }
 
 const response = http_put("https://www.httpbin.org/put","xyz",,
-    { 
-        "sslVerifyPeer": true, 
+    {
+        "sslVerifyPeer": true,
         "sslVerifyHost": true
     });
 
 return response.response_code;
 
 //? test: http_put_404
-//? description: Call http_put with 404 rc
+//? description: Call http_put against the local HTTP stub, forcing a 404
 //? expect: 404
 //? source: ...
 #!/usr/bin/env afw
 
-// only do live HTTP requests, if configured to do so
-if (environment::TEST_CURL_HTTPBIN === undefined) {
-    return 404;
-}
-
-const response = http_put("https://www.httpbin.org/status/404", "xyz");
+const response = http_put(
+    "http://127.0.0.1:" + string(integer(environment::AFW_CURL_TEST_HTTP_PORT)) + "/status/404",
+    "xyz"
+);
 
 return response.response_code;
 
 
 //? test: http_put_500
-//? description: Call http_put with 500 rc
+//? description: Call http_put against the local HTTP stub, forcing a 500
 //? expect: 500
 //? source: ...
 #!/usr/bin/env afw
 
-// only do live HTTP requests, if configured to do so
-if (environment::TEST_CURL_HTTPBIN === undefined) {
-    return 500;
+const response = http_put(
+    "http://127.0.0.1:" + string(integer(environment::AFW_CURL_TEST_HTTP_PORT)) + "/status/500",
+    "xyz"
+);
+
+return response.response_code;
+
+
+//? test: http_put_callbacks
+//? description: Call http_put with callbacks against the local HTTP stub
+//? expect: 200
+//? source: ...
+#!/usr/bin/env afw
+
+let userData = {
+    "payload": "",
+    "headers": []
+};
+
+function writer(buffer, userData) {
+    const str = decode_to_string(buffer);
+    const len = length(str);
+
+    if (userData.payload !== undefined)
+        userData["payload"] += str;
+    else
+        userData["payload"] = str;
+
+    return len;
 }
 
-const response = http_put("https://www.httpbin.org/status/500", "xyz");
+function headers(header, userData) {
+    const len = length(header);
+
+    if (len > 0) {
+        add_entries(userData.headers, header);
+    }
+
+    return len;
+}
+
+const options = {
+    "headerFunction": headers,
+    "headerUserData": userData,
+    "writeFunction": writer,
+    "writeUserData": userData,
+};
+
+const response = http_put(
+    "http://127.0.0.1:" + string(integer(environment::AFW_CURL_TEST_HTTP_PORT)) + "/put",
+    "xyz",
+    undefined,
+    options
+);
+
+assert(length(userData.headers) > 0);
+assert(length(userData.payload) > 0);
 
 return response.response_code;

--- a/src/afw_curl/tests/smtp/smtp_send_upload.as
+++ b/src/afw_curl/tests/smtp/smtp_send_upload.as
@@ -28,6 +28,60 @@ smtp_send(
 return 0;
 
 
+//? test: smtp_upload_read_callback
+//? description: smtp_send() with a custom readFunction (see afw_curl_internal_request_cb), streaming the body from script-controlled chunks instead of the internal single-shot buffer copy. Chunks are returned larger than libcurl's offered read-buffer capacity, exercising the pending_payload partial-drain path.
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+const bodyLen = 20000;
+let body = "A";
+while (length(body) < bodyLen) {
+    body += body;
+}
+body = substring(body, 0, bodyLen);
+
+let userData = {
+    "body": body,
+    "offset": 0,
+    "calls": 0
+};
+
+function reader(userData, size, nitems) {
+    if (userData.offset >= length(userData.body)) {
+        return null;
+    }
+
+    // return a chunk far bigger than libcurl's offered capacity (size * nitems),
+    // to exercise the pending_payload partial-drain path across calls
+    const chunkSize = 8000;
+    const remaining = length(userData.body) - userData.offset;
+    const n = (remaining < chunkSize) ? remaining : chunkSize;
+    const chunk = substring(userData.body, userData.offset, userData.offset + n);
+
+    userData["offset"] = userData.offset + n;
+    userData["calls"] = userData.calls + 1;
+
+    return encode_as_hexBinary(chunk);
+}
+
+smtp_send(
+    "smtp://127.0.0.1:" + string(integer(environment::AFW_CURL_TEST_SMTP_PORT)),
+    "stub-len-" + string(bodyLen) + "@example.com",
+    ["recipient@example.com"],
+    "",
+    {
+        "readFunction": reader,
+        "readUserData": userData
+    }
+);
+
+assert(userData.calls > 1);
+assert(userData.offset === bodyLen);
+
+return 0;
+
+
 //? test: smtp_upload_multi_buffer
 //? description: Payload far larger than libcurl's internal upload buffer, forcing multiple READFUNCTION invocations. This is the case that crashed before the C1 fix.
 //? expect: 0


### PR DESCRIPTION
## Summary

PR #111 added `readFunction`/`writeFunction`/`headerFunction` script callback support for curl (#107, #108), but the wiring only actually worked for `http_get` and `http_post`:

- `http_put`, `http_patch`, `http_delete`, `http_head`, and `http_options` all built the `reader`/`writer`/`header` structs via `afw_curl_internal_options()` and then discarded them by calling `afw_curl_internal_register_response_callbacks(curl, NULL, NULL, ...)`, silently falling back to internal buffering regardless of what the caller passed. `http_delete`/`http_head`/`http_options` also passed `reader`/`writer`/`header` into `afw_curl_internal_options()` in the wrong argument slots.
- Fixing that surfaced a second, independent bug: `http_head` and `http_options` checked `AFW_FUNCTION_PARAMETER_IS_PRESENT(3)`/`(4)` for their `headers`/`options` parameters instead of `(2)`/`(3)` — apparently copied from the payload-bearing verbs (POST/PUT/PATCH, which have an extra argument at slot 2). `headers`/`options` were never read on HEAD/OPTIONS at all.
- `smtp_send()` had the same problem on the request side: it called `afw_curl_internal_options(curl, options, NULL, NULL, NULL, ...)`, discarding any `readFunction`/`readUserData` the caller supplied, always sending the full payload buffer through the internal single-shot copy.

## Changes

- `afw_curl_internal.c` / `afw_curl_function_http.c`: fixed the callback wiring and parameter-index bugs above.
- `tests/http/config.py`: added a local HTTP stub server (mirroring the existing `tests/smtp/config.py` stub), so the http test group runs deterministically offline instead of being gated behind `TEST_CURL_HTTPBIN` (which meant most of these tests were silent no-ops by default). Two TLS-specific tests stay opt-in against the real network since a plain stub can't stand in for certificate verification.
- Added `_callbacks` regression tests for every HTTP verb, and a new `smtp_upload_read_callback` test that streams a body through a custom `readFunction` in chunks larger than libcurl's offered buffer, exercising the `pending_payload` partial-drain path for the first time.
- Verified each new test actually catches its bug by reverting the corresponding fix and confirming the test fails, then re-verified clean.

`readFunction`-driven streaming uploads for the HTTP verbs (POST/PUT/PATCH via `CURLOPT_UPLOAD`/`CURLOPT_READFUNCTION` instead of `CURLOPT_POSTFIELDS`) is a separate, larger change and is intentionally out of scope here; #108 stays open for that.

## Test plan

- [x] `afwdev test --srcdir-pattern afw_curl` — 47 passed
- [x] `TEST_CURL_HTTPBIN=1 afwdev test --srcdir-pattern afw_curl` — 47 passed (live network TLS tests included)
- [x] `afwdev test --srcdir-pattern afw_curl --env-mode valgrind` — 47 passed, no valgrind errors
- [x] Each new regression test manually confirmed to fail against the pre-fix code

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>