### PR TITLE
Docker: buildx env-var docs, AlmaLinux 9 image trio, package-build fix

### DIFF
--- a/docker/images/README.md
+++ b/docker/images/README.md
@@ -1,11 +1,11 @@
 # Docker Images
 
-Some of these images are intended to be built automatically from
-workflows and be published so they are publicly available for download and use.
-However, anyone can build these images on their local workstation or Docker
-registry.
+Some of these images are intended to be built automatically from 
+workflows and be published so they are publicly available for download and use. 
+However, anyone can build these images on their local workstation or Docker 
+registry. 
 
-When publishing the docker images, we use the GitHub container registry uri
+When publishing the docker images, we use the GitHub container registry uri 
 and the `afw-org` prefix:
 
 | Folder | Image Name | Tag(s) |
@@ -24,152 +24,152 @@ An example of one of the full image names, along with its description of tag par
 ghcr.io/afw-org/<image-name>:<distribution><version>
 ```
 
-The `distribution` refers to the Docker base OS (`alpine`, `ubuntu`, `nginx`,
-`node`) and `version` refers to the distribution version (`3.16.9`). The
-`version` may be omitted to indicate it's the "latest" tagged version for a
-particular distribution. Furthermore, the `distribution` name may also be
-omitted to indicate it's the default/preferred distribution for a particular
+The `distribution` refers to the Docker base OS (`alpine`, `ubuntu`, `nginx`, 
+`node`) and `version` refers to the distribution version (`3.16.9`). The 
+`version` may be omitted to indicate it's the "latest" tagged version for a 
+particular distribution. Furthermore, the `distribution` name may also be 
+omitted to indicate it's the default/preferred distribution for a particular 
 image.
 
 ## Image Descriptions
 
 Each folder inside here contains Dockerfile templates for building individual images.
 
-* `afw-dev-base` - This image has all of the necessary base software installed
-for building Adaptive Framework on a variety of platforms. It also serves as the
-base image for the `devcontainer`, that VS Code can use for remote development.
-This would ideally only be updated when an underlying base distribution image
+* `afw-dev-base` - This image has all of the necessary base software installed 
+for building Adaptive Framework on a variety of platforms. It also serves as the 
+base image for the `devcontainer`, that VS Code can use for remote development. 
+This would ideally only be updated when an underlying base distribution image 
 changes.
 
-* `afw-base` - This image is the base image for running Adaptive Framework.  It
-contains the bare minimum dependencies without all of the development
-requirements. This image would not be used to create instances from - instead,
+* `afw-base` - This image is the base image for running Adaptive Framework.  It 
+contains the bare minimum dependencies without all of the development 
+requirements. This image would not be used to create instances from - instead, 
 it should be used to inherit other images from, such as `afwfcgi` and `afw`.
-This would ideally only be updated when an underlying base distribution image
+This would ideally only be updated when an underlying base distribution image 
 changes.
 
-* `builder` - This image copies the current source into the image and does a
+* `builder` - This image copies the current source into the image and does a 
 full build. This image is intended to be a temporary storage image from which
-artifacts can be copied out of to use for the remaining images, as well as
+artifacts can be copied out of to use for the remaining images, as well as 
 for extracting and/or publishing installable packages from. It uses a multi-
 stage build process to store the artifacts into a small `scratch` image.
 
-* `afw-dev` - This image is nearly identical to `afw-dev-base`, with the addition
-of a version of `afw` installed. Where `afw-dev-base` is used to build
-Adaptive Framework core itself, `afw-dev` is used to build and develop
-extensions, layouts, etc without having to obtain or build Adaptive Framework
+* `afw-dev` - This image is nearly identical to `afw-dev-base`, with the addition 
+of a version of `afw` installed. Where `afw-dev-base` is used to build 
+Adaptive Framework core itself, `afw-dev` is used to build and develop 
+extensions, layouts, etc without having to obtain or build Adaptive Framework 
 core source code.
 
-* `afw-admin` - The Administrative Web Application for Administrating an Adaptive
-Framework instance.  It's based on the `nginx` image. This image can be used to
-create container instances that only hosts the admin app. This image is useful
-if you have one or more FastCGI containers, running in orchestration, and wish
+* `afw-admin` - The Administrative Web Application for Administrating an Adaptive 
+Framework instance.  It's based on the `nginx` image. This image can be used to 
+create container instances that only hosts the admin app. This image is useful 
+if you have one or more FastCGI containers, running in orchestration, and wish 
 to isolate a single admin web app to front them.
 
-* `afwfcgi` - This image combines `base` with an installed instance of Adaptive
+* `afwfcgi` - This image combines `base` with an installed instance of Adaptive 
 Framework. It starts an instance of `afwfcgi`, the FastCGI service to handle
-Adaptive Framework requests. This image can be used to create containers that
-only start the FastCGI service. In order to use this container, you will need
-to proxy it behind a HTTP service container, such as Nginx or Apache to create
+Adaptive Framework requests. This image can be used to create containers that 
+only start the FastCGI service. In order to use this container, you will need 
+to proxy it behind a HTTP service container, such as Nginx or Apache to create 
 a fully functional HTTP service.
 
-* `afw` - This image contains nginx, `afwfcgi` and a lot of configurations to
-serve up everything in one convenient image. It includes `nginx`, `afwfcgi`,
-the `admin` app and uses `supervisord` to start everything. It contains some
-built-in demo-able configurations, but can be used to stand up a production
+* `afw` - This image contains nginx, `afwfcgi` and a lot of configurations to 
+serve up everything in one convenient image. It includes `nginx`, `afwfcgi`, 
+the `admin` app and uses `supervisord` to start everything. It contains some 
+built-in demo-able configurations, but can be used to stand up a production 
 instance by providing your own volume/configuration.
 
 
 ## Ordered Steps for Building Images
 
 **Note:** The sample command snippets that use the buildx plugin for multi-
-architecture support will make use of the `--push` option. This instructs
+architecture support will make use of the `--push` option. This instructs 
 Docker to push the multi-arch platform images to the remote container registry
 on GitHub to be stored. By default, GitHub, DockerHub, etc will store multi-
-arch platform images because they have the ability to store manifest lists.
+arch platform images because they have the ability to store manifest lists. 
 Your local Docker Desktop currently does not, and trying to build a multi-arch
-image without pushing it will only keep them around in build cache, as any
-attempt to store them with `--load` will result in the error message
+image without pushing it will only keep them around in build cache, as any 
+attempt to store them with `--load` will result in the error message 
 
-`ERROR: docker exporter does not currently support exporting manifest lists`.
+`ERROR: docker exporter does not currently support exporting manifest lists`.   
 
 If your Docker Desktop engine supports `containerd` to store images, along with
-architecture manifests, then you can build for multi-platform locally without
+architecture manifests, then you can build for multi-platform locally without 
 having to push them to a remote repository.
 
-This is a basic walk-through for building all of the Docker images, using
-Alpine Linux as the underlying distribution.  The tag name should be based on
-the tag name of the distribution and afw version (in these examples,
+This is a basic walk-through for building all of the Docker images, using 
+Alpine Linux as the underlying distribution.  The tag name should be based on 
+the tag name of the distribution and afw version (in these examples, 
 `alpine3.16.9` and `0.9.0-0`).
 
 0. Set some environment variables to aid with the code examples:
 
   ```
