### PR TITLE
fix(lmdb): key _AdaptiveProvisioningPeer_ journal peers like every other object

### DIFF
--- a/src/afw_lmdb/afw_lmdb_journal.c
+++ b/src/afw_lmdb/afw_lmdb_journal.c
@@ -134,11 +134,19 @@ afw_lmdb_adapter_journal_get_peer_object(
     const afw_object_t *object = NULL;
     const afw_value_t *value;
     afw_memory_t raw;
+    afw_memory_t raw_key;
     MDB_val key, data;
 
     memset(&data, 0, sizeof(MDB_val));
-    key.mv_data = (void*)uuid;
-    key.mv_size = sizeof(afw_uuid_t);
+
+    /* Peer objects are stored in the Primary database under the
+       standard {object_type_id}{uuid} composite key, same as every
+       other object written via the generic add_object/modify_object
+       path. */
+    afw_lmdb_internal_set_key(&raw_key,
+        afw_s__AdaptiveProvisioningPeer_, uuid, xctx->p, xctx);
+    key.mv_data = (void *)raw_key.ptr;
+    key.mv_size = raw_key.size;
 
     if (mdb_get(txn, dbi, &key, &data) == 0) {
         raw.size = data.mv_size;
@@ -173,7 +181,7 @@ afw_lmdb_journal_update_peer(
     object_id = afw_uuid_to_utf8(uuid, xctx->p, xctx);
 
     afw_lmdb_internal_replace_entry_from_object(session,
-        afw_s__AdaptiveJournalEntry_, object_id, updated_object,
+        afw_s__AdaptiveProvisioningPeer_, object_id, updated_object,
         dbi, xctx);
 }
 
@@ -330,10 +338,10 @@ afw_lmdb_journal_get_next_for_consumer_after_cursor(
     const afw_dateTime_t *now;
     afw_size_t i;
     
-    /* In this routine, we can simply start with entry_cursor 
-        and work our way up until we find the next entry */
+    /* set our cursor to one after the entry_cursor, then work our
+        way up until we find the next applicable entry */
     cursor = apr_strtoi64(
-        afw_utf8_to_utf8_z(entry_cursor, xctx->p, xctx), NULL, 10);
+        afw_utf8_to_utf8_z(entry_cursor, xctx->p, xctx), NULL, 10) + 1;
 
     dbiConsumers = afw_lmdb_internal_open_database(session->adapter, 
         txn, afw_lmdb_s_Primary, 0, xctx->p, xctx);
@@ -777,6 +785,10 @@ impl_afw_adapter_journal_mark_entry_consumed(
 
         peer = afw_lmdb_adapter_journal_get_peer_object(
             self, session, adapter, dbiConsumers, txn, uuid, xctx);
+        if (peer == NULL) {
+            AFW_THROW_ERROR_Z(general,
+                "Error, provisioning peer not found.", xctx);
+        }
 
         consume_cursor = afw_object_old_get_property_as_string(peer,
             afw_v_consumeCursor, xctx);

--- a/src/afw_lmdb/tests/journal/journal_tests_4.as
+++ b/src/afw_lmdb/tests/journal/journal_tests_4.as
@@ -1,0 +1,111 @@
+#!/usr/bin/env -S afw --syntax test_script
+//?
+//? testScript: journal_tests_4.as
+//? customPurpose: Part of lmdb tests
+//? description: Regression for afw#231 (peer objects created via add_object() were stored under a different LMDB key than the journal consumer functions looked them up with) plus a related get_next_for_consumer_after_cursor skip-cursor fix.
+//? sourceType: script
+//?
+//? test: journal_get_next_for_consumer
+//? description: a peer created via add_object() must be discoverable by journal_get_next_for_consumer()
+//? skip: false
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+const peerUuid: string = generate_uuid();
+
+add_object("journal", "_AdaptiveProvisioningPeer_", {
+    peerId: "consumer1"
+}, peerUuid);
+
+// sanity: the peer is readable the normal way
+const peer: object = get_object("journal", "_AdaptiveProvisioningPeer_", peerUuid);
+assert(peer.peerId == "consumer1");
+
+// generate a journal entry for the consumer to find
+add_object("lmdb", "_AdaptiveObject_", { firstName: "bob" });
+
+const result: object = journal_get_next_for_consumer("journal", peerUuid, 10);
+assert(is_defined(result.entryCursor), "expected an entryCursor, peer lookup likely failed");
+
+return 0;
+
+
+//? test: journal_get_next_for_consumer_after_cursor
+//? description: peer must be discoverable, and the passed-in cursor's own entry must be skipped rather than re-returned
+//? skip: false
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+const peerUuid: string = generate_uuid();
+
+add_object("journal", "_AdaptiveProvisioningPeer_", {
+    peerId: "consumer2"
+}, peerUuid);
+
+add_object("lmdb", "_AdaptiveObject_", { firstName: "bob" });
+add_object("lmdb", "_AdaptiveObject_", { firstName: "sue" });
+
+// entry_cursor "1" is the entry we've already seen; the next one is "2"
+const result: object = journal_get_next_for_consumer_after_cursor(
+    "journal", peerUuid, "1", 10);
+assert(is_defined(result.entryCursor), "expected an entryCursor, peer lookup likely failed");
+assert(result.entryCursor == "2",
+    "journal_get_next_for_consumer_after_cursor should skip the passed-in cursor and return the next entry, got " + string(result.entryCursor));
+
+return 0;
+
+
+//? test: journal_advance_cursor_for_consumer
+//? description: peer created via add_object() must be discoverable by journal_advance_cursor_for_consumer()
+//? skip: false
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+const peerUuid: string = generate_uuid();
+
+add_object("journal", "_AdaptiveProvisioningPeer_", {
+    peerId: "consumer3"
+}, peerUuid);
+
+add_object("lmdb", "_AdaptiveObject_", { firstName: "bob" });
+
+// must not throw "provisioning peer not found"
+journal_advance_cursor_for_consumer("journal", peerUuid, 10);
+
+return 0;
+
+
+//? test: journal_mark_consumed
+//? description: peer created via add_object() must be discoverable by journal_mark_consumed(), and an unknown consumer must throw rather than dereference a null peer
+//? skip: false
+//? expect: 0
+//? source: ...
+#!/usr/bin/env afw
+
+const peerUuid: string = generate_uuid();
+
+add_object("journal", "_AdaptiveProvisioningPeer_", {
+    peerId: "consumer4"
+}, peerUuid);
+
+add_object("lmdb", "_AdaptiveObject_", { firstName: "bob" });
+
+const result: object = journal_get_next_for_consumer("journal", peerUuid, 10);
+assert(is_defined(result.entryCursor));
+
+// must not throw "provisioning peer not found"
+journal_mark_consumed("journal", peerUuid, result.entryCursor);
+
+// an unknown consumerId must throw, not crash on a null peer
+assert(
+    safe_evaluate(
+        journal_mark_consumed("journal", generate_uuid(), result.entryCursor),
+        "error"
+    ) == "error",
+    "journal_mark_consumed should throw for an unknown consumer"
+);
+
+return 0;


### PR DESCRIPTION
## Summary

- Closes #231. `_AdaptiveProvisioningPeer_` objects created via the normal `add_object()` path are stored under the standard `{object_type_id}{uuid}` composite key, same as any other object. But the LMDB journal consumer functions (`journal_get_next_for_consumer`, `journal_get_next_for_consumer_after_cursor`, `journal_advance_cursor_for_consumer`, `journal_mark_consumed`) looked peers up by a bare 16-byte UUID key and wrote them back under the wrong object-type id (`_AdaptiveJournalEntry_` instead of `_AdaptiveProvisioningPeer_`). Every consumer function threw `"Error, provisioning peer not found."` even though the peer object was reachable via `get_object()`. Fixed `afw_lmdb_adapter_journal_get_peer_object()` and `afw_lmdb_journal_update_peer()` to use the same composite-key addressing as the rest of the adapter — cross-checked against the file adapter's journal implementation (`src/afw/file/afw_file_journal.c`), which stores/looks up peers the same way.
- `journal_mark_consumed` dereferenced the peer without a NULL check (the other three consumer functions already had one); added it.
- `journal_get_next_for_consumer_after_cursor` started its scan *at* the passed `entry_cursor` instead of after it, so it could re-return an already-seen entry. Aligned it with its own sibling `journal_get_next_after_cursor` (which does `cursor + 1`) and with the file adapter's skip-first-entry semantics for the same option.

## Test plan

- New regression test `src/afw_lmdb/tests/journal/journal_tests_4.as` exercises all four consumer functions against a peer created via the documented `add_object()` API, plus an unknown-consumer case for the NULL-check fix and a cursor-skip assertion for the after-cursor fix.
- Verified each fix independently: reverted one hunk at a time, confirmed the corresponding test assertion(s) fail with the exact bug symptom, then restored and confirmed all pass.
- `afwdev test --srcdir-pattern afw_lmdb -j`: 25/25 pass.
- Full `afwdev test -j`: 4260 passed, 71 skipped, 1 pre-existing unrelated failure (`pool_heap_probe.c` C-probe compile error tied to in-flight `#267` pool work) confirmed to also fail on unmodified `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)