### PR TITLE
fix(adapter): scope retroactive index_create scan to configured objectType (#252)

### DIFF
--- a/src/afw/adapter/afw_adapter_impl_index.c
+++ b/src/afw/adapter/afw_adapter_impl_index.c
@@ -865,6 +865,8 @@ AFW_DEFINE(const afw_object_t *) afw_adapter_impl_index_create(
     const afw_object_t                 * indexDefinition;
     const afw_object_t                 * result;
     const afw_adapter_transaction_t    * transaction;
+    const afw_iterator_old_t           * object_type_iterator;
+    const afw_utf8_t                   * object_type_id;
 
     session = afw_adapter_session_get_cached(adapterId, false, xctx);
 
@@ -929,11 +931,34 @@ AFW_DEFINE(const afw_object_t *) afw_adapter_impl_index_create(
 
     /* the callback routine does all of our work for us */
     if (retroactive) {
-        /* if we need to build indexes retroactively, go ahead and
-            scan for objects. */
-        /** @fixme should this be session->p, pool, or xctx->p? */
-        afw_adapter_session_retrieve_objects(session, NULL, NULL,
-            NULL, &ctx, afw_adapter_impl_index_cb, NULL, pool, xctx);
+        /*
+         * If this definition is scoped to specific objectTypes, scan only
+         * those types instead of paying for a full-table walk (mirrors the
+         * per-objectType loop afw_adapter_impl_index_remove() already uses).
+         * An omitted or empty objectType list means all types apply, so
+         * fall back to a single unscoped scan for that case.
+         */
+        object_type_iterator = NULL;
+        object_type_id = (objectType)
+            ? afw_array_of_string_get_next(
+                objectType, &object_type_iterator, xctx)
+            : NULL;
+
+        if (object_type_id) {
+            do {
+                /** @fixme should this be session->p, pool, or xctx->p? */
+                afw_adapter_session_retrieve_objects(session, NULL,
+                    object_type_id,
+                    NULL, &ctx, afw_adapter_impl_index_cb, NULL, pool, xctx);
+
+                object_type_id = afw_array_of_string_get_next(
+                    objectType, &object_type_iterator, xctx);
+            } while (object_type_id);
+        } else {
+            /** @fixme should this be session->p, pool, or xctx->p? */
+            afw_adapter_session_retrieve_objects(session, NULL, NULL,
+                NULL, &ctx, afw_adapter_impl_index_cb, NULL, pool, xctx);
+        }
     }
 
     /* now, tell the adapter to add the new indexDefinition for configuration */

--- a/src/afw_lmdb/tests/indexes/index_objecttype_scoping.as
+++ b/src/afw_lmdb/tests/indexes/index_objecttype_scoping.as
@@ -28,6 +28,8 @@ add_object("lmdb", otB, { surname: "Smith" }, idB1);
 const created: object = index_create("lmdb", "surname", undefined, [otA], undefined, undefined, true, false);
 assert(created.num_indexed === 2,
     "retroactive index_create scoped to otA should only index otA's 2 objects, not otB's");
+assert(created.num_processed === 2,
+    "retroactive scan scoped to otA should only fetch otA's 2 objects -- num_processed === 3 would mean otB was scanned too (issue #252 item 2)");
 
 // A query against the scoped type still finds its match.
 const foundA: array = retrieve_objects("lmdb", otA,


### PR DESCRIPTION
## Summary

Second slice of #252 (item 2, "a real but modest efficiency win").

`afw_adapter_impl_index_create()`'s retroactive scan always ran a single unscoped `retrieve_objects(object_type_id: NULL)`, regardless of whether the definition's `objectType` list restricted it to specific types. Correctness held only because `afw_adapter_impl_index_object_type_applicable()` filtered per-object afterward — but a definition scoped to one type out of many still paid for a full-table walk.

Now the retroactive scan loops per configured objectType, mirroring the per-objectType drop loop `afw_adapter_impl_index_remove()` already uses, and falls back to a single unscoped scan only when `objectType` is omitted or empty (meaning "all types").

## Test plan

- [x] `./afwdev build --cdev` clean
- [x] `./afwdev build --fulldev` clean
- [x] `afwdev test -j` — 4241 passed, 0 failed
- [x] Extended `index_objecttype_scoping.as` with a `num_processed` assertion that proves the *scan itself* is scoped, not just the resulting index content — the existing test only checked `num_indexed`, which the old unscoped-scan-then-filter code also satisfied. Verified the new assertion fails against the pre-fix code (`num_processed === 3`, all three seeded objects across both types get fetched) and passes with the fix (`num_processed === 2`, only the scoped type's objects are fetched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>