### PR TITLE
fix(ubjson): sync double encode/decode endian handling (#263)

### DIFF
--- a/src/afw_lmdb/tests/indexes/index_range_numeric.as
+++ b/src/afw_lmdb/tests/indexes/index_range_numeric.as
@@ -110,16 +110,11 @@ const ltZero: array = retrieve_objects("lmdb", ot,
 assert(length(ltZero) === 2, "lt 0.0 should return the 2 negative scores (-3.5, -1.25)");
 
 // -3.5 is more negative than -1.25, so it must sort first (lower), not by
-// naive text/magnitude comparison. Checked by count (not by reading back
-// the matched object's `score`): the LMDB adapter has a separate,
-// pre-existing bug that corrupts a `double` property's value on readback
-// (reproduces via plain get_object(), with no index involved -- unrelated
-// to issue #251 and not touched by this fix, since the index-accelerated
-// comparisons here run against the live in-memory value, never the
-// corrupted decoded one). Worth its own issue, not fixed here.
+// naive text/magnitude comparison.
 const ltNeg1_25: array = retrieve_objects("lmdb", ot,
     { "filter": { "op": "lt", "property": "score", "value": -1.25 } });
 assert(length(ltNeg1_25) === 1, "lt -1.25 should return only -3.5");
+assert(ltNeg1_25[0].score === -3.5, "lt -1.25 should return the object with score -3.5 (issue #263)");
 
 const leNeg1_25: array = retrieve_objects("lmdb", ot,
     { "filter": { "op": "le", "property": "score", "value": -1.25 } });

--- a/src/afw_ubjson/afw_ubjson_from_value.c
+++ b/src/afw_ubjson/afw_ubjson_from_value.c
@@ -192,10 +192,13 @@ static void convert_double_to_ubjson(
         high-precision    1-byte+      H       Yes     Yes (if non-empty)
      */
 
+    afw_c_types_t c_type;
+
     impl_putc(wa, AFW_UBJSON_MARKER_FLOAT64);
 
-    /** @fixme endian on a double? */
-    impl_write(wa, &d, sizeof(d));
+    c_type.float64 = d;
+    AFW_ENDIAN_NATIVE_TO_BIG(&c_type, 64);
+    impl_write(wa, &c_type, sizeof(d));
 }
 
 static void convert_object_to_ubjson(

--- a/src/afw_ubjson/tests/parser/ubjson_double_roundtrip.as
+++ b/src/afw_ubjson/tests/parser/ubjson_double_roundtrip.as
@@ -1,0 +1,51 @@
+#!/usr/bin/env -S afw --syntax test_script
+//?
+//? testScript: ubjson_double_roundtrip.as
+//? customPurpose: Part of afw_ubjson tests
+//? description: Regression for issue #263 -- a `double` property must round-trip through UBJSON encode/decode unchanged. Pre-fix, convert_double_to_ubjson() wrote raw native-endian bytes while afw_ubjson_parse_number() always byte-swapped float64 on read, so any non-zero double came back corrupted (a different, usually subnormal, value) on a little-endian host.
+//? sourceType: script
+//?
+//? test: ubjson_double_roundtrip_negative_fractional
+//? description: A negative fractional double round-trips through add_object/get_object unchanged (the exact repro from issue #263).
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+const uuid: string = generate_uuid();
+
+add_object("ubjson", "TestDoubleType", { score: -3.5 }, uuid);
+const g: object = get_object("ubjson", "TestDoubleType", uuid);
+assert(g.score === -3.5, "expected -3.5, got " + string(g.score));
+
+delete_object("ubjson", "TestDoubleType", uuid);
+
+return 0;
+
+
+//? test: ubjson_double_roundtrip_values
+//? description: Positive, negative, zero, and fractional doubles all round-trip unchanged. Zero round-tripped correctly even pre-fix (its all-zero byte pattern is its own byte-reversal), so it is included as a non-regressing baseline alongside the values that were corrupted.
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+const uuidA: string = generate_uuid();
+const uuidB: string = generate_uuid();
+const uuidC: string = generate_uuid();
+const uuidD: string = generate_uuid();
+
+add_object("ubjson", "TestDoubleType", { score: 3.5 }, uuidA);
+add_object("ubjson", "TestDoubleType", { score: 0.0 }, uuidB);
+add_object("ubjson", "TestDoubleType", { score: 42.0 }, uuidC);
+add_object("ubjson", "TestDoubleType", { score: 100.25 }, uuidD);
+
+assert(get_object("ubjson", "TestDoubleType", uuidA).score === 3.5, "expected 3.5 to round-trip");
+assert(get_object("ubjson", "TestDoubleType", uuidB).score === 0.0, "expected 0.0 to round-trip");
+assert(get_object("ubjson", "TestDoubleType", uuidC).score === 42.0, "expected 42.0 to round-trip");
+assert(get_object("ubjson", "TestDoubleType", uuidD).score === 100.25, "expected 100.25 to round-trip");
+
+delete_object("ubjson", "TestDoubleType", uuidA);
+delete_object("ubjson", "TestDoubleType", uuidB);
+delete_object("ubjson", "TestDoubleType", uuidC);
+delete_object("ubjson", "TestDoubleType", uuidD);
+
+return 0;


### PR DESCRIPTION
## Summary
- `convert_double_to_ubjson()` wrote a `double`'s raw native-endian bytes to the UBJSON `float64` wire format, while `afw_ubjson_parse_number()` on read always byte-swapped assuming big-endian, matching every other numeric type (`int16`/`int32`/`int64`) except this one. On a little-endian host, every non-zero double came back corrupted on read (e.g. `-3.5` round-tripped to `1.6126302680258287E-32`); `0.0` was the only value that happened to survive, since its all-zero byte pattern is its own reverse.
- Fixes the write side to swap to big-endian using the same `AFW_ENDIAN_NATIVE_TO_BIG(..., 64)` macro and `afw_c_types_t` union pattern already used by the integer writers and by the reader, closing the `/** @fixme endian on a double? */` gap.
- Per maintainer direction, no migration path is included for existing LMDB databases with previously-corrupted doubles (project is pre-1.0/beta).

## Test plan
- [x] New `src/afw_ubjson/tests/parser/ubjson_double_roundtrip.as` — direct `add_object`/`get_object` round-trip through the `ubjson` file adapter, covering negative, positive, zero, and fractional doubles. Verified it fails pre-fix with the exact corrupted value from the issue repro, and passes post-fix.
- [x] Strengthened `src/afw_lmdb/tests/indexes/index_range_numeric.as` (from #251) to assert the actual returned `score` value instead of just a result count, removing the comment that documented this as a known unfixed bug.
- [x] `afwdev test -j` — full suite green (4247 passed, 0 failed, 70 skipped as usual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)