-  # set env variables to use for commands
+  # set env variables to use for commands  
   export OS="alpine"
   export OS_RELEASE="3.16.9"
   export AFW_VERSION="0.9.0"
   ```
 
-1. `afw-base` and `afw-dev-base`: These should be built first and in no order
+1. `afw-base` and `afw-dev-base`: These should be built first and in no order 
 in particular.
 
-  ```
+  ```  
   # build the afw-base image
   docker build -f docker/images/afw-base/Dockerfile.${OS} \
     -t ghcr.io/afw-org/afw-base:${OS}${ALPINE_RELEASE} \
     -t ghcr.io/afw-org/afw-base:${OS} \
     docker/images/afw-base
 
-  # Alternatively, build multi-architecture support, pushing it at
+  # Alternatively, build multi-architecture support, pushing it at 
   # build-time, which requires the Docker buildx:
   docker buildx build --platform linux/amd64,linux/arm64 \
     -f docker/images/afw-base/Dockerfile.${OS} \
     -t ghcr.io/afw-org/afw-base:${OS}${ALPINE_RELEASE} \
     -t ghcr.io/afw-org/afw-base:${OS} \
     --push docker/images/afw-base
-
+  
   # build the afw-dev-base image
   docker build -f docker/images/afw-dev-base/Dockerfile.${OS} \
     -t ghcr.io/afw-org/afw-dev-base:${OS}${ALPINE_RELEASE} \
     -t ghcr.io/afw-org/afw-dev-base:${OS} \
     .
 
-  # Alternatively, build multi-architecture support, pushing it at
-  # build-time, which requires the Docker buildx:
+  # Alternatively, build multi-architecture support, pushing it at 
+  # build-time, which requires the Docker buildx:  
   docker buildx build --platform linux/amd64,linux/arm64 \
-    -f docker/images/afw-dev-base/Dockerfile.${OS} \
+    -f docker/images/afw-dev-base/Dockerfile.${OS} \  
     -t ghcr.io/afw-org/afw-dev-base:${OS}${ALPINE_RELEASE} \
     -t ghcr.io/afw-org/afw-dev-base:${OS} \
     --push .
   ```
 
-2. Next, optionally use the `ghcr.io/afw-org/afw-dev-base:${OS}` image you
-created in the previous step to build Adaptive Framework into a builder image,
-if you wish to produce and distribute individual artifacts (RPM's/TAR's/etc).
-If you do not need these, then skip to the next step.
-This assumes that you are at the top-level source code. This step will actually
-*copy* all of the current source code into the `afw-builder` image and run the
-full build. Make sure you do not have residual build directories already in your
-source tree (node_modules, etc.). Otherwise, the image is much larger and slower
+2. Next, optionally use the `ghcr.io/afw-org/afw-dev-base:${OS}` image you 
+created in the previous step to build Adaptive Framework into a builder image, 
+if you wish to produce and distribute individual artifacts (RPM's/TAR's/etc). 
+If you do not need these, then skip to the next step. 
+This assumes that you are at the top-level source code. This step will actually 
+*copy* all of the current source code into the `afw-builder` image and run the 
+full build. Make sure you do not have residual build directories already in your 
+source tree (node_modules, etc.). Otherwise, the image is much larger and slower 
 than it needs to be.
 
 ```
   docker build -f docker/images/builder/Dockerfile.${OS} -o type=local,dest=. .
 
-  # Alternatively, build multi-arch support, which requires the Docker buildx
+  # Alternatively, build multi-arch support, which requires the Docker buildx   
   docker buildx build --platform linux/amd64,linux/arm64 \
     -f docker/images/builder/Dockerfile.${OS} -o type=local,dest=. .
 ```
 
-This will produce multiple folders, `linux_amd64`, `linux_arm64`, each
-containing artifacts for that architecture.
+This will produce multiple folders, `linux_amd64`, `linux_arm64`, each 
+containing artifacts for that architecture. 
 
-3. From here, you can now build the `afw` image,
+3. From here, you can now build the `afw` image, 
 `ghcr.io/afw-org/afw:${OS}${OS_RELEASE}-${AFW_VERSION}`:
 
-```
-  docker build \
+```  
+  docker build \    
     -t ghcr.io/afw-org/afw:${OS}${ALPINE_RELEASE}-${AFW_RELEASE} \
     -t ghcr.io/afw-org/afw:${OS} \
     -t ghcr.io/afw-org/afw:latest \
@@ -177,7 +177,7 @@ containing artifacts for that architecture.
 
   # Alternatively, build multi-arch support, pushing it at build-time
   # which requires the Docker buildx:
