### PR TITLE
fix(lmdb): drop the non-functional index "integer" option (#266)

### DIFF
--- a/src/afw/adapter/afw_adapter_impl_index.c
+++ b/src/afw/adapter/afw_adapter_impl_index.c
@@ -189,11 +189,16 @@ impl_index_current_variables[] = {
  *  The "filter" property optionally determines if a given object is applicable for
  *      this index definition (script must return boolean).
  *
- *  The "options" property is a list of options for how the index needs to 
- *      be used.  Some options may possibly be:
+ *  The "options" property is a list of options for how the index needs to
+ *      be used.  Implemented options:
+ *
+ *          unique                  - reject/skip duplicate index values
+ *          sort-reverse            - store index values in reverse order
+ *          case-insensitive-string - fold string values for comparison
+ *
+ *      Aspirational (parsed nowhere / not yet implemented):
  *
  *          presence
- *          case-insensitive-string
  *          case-sensitive-string
  *          starts-with
  *          ends-with
@@ -670,7 +675,6 @@ void afw_adapter_impl_index_open_definition(
     const afw_utf8_t *object_type_id;
     afw_boolean_t unique  = false;
     afw_boolean_t reverse = false;
-    afw_boolean_t integer = false;
 
     options = afw_object_old_get_property_as_array(
         indexDefinition, afw_v_options, xctx);
@@ -685,8 +689,6 @@ void afw_adapter_impl_index_open_definition(
 
                 if (afw_utf8_equal(option_str, afw_s_sort_reverse))
                     reverse = true;
-                else if (afw_utf8_equal(option_str, afw_s_integer))
-                    integer = true;
                 else if (afw_utf8_equal(option_str, afw_s_unique))
                     unique = true;
             }
@@ -704,15 +706,15 @@ void afw_adapter_impl_index_open_definition(
         object_type_id = afw_array_of_string_get_next(
             objectType, &object_type_iterator, xctx);
         while (object_type_id) {
-            afw_adapter_impl_index_open(indexer, object_type_id, 
-                key, integer, unique, reverse, pool, xctx);
-            
+            afw_adapter_impl_index_open(indexer, object_type_id,
+                key, unique, reverse, pool, xctx);
+
             object_type_id = afw_array_of_string_get_next(
                 objectType, &object_type_iterator, xctx);
         }
     } else {
-        afw_adapter_impl_index_open(indexer, NULL, key, 
-            integer, unique, reverse, pool, xctx);
+        afw_adapter_impl_index_open(indexer, NULL, key,
+            unique, reverse, pool, xctx);
     }
 }
 

--- a/src/afw/generate/interfaces/afw_interface.xml
+++ b/src/afw/generate/interfaces/afw_interface.xml
@@ -1376,10 +1376,6 @@ AFW_DEFINE(const afw_adapter_t *)
     <description>Index key associated with the index value we are creating.</description>
       </parameter>
 
-      <parameter name="integer" type="afw_boolean_t">
-    <description>Should index values be stored as integer values.</description>
-      </parameter>
-
       <parameter name="unique" type="afw_boolean_t">
     <description>Should generated index values be unique.</description>
       </parameter>

--- a/src/afw/generated/afw_adapter_impl_index_impl_declares.h
+++ b/src/afw/generated/afw_adapter_impl_index_impl_declares.h
@@ -112,7 +112,6 @@ impl_afw_adapter_impl_index_open(
     AFW_ADAPTER_IMPL_INDEX_SELF_T *self,
     const afw_utf8_t * object_type_id,
     const afw_utf8_t * key,
-    afw_boolean_t integer,
     afw_boolean_t unique,
     afw_boolean_t reverse,
     const afw_pool_t * pool,

--- a/src/afw/generated/afw_interface.h
+++ b/src/afw/generated/afw_interface.h
@@ -1659,7 +1659,6 @@ typedef void
     const afw_adapter_impl_index_t * instance,
     const afw_utf8_t * object_type_id,
     const afw_utf8_t * key,
-    afw_boolean_t integer,
     afw_boolean_t unique,
     afw_boolean_t reverse,
     const afw_pool_t * pool,
@@ -1764,7 +1763,6 @@ struct afw_adapter_impl_index_inf_s {
  * target table or database to store the index. NULL means all objectTypes are
  * applicable.
  * @param key Index key associated with the index value we are creating.
- * @param integer Should index values be stored as integer values.
  * @param unique Should generated index values be unique.
  * @param reverse Should index values be stored in reverse order.
  * @param pool Caller's pool.
@@ -1776,7 +1774,6 @@ struct afw_adapter_impl_index_inf_s {
     instance, \
     object_type_id, \
     key, \
-    integer, \
     unique, \
     reverse, \
     pool, \
@@ -1786,7 +1783,6 @@ struct afw_adapter_impl_index_inf_s {
     (instance), \
     (object_type_id), \
     (key), \
-    (integer), \
     (unique), \
     (reverse), \
     (pool), \

--- a/src/afw/generated/interface_closet/skeleton_afw_adapter_impl_index.c
+++ b/src/afw/generated/interface_closet/skeleton_afw_adapter_impl_index.c
@@ -25,7 +25,6 @@ impl_afw_adapter_impl_index_open(
     AFW_ADAPTER_IMPL_INDEX_SELF_T *self,
     const afw_utf8_t * object_type_id,
     const afw_utf8_t * key,
-    afw_boolean_t integer,
     afw_boolean_t unique,
     afw_boolean_t reverse,
     const afw_pool_t * pool,

--- a/src/afw_lmdb/afw_lmdb_index.c
+++ b/src/afw_lmdb/afw_lmdb_index.c
@@ -201,7 +201,6 @@ impl_afw_adapter_impl_index_open(
     AFW_ADAPTER_IMPL_INDEX_SELF_T *self,
     const afw_utf8_t * object_type_id,
     const afw_utf8_t * key,
-    afw_boolean_t integer,
     afw_boolean_t unique,
     afw_boolean_t reverse,
     const afw_pool_t * pool,
@@ -221,8 +220,6 @@ impl_afw_adapter_impl_index_open(
     if (!unique) flags |= MDB_DUPSORT;
 
     if (reverse) flags |= MDB_REVERSEKEY | MDB_REVERSEDUP;
-  
-    if (integer) flags |= MDB_INTEGERKEY;
 
     /* open up our exclusive transaction, if we haven't already */
     if (self->txn == NULL) {

--- a/src/afw_lmdb/tests/indexes/index_integer_option_noop.as
+++ b/src/afw_lmdb/tests/indexes/index_integer_option_noop.as
@@ -1,0 +1,57 @@
+#!/usr/bin/env -S afw --syntax test_script
+//?
+//? testScript: index_integer_option_noop.as
+//? customPurpose: Part of lmdb tests
+//? description: The (removed) "integer" index option is a harmless no-op -- range queries on an integer-property index still return numerically correct results via the sortable-text key encoding, not a mismatched MDB_INTEGERKEY database (issue #266).
+//? sourceType: script
+//?
+//? test: index_integer_option_noop_range
+//? description: Passing options: ["integer"] no longer sets MDB_INTEGERKEY against a sortable-text key; lt/le/gt/ge range queries remain numerically correct.
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+const ot: string = "TestIndexIntegerOptionNoopType";
+
+// Same ordering-trap values as index_range_numeric.as (issue #251): a
+// lexicographic ("100" < "20" < "9") comparison, or a raw MDB_INTEGERKEY
+// mismatch against a text key, would get these wrong.
+const idNeg: string = generate_uuid();
+const idZero: string = generate_uuid();
+const id9: string = generate_uuid();
+const id10: string = generate_uuid();
+const id100: string = generate_uuid();
+
+index_create("lmdb", "age", undefined, [ot], undefined, ["integer"], false, false);
+
+add_object("lmdb", ot, { age: -50 }, idNeg);
+add_object("lmdb", ot, { age: 0 }, idZero);
+add_object("lmdb", ot, { age: 9 }, id9);
+add_object("lmdb", ot, { age: 10 }, id10);
+add_object("lmdb", ot, { age: 100 }, id100);
+
+const gt9: array = retrieve_objects("lmdb", ot,
+    { "filter": { "op": "gt", "property": "age", "value": 9 } });
+assert(length(gt9) === 2, "gt 9 should return the 2 objects with age > 9 (10, 100)");
+
+const ge9: array = retrieve_objects("lmdb", ot,
+    { "filter": { "op": "ge", "property": "age", "value": 9 } });
+assert(length(ge9) === 3, "ge 9 should include the boundary (9, 10, 100)");
+
+const lt0: array = retrieve_objects("lmdb", ot,
+    { "filter": { "op": "lt", "property": "age", "value": 0 } });
+assert(length(lt0) === 1, "lt 0 should return only the negative object (-50)");
+assert(lt0[0].age === -50, "lt 0 should return the object with age -50");
+
+const le0: array = retrieve_objects("lmdb", ot,
+    { "filter": { "op": "le", "property": "age", "value": 0 } });
+assert(length(le0) === 2, "le 0 should include the boundary (-50, 0)");
+
+safe_evaluate(index_remove("lmdb", "age"), null);
+safe_evaluate(delete_object("lmdb", ot, idNeg), null);
+safe_evaluate(delete_object("lmdb", ot, idZero), null);
+safe_evaluate(delete_object("lmdb", ot, id9), null);
+safe_evaluate(delete_object("lmdb", ot, id10), null);
+safe_evaluate(delete_object("lmdb", ot, id100), null);
+
+return 0;


### PR DESCRIPTION
## Summary

Closes #266.

- `afw_adapter_impl_index_open_definition()` parsed `options: ["integer"]` into a boolean that reached the LMDB adapter's `impl_afw_adapter_impl_index_open()`, which set `MDB_INTEGERKEY` on the underlying database.
- `impl_afw_adapter_impl_index_add`/`_delete` never referenced that flag and always wrote the fixed-width sortable-text key introduced by #251/#264 — a key-size/type mismatch against `MDB_INTEGERKEY`'s native-binary comparator contract.
- Since the sortable-text encoding already gives correct, portable ordering for every indexed type through one comparator, this drops the `"integer"` option rather than finishing `MDB_INTEGERKEY` support (which would require re-deriving the same negative-number sign-bias trick, just in native-endian binary — the same bug class #251/#264 and #263/#265 just fixed). Any lingering `options: ["integer"]` usage is now a harmless no-op, same as any other unrecognized option string.
- Also corrects the stale "options may possibly be" docstring in `afw_adapter_impl_index.c` to separate implemented options (`unique`, `sort-reverse`, `case-insensitive-string`) from aspirational/unimplemented ones.

## Changes

- `src/afw/generate/interfaces/afw_interface.xml` — remove the `integer` parameter from `afw_adapter_impl_index`'s `open` method; regenerated bindings via `./afwdev build --cdev`.
- `src/afw/adapter/afw_adapter_impl_index.c` — drop `integer` option parsing/plumbing; fix docstring.
- `src/afw_lmdb/afw_lmdb_index.c` — drop the `integer` parameter and `MDB_INTEGERKEY` flag.
- `src/afw_lmdb/tests/indexes/index_integer_option_noop.as` — new regression test proving `options: ["integer"]` is a harmless no-op and range queries on the indexed property remain numerically correct.

## Test plan

- [x] `./afwdev build --cdev` — regenerates interface bindings, builds core + lmdb extension clean.
- [x] `afwdev test -j --srcdir-pattern afw_lmdb --test-pattern 'indexes/.*'` — all 13 tests pass, including the new one.
- [x] `afwdev test -j` (full suite) — 4267 passed, 71 pre-existing skips, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>