### PR TITLE
refactor(adapter): make index add/delete throw-only (#252)

### DIFF
--- a/src/afw/adapter/afw_adapter_impl_index.c
+++ b/src/afw/adapter/afw_adapter_impl_index.c
@@ -762,11 +762,13 @@ AFW_DEFINE(const afw_object_t *) afw_adapter_impl_index_remove(
 {
     const afw_adapter_session_t        * session;
     const afw_adapter_impl_index_t     * indexer;
+    impl_retrieve_objects_cb_context_t   ctx;
     const afw_object_t                 * indexDefinition;
     const afw_array_t                   * objectTypes;
     const afw_object_t                 * result;
     const afw_iterator_old_t               * object_type_iterator;
     const afw_utf8_t                   * object_type_id;
+    afw_rc_t                             rc;
 
     session = afw_adapter_session_get_cached(adapterId, true, xctx);
 
@@ -810,9 +812,23 @@ AFW_DEFINE(const afw_object_t *) afw_adapter_impl_index_remove(
             objectTypes, &object_type_iterator, xctx);
         do
         {
-            /* drop the underlying index database for this objectType */
-            afw_adapter_impl_index_drop(indexer,
+            /* try to drop it first, if possible */
+            rc = afw_adapter_impl_index_drop(indexer,
                 object_type_id, key, pool, xctx);
+            if (rc) {
+                ctx.instance = indexer;
+                ctx.key = key;
+                ctx.indexDefinition = indexDefinition;
+                ctx.num_indexed = 0;
+                ctx.num_processed = 0;
+                ctx.mode = afw_adapter_impl_index_mode_delete;
+
+                /** @fixme xctx->p, session->p, or pool?  */
+                afw_adapter_session_retrieve_objects(session, NULL,
+                    object_type_id,
+                    NULL, &ctx, afw_adapter_impl_index_cb, NULL,
+                    /** @fixme is pool correct? */ pool, xctx);
+            }
 
             if (object_type_id)
                 object_type_id = afw_array_of_string_get_next(

--- a/src/afw/adapter/afw_adapter_impl_index.c
+++ b/src/afw/adapter/afw_adapter_impl_index.c
@@ -762,13 +762,11 @@ AFW_DEFINE(const afw_object_t *) afw_adapter_impl_index_remove(
 {
     const afw_adapter_session_t        * session;
     const afw_adapter_impl_index_t     * indexer;
-    impl_retrieve_objects_cb_context_t   ctx;
     const afw_object_t                 * indexDefinition;
     const afw_array_t                   * objectTypes;
     const afw_object_t                 * result;
     const afw_iterator_old_t               * object_type_iterator;
     const afw_utf8_t                   * object_type_id;
-    afw_rc_t                             rc;
 
     session = afw_adapter_session_get_cached(adapterId, true, xctx);
 
@@ -810,25 +808,11 @@ AFW_DEFINE(const afw_object_t *) afw_adapter_impl_index_remove(
 
         object_type_id = afw_array_of_string_get_next(
             objectTypes, &object_type_iterator, xctx);
-        do 
+        do
         {
-            /* try to drop it first, if possible */
-            rc = afw_adapter_impl_index_drop(indexer, 
+            /* drop the underlying index database for this objectType */
+            afw_adapter_impl_index_drop(indexer,
                 object_type_id, key, pool, xctx);
-            if (rc) {
-                ctx.instance = indexer;
-                ctx.key = key;
-                ctx.indexDefinition = indexDefinition;
-                ctx.num_indexed = 0;
-                ctx.num_processed = 0;
-                ctx.mode = afw_adapter_impl_index_mode_delete;
-
-                /** @fixme xctx->p, session->p, or pool?  */
-                afw_adapter_session_retrieve_objects(session, NULL,
-                    object_type_id,
-                    NULL, &ctx, afw_adapter_impl_index_cb, NULL,
-                    /** @fixme is pool correct? */ pool, xctx);
-            }
 
             if (object_type_id)
                 object_type_id = afw_array_of_string_get_next(

--- a/src/afw/generate/interfaces/afw_interface.xml
+++ b/src/afw/generate/interfaces/afw_interface.xml
@@ -1495,7 +1495,7 @@ AFW_DEFINE(const afw_adapter_t *)
     <description>This is the caller's xctx.</description>
       </parameter>
 
-      <return type="afw_rc_t" />
+      <return type="void" />
 
     </method>
 
@@ -1533,14 +1533,14 @@ AFW_DEFINE(const afw_adapter_t *)
     <description>This is the caller's xctx.</description>
       </parameter>
 
-      <return type="afw_rc_t" />
+      <return type="void" />
 
     </method>
 
     <method name="drop">
 
       <description>
-        Drop an in index. The underlying store may decide to drop an entire table or database. Returns a boolean, determining whether the operation was successful.
+        Drop an index. The underlying store may decide to drop an entire table or database. Throws on failure.
       </description>
 
       <parameter name="instance" type="const afw_adapter_impl_index_t *">
@@ -1563,7 +1563,7 @@ AFW_DEFINE(const afw_adapter_t *)
     <description>This is the caller's xctx.</description>
       </parameter>
 
-      <return type="afw_rc_t" />
+      <return type="void" />
 
     </method>
 

--- a/src/afw/generate/interfaces/afw_interface.xml
+++ b/src/afw/generate/interfaces/afw_interface.xml
@@ -1540,7 +1540,7 @@ AFW_DEFINE(const afw_adapter_t *)
     <method name="drop">
 
       <description>
-        Drop an index. The underlying store may decide to drop an entire table or database. Throws on failure.
+        Drop an in index. The underlying store may decide to drop an entire table or database. Returns a non-zero code if the implementation could not perform the drop (for example, if it doesn't support dropping an entire table/database), in which case the caller falls back to removing index entries one object at a time.
       </description>
 
       <parameter name="instance" type="const afw_adapter_impl_index_t *">
@@ -1563,7 +1563,7 @@ AFW_DEFINE(const afw_adapter_t *)
     <description>This is the caller's xctx.</description>
       </parameter>
 
-      <return type="void" />
+      <return type="afw_rc_t" />
 
     </method>
 

--- a/src/afw/generated/afw_adapter_impl_index_impl_declares.h
+++ b/src/afw/generated/afw_adapter_impl_index_impl_declares.h
@@ -173,7 +173,7 @@ impl_afw_adapter_impl_index_delete(
 
 #ifndef impl_afw_adapter_impl_index_drop
 /* Declare method drop */
-AFW_DECLARE_STATIC(void)
+AFW_DECLARE_STATIC(afw_rc_t)
 impl_afw_adapter_impl_index_drop(
     AFW_ADAPTER_IMPL_INDEX_SELF_T *self,
     const afw_utf8_t * object_type_id,

--- a/src/afw/generated/afw_adapter_impl_index_impl_declares.h
+++ b/src/afw/generated/afw_adapter_impl_index_impl_declares.h
@@ -146,7 +146,7 @@ impl_afw_adapter_impl_index_update_index_definitions(
 
 #ifndef impl_afw_adapter_impl_index_add
 /* Declare method add */
-AFW_DECLARE_STATIC(afw_rc_t)
+AFW_DECLARE_STATIC(void)
 impl_afw_adapter_impl_index_add(
     AFW_ADAPTER_IMPL_INDEX_SELF_T *self,
     const afw_utf8_t * object_type_id,
@@ -160,7 +160,7 @@ impl_afw_adapter_impl_index_add(
 
 #ifndef impl_afw_adapter_impl_index_delete
 /* Declare method delete */
-AFW_DECLARE_STATIC(afw_rc_t)
+AFW_DECLARE_STATIC(void)
 impl_afw_adapter_impl_index_delete(
     AFW_ADAPTER_IMPL_INDEX_SELF_T *self,
     const afw_utf8_t * object_type_id,
@@ -173,7 +173,7 @@ impl_afw_adapter_impl_index_delete(
 
 #ifndef impl_afw_adapter_impl_index_drop
 /* Declare method drop */
-AFW_DECLARE_STATIC(afw_rc_t)
+AFW_DECLARE_STATIC(void)
 impl_afw_adapter_impl_index_drop(
     AFW_ADAPTER_IMPL_INDEX_SELF_T *self,
     const afw_utf8_t * object_type_id,

--- a/src/afw/generated/afw_interface.h
+++ b/src/afw/generated/afw_interface.h
@@ -1685,7 +1685,7 @@ typedef void
     afw_xctx_t * xctx);
 
 /** @sa afw_adapter_impl_index_add() */
-typedef afw_rc_t
+typedef void
 (*afw_adapter_impl_index_add_t)(
     const afw_adapter_impl_index_t * instance,
     const afw_utf8_t * object_type_id,
@@ -1697,7 +1697,7 @@ typedef afw_rc_t
     afw_xctx_t * xctx);
 
 /** @sa afw_adapter_impl_index_delete() */
-typedef afw_rc_t
+typedef void
 (*afw_adapter_impl_index_delete_t)(
     const afw_adapter_impl_index_t * instance,
     const afw_utf8_t * object_type_id,
@@ -1708,7 +1708,7 @@ typedef afw_rc_t
     afw_xctx_t * xctx);
 
 /** @sa afw_adapter_impl_index_drop() */
-typedef afw_rc_t
+typedef void
 (*afw_adapter_impl_index_drop_t)(
     const afw_adapter_impl_index_t * instance,
     const afw_utf8_t * object_type_id,
@@ -1871,7 +1871,6 @@ struct afw_adapter_impl_index_inf_s {
  * @param unique Flag indicating that the index being added should be unique.
  * @param pool Caller's pool.
  * @param xctx This is the caller's xctx.
- * @return Value of type `afw_rc_t`.
  * @relates afw_adapter_impl_index_t
  * @see @ref afw_adapter_impl_index_s "afw_adapter_impl_index_t"
  */
@@ -1912,7 +1911,6 @@ struct afw_adapter_impl_index_inf_s {
  * should be used by the adapter as the key to the index entry.
  * @param pool Caller's pool.
  * @param xctx This is the caller's xctx.
- * @return Value of type `afw_rc_t`.
  * @relates afw_adapter_impl_index_t
  * @see @ref afw_adapter_impl_index_s "afw_adapter_impl_index_t"
  */
@@ -1938,9 +1936,8 @@ struct afw_adapter_impl_index_inf_s {
 /**
  * @brief Call method `drop` of interface `afw_adapter_impl_index`.
  *
- * Drop an in index. The underlying store may decide to drop an entire table or
- * database. Returns a boolean, determining whether the operation was
- * successful.
+ * Drop an index. The underlying store may decide to drop an entire table or
+ * database. Throws on failure.
  * @param instance Pointer to this adapter impl index instance.
  * @param object_type_id Object type id associated with the index. This may be
  * useful for the adapter to determine the target table or database for the
@@ -1948,7 +1945,6 @@ struct afw_adapter_impl_index_inf_s {
  * @param key Index key.
  * @param pool Caller's pool.
  * @param xctx This is the caller's xctx.
- * @return Value of type `afw_rc_t`.
  * @relates afw_adapter_impl_index_t
  * @see @ref afw_adapter_impl_index_s "afw_adapter_impl_index_t"
  */

--- a/src/afw/generated/afw_interface.h
+++ b/src/afw/generated/afw_interface.h
@@ -1708,7 +1708,7 @@ typedef void
     afw_xctx_t * xctx);
 
 /** @sa afw_adapter_impl_index_drop() */
-typedef void
+typedef afw_rc_t
 (*afw_adapter_impl_index_drop_t)(
     const afw_adapter_impl_index_t * instance,
     const afw_utf8_t * object_type_id,
@@ -1936,8 +1936,11 @@ struct afw_adapter_impl_index_inf_s {
 /**
  * @brief Call method `drop` of interface `afw_adapter_impl_index`.
  *
- * Drop an index. The underlying store may decide to drop an entire table or
- * database. Throws on failure.
+ * Drop an in index. The underlying store may decide to drop an entire table or
+ * database. Returns a non-zero code if the implementation could not perform the
+ * drop (for example, if it doesn't support dropping an entire table/database),
+ * in which case the caller falls back to removing index entries one object at a
+ * time.
  * @param instance Pointer to this adapter impl index instance.
  * @param object_type_id Object type id associated with the index. This may be
  * useful for the adapter to determine the target table or database for the
@@ -1945,6 +1948,7 @@ struct afw_adapter_impl_index_inf_s {
  * @param key Index key.
  * @param pool Caller's pool.
  * @param xctx This is the caller's xctx.
+ * @return Value of type `afw_rc_t`.
  * @relates afw_adapter_impl_index_t
  * @see @ref afw_adapter_impl_index_s "afw_adapter_impl_index_t"
  */

--- a/src/afw/generated/interface_closet/skeleton_afw_adapter_impl_index.c
+++ b/src/afw/generated/interface_closet/skeleton_afw_adapter_impl_index.c
@@ -77,7 +77,7 @@ impl_afw_adapter_impl_index_update_index_definitions(
 /*
  * Implementation of method add for interface afw_adapter_impl_index.
  */
-afw_rc_t
+void
 impl_afw_adapter_impl_index_add(
     AFW_ADAPTER_IMPL_INDEX_SELF_T *self,
     const afw_utf8_t * object_type_id,
@@ -95,7 +95,7 @@ impl_afw_adapter_impl_index_add(
 /*
  * Implementation of method delete for interface afw_adapter_impl_index.
  */
-afw_rc_t
+void
 impl_afw_adapter_impl_index_delete(
     AFW_ADAPTER_IMPL_INDEX_SELF_T *self,
     const afw_utf8_t * object_type_id,
@@ -112,7 +112,7 @@ impl_afw_adapter_impl_index_delete(
 /*
  * Implementation of method drop for interface afw_adapter_impl_index.
  */
-afw_rc_t
+void
 impl_afw_adapter_impl_index_drop(
     AFW_ADAPTER_IMPL_INDEX_SELF_T *self,
     const afw_utf8_t * object_type_id,

--- a/src/afw/generated/interface_closet/skeleton_afw_adapter_impl_index.c
+++ b/src/afw/generated/interface_closet/skeleton_afw_adapter_impl_index.c
@@ -112,7 +112,7 @@ impl_afw_adapter_impl_index_delete(
 /*
  * Implementation of method drop for interface afw_adapter_impl_index.
  */
-void
+afw_rc_t
 impl_afw_adapter_impl_index_drop(
     AFW_ADAPTER_IMPL_INDEX_SELF_T *self,
     const afw_utf8_t * object_type_id,

--- a/src/afw_lmdb/afw_lmdb_index.c
+++ b/src/afw_lmdb/afw_lmdb_index.c
@@ -247,7 +247,7 @@ impl_afw_adapter_impl_index_open(
 /*
  * Implementation of method add of interface afw_adapter_impl_index.
  */
-afw_rc_t impl_afw_adapter_impl_index_add(
+void impl_afw_adapter_impl_index_add(
     AFW_ADAPTER_IMPL_INDEX_SELF_T *self,
     const afw_utf8_t * object_type_id,
     const afw_utf8_t * object_id,
@@ -259,7 +259,7 @@ afw_rc_t impl_afw_adapter_impl_index_add(
 {
     const afw_lmdb_adapter_t *adapter = self->adapter;
     const afw_lmdb_adapter_session_t *session = self->session;
-    afw_rc_t rc = 0;
+    afw_rc_t rc;
     MDB_txn * txn;
     MDB_dbi dbi;
     MDB_val key, data;
@@ -272,7 +272,7 @@ afw_rc_t impl_afw_adapter_impl_index_add(
     we should determine if this is an error condition or not
      */
     if (value->len == 0) {
-        return 0;
+        return;
     }
 
     database = afw_lmdb_index_database(
@@ -339,14 +339,12 @@ afw_rc_t impl_afw_adapter_impl_index_add(
             }
         }
     }
-
-    return rc;
 }
 
 /*
  * Implementation of method delete of interface afw_adapter_impl_index.
  */
-afw_rc_t impl_afw_adapter_impl_index_delete(
+void impl_afw_adapter_impl_index_delete(
     AFW_ADAPTER_IMPL_INDEX_SELF_T *self,
     const afw_utf8_t *object_type_id,
     const afw_utf8_t *object_id,
@@ -362,7 +360,7 @@ afw_rc_t impl_afw_adapter_impl_index_delete(
     MDB_txn *txn;
     const afw_utf8_t *database;
     const afw_uuid_t *uuid;
-    afw_rc_t rc = 0;
+    afw_rc_t rc;
     afw_memory_t raw;
 
     /* we will get an error if we try to delete a key of length 0 */
@@ -370,7 +368,7 @@ afw_rc_t impl_afw_adapter_impl_index_delete(
     we should determine if this is an error condition or not
      */
     if (value->len == 0) {
-        return 0;
+        return;
     }
 
     database = afw_lmdb_index_database(
@@ -422,14 +420,12 @@ afw_rc_t impl_afw_adapter_impl_index_delete(
                 "Unable to delete index value.", xctx);
         }
     }
-
-    return rc;
 }
 
 /*
  * Implementation of method drop of interface afw_adapter_impl_index.
  */
-afw_rc_t
+void
 impl_afw_adapter_impl_index_drop (
     AFW_ADAPTER_IMPL_INDEX_SELF_T *self,
     const afw_utf8_t  * object_type_id,
@@ -442,7 +438,7 @@ impl_afw_adapter_impl_index_drop (
     const afw_utf8_t *database;
     MDB_dbi dbi;
     MDB_txn *txn;
-    afw_rc_t rc = 0;
+    afw_rc_t rc;
 
     database = afw_lmdb_index_database(
         object_type_id, key, pool, xctx);
@@ -462,6 +458,10 @@ impl_afw_adapter_impl_index_drop (
 
             /* (1) means delete it from the environment and close the DB handle */
             rc = mdb_drop(txn, dbi, 1);
+            if (rc != 0) {
+                AFW_THROW_ERROR_RV_Z(general, lmdb, rc,
+                    "Unable to drop index database.", xctx);
+            }
 
             AFW_LMDB_COMMIT_TRANSACTION();
         }
@@ -474,9 +474,11 @@ impl_afw_adapter_impl_index_drop (
 
         /* (1) means delete it from the environment and close the DB handle */
         rc = mdb_drop(txn, dbi, 1);
+        if (rc != 0) {
+            AFW_THROW_ERROR_RV_Z(general, lmdb, rc,
+                "Unable to drop index database.", xctx);
+        }
     }
-
-    return rc;
 }
 
 /*

--- a/src/afw_lmdb/afw_lmdb_index.c
+++ b/src/afw_lmdb/afw_lmdb_index.c
@@ -425,7 +425,7 @@ void impl_afw_adapter_impl_index_delete(
 /*
  * Implementation of method drop of interface afw_adapter_impl_index.
  */
-void
+afw_rc_t
 impl_afw_adapter_impl_index_drop (
     AFW_ADAPTER_IMPL_INDEX_SELF_T *self,
     const afw_utf8_t  * object_type_id,
@@ -438,7 +438,7 @@ impl_afw_adapter_impl_index_drop (
     const afw_utf8_t *database;
     MDB_dbi dbi;
     MDB_txn *txn;
-    afw_rc_t rc;
+    afw_rc_t rc = 0;
 
     database = afw_lmdb_index_database(
         object_type_id, key, pool, xctx);
@@ -458,10 +458,6 @@ impl_afw_adapter_impl_index_drop (
 
             /* (1) means delete it from the environment and close the DB handle */
             rc = mdb_drop(txn, dbi, 1);
-            if (rc != 0) {
-                AFW_THROW_ERROR_RV_Z(general, lmdb, rc,
-                    "Unable to drop index database.", xctx);
-            }
 
             AFW_LMDB_COMMIT_TRANSACTION();
         }
@@ -474,11 +470,9 @@ impl_afw_adapter_impl_index_drop (
 
         /* (1) means delete it from the environment and close the DB handle */
         rc = mdb_drop(txn, dbi, 1);
-        if (rc != 0) {
-            AFW_THROW_ERROR_RV_Z(general, lmdb, rc,
-                "Unable to drop index database.", xctx);
-        }
     }
+
+    return rc;
 }
 
 /*


### PR DESCRIPTION
## Summary

Third slice of #252 (item 5, "a judgment call on interface design").

`add`, `delete`, and `drop` all declared `afw_rc_t` returns. Only `add`/`delete`'s turned out to be genuinely unused:

- **`add`/`delete`**: rc never consulted anywhere. `afw_adapter_impl_index_apply()` calls them without even assigning the result. LMDB already throws on real errors and only returned soft signals (`MDB_KEYEXIST`/`MDB_NOTFOUND`) nobody read. Converted both to `void`.
- **`drop`**: initially converted this too, reasoning from LMDB's specific behavior (by the time `mdb_drop()` runs, `afw_lmdb_internal_open_database()` has already thrown on any real open/create failure, so `mdb_drop()` itself seemed to only be able to fail on unreachable conditions). That reasoning missed the actual interface-level intent: `drop`'s return code is a **capability signal**, not an error code. Not every adapter implementing this interface can necessarily do a fast bulk/table-level drop; a non-zero return tells `afw_adapter_impl_index_remove()` to fall back to the generic per-object delete path instead. That's a legitimate, expected outcome for some future implementation, not something LMDB's current behavior can prove dead. Reverted `drop` and `remove()`'s fallback back to their original behavior, and clarified the XML doc comment to state the contract explicitly instead of leaving it implicit.

## Test plan

- [x] `./afwdev build --cdev` clean
- [x] `./afwdev build --fulldev` clean
- [x] `afwdev test -j` -- 4241 passed, 0 failed
- [x] Diffed `afw_adapter_impl_index.c` / `afw_lmdb_index.c` / interface XML against the pre-#252-item-5 baseline to confirm `drop` and `remove()`'s fallback are byte-for-byte unchanged (only whitespace), and only `add`/`delete` differ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