-  docker buildx build --platform linux/amd64,linux/arm64 \
+  docker buildx build --platform linux/amd64,linux/arm64 \  
     -f docker/images/afw/Dockerfile.${OS} \
     -t ghcr.io/afw-org/afw:${OS}${ALPINE_RELEASE}-${AFW_RELEASE} \
     -t ghcr.io/afw-org/afw:${OS} \
@@ -187,18 +187,18 @@ containing artifacts for that architecture.
 4. To build the `afw-dev` image, `ghcr.io/afw-org/afw-dev:${OS}${OS_RELEASE}-${AFW_VERSION}`:
 
 ```
-  docker build \
+  docker build \    
     -t ghcr.io/afw-org/afw-dev:${OS}${OS_RELEASE}-${AFW_VERSION} \
     -t ghcr.io/afw-org/afw-dev:${OS} \
     -f docker/images/afw-dev/Dockerfile.${OS} .
 
   # Alternatively, build multi-arch support, pushing it at build-time
   # which requires the Docker buildx plugin:
-  docker buildx build --platform linux/amd64,linux/arm64 \
+  docker buildx build --platform linux/amd64,linux/arm64 \  
     -f docker/images/afw-dev/Dockerfile.${OS} \
     -t ghcr.io/afw-org/afw-dev:${OS}${OS_RELEASE}-${AFW_VERSION} \
     -t ghcr.io/afw-org/afw-dev:${OS} --push .
 ```
 
-4. The `afwfcgi` and `afw-admin` can be build in the same way as
+4. The `afwfcgi` and `afw-admin` can be build in the same way as 
 `afw` in step 3.

--- a/docker/images/README.md
+++ b/docker/images/README.md
@@ -10,7 +10,7 @@ and the `afw-org` prefix:
 
 | Folder | Image Name | Tag(s) |
 |------------|--------------------------------|------|
-| `afw-dev-base` | `ghcr.io/afw-org/afw-dev-base` | `latest`, `alpine`, `ubuntu`, `alpine${3.16.9}$`, `ubuntu22.04` |
+| `afw-dev-base` | `ghcr.io/afw-org/afw-dev-base` | `latest`, `alpine`, `ubuntu`, `alpine3.16.9`, `ubuntu22.04` |
 | `afw-base`     | `ghcr.io/afw-org/afw-base`     | `latest`, `alpine`, `ubuntu`, `alpine3.16.9`, `ubuntu22.04` |
 | `afw-dev`      | `ghcr.io/afw-org/afw-dev`      | `latest`, `alpine3.16.9-0.9.0-0`, `ubuntu22.04-0.9.0-0`   |
 | `afw-admin`    | `ghcr.io/afw-org/afw-admin`    | `latest`, `nginx1.23.1-0.9.0-0`                            |
@@ -117,7 +117,7 @@ in particular.
   ```  
   # build the afw-base image
   docker build -f docker/images/afw-base/Dockerfile.${OS} \
-    -t ghcr.io/afw-org/afw-base:${OS}${ALPINE_RELEASE} \
+    -t ghcr.io/afw-org/afw-base:${OS}${OS_RELEASE} \
     -t ghcr.io/afw-org/afw-base:${OS} \
     docker/images/afw-base
 
@@ -125,13 +125,13 @@ in particular.
   # build-time, which requires the Docker buildx:
   docker buildx build --platform linux/amd64,linux/arm64 \
     -f docker/images/afw-base/Dockerfile.${OS} \
-    -t ghcr.io/afw-org/afw-base:${OS}${ALPINE_RELEASE} \
+    -t ghcr.io/afw-org/afw-base:${OS}${OS_RELEASE} \
     -t ghcr.io/afw-org/afw-base:${OS} \
     --push docker/images/afw-base
   
   # build the afw-dev-base image
   docker build -f docker/images/afw-dev-base/Dockerfile.${OS} \
-    -t ghcr.io/afw-org/afw-dev-base:${OS}${ALPINE_RELEASE} \
+    -t ghcr.io/afw-org/afw-dev-base:${OS}${OS_RELEASE} \
     -t ghcr.io/afw-org/afw-dev-base:${OS} \
     .
 
@@ -139,7 +139,7 @@ in particular.
   # build-time, which requires the Docker buildx:  
   docker buildx build --platform linux/amd64,linux/arm64 \
     -f docker/images/afw-dev-base/Dockerfile.${OS} \  
-    -t ghcr.io/afw-org/afw-dev-base:${OS}${ALPINE_RELEASE} \
+    -t ghcr.io/afw-org/afw-dev-base:${OS}${OS_RELEASE} \
     -t ghcr.io/afw-org/afw-dev-base:${OS} \
     --push .
   ```
@@ -170,7 +170,7 @@ containing artifacts for that architecture.
 
 ```  
   docker build \    
-    -t ghcr.io/afw-org/afw:${OS}${ALPINE_RELEASE}-${AFW_RELEASE} \
+    -t ghcr.io/afw-org/afw:${OS}${OS_RELEASE}-${AFW_VERSION} \
     -t ghcr.io/afw-org/afw:${OS} \
     -t ghcr.io/afw-org/afw:latest \
     -f docker/images/afw/Dockerfile.${OS} .
@@ -179,7 +179,7 @@ containing artifacts for that architecture.
   # which requires the Docker buildx:
   docker buildx build --platform linux/amd64,linux/arm64 \  
     -f docker/images/afw/Dockerfile.${OS} \
-    -t ghcr.io/afw-org/afw:${OS}${ALPINE_RELEASE}-${AFW_RELEASE} \
+    -t ghcr.io/afw-org/afw:${OS}${OS_RELEASE}-${AFW_VERSION} \
     -t ghcr.io/afw-org/afw:${OS} \
     -t ghcr.io/afw-org/afw:latest --push .
 ```
