### PR TITLE
fix(test): sync stale JS admin test mocks (Extensions/Services)

### DIFF
--- a/src/afw_test/javascript/src/__mocks__/get_object/afw/_AdaptiveEnvironmentRegistry_/current.json
+++ b/src/afw_test/javascript/src/__mocks__/get_object/afw/_AdaptiveEnvironmentRegistry_/current.json
@@ -226,6 +226,48 @@
                 "referenceCount": 3,
                 "serviceId": "adapter-dev"
             },
+            "lmdb": {
+                "adapterId": "lmdb",
+                "metrics": {
+                    "addObjectCount": 0,
+                    "deleteObjectCount": 0,
+                    "getObjectCount": 0,
+                    "modifyObjectCount": 0,
+                    "replaceObjectCount": 0,
+                    "retrieveObjectsCount": 0,
+                    "updateObjectCount": 0
+                },
+                "properties": {
+                    "_meta_": {
+                        "path": "/afw/_AdaptiveConf_adapter_lmdb/lmdb"
+                    },
+                    "checkIndividualObjectReadAccess": false,
+                    "sourceLocation": "/conf/_AdaptiveServiceConf_/adapter-lmdb/conf",
+                    "env": {
+                        "path": "/afw/lmdb",
+                        "mode": 384,
+                        "maxreaders": 126,
+                        "maxdbs": 128,
+                        "mapsize": 137438953472
+                    },
+                    "limits": {
+                        "size": {
+                            "soft": 500,
+                            "hard": 1000
+                        },
+                        "time": {
+                            "soft": 3600,
+                            "hard": 14400
+                        }
+                    },
+                    "description": "A LMDB (Lightning Memory-Mapped Database).",
+                    "type": "adapter",
+                    "adapterType": "lmdb",
+                    "adapterId": "lmdb"
+                },
+                "referenceCount": 3,
+                "serviceId": "adapter-lmdb"
+            },
             "vfs": {
                 "adapterId": "vfs",
                 "metrics": {

--- a/src/afw_test/javascript/src/__mocks__/get_object/afw/_AdaptiveEnvironmentRegistry_/current.json
+++ b/src/afw_test/javascript/src/__mocks__/get_object/afw/_AdaptiveEnvironmentRegistry_/current.json
@@ -472,7 +472,27 @@
                 "description": "Adapter type for Lightweight Directory Access Protocol (LDAP)."
             }
         },
-        "authorization_handler_id": {},
+        "authorization_handler_id": {
+            "auth-script": {
+                "authorizationHandlerId": "auth-script",
+                "processingOrder": 1,
+                "properties": {
+                    "_meta_": {
+                        "path": "/afw/_AdaptiveConf_authorizationHandler_script/auth-script",
+                        "objectType": "_AdaptiveConf_authorizationHandler_script"
+                    },
+                    "authorizationHandlerId": "auth-script",
+                    "authorizationHandlerType": "script",
+                    "type": "authorizationHandler",
+                    "description": "Handles authorization using an adaptive script.",
+                    "sourceLocation": "/conf/_AdaptiveServiceConf_/authorizationHandler-auth-script/conf",
+                    "priority": 9999
+                },
+                "referenceCount": 1,
+                "serviceId": "authorizationHandler-auth-script",
+                "stopping": []
+            }
+        },
         "authorization_handler_type": {
             "script": {
                 "authorizationHandlerType": "script",

--- a/src/afw_test/javascript/src/__mocks__/retrieve_objects/afw/_AdaptiveManifest_.json
+++ b/src/afw_test/javascript/src/__mocks__/retrieve_objects/afw/_AdaptiveManifest_.json
@@ -118,6 +118,25 @@
         },
         {
             "_meta_": {
+                "path": "/afw/_AdaptiveManifest_/afw_vfs",
+                "objectId": "afw_vfs",
+                "objectType": "_AdaptiveManifest_"
+            },
+            "registers": [
+                "adapter_type/vfs"
+            ],
+            "providesObjects": [
+                "/afw/_AdaptiveObjectType_/_AdaptiveAdapterTypeSpecific_vfs_retrieve_objects",
+                "/afw/_AdaptiveObjectType_/_AdaptiveConf_adapter_vfs",
+                "/afw/_AdaptiveObjectType_/_AdaptiveFile_vfs"
+            ],
+            "modulePath": "libafwvfs",
+            "extensionId": "afw_vfs",
+            "description": "This extension provides an adapter for accessing local files through a Virtual File System interface.",
+            "brief": "Extension for VFS (Virtual File System)"
+        },
+        {
+            "_meta_": {
                 "path": "/afw/_AdaptiveManifest_/afw_authorization_policy",
                 "objectId": "afw_authorization_policy",
                 "objectType": "_AdaptiveManifest_"


### PR DESCRIPTION
## Summary
- Fixes the 3 pre-existing failures in `Extensions.test.js` and `Services.test.js` reported in #238.
- Root cause: mock data in `src/afw_test/javascript/src/__mocks__` was internally inconsistent — objects referenced elsewhere in the fixtures (a loaded `afw_vfs` extension, a running `authorizationHandler-auth-script` service, a running `adapter-lmdb` service and its `adapter-tier` model consumer) had no matching entry in the `_AdaptiveEnvironmentRegistry_`/`_AdaptiveManifest_` mocks that the components actually render from.
- Added the missing entries (`afw_vfs` manifest entry, `auth-script` authorization handler, `lmdb` adapter), each built from the real/adjacent mock data already in the fixtures, so the mock catalog is self-consistent again. No application code changed.
- Also clears the `MUI: out-of-range value 'lmdb'` console warning noted as a side observation in #238.

## Test plan
- [x] Rebuilt `@afw/test` and `@afw/core` JS packages
- [x] `npm test` (admin) narrowed to `Extensions.test.js` + `Services.test.js` — 29/29 passing
- [x] Full admin suite (`npm run test:admin`-equivalent, all suites) — 35/35 suites, 116 passed, 0 failed, 14 pre-existing skips
- [x] No more `MUI: out-of-range value` console warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)