### PR TITLE
fix(lmdb): give add/modify/replace/delete_object their own nested transaction (#249)

### DIFF
--- a/src/afw_lmdb/afw_lmdb_adapter_session.c
+++ b/src/afw_lmdb/afw_lmdb_adapter_session.c
@@ -215,12 +215,12 @@ impl_afw_adapter_session_add_object(
         uuid_string = afw_uuid_to_utf8(uuid, xctx->p, xctx);
     }
 
-    AFW_LMDB_BEGIN_TRANSACTION(adapter, self, 0, false, xctx) {
+    AFW_LMDB_BEGIN_ATOMIC_TRANSACTION(adapter, self, xctx) {
 
         txn = AFW_LMDB_GET_TRANSACTION();
 
         /* open our primary database */
-        dbi = afw_lmdb_internal_open_database(adapter, 
+        dbi = afw_lmdb_internal_open_database(adapter,
             txn, afw_lmdb_s_Primary, MDB_CREATE, xctx->p, xctx);
 
         /* add the object to our primary database */
@@ -231,9 +231,9 @@ impl_afw_adapter_session_add_object(
         afw_adapter_impl_index_object(self->indexer, object_type_id,
             object, uuid_string, xctx);
 
-        AFW_LMDB_COMMIT_TRANSACTION();
+        AFW_LMDB_COMMIT_ATOMIC_TRANSACTION();
     }
-    AFW_LMDB_END_TRANSACTION();
+    AFW_LMDB_END_ATOMIC_TRANSACTION();
 
     return uuid_string;
 }
@@ -263,12 +263,12 @@ impl_afw_adapter_session_modify_object(
             "Missing id or object_type.", xctx);
     }
 
-    AFW_LMDB_BEGIN_TRANSACTION(adapter, self, 0, false, xctx) {
+    AFW_LMDB_BEGIN_ATOMIC_TRANSACTION(adapter, self, xctx) {
 
         txn = AFW_LMDB_GET_TRANSACTION(),
 
         /* open our primary database */
-        dbi = afw_lmdb_internal_open_database(adapter, 
+        dbi = afw_lmdb_internal_open_database(adapter,
             txn, afw_lmdb_s_Primary, 0, xctx->p, xctx);
 
         /* load our object into memory and apply the modifications */
@@ -281,16 +281,16 @@ impl_afw_adapter_session_modify_object(
             entry, new_object, xctx);
 
         /* Write updated object */
-        afw_lmdb_internal_replace_entry_from_object(self, object_type_id, 
+        afw_lmdb_internal_replace_entry_from_object(self, object_type_id,
             object_id, new_object, dbi, xctx);
 
         /* Re-index object, if necessary */
         afw_adapter_impl_index_reindex_object(self->indexer, object_type_id,
             object, new_object, object_id, xctx);
 
-        AFW_LMDB_COMMIT_TRANSACTION();
+        AFW_LMDB_COMMIT_ATOMIC_TRANSACTION();
     }
-    AFW_LMDB_END_TRANSACTION();
+    AFW_LMDB_END_ATOMIC_TRANSACTION();
 }
 
 
@@ -318,7 +318,7 @@ impl_afw_adapter_session_replace_object(
             "Missing id or object_type.", xctx);
     }
 
-    AFW_LMDB_BEGIN_TRANSACTION(adapter, self, 0, false, xctx) {
+    AFW_LMDB_BEGIN_ATOMIC_TRANSACTION(adapter, self, xctx) {
 
         txn = AFW_LMDB_GET_TRANSACTION();
 
@@ -327,7 +327,7 @@ impl_afw_adapter_session_replace_object(
             txn, afw_lmdb_s_Primary, 0, xctx->p, xctx);
 
         /* get the old object */
-        value = afw_lmdb_internal_create_value_from_entry(self, 
+        value = afw_lmdb_internal_create_value_from_entry(self,
                 object_type_id, object_id, dbi, xctx);
 
         if (value && !afw_value_is_object(value)) {
@@ -342,12 +342,12 @@ impl_afw_adapter_session_replace_object(
             object_type_id, object_id, replacement_object, dbi, xctx);
 
         /* Re-index object, if necessary */
-        afw_adapter_impl_index_reindex_object(self->indexer, object_type_id, 
+        afw_adapter_impl_index_reindex_object(self->indexer, object_type_id,
             old_object, replacement_object, object_id, xctx);
-    
-        AFW_LMDB_COMMIT_TRANSACTION();
+
+        AFW_LMDB_COMMIT_ATOMIC_TRANSACTION();
     }
-    AFW_LMDB_END_TRANSACTION();
+    AFW_LMDB_END_ATOMIC_TRANSACTION();
 }
 
 
@@ -374,7 +374,7 @@ impl_afw_adapter_session_delete_object(
     uuid = afw_uuid_from_utf8(object_id, xctx->p, xctx);
 
     /* open the transaction */
-    AFW_LMDB_BEGIN_TRANSACTION(adapter, self, 0, false, xctx) {
+    AFW_LMDB_BEGIN_ATOMIC_TRANSACTION(adapter, self, xctx) {
 
         txn = AFW_LMDB_GET_TRANSACTION();
 
@@ -415,9 +415,9 @@ impl_afw_adapter_session_delete_object(
         }
         AFW_ENDTRY;
 
-        AFW_LMDB_COMMIT_TRANSACTION();
+        AFW_LMDB_COMMIT_ATOMIC_TRANSACTION();
     }
-    AFW_LMDB_END_TRANSACTION();
+    AFW_LMDB_END_ATOMIC_TRANSACTION();
 }
 
 

--- a/src/afw_lmdb/afw_lmdb_internal.h
+++ b/src/afw_lmdb/afw_lmdb_internal.h
@@ -381,20 +381,27 @@ do { \
     afw_xctx_t * this_xctx = xctx; \
     int this_rc; \
     AFW_TRY { \
-        if (session && session->transaction) { \
-            ((afw_lmdb_adapter_session_t *)session)->currTxn = session->transaction->txn; \
-        } else if (session && session->currTxn) { \
+        if (session && session->currTxn) { \
             /* \
              * A transaction is already active for this session on this \
              * thread, e.g. this is a recursive/reentrant call (such as a \
              * mapped model property that triggers another retrieve while \
              * an outer retrieve for the same underlying adapter session \
-             * is still iterating). LMDB only allows a single read \
-             * transaction per thread, so reuse the active one instead of \
-             * calling mdb_txn_begin() again, which would fail with \
-             * MDB_BAD_RSLOT ("Invalid reuse of reader locktable slot"). \
+             * is still iterating), OR session->currTxn is a nested atomic \
+             * child begun by AFW_LMDB_BEGIN_ATOMIC_TRANSACTION for the \
+             * enclosing add/modify/replace/delete_object call. Either way, \
+             * currTxn -- not session->transaction, which may be an outer \
+             * ancestor of it -- is always the innermost transaction \
+             * currently active, so reuse it directly instead of calling \
+             * mdb_txn_begin() again, which would either fail with \
+             * MDB_BAD_RSLOT ("Invalid reuse of reader locktable slot") for \
+             * a read, or hand back a transaction LMDB will reject with \
+             * MDB_BAD_TXN once its child (this one) is left dangling. \
              */ \
             this_txn = session->currTxn; \
+        } else if (session && session->transaction) { \
+            ((afw_lmdb_adapter_session_t *)session)->currTxn = session->transaction->txn; \
+            this_txn = session->transaction->txn; \
         } else { \
             if (exclusive) { \
                 apr_thread_rwlock_wrlock(adapter->dbLock); \
@@ -479,6 +486,136 @@ do { \
             if (this_session) \
                 ((afw_lmdb_adapter_session_t *)this_session)->currTxn = NULL; \
             apr_thread_rwlock_unlock(this_adapter->dbLock); \
+        } \
+        AFW_ERROR_RETHROW; \
+    } \
+    AFW_ENDTRY; \
+} while(0)
+
+/**
+ * @brief Begin an LMDB transaction that is atomic for *this* call, even
+ * when a wider transaction (the implicit per-request transaction, or an
+ * explicit begin_transaction()) is already active on the session.
+ *
+ * Use this ONLY at the session's top-level mutators -- add_object,
+ * modify_object, replace_object, delete_object -- the boundary where a
+ * primary-database write and its associated index maintenance must
+ * succeed or fail together (issue #249). Every other LMDB call site
+ * (index maintenance helpers, retrieve/dump, open_database, and anything
+ * else invoked *from within* one of these four) must keep using plain
+ * AFW_LMDB_BEGIN_TRANSACTION, so it continues to reentrantly participate
+ * in whichever transaction -- this one, or an ancestor -- is current,
+ * rather than opening a boundary of its own.
+ *
+ * If no ambient transaction is active, this opens a real top-level owned
+ * transaction, same as AFW_LMDB_BEGIN_TRANSACTION's "new owner" branch.
+ * If an ambient transaction IS active, this opens a genuine LMDB *nested*
+ * transaction (mdb_txn_begin with parent = the ambient transaction).
+ * Committing it merges its writes into the parent (not durable until the
+ * outermost owner eventually commits); aborting it -- the normal outcome
+ * when a thrown error unwinds through this macro's FINALLY -- discards
+ * only this call's writes. The ambient transaction, and anything an
+ * earlier sibling call already committed into it, are left untouched.
+ *
+ * session->currTxn is pointed at this transaction (nested or not) for
+ * the duration of the call, so reentrant helpers keep working unchanged,
+ * then restored to whatever it was before (the parent, or NULL) once
+ * this transaction is committed or aborted.
+ */
+#define AFW_LMDB_BEGIN_ATOMIC_TRANSACTION( \
+    adapter,    \
+    session,    \
+    xctx)      \
+do { \
+    MDB_txn * this_txn = NULL; \
+    MDB_txn * this_ambient_txn = NULL; \
+    MDB_txn * this_saved_currTxn = NULL; \
+    bool this_txnHandled = false; \
+    bool this_txnOwner = false; \
+    bool this_txnNested = false; \
+    const afw_lmdb_adapter_t * this_adapter = adapter; \
+    const afw_lmdb_adapter_session_t * this_session = session; \
+    afw_xctx_t * this_xctx = xctx; \
+    int this_rc; \
+    AFW_TRY { \
+        if (session && !session->currTxn && session->transaction) { \
+            ((afw_lmdb_adapter_session_t *)session)->currTxn = session->transaction->txn; \
+        } \
+        this_saved_currTxn = (session) ? session->currTxn : NULL; \
+        this_ambient_txn = this_saved_currTxn; \
+        if (this_ambient_txn) { \
+            afw_trace_z(1, adapter->pub.trace_flag_index, \
+                NULL, "LMDB Begin nested write transaction", this_xctx); \
+            this_rc = mdb_txn_begin(adapter->dbEnv, this_ambient_txn, 0, &this_txn); \
+            if (this_rc) { \
+                afw_trace_fz(1, adapter->pub.trace_flag_index, \
+                    NULL, this_xctx, "LMDB nested transaction begin failed with error: " \
+                    AFW_INTEGER_FMT, this_rc); \
+                AFW_THROW_ERROR_RV_Z(general, lmdb, this_rc, \
+                    "Unable to begin nested transaction.", this_xctx); \
+            } \
+            this_txnOwner = true; \
+            this_txnNested = true; \
+            if (session) \
+                ((afw_lmdb_adapter_session_t *)session)->currTxn = this_txn; \
+        } else { \
+            apr_thread_rwlock_rdlock(adapter->dbLock); \
+            afw_trace_z(1, adapter->pub.trace_flag_index, \
+                NULL, "LMDB Begin write transaction", this_xctx); \
+            this_rc = mdb_txn_begin(adapter->dbEnv, NULL, 0, &this_txn); \
+            if (this_rc) { \
+                apr_thread_rwlock_unlock(adapter->dbLock); \
+                afw_trace_fz(1, adapter->pub.trace_flag_index, \
+                    NULL, this_xctx, "LMDB transaction begin failed with error: " \
+                    AFW_INTEGER_FMT, this_rc); \
+                AFW_THROW_ERROR_RV_Z(general, lmdb, this_rc, \
+                    "Unable to begin transaction.", this_xctx); \
+            } \
+            this_txnOwner = true; \
+            if (session) \
+                ((afw_lmdb_adapter_session_t *)session)->currTxn = this_txn; \
+        } \
+        do {
+
+/**
+ * @brief Commit an atomic transaction begun with
+ * AFW_LMDB_BEGIN_ATOMIC_TRANSACTION.
+ */
+#define AFW_LMDB_COMMIT_ATOMIC_TRANSACTION() \
+    if (this_txnOwner) { \
+        if (this_txn && !this_txnHandled) { \
+            this_rc = mdb_txn_commit(this_txn); \
+            this_txnHandled = true; \
+            if (this_session) \
+                ((afw_lmdb_adapter_session_t *)this_session)->currTxn = this_saved_currTxn; \
+            if (this_rc) { \
+                AFW_THROW_ERROR_RV_Z(general, lmdb_internal, this_rc, \
+                    "Unable to commit transaction.", this_xctx); \
+            } \
+            afw_trace_z(1, this_adapter->pub.trace_flag_index, \
+                NULL, "LMDB Transaction committed.", this_xctx); \
+        } \
+    }
+
+/**
+ * @brief End an atomic transaction begun with
+ * AFW_LMDB_BEGIN_ATOMIC_TRANSACTION.
+ */
+#define AFW_LMDB_END_ATOMIC_TRANSACTION() \
+        } while (0); \
+    } AFW_FINALLY { \
+        if (this_txnOwner) { \
+            if (this_txn && !this_txnHandled) { \
+                mdb_txn_abort(this_txn); \
+                this_txnHandled = true; \
+                afw_trace_z(1, this_adapter->pub.trace_flag_index, \
+                    NULL, "LMDB Transaction aborted.", this_xctx); \
+            } \
+            if (this_session) \
+                ((afw_lmdb_adapter_session_t *)this_session)->currTxn = this_saved_currTxn; \
+            if (!this_txnNested) { \
+                apr_thread_rwlock_unlock(this_adapter->dbLock); \
+            } \
         } \
         AFW_ERROR_RETHROW; \
     } \

--- a/src/afw_lmdb/tests/indexes/index_unique_option.as
+++ b/src/afw_lmdb/tests/indexes/index_unique_option.as
@@ -30,17 +30,17 @@ const found: array = retrieve_objects("lmdb", ot,
     { "filter": { "op": "eq", "property": "email", "value": "a@example.com" } });
 assert(length(found) === 1, "only the original object should be reachable via the indexed value after the duplicate add was rejected");
 
-// KNOWN BUG (issue #249): the rejected duplicate's *primary* object is not
-// actually rolled back -- it leaks as an orphaned, unindexed record. This is
-// only reproducible when the failing add_object() is the second-or-later
-// add on the same session (a fresh session/process rolls back correctly),
-// which is exactly what this test file does. An unfiltered retrieve_objects
-// (bypassing the index) would show 2 objects here, not 1. Left disabled
-// until #249 is fixed -- uncomment to see it fail:
-//
-// const allObjects: array = retrieve_objects("lmdb", ot, undefined, undefined, undefined, 0);
-// assert(length(allObjects) === 1,
-//     "rejected duplicate add_object() should not leave its primary object persisted (issue #249)");
+// Regression for issue #249: a rejected duplicate's *primary* object used
+// to leak as an orphaned, unindexed record -- reproducible only when the
+// failing add_object() was the second-or-later add on the same session,
+// because the primary write and the index write shared the session's
+// implicit per-request transaction with no way to roll back just this
+// call. Fixed by giving add/modify/replace/delete_object their own nested
+// LMDB transaction (AFW_LMDB_BEGIN_ATOMIC_TRANSACTION) so a failure here
+// only discards this call's own writes.
+const allObjects: array = retrieve_objects("lmdb", ot, undefined, undefined, undefined, 0);
+assert(length(allObjects) === 1,
+    "rejected duplicate add_object() should not leave its primary object persisted (issue #249)");
 
 safe_evaluate(index_remove("lmdb", "email"), null);
 safe_evaluate(delete_object("lmdb", ot, id1), null);

--- a/src/afw_lmdb/tests/indexes/index_unique_option_modify.as
+++ b/src/afw_lmdb/tests/indexes/index_unique_option_modify.as
@@ -1,0 +1,58 @@
+#!/usr/bin/env -S afw --syntax test_script
+//?
+//? testScript: index_unique_option_modify.as
+//? customPurpose: Part of lmdb tests
+//? description: The "unique" index option also protects modify_object (issue #249).
+//? sourceType: script
+//?
+//? test: index_unique_option_modify
+//? description: A unique-index violation during modify_object's reindex must not leave the primary object partially updated, and must leave the old index entry intact.
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+const ot: string = "TestIndexUniqueModifyType";
+const id1: string = generate_uuid();
+const id2: string = generate_uuid();
+
+index_create("lmdb", "email", undefined, [ot], undefined, ["unique"], false, false);
+
+add_object("lmdb", ot, { email: "a@example.com" }, id1);
+add_object("lmdb", ot, { email: "b@example.com" }, id2);
+
+// Regression for issue #249 (modify side): reindexing id2 to a value
+// already used by id1 must fail atomically -- id2's primary object write
+// and its reindex share one nested LMDB transaction, so a rejected unique
+// value rolls back the whole modify, not just the failed index put.
+const dup: string = safe_evaluate(
+    modify_object("lmdb", ot, id2, [["set_property", "email", "a@example.com"]]),
+    "error");
+assert(dup === "error", "modifying an object to a duplicate value on a unique index should fail");
+
+// id2's primary object must be unchanged -- not partially applied.
+const unchanged: object = get_object("lmdb", ot, id2);
+assert(unchanged.email === "b@example.com",
+    "id2 should still have its original email after the rejected modify (issue #249)");
+
+// No third object should have appeared, and both original objects remain.
+const allObjects: array = retrieve_objects("lmdb", ot, undefined, undefined, undefined, 0);
+assert(length(allObjects) === 2,
+    "a rejected modify_object() should not change how many objects exist (issue #249)");
+
+// id2's old indexed value must still be intact (reindex must not have
+// removed the old entry before the new one was rejected).
+const foundByOldValue: array = retrieve_objects("lmdb", ot,
+    { "filter": { "op": "eq", "property": "email", "value": "b@example.com" } });
+assert(length(foundByOldValue) === 1,
+    "id2 should still be reachable by its original indexed value (issue #249)");
+
+const foundByRejectedValue: array = retrieve_objects("lmdb", ot,
+    { "filter": { "op": "eq", "property": "email", "value": "a@example.com" } });
+assert(length(foundByRejectedValue) === 1,
+    "only id1 should be reachable by the contested indexed value");
+
+safe_evaluate(index_remove("lmdb", "email"), null);
+safe_evaluate(delete_object("lmdb", ot, id1), null);
+safe_evaluate(delete_object("lmdb", ot, id2), null);
+
+return 0;


### PR DESCRIPTION
## Summary

- `add_object()` rejected by a `unique` index still persisted its primary object whenever it was the second-or-later write on a session — the rejected write and an earlier successful write shared one ambient LMDB transaction (the implicit per-request transaction, or an explicit `begin_transaction()`), which only commits or aborts once, at end of request. A failure caught inside the script (e.g. via `safe_evaluate`) never touched that ambient transaction, so the failed call's already-buffered primary write rode along to the final commit.
- `AFW_LMDB_BEGIN_TRANSACTION`'s reentrant `currTxn` reuse was working as designed (it's what lets nested reads/index writes safely share a transaction handle) — there was just no atomic unit smaller than "the whole ambient transaction" for a single `add_object`/`modify_object`/`replace_object`/`delete_object` call to roll back to.
- Adds `AFW_LMDB_BEGIN_ATOMIC_TRANSACTION` (+ `COMMIT`/`END` variants), used only at those four session mutators. When an ambient transaction is already active, it opens a genuine LMDB **nested (child) transaction** instead of reusing the ambient one directly. Committing merges the child into its parent (not durable until the outermost owner eventually commits); a thrown error — e.g. a unique-index rejection — aborts only that call's own child, discarding just its own writes. Earlier sibling calls already merged into the parent, and the parent itself, are untouched. With no ambient transaction active, behavior is unchanged (a plain top-level owned transaction, same as before).
- Every other LMDB call site (index maintenance helpers, `retrieve_objects`/dump, `open_database`) is untouched — still plain reentrant reuse, since those are always sub-operations of one of the four mutators above, never boundaries themselves.
- Fixing the new macro's ambient-detection surfaced a latent bug shared by both macros' preamble: it unconditionally re-synced `currTxn` from `session->transaction` on every call, which stomped a just-opened nested child back to its parent before a reentrant sub-write (e.g. the index `put`) ran — LMDB then correctly refused to use a parent with an active, uncommitted child (`MDB_BAD_TXN`). Fixed by checking `currTxn` first and only falling back to `session->transaction` when `currTxn` is unset.

## Test plan

- [x] Re-enabled the previously-disabled assertion in `src/afw_lmdb/tests/indexes/index_unique_option.as` (issue #249's own regression case).
- [x] Added `src/afw_lmdb/tests/indexes/index_unique_option_modify.as` covering the same bug class on `modify_object`'s reindex path (same shared-child-transaction fix, previously completely untested).
- [x] Confirmed both fail without this change (reverted just the source changes via `git stash`, reran, restored) — not vacuous passes.
- [x] Full `afw_lmdb` suite: 17/17 pass, including under `afwdev test --env-mode valgrind`.
- [x] Full `afwdev test -j` suite: 4242/4312 pass, 70 pre-existing/unrelated skips (same baseline), no regressions.

Fixes #249.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>