@@ -200,5 +200,5 @@ containing artifacts for that architecture.
     -t ghcr.io/afw-org/afw-dev:${OS} --push .
 ```
 
-4. The `afwfcgi` and `afw-admin` can be build in the same way as 
+5. The `afwfcgi` and `afw-admin` can be build in the same way as 
 `afw` in step 3.

--- a/docker/images/README.md
+++ b/docker/images/README.md
@@ -1,22 +1,22 @@
 # Docker Images
 
-Some of these images are intended to be built automatically from 
-workflows and be published so they are publicly available for download and use. 
-However, anyone can build these images on their local workstation or Docker 
-registry. 
+Some of these images are intended to be built automatically from
+workflows and be published so they are publicly available for download and use.
+However, anyone can build these images on their local workstation or Docker
+registry.
 
-When publishing the docker images, we use the GitHub container registry uri 
+When publishing the docker images, we use the GitHub container registry uri
 and the `afw-org` prefix:
 
 | Folder | Image Name | Tag(s) |
 |------------|--------------------------------|------|
-| `afw-dev-base` | `ghcr.io/afw-org/afw-dev-base` | `latest`, `alpine`, `ubuntu`, `alpine3.16.6`, `ubuntu22.04` |
-| `afw-base`     | `ghcr.io/afw-org/afw-base`     | `latest`, `alpine`, `ubuntu`, `alpine3.16.6`, `ubuntu22.04` |
-| `afw-dev`      | `ghcr.io/afw-org/afw-dev`      | `latest`, `alpine3.16.6-0.9.0-0`, `ubuntu22.04-0.9.0-0`   |
+| `afw-dev-base` | `ghcr.io/afw-org/afw-dev-base` | `latest`, `alpine`, `ubuntu`, `alpine${3.16.9}$`, `ubuntu22.04` |
+| `afw-base`     | `ghcr.io/afw-org/afw-base`     | `latest`, `alpine`, `ubuntu`, `alpine3.16.9`, `ubuntu22.04` |
+| `afw-dev`      | `ghcr.io/afw-org/afw-dev`      | `latest`, `alpine3.16.9-0.9.0-0`, `ubuntu22.04-0.9.0-0`   |
 | `afw-admin`    | `ghcr.io/afw-org/afw-admin`    | `latest`, `nginx1.23.1-0.9.0-0`                            |
-| `afw`      | `ghcr.io/afw-org/afw`          | `latest`, `alpine3.16.6-0.9.0-0`, `ubuntu22.04-0.9.0-0`   |
-| `afwfcgi`  | `ghcr.io/afw-org/afwfcgi`      | `latest`, `alpine3.16.6-0.9.0-0`, `ubuntu22.04-0.9.0-0`   |
-| `builder`  | `N/A`  | `alpine3.16.6-0.9.0-0`, `alpine`, `node-0.9.0-0`, `node`  |
+| `afw`      | `ghcr.io/afw-org/afw`          | `latest`, `alpine3.16.9-0.9.0-0`, `ubuntu22.04-0.9.0-0`   |
+| `afwfcgi`  | `ghcr.io/afw-org/afwfcgi`      | `latest`, `alpine3.16.9-0.9.0-0`, `ubuntu22.04-0.9.0-0`   |
+| `builder`  | `N/A`  | `alpine3.16.9-0.9.0-0`, `alpine`, `node-0.9.0-0`, `node`  |
 
 An example of one of the full image names, along with its description of tag parts:
 
@@ -24,171 +24,181 @@ An example of one of the full image names, along with its description of tag par
 ghcr.io/afw-org/<image-name>:<distribution><version>
 ```
 
-The `distribution` refers to the Docker base OS (`alpine`, `ubuntu`, `nginx`, 
-`node`) and `version` refers to the distribution version (`3.16.1`). The 
-`version` may be omitted to indicate it's the "latest" tagged version for a 
-particular distribution. Furthermore, the `distribution` name may also be 
-omitted to indicate it's the default/preferred distribution for a particular 
+The `distribution` refers to the Docker base OS (`alpine`, `ubuntu`, `nginx`,
+`node`) and `version` refers to the distribution version (`3.16.9`). The
+`version` may be omitted to indicate it's the "latest" tagged version for a
+particular distribution. Furthermore, the `distribution` name may also be
+omitted to indicate it's the default/preferred distribution for a particular
 image.
 
 ## Image Descriptions
 
 Each folder inside here contains Dockerfile templates for building individual images.
 
-* `afw-dev-base` - This image has all of the necessary base software installed 
-for building Adaptive Framework on a variety of platforms. It also serves as the 
-base image for the `devcontainer`, that VS Code can use for remote development. 
-This would ideally only be updated when an underlying base distribution image 
+* `afw-dev-base` - This image has all of the necessary base software installed
+for building Adaptive Framework on a variety of platforms. It also serves as the
+base image for the `devcontainer`, that VS Code can use for remote development.
+This would ideally only be updated when an underlying base distribution image
 changes.
 
-* `afw-base` - This image is the base image for running Adaptive Framework.  It 
-contains the bare minimum dependencies without all of the development 
-requirements. This image would not be used to create instances from - instead, 
+* `afw-base` - This image is the base image for running Adaptive Framework.  It
+contains the bare minimum dependencies without all of the development
+requirements. This image would not be used to create instances from - instead,
 it should be used to inherit other images from, such as `afwfcgi` and `afw`.
-This would ideally only be updated when an underlying base distribution image 
+This would ideally only be updated when an underlying base distribution image
 changes.
 
-* `builder` - This image copies the current source into the image and does a 
+* `builder` - This image copies the current source into the image and does a
 full build. This image is intended to be a temporary storage image from which
-artifacts can be copied out of to use for the remaining images, as well as 
+artifacts can be copied out of to use for the remaining images, as well as
 for extracting and/or publishing installable packages from. It uses a multi-
 stage build process to store the artifacts into a small `scratch` image.
 
-* `afw-dev` - This image is nearly identical to `afw-dev-base`, with the addition 
-of a version of `afw` installed. Where `afw-dev-base` is used to build 
-Adaptive Framework core itself, `afw-dev` is used to build and develop 
-extensions, layouts, etc without having to obtain or build Adaptive Framework 
+* `afw-dev` - This image is nearly identical to `afw-dev-base`, with the addition
+of a version of `afw` installed. Where `afw-dev-base` is used to build
+Adaptive Framework core itself, `afw-dev` is used to build and develop
+extensions, layouts, etc without having to obtain or build Adaptive Framework
 core source code.
 
-* `afw-admin` - The Administrative Web Application for Administrating an Adaptive 
-Framework instance.  It's based on the `nginx` image. This image can be used to 
-create container instances that only hosts the admin app. This image is useful 
-if you have one or more FastCGI containers, running in orchestration, and wish 
+* `afw-admin` - The Administrative Web Application for Administrating an Adaptive
+Framework instance.  It's based on the `nginx` image. This image can be used to
+create container instances that only hosts the admin app. This image is useful
+if you have one or more FastCGI containers, running in orchestration, and wish
 to isolate a single admin web app to front them.
 
-* `afwfcgi` - This image combines `base` with an installed instance of Adaptive 
+* `afwfcgi` - This image combines `base` with an installed instance of Adaptive
 Framework. It starts an instance of `afwfcgi`, the FastCGI service to handle
-Adaptive Framework requests. This image can be used to create containers that 
-only start the FastCGI service. In order to use this container, you will need 
-to proxy it behind a HTTP service container, such as Nginx or Apache to create 
+Adaptive Framework requests. This image can be used to create containers that
+only start the FastCGI service. In order to use this container, you will need
+to proxy it behind a HTTP service container, such as Nginx or Apache to create
 a fully functional HTTP service.
 
-* `afw` - This image contains nginx, `afwfcgi` and a lot of configurations to 
-serve up everything in one convenient image. It includes `nginx`, `afwfcgi`, 
-the `admin` app and uses `supervisord` to start everything. It contains some 
-built-in demo-able configurations, but can be used to stand up a production 
+* `afw` - This image contains nginx, `afwfcgi` and a lot of configurations to
+serve up everything in one convenient image. It includes `nginx`, `afwfcgi`,
+the `admin` app and uses `supervisord` to start everything. It contains some
+built-in demo-able configurations, but can be used to stand up a production
 instance by providing your own volume/configuration.
 
 
 ## Ordered Steps for Building Images
 
 **Note:** The sample command snippets that use the buildx plugin for multi-
-architecture support will make use of the `--push` option. This instructs 
+architecture support will make use of the `--push` option. This instructs
 Docker to push the multi-arch platform images to the remote container registry
 on GitHub to be stored. By default, GitHub, DockerHub, etc will store multi-
-arch platform images because they have the ability to store manifest lists. 
+arch platform images because they have the ability to store manifest lists.
 Your local Docker Desktop currently does not, and trying to build a multi-arch
-image without pushing it will only keep them around in build cache, as any 
-attempt to store them with `--load` will result in the error message 
+image without pushing it will only keep them around in build cache, as any
+attempt to store them with `--load` will result in the error message
 
-`ERROR: docker exporter does not currently support exporting manifest lists`.   
+`ERROR: docker exporter does not currently support exporting manifest lists`.
 
-As of January, 2023, however, Docker Desktop does have an experimental 
-`containerd` image storage feature to store manifests! It's not clear at the 
-moment how it'll be used and when it'll be fully functional.
+If your Docker Desktop engine supports `containerd` to store images, along with
+architecture manifests, then you can build for multi-platform locally without
+having to push them to a remote repository.
 
-This is a basic walk-through for building all of the Docker images, using 
-Alpine Linux as the underlying distribution.  The tag name should be based on 
-the tag name of the distribution and afw version (in these examples, 
-`alpine3.16.6` and `0.9.0-0`).
+This is a basic walk-through for building all of the Docker images, using
+Alpine Linux as the underlying distribution.  The tag name should be based on
+the tag name of the distribution and afw version (in these examples,
+`alpine3.16.9` and `0.9.0-0`).
 
-1. `afw-base` and `afw-dev-base`: These should be built first and in no order 
+0. Set some environment variables to aid with the code examples:
+
+  ```
+  # set env variables to use for commands
+  export OS="alpine"
+  export OS_RELEASE="3.16.9"
+  export AFW_VERSION="0.9.0"
+  ```
+
+1. `afw-base` and `afw-dev-base`: These should be built first and in no order
 in particular.
 
-  ```  
-  docker build -f docker/images/afw-base/Dockerfile.alpine \
-    -t ghcr.io/afw-org/afw-base:alpine3.16.6 \
-    -t ghcr.io/afw-org/afw-base:alpine \
+  ```
+  # build the afw-base image
+  docker build -f docker/images/afw-base/Dockerfile.${OS} \
+    -t ghcr.io/afw-org/afw-base:${OS}${ALPINE_RELEASE} \
+    -t ghcr.io/afw-org/afw-base:${OS} \
     docker/images/afw-base
 
-  # Alternatively, build multi-architecture support, pushing it at 
-  # build-time, which requires the Docker buildx plugin:
+  # Alternatively, build multi-architecture support, pushing it at
+  # build-time, which requires the Docker buildx:
   docker buildx build --platform linux/amd64,linux/arm64 \
-    -f docker/images/afw-base/Dockerfile.alpine \
-    -t ghcr.io/afw-org/afw-base:alpine3.16.6 \
-    -t ghcr.io/afw-org/afw-base:alpine \
+    -f docker/images/afw-base/Dockerfile.${OS} \
+    -t ghcr.io/afw-org/afw-base:${OS}${ALPINE_RELEASE} \
+    -t ghcr.io/afw-org/afw-base:${OS} \
     --push docker/images/afw-base
