### PR TITLE
fix(adapter): sortable text encoding for indexed integer/double range queries (#251)

### DIFF
--- a/src/afw/adapter/afw_adapter_impl_index.c
+++ b/src/afw/adapter/afw_adapter_impl_index.c
@@ -372,6 +372,98 @@ afw_boolean_t afw_adapter_impl_index_option_unique(
 }
 
 /*
+ * Encodes a signed 64-bit integer as a fixed-width (20-digit),
+ * zero-padded decimal string whose byte-lexicographic order matches
+ * numeric order.
+ *
+ * Index keys are stored/compared as plain text (see
+ * impl_index_value_as_key_utf8), so a naive decimal rendering sorts
+ * wrong ("100" < "9" as text). Flipping the sign bit maps the full
+ * afw_integer_t range onto 0..UINT64_MAX while preserving order (the
+ * standard two's-complement-to-offset-binary trick); zero-padding
+ * that to a fixed width then makes text comparison match numeric
+ * comparison (issue #251).
+ */
+static const afw_utf8_t *
+impl_index_integer_as_sortable_utf8(
+    afw_integer_t value, const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    afw_uint64_t offset;
+    char buf[20];
+    int i;
+
+    offset = (afw_uint64_t)value ^ ((afw_uint64_t)1 << 63);
+
+    for (i = 19; i >= 0; i--) {
+        buf[i] = (char)('0' + (offset % 10));
+        offset /= 10;
+    }
+
+    return afw_utf8_create(buf, sizeof(buf), p, xctx);
+}
+
+/*
+ * Encodes an IEEE 754 double as a fixed-width, zero-padded decimal
+ * string whose byte-lexicographic order matches numeric order.
+ *
+ * Same sortable-text goal as impl_index_integer_as_sortable_utf8, but
+ * doubles need the standard IEEE-754-bit-pattern trick instead of a
+ * sign-bit flip: for a non-negative double (sign bit 0), setting the
+ * sign bit pushes it above all negative doubles; for a negative
+ * double (sign bit 1), flipping every bit reverses its (otherwise
+ * backwards) magnitude order and pushes it below all non-negative
+ * doubles. The result is a uint64 whose unsigned order matches the
+ * double's numeric order, which is then zero-padded as text the same
+ * way (issue #251).
+ */
+static const afw_utf8_t *
+impl_index_double_as_sortable_utf8(
+    double value, const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    afw_uint64_t bits;
+    char buf[20];
+    int i;
+
+    memcpy(&bits, &value, sizeof(bits));
+    bits = (bits & ((afw_uint64_t)1 << 63))
+        ? ~bits
+        : (bits | ((afw_uint64_t)1 << 63));
+
+    for (i = 19; i >= 0; i--) {
+        buf[i] = (char)('0' + (bits % 10));
+        bits /= 10;
+    }
+
+    return afw_utf8_create(buf, sizeof(buf), p, xctx);
+}
+
+/*
+ * Returns the utf8 text used as an index key/comparison value for
+ * `value`. Integer and double values get the fixed-width sortable
+ * encoding above so lt/le/gt/ge walk keys in numeric order; LMDB (and
+ * afw_utf8_compare) order index text byte-lexicographically, which
+ * does not match numeric order for plain decimal text (issue #251).
+ * Other types keep the existing plain-text representation, which is
+ * already naturally sortable (e.g. zero-padded ISO 8601 dateTime).
+ */
+static const afw_utf8_t *
+impl_index_value_as_key_utf8(
+    const afw_value_t *value, const afw_pool_t *p, afw_xctx_t *xctx)
+{
+    if (afw_value_is_integer(value)) {
+        return impl_index_integer_as_sortable_utf8(
+            afw_value_as_integer(value, xctx), p, xctx);
+    }
+
+    if (afw_value_is_double(value)) {
+        return impl_index_double_as_sortable_utf8(
+            afw_value_as_double(value, xctx), p, xctx);
+    }
+
+    return afw_value_as_utf8(value, p, xctx);
+}
+
+/*
  * When we need to add or remove an index value, this routine
  * will determine the appropriate way to do so, depending on
  * the indexDefinition options.
@@ -395,10 +487,10 @@ void afw_adapter_impl_index_apply(
         indexDefinition, xctx);
     unique = afw_adapter_impl_index_option_unique(indexDefinition, xctx);
 
-    /* Generate the utf8 value of the index; this will be used as the 
-        index key in the underlying database. 
+    /* Generate the utf8 value of the index; this will be used as the
+        index key in the underlying database.
      */
-    value_string = afw_value_as_utf8(value, object->p, xctx);
+    value_string = impl_index_value_as_key_utf8(value, object->p, xctx);
     if (!case_sensitive) {
         /* For case-insensitive indexes, lower-case it so we will always
             do case-insensitive comparisons */
@@ -1489,9 +1581,10 @@ apr_array_header_t * afw_adapter_impl_index_cursor_list(
         return cursor_list;
     }
 
-    /* use the internal utf-8 string representation */
-    /** @fixme this may not help us with date or integer comparisons */
-    value_string = afw_value_as_utf8(entry->value, xctx->p, xctx);
+    /* use the internal utf-8 string representation; integer/double
+       get the sortable encoding so range ops walk keys in numeric
+       order (issue #251) */
+    value_string = impl_index_value_as_key_utf8(entry->value, xctx->p, xctx);
 
     /* Determine if this property is indexed */
     indexDefinition = afw_adapter_impl_index_get_index_definition(
@@ -1620,9 +1713,10 @@ static int afw_adapter_impl_index_compare(
     int i;
     const afw_utf8_t *property_value;
 
-    /* use the internal utf-8 string representation */
-    /** @fixme this may not help us with date or integer comparisons */
-    property_value = afw_value_as_utf8(entry->value, xctx->p, xctx);
+    /* use the internal utf-8 string representation; integer/double
+       get the sortable encoding so lt/le/gt/ge below compare
+       numerically, not lexicographically (issue #251) */
+    property_value = impl_index_value_as_key_utf8(entry->value, xctx->p, xctx);
 
     /* can't compare Objects */
     if (afw_value_is_object(value)) {
@@ -1635,16 +1729,16 @@ static int afw_adapter_impl_index_compare(
         values = afw_value_as_array_of_values(value, xctx->p, xctx);
         for (i = 0; values[i]; i++) {
             v = values[i];
-            string = afw_value_as_utf8(v, xctx->p, xctx);
+            string = impl_index_value_as_key_utf8(v, xctx->p, xctx);
 
             if (afw_utf8_equal(string, property_value))
                 return 0;
         }
-    } 
+    }
 
     else {
         /* scalars are easy */
-        string = afw_value_as_utf8(value, xctx->p, xctx);
+        string = impl_index_value_as_key_utf8(value, xctx->p, xctx);
         return afw_utf8_compare(string, property_value);
     }
 

--- a/src/afw_lmdb/tests/indexes/index_range_numeric.as
+++ b/src/afw_lmdb/tests/indexes/index_range_numeric.as
@@ -1,0 +1,139 @@
+#!/usr/bin/env -S afw --syntax test_script
+//?
+//? testScript: index_range_numeric.as
+//? customPurpose: Part of lmdb tests
+//? description: Index-accelerated lt/le/gt/ge range queries on integer/double properties return numerically, not lexicographically, correct results (issue #251).
+//? sourceType: script
+//?
+//? test: index_range_numeric_integer
+//? description: An indexed integer property's range queries (lt/le/gt/ge) return numerically correct results.
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+const ot: string = "TestIndexRangeIntType";
+
+// Values chosen so that a naive lexicographic ("100" < "20" < "9") text
+// comparison would get lt/le/gt/ge wrong -- this is the exact failure
+// mode from issue #251 (an indexed `gt 9` query returned only `age: 9`).
+const idNeg: string = generate_uuid();
+const idZero: string = generate_uuid();
+const id5: string = generate_uuid();
+const id9: string = generate_uuid();
+const id10: string = generate_uuid();
+const id20: string = generate_uuid();
+const id100: string = generate_uuid();
+
+index_create("lmdb", "age", undefined, [ot], undefined, undefined, false, false);
+
+add_object("lmdb", ot, { age: -50 }, idNeg);
+add_object("lmdb", ot, { age: 0 }, idZero);
+add_object("lmdb", ot, { age: 5 }, id5);
+add_object("lmdb", ot, { age: 9 }, id9);
+add_object("lmdb", ot, { age: 10 }, id10);
+add_object("lmdb", ot, { age: 20 }, id20);
+add_object("lmdb", ot, { age: 100 }, id100);
+
+const gt9: array = retrieve_objects("lmdb", ot,
+    { "filter": { "op": "gt", "property": "age", "value": 9 } });
+assert(length(gt9) === 3, "gt 9 should return the 3 objects with age > 9 (10, 20, 100)");
+
+// The exact issue #251 repro: age === 9 must never satisfy gt 9. Combining
+// with an "eq" clause proves it directly, rather than just trusting a count.
+const gt9EqualsNine: array = retrieve_objects("lmdb", ot, { "filter": {
+    "op": "and",
+    "filters": [
+        { "op": "gt", "property": "age", "value": 9 },
+        { "op": "eq", "property": "age", "value": 9 }
+    ]
+}});
+assert(length(gt9EqualsNine) === 0,
+    "age === 9 must not satisfy gt 9 (issue #251: lexicographic \"9\" > \"100\" made this pass)");
+
+const ge9: array = retrieve_objects("lmdb", ot,
+    { "filter": { "op": "ge", "property": "age", "value": 9 } });
+assert(length(ge9) === 4, "ge 9 should include the boundary (9, 10, 20, 100)");
+
+const lt9: array = retrieve_objects("lmdb", ot,
+    { "filter": { "op": "lt", "property": "age", "value": 9 } });
+assert(length(lt9) === 3, "lt 9 should return the 3 objects with age < 9 (-50, 0, 5)");
+
+const le9: array = retrieve_objects("lmdb", ot,
+    { "filter": { "op": "le", "property": "age", "value": 9 } });
+assert(length(le9) === 4, "le 9 should include the boundary (-50, 0, 5, 9)");
+
+// Negative values must sort below zero and below all positive values.
+const ltZero: array = retrieve_objects("lmdb", ot,
+    { "filter": { "op": "lt", "property": "age", "value": 0 } });
+assert(length(ltZero) === 1, "lt 0 should return only the negative object (-50)");
+assert(ltZero[0].age === -50, "lt 0 should return the object with age -50");
+
+safe_evaluate(index_remove("lmdb", "age"), null);
+safe_evaluate(delete_object("lmdb", ot, idNeg), null);
+safe_evaluate(delete_object("lmdb", ot, idZero), null);
+safe_evaluate(delete_object("lmdb", ot, id5), null);
+safe_evaluate(delete_object("lmdb", ot, id9), null);
+safe_evaluate(delete_object("lmdb", ot, id10), null);
+safe_evaluate(delete_object("lmdb", ot, id20), null);
+safe_evaluate(delete_object("lmdb", ot, id100), null);
+
+return 0;
+
+//? test: index_range_numeric_double
+//? description: An indexed double property's range queries (lt/le/gt/ge) return numerically correct results, including negative and fractional values.
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+const ot: string = "TestIndexRangeDoubleType";
+
+const idA: string = generate_uuid();
+const idB: string = generate_uuid();
+const idC: string = generate_uuid();
+const idD: string = generate_uuid();
+const idE: string = generate_uuid();
+
+index_create("lmdb", "score", undefined, [ot], undefined, undefined, false, false);
+
+add_object("lmdb", ot, { score: -3.5 }, idA);
+add_object("lmdb", ot, { score: -1.25 }, idB);
+add_object("lmdb", ot, { score: 0.0 }, idC);
+add_object("lmdb", ot, { score: 2.75 }, idD);
+add_object("lmdb", ot, { score: 10.5 }, idE);
+
+const gtZero: array = retrieve_objects("lmdb", ot,
+    { "filter": { "op": "gt", "property": "score", "value": 0.0 } });
+assert(length(gtZero) === 2, "gt 0.0 should return the 2 positive scores (2.75, 10.5)");
+
+const ltZero: array = retrieve_objects("lmdb", ot,
+    { "filter": { "op": "lt", "property": "score", "value": 0.0 } });
+assert(length(ltZero) === 2, "lt 0.0 should return the 2 negative scores (-3.5, -1.25)");
+
+// -3.5 is more negative than -1.25, so it must sort first (lower), not by
+// naive text/magnitude comparison. Checked by count (not by reading back
+// the matched object's `score`): the LMDB adapter has a separate,
+// pre-existing bug that corrupts a `double` property's value on readback
+// (reproduces via plain get_object(), with no index involved -- unrelated
+// to issue #251 and not touched by this fix, since the index-accelerated
+// comparisons here run against the live in-memory value, never the
+// corrupted decoded one). Worth its own issue, not fixed here.
+const ltNeg1_25: array = retrieve_objects("lmdb", ot,
+    { "filter": { "op": "lt", "property": "score", "value": -1.25 } });
+assert(length(ltNeg1_25) === 1, "lt -1.25 should return only -3.5");
+
+const leNeg1_25: array = retrieve_objects("lmdb", ot,
+    { "filter": { "op": "le", "property": "score", "value": -1.25 } });
+assert(length(leNeg1_25) === 2, "le -1.25 should include the boundary (-3.5, -1.25)");
+
+const geNeg1_25: array = retrieve_objects("lmdb", ot,
+    { "filter": { "op": "ge", "property": "score", "value": -1.25 } });
+assert(length(geNeg1_25) === 4, "ge -1.25 should include the boundary (-1.25, 0.0, 2.75, 10.5)");
+
+safe_evaluate(index_remove("lmdb", "score"), null);
+safe_evaluate(delete_object("lmdb", ot, idA), null);
+safe_evaluate(delete_object("lmdb", ot, idB), null);
+safe_evaluate(delete_object("lmdb", ot, idC), null);
+safe_evaluate(delete_object("lmdb", ot, idD), null);
+safe_evaluate(delete_object("lmdb", ot, idE), null);
+
+return 0;

--- a/src/afw_lmdb/tests/indexes/index_sargable_trace.py
+++ b/src/afw_lmdb/tests/indexes/index_sargable_trace.py
@@ -89,6 +89,22 @@ def run():
             "retrieve_objects: using index query",
             "retrieve_objects: using full scan (not sargable)",
         ),
+        (
+            "sargable_range_op_after_index",
+            "A gt filter on an indexed integer property is sargable: retrieve_objects uses the index (issue #251)",
+            """
+            const ot = "TestSargableTraceRangeType";
+            add_object("lmdb", ot, { age: 9 }, generate_uuid());
+            add_object("lmdb", ot, { age: 20 }, generate_uuid());
+            index_create("lmdb", "age", undefined, [ot], undefined, undefined, true, false);
+            flag_set(["trace:adapterId:lmdb"], true);
+            retrieve_objects("lmdb", ot,
+                { "filter": { "op": "gt", "property": "age", "value": 9 } });
+            return 0;
+            """,
+            "retrieve_objects: using index query",
+            "retrieve_objects: using full scan (not sargable)",
+        ),
     ]
 
     for name, desc, body, must_contain, must_not_contain in cases:


### PR DESCRIPTION
## Summary
- Index keys were stored as plain decimal text and compared byte-lexicographically, so `lt`/`le`/`gt`/`ge` on an indexed integer or double property silently returned wrong results (e.g. an indexed `age gt 9` query matched `age: 9` itself, since `"9" > "100"` as text). Reported in #251.
- Adds a type-aware sortable key encoder (sign-bit flip for integers, the standard IEEE-754-bit-pattern trick for doubles, both zero-padded to a fixed width) and wires it into the three places that built index keys/comparison values: the write path (`afw_adapter_impl_index_apply`), the query-side cursor open (`afw_adapter_impl_index_cursor_list`), and the conjunction-dedup compare (`afw_adapter_impl_index_compare`). This resolves the two pre-existing `@fixme ... integer comparisons` comments at those call sites. Non-numeric types (including `dateTime`, which was already correct) are unaffected.

## Test plan
- [x] `src/afw_lmdb/tests/indexes/index_range_numeric.as` — integer and double range correctness, including the exact issue #251 repro (`age gt 9` must not match `age: 9`, proven via a combined `and` filter, not just a count) and negative/boundary values.
- [x] `src/afw_lmdb/tests/indexes/index_sargable_trace.py` — new case proving a `gt` query on an indexed property actually takes the index-accelerated path (not a full-scan fallback that would mask the bug).
- [x] `afwdev test -j` — full suite, 4245 passed, 0 failed, 0 regressions.

## Note
While writing the double-range test, found and filed a separate, pre-existing bug unrelated to this fix: #263 (a `double` property is corrupted on any UBJSON round-trip — reproduces with a bare `add_object`/`get_object`, no indexing involved). This PR's fix is unaffected since index-accelerated comparisons run against the live in-memory value, never the corrupted decoded one; the double test in this PR works around it via count-only assertions instead of reading back the property value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)