-  
-  docker build -f docker/images/afw-dev-base/Dockerfile.alpine \
-    -t ghcr.io/afw-org/afw-dev-base:alpine3.16.6 \
-    -t ghcr.io/afw-org/afw-dev-base:alpine \
+
+  # build the afw-dev-base image
+  docker build -f docker/images/afw-dev-base/Dockerfile.${OS} \
+    -t ghcr.io/afw-org/afw-dev-base:${OS}${ALPINE_RELEASE} \
+    -t ghcr.io/afw-org/afw-dev-base:${OS} \
     .
 
-  # Alternatively, build multi-architecture support, pushing it at 
-  # build-time, which requires the Docker buildx plugin:  
+  # Alternatively, build multi-architecture support, pushing it at
+  # build-time, which requires the Docker buildx:
   docker buildx build --platform linux/amd64,linux/arm64 \
-    -f docker/images/afw-dev-base/Dockerfile.alpine \  
-    -t ghcr.io/afw-org/afw-dev-base:alpine3.16.6 \
-    -t ghcr.io/afw-org/afw-dev-base:alpine \
+    -f docker/images/afw-dev-base/Dockerfile.${OS} \
+    -t ghcr.io/afw-org/afw-dev-base:${OS}${ALPINE_RELEASE} \
+    -t ghcr.io/afw-org/afw-dev-base:${OS} \
     --push .
   ```
 
-2. Next, optionally use the `ghcr.io/afw-org/afw-dev-base:alpine` image you 
-created in the previous step to build Adaptive Framework into a builder image, 
-if you wish to produce and distribute individual artifacts (RPM's/TAR's/etc). 
-If you do not need these, then skip to the next step. 
-This assumes that you are at the top-level source code. This step will actually 
-*copy* all of thecurrent source code into the `afw-builder` image and run the 
-full build. Make sure you do not have residual build directories already in your 
-source tree (node_modules, etc.). Otherwise, the image is much larger and slower 
+2. Next, optionally use the `ghcr.io/afw-org/afw-dev-base:${OS}` image you
+created in the previous step to build Adaptive Framework into a builder image,
+if you wish to produce and distribute individual artifacts (RPM's/TAR's/etc).
+If you do not need these, then skip to the next step.
+This assumes that you are at the top-level source code. This step will actually
+*copy* all of the current source code into the `afw-builder` image and run the
+full build. Make sure you do not have residual build directories already in your
+source tree (node_modules, etc.). Otherwise, the image is much larger and slower
 than it needs to be.
 
 ```
-  docker build -f docker/images/builder/Dockerfile.alpine -o type=local,dest=. .
+  docker build -f docker/images/builder/Dockerfile.${OS} -o type=local,dest=. .
 
-  # Alternatively, build multi-arch support, which requires the Docker buildx 
-  # plugin:  
+  # Alternatively, build multi-arch support, which requires the Docker buildx
   docker buildx build --platform linux/amd64,linux/arm64 \
-    -f docker/images/builder/Dockerfile.alpine -o type=local,dest=. .
+    -f docker/images/builder/Dockerfile.${OS} -o type=local,dest=. .
 ```
 
-This will produce multiple folders, `linux_amd64`, `linux_arm64`, each 
-containing artifacts for that architecture. 
+This will produce multiple folders, `linux_amd64`, `linux_arm64`, each
+containing artifacts for that architecture.
 
-3. From here, you can now build the `afw` image, 
-`ghcr.io/afw-org/afw:alpine3.16.6-0.9.0-0`:
+3. From here, you can now build the `afw` image,
+`ghcr.io/afw-org/afw:${OS}${OS_RELEASE}-${AFW_VERSION}`:
 
-```  
-  docker build \    
-    -t ghcr.io/afw-org/afw:alpine3.16.6-0.9.0-0 \
-    -t ghcr.io/afw-org/afw:alpine \
+```
+  docker build \
+    -t ghcr.io/afw-org/afw:${OS}${ALPINE_RELEASE}-${AFW_RELEASE} \
+    -t ghcr.io/afw-org/afw:${OS} \
     -t ghcr.io/afw-org/afw:latest \
-    -f docker/images/afw/Dockerfile.alpine .
+    -f docker/images/afw/Dockerfile.${OS} .
 
   # Alternatively, build multi-arch support, pushing it at build-time
-  # which requires the Docker buildx plugin:
-  docker buildx build --platform linux/amd64,linux/arm64 \  
-    -f docker/images/afw/Dockerfile.alpine \
-    -t ghcr.io/afw-org/afw:alpine3.16.6-0.9.0-0 \
-    -t ghcr.io/afw-org/afw:alpine \
+  # which requires the Docker buildx:
+  docker buildx build --platform linux/amd64,linux/arm64 \
+    -f docker/images/afw/Dockerfile.${OS} \
+    -t ghcr.io/afw-org/afw:${OS}${ALPINE_RELEASE}-${AFW_RELEASE} \
+    -t ghcr.io/afw-org/afw:${OS} \
     -t ghcr.io/afw-org/afw:latest --push .
 ```
 
-4. To build the `afw-dev` image, `ghcr.io/afw-org/afw-dev:alpine3.16.6-0.9.0-0`:
+4. To build the `afw-dev` image, `ghcr.io/afw-org/afw-dev:${OS}${OS_RELEASE}-${AFW_VERSION}`:
 
 ```
-  docker build \    
-    -t ghcr.io/afw-org/afw-dev:alpine3.16.6-0.9.0-0 \
-    -t ghcr.io/afw-org/afw-dev:alpine \
-    -f docker/images/afw-dev/Dockerfile.alpine .
+  docker build \
+    -t ghcr.io/afw-org/afw-dev:${OS}${OS_RELEASE}-${AFW_VERSION} \
+    -t ghcr.io/afw-org/afw-dev:${OS} \
+    -f docker/images/afw-dev/Dockerfile.${OS} .
 
   # Alternatively, build multi-arch support, pushing it at build-time
   # which requires the Docker buildx plugin:
-  docker buildx build --platform linux/amd64,linux/arm64 \  
-    -f docker/images/afw-dev/Dockerfile.alpine \
-    -t ghcr.io/afw-org/afw-dev:alpine3.16.6-0.9.0-0 \
-    -t ghcr.io/afw-org/afw-dev:alpine --push .
+  docker buildx build --platform linux/amd64,linux/arm64 \
+    -f docker/images/afw-dev/Dockerfile.${OS} \
+    -t ghcr.io/afw-org/afw-dev:${OS}${OS_RELEASE}-${AFW_VERSION} \
+    -t ghcr.io/afw-org/afw-dev:${OS} --push .
 ```
 
-4. The `afwfcgi` and `afw-admin` can be build in the same way as 
+4. The `afwfcgi` and `afw-admin` can be build in the same way as
 `afw` in step 3.

--- a/docker/images/afw-base/Dockerfile.alpine
+++ b/docker/images/afw-base/Dockerfile.alpine
@@ -1,4 +1,5 @@
-FROM alpine:3.16.8
+ARG OS_VERSION=3.16.9
+FROM alpine:${OS_VERSION}
 
 LABEL org.opencontainers.image.source=https://github.com/afw-org/afw
 

--- a/docker/images/afw-dev-base/Dockerfile.almalinux
+++ b/docker/images/afw-dev-base/Dockerfile.almalinux
@@ -1,0 +1,35 @@
+FROM almalinux:9
+
+LABEL org.opencontainers.image.source=https://github.com/afw-org/afw
+
+# Install packages
+RUN dnf install -y epel-release && \
+    dnf install -y 'dnf-command(config-manager)' && \
+    dnf install -y glibc-langpack-en && \
+    dnf config-manager --set-enabled crb && \
+    dnf group install "Development Tools" -y && \
+    dnf --enablerepo=crb install -y \
+    make libtool cmake clang-analyzer \
+    nginx gdb gdb-gdbserver valgrind valgrind-devel \
+    apr-devel apr-util-mysql apr-util-ldap \
+    libxml2-devel libxslt-devel libicu-devel \
+    elfutils elfutils-devel libunwind-devel \
+    httpd-devel mariadb mariadb-devel lmdb lmdb-devel \
+    libcurl-devel libyaml libyaml-devel libedit-devel \
+    python3-pip python3-devel \
+    fcgi fcgi-devel wget git \
+    rpm-build npm \
+    openssl openssl-devel doxygen && \
+    dnf clean all && rm -rf /var/cache/*
+
+RUN npm install -g npm-upgrade && npm install -g n && n stable
+RUN npm install -g npm@10 eclint cspell
+
+# install python packages
+COPY python-requirements.txt /tmp/python-requirements.txt
+RUN pip3 install -r /tmp/python-requirements.txt
+
+# install railroad ebnf syntax diagram generator
+ADD https://github.com/afw-org/rr/releases/download/v1.63/rr.war /usr/local/bin/rr.war
+
+CMD [ "bash" ]

--- a/docker/images/afw-dev-base/Dockerfile.alpine
+++ b/docker/images/afw-dev-base/Dockerfile.alpine
@@ -1,4 +1,5 @@
-FROM alpine:3.16.8
+ARG OS_VERSION=3.16.9
+FROM alpine:${OS_VERSION}
 
 LABEL org.opencontainers.image.source=https://github.com/afw-org/afw
 

--- a/docker/images/afw-dev/Dockerfile.almalinux
+++ b/docker/images/afw-dev/Dockerfile.almalinux
@@ -1,0 +1,46 @@
+# Build stage for C compilation, which may use multi-arch builds
+FROM ghcr.io/afw-org/afw-dev-base:almalinux AS build-stage-c
+
+COPY ./ /src
+COPY ./docker/images/builder/builder-almalinux.sh /builder.sh
+
+RUN chmod +x /builder.sh && /builder.sh
+
+
+# Build stage for Javascript compiles (only build on native platform for JS)
+FROM --platform=$BUILDPLATFORM ghcr.io/afw-org/afw-dev-base:almalinux AS build-stage-js
+
+COPY ./ /src
+COPY ./docker/images/builder/builder-almalinux.sh /builder.sh
+
+RUN chmod +x /builder.sh && BUILD_TARGET=js /builder.sh
+
+# Create a single image with all artifacts
+# This stage can also be executed individually, using --target to emit artifacts
+# into the local file system
+FROM scratch AS build-stage
+
+COPY --from=build-stage-c /*.rpm /
+COPY --from=build-stage-js /*.tar /
+
+
+# create a final output image
+FROM ghcr.io/afw-org/afw-dev-base:almalinux
+
+LABEL org.opencontainers.image.source=https://github.com/afw-org/afw
+
+# obtain the artifacts from build-stage
+COPY --from=build-stage /afw-*.rpm /
+COPY --from=build-stage /afw-apps-*.tar /var/www/html/
+COPY --from=build-stage /afw-docs-*.tar /var/www/html/
+COPY .devcontainer/afw/nginx.conf /etc/nginx/nginx.conf
+
+RUN cd / && rpm -ivh /afw-*.rpm && rm -f /afw-*.rpm && \
+    cd /var/www/html && tar xvf afw-apps-*.tar && rm -f afw-apps-*.tar && \
+    tar xvf afw-docs-*.tar && rm -f afw-docs-*.tar
+
+# open ports
+EXPOSE 8080
+
+# persist data in /afw
+VOLUME "/afw"

--- a/docker/images/builder/Dockerfile.almalinux
+++ b/docker/images/builder/Dockerfile.almalinux
@@ -1,0 +1,21 @@
+# Build stage for C compilation, which may use multi-arch builds
+FROM ghcr.io/afw-org/afw-dev-base:almalinux AS build-stage-c
+
+COPY ./ /src
+COPY ./docker/images/builder/builder-almalinux.sh /builder.sh
+
+RUN chmod +x /builder.sh && /builder.sh
+
+# Build stage for Javascript compiles (only build on native platform for JS)
+FROM --platform=$BUILDPLATFORM ghcr.io/afw-org/afw-dev-base:almalinux AS build-stage-js
+
+COPY ./ /src
+COPY ./docker/images/builder/builder-almalinux.sh /builder.sh
+
+RUN chmod +x /builder.sh && BUILD_TARGET=js /builder.sh
+
+
+FROM scratch
+
+COPY --from=build-stage-c /*.rpm /
+COPY --from=build-stage-js /*.tar /

--- a/docker/images/builder/builder-almalinux.sh
+++ b/docker/images/builder/builder-almalinux.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# This script is executed when building the Docker afw-builder image.
+#
+#   docker build
+#     [-e RPM_VERSION=<version>]
+#     [-e BUILD_TARGET=<target>]
+#     -f docker/images/builder/Dockerfile.almalinux
+#     -t ghcr.io/afw-org/afw-dev-base:almalinux .
+#
+# The RPM_VERSION env var can be specified at run-time to
+#   name the output file.
+#
+
+if [ ! -f /src/afw-package.json ]; then
+    echo "** You need to map the source directory into /src in order to build."
+    exit 1
+fi
+
+# change to source directory
+cd /src
+
+# use what was passed in, defaulting to afwdev
+RPM_VERSION=${RPM_VERSION:=`./afwdev --version-string`}
+BUILD_TARGET=${BUILD_TARGET:='c'}
+ARCH=`arch`
+
+echo "Building ${RPM_VERSION}, target: ${BUILD_TARGET}"
+
+if [ "$BUILD_TARGET" == "c" ] || [ "$BUILD_TARGET" == "all" ];
+then
+    echo "Building C code..."
+
+    # build the source
+    cd /src && ./afwdev build --prefix /usr/local --package
+    if [ $? -ne 0 ]; then
+        echo "** Core Build failed!"
+        exit 1
+    fi
+
+    # copy to /
+    cp build/cmake/afw-${RPM_VERSION}_${ARCH}.rpm /afw-${RPM_VERSION}-almalinux.${ARCH}.rpm
+fi
+
+if [ "$BUILD_TARGET" == "js" ] || [ "$BUILD_TARGET" == "all" ];
+then
+    echo "Building JS code..."
+
+    cd /src && \
+    ./afwdev build --js --docs && \
+    cd build/js && \
+    tar cf /afw-apps-${RPM_VERSION}.tar apps
+    cd /src/build && \
+    tar cf /afw-docs-${RPM_VERSION}.tar docs
+
+    echo ""
+    echo "File /afw-apps-${RPM_VERSION}.tar created."
+    echo "File /afw-docs-${RPM_VERSION}.tar created."
+fi

--- a/src/afw/pool/afw_pool_heap.c
+++ b/src/afw/pool/afw_pool_heap.c
@@ -658,6 +658,7 @@ impl_malloc_user(
     size_with_prefix = size + sizeof(afw_pool_heap_chunk_t);
     reused = impl_alloc_memory(&mem, &actual_size, self,
         size_with_prefix, xctx);
+    (void)reused;
     IMPL_PRINT_DEBUG_INFO_FZ(detail, "alloc %s " AFW_SIZE_T_FMT,
         reused ? "reuse" : "apr", size);
     block = (afw_pool_heap_chunk_t *)mem;


### PR DESCRIPTION
## Summary
- Rebase onto current `develop` (this branch was ~448 commits stale).
- `afw-base`/`afw-dev-base` Alpine Dockerfiles now take the OS version via `ARG OS_VERSION` (bumped 3.16.8 → 3.16.9), and `docker/images/README.md`'s build walkthrough uses env vars (`$OS`/`$OS_RELEASE`/`$AFW_VERSION`) instead of hardcoded tags.
- Fix a follow-up bug in that README: the walkthrough exported `OS_RELEASE`/`AFW_VERSION` but the command snippets referenced undefined `ALPINE_RELEASE`/`AFW_RELEASE`, so copy-pasting them would tag images with an empty version. Also fixes a garbled `alpine${3.16.9}$` placeholder and a duplicate "4." step number.
- Add an AlmaLinux 9 image trio (`afw-dev-base`, `afw-dev`, `builder` + `builder-almalinux.sh`), mirroring the existing rockylinux pattern with EL9 adjustments (`crb` repo instead of `powertools`, `pip3`, `libdb-devel` dropped since Berkeley DB isn't packaged past EL8).
- Fix `src/afw/pool/afw_pool_heap.c`: `reused` was only read inside `IMPL_PRINT_DEBUG_INFO_FZ`, which is a no-op unless `AFW_DEBUG_POOL` is defined. `afwdev build --package` (what every distro's `builder-*.sh` uses) doesn't define it, so `-Werror=unused-but-set-variable` broke Docker packaging builds for **every** distro, not just AlmaLinux. Confirmed via a full-tree build with `AFW_DEBUG_*` undefined that this is the only instance of the pattern in the codebase.

## Test plan
- [x] `afw-dev-base:almalinux` built successfully; verified toolchain (gcc 11.5, cmake 3.31, node 24, valgrind, nginx) inside the image.
- [x] `builder/Dockerfile.almalinux` `build-stage-c` target ran a full `afwdev build --package` + `cpack` to a successful RPM build.
- [x] Reproduced the `afw_pool_heap.c` failure in isolation (direct `gcc` compile with/without `-DAFW_DEBUG_POOL`, using the real project flags) and confirmed the fix resolves it in both configurations.
- [x] Full-tree build (core + `afw_command` + `afw_server_fcgi` + all extensions) with debug defines off, `-Werror` downgraded to warnings for the relevant checks — zero other instances found.
- [ ] Other distros' Dockerfiles (ubuntu/opensuse/rockylinux, and non-alpine `afw`/`afwfcgi`) were not touched in this PR — Alpine version bump and AlmaLinux addition